### PR TITLE
Fix: Ensure SIGINT is passed to child processes

### DIFF
--- a/src/os/pty.rs
+++ b/src/os/pty.rs
@@ -100,6 +100,7 @@ impl NixPty {
                 let mut termios_attrs = termios::tcgetattr(&slave_fd)
                     .with_context(|| "Child: Failed to get terminal attributes")?;
                 termios::cfmakeraw(&mut termios_attrs);
+                termios_attrs.c_lflag |= termios::LocalFlags::ISIG;
                 termios::tcsetattr(&slave_fd, termios::SetArg::TCSANOW, &termios_attrs)
                     .with_context(|| "Child: Failed to set terminal attributes to raw mode")?;
 


### PR DESCRIPTION
The `cfmakeraw()` function, used to set the pseudo-terminal to raw mode, disables the `ISIG` flag in the terminal's local modes (`c_lflag`). This prevents the terminal driver from generating signals (like SIGINT when Ctrl+C is pressed) for the foreground process group.

This change re-enables the `ISIG` flag immediately after the call to `cfmakeraw()` and before the modified terminal attributes are applied with `tcsetattr()`. This ensures that while other raw mode characteristics are maintained, the terminal will still process special characters like Ctrl+C and generate the appropriate signal, allowing it to be correctly propagated to child processes running in the terminal.

I've confirmed through manual testing that child processes now terminate as expected when Ctrl+C is pressed.