### PR TITLE
Fix: Resolve test compilation errors and failures

### DIFF
--- a/src/ansi/commands.rs
+++ b/src/ansi/commands.rs
@@ -275,6 +275,7 @@ impl AnsiCommand {
         C0Control::from_byte(byte).map(AnsiCommand::C0Control)
     }
 
+    /*
     pub(crate) fn from_c1(byte: u8) -> Option<Self> {
         match byte {
             0x84 => Some(AnsiCommand::Esc(EscCommand::Index)),
@@ -288,6 +289,7 @@ impl AnsiCommand {
             _ => Some(AnsiCommand::C1Control(byte)),
         }
     }
+    */
 
     pub(crate) fn from_esc(final_char: char) -> Option<Self> {
         match final_char {

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,7 +150,7 @@ fn main() -> anyhow::Result<()> {
 
     // --- Instantiate AppOrchestrator ---
     let mut orchestrator = AppOrchestrator::new(
-        &mut platform,
+        platform.as_mut(),
         &mut term_emulator,
         &mut ansi_parser,
         renderer,
@@ -182,7 +182,7 @@ fn main() -> anyhow::Result<()> {
 
     // --- Cleanup ---
     info!("Shutting down platform...");
-    platform.shutdown().context("Failed to shutdown platform")?;
+    platform.cleanup().context("Failed to cleanup platform")?;
     info!("myterm exited successfully.");
 
     Ok(())

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -38,8 +38,8 @@ pub enum OrchestratorStatus {
     Shutdown,
 }
 
-pub struct AppOrchestrator<'a, P: Platform> {
-    platform: &'a mut P,
+pub struct AppOrchestrator<'a> {
+    platform: &'a mut dyn Platform,
     term_emulator: &'a mut TerminalEmulator,
     ansi_parser: &'a mut AnsiProcessor,
     renderer: Renderer,
@@ -49,9 +49,9 @@ pub struct AppOrchestrator<'a, P: Platform> {
     pending_emulator_actions: Vec<EmulatorAction>,
 }
 
-impl<'a, P: Platform> AppOrchestrator<'a, P> {
+impl<'a> AppOrchestrator<'a> {
     pub fn new(
-        platform: &'a mut P,
+        platform: &'a mut dyn Platform,
         term_emulator: &'a mut TerminalEmulator,
         ansi_parser: &'a mut AnsiProcessor,
         renderer: Renderer,
@@ -207,7 +207,7 @@ impl<'a, P: Platform> AppOrchestrator<'a, P> {
                         } => {
                             
                             debug!("Key: {:?} + {:?}\nText: {:?}", modifiers, symbol, text);
-                            let key_input_action = keys::map_key_event_to_action(symbol, modifiers).unwrap_or(UserInputAction::KeyInput {
+                            let key_input_action = keys::map_key_event_to_action(symbol, modifiers, &crate::config::CONFIG).unwrap_or(UserInputAction::KeyInput {
                                 symbol,
                                 modifiers,
                                 text: if text.is_empty() { None } else { Some(text) },

--- a/src/platform/backends/cocoa.rs
+++ b/src/platform/backends/cocoa.rs
@@ -1,12 +1,13 @@
 use crate::platform::backends::{
-    BackendEvent, Driver, PlatformState, RenderCommand, UiActionCommand,
+    BackendEvent, CursorVisibility, Driver, FocusState, PlatformState, RenderCommand,
 };
 use anyhow::Result; // For Result type in new()
+use std::os::unix::io::RawFd;
 
 pub struct CocoaDriver;
 
 impl Driver for CocoaDriver {
-    fn new() -> Result<Self> // Changed to Result<Self>
+    fn new() -> Result<Self>
     where
         Self: Sized,
     {
@@ -15,41 +16,109 @@ impl Driver for CocoaDriver {
         Ok(CocoaDriver)
     }
 
+    fn get_event_fd(&self) -> Option<RawFd> {
+        // Placeholder
+        None
+    }
+
+    fn process_events(&mut self) -> Result<Vec<BackendEvent>> {
+        // Return Ok(vec![]) or a stubbed event for now
+        // println!("CocoaDriver: process_events()");
+        Ok(vec![])
+    }
+
     fn get_platform_state(&self) -> PlatformState {
         // Return a default/stubbed PlatformState
-        PlatformState::default()
+        // TODO: Fix PlatformState::default() call by deriving Default or providing a constructor
+        PlatformState {
+            event_fd: None,
+            font_cell_width_px: 8,
+            font_cell_height_px: 16,
+            scale_factor: 1.0,
+            display_width_px: 800,
+            display_height_px: 600,
+        }
     }
 
-    fn poll_event(&mut self) -> Result<Option<BackendEvent>> { // Changed error type to anyhow::Error implicitly
-        // Return Ok(None) or a stubbed event for now
-        // println!("CocoaDriver: poll_event()");
-        Ok(None)
-    }
-
-    fn dispatch_ui_action(&mut self, action: UiActionCommand) -> Result<()> { // Changed error type
-        // Placeholder for handling UiActionCommands
-        // println!("CocoaDriver: dispatch_ui_action({:?})", action);
-        match action {
-            UiActionCommand::Render(render_commands) => { // Now a Vec
-                println!("CocoaDriver: Rendering - {} commands", render_commands.len());
-                // Potentially call self.present() here if Render implies immediate presentation
-            }
-            UiActionCommand::SetWindowTitle(title) => {
-                println!("CocoaDriver: Setting window title - {}", title);
-            }
-            UiActionCommand::RingBell => {
-                println!("CocoaDriver: RingBell");
-            }
-            UiActionCommand::CopyToClipboard(text) => {
-                println!("CocoaDriver: CopyToClipboard - {} chars", text.len());
-            }
-            UiActionCommand::SetCursorVisibility(visible) => {
-                println!("CocoaDriver: SetCursorVisibility - {}", visible);
-            }
-            UiActionCommand::PresentFrame => {
-                println!("CocoaDriver: PresentFrame");
+    fn execute_render_commands(&mut self, commands: Vec<RenderCommand>) -> Result<()> {
+        println!("CocoaDriver: Rendering - {} commands", commands.len());
+        // Placeholder for handling RenderCommands
+        for command in commands {
+            match command {
+                RenderCommand::ClearAll { bg } => {
+                    println!("CocoaDriver: ClearAll with color {:?}", bg);
+                }
+                RenderCommand::DrawTextRun {
+                    x,
+                    y,
+                    text,
+                    fg,
+                    bg,
+                    flags,
+                    is_selected,
+                } => {
+                    println!(
+                        "CocoaDriver: DrawTextRun at ({}, {}): '{}', fg={:?}, bg={:?}, flags={:?}, selected={}",
+                        x, y, text, fg, bg, flags, is_selected
+                    );
+                }
+                RenderCommand::FillRect {
+                    x,
+                    y,
+                    width,
+                    height,
+                    color,
+                    is_selection_bg,
+                } => {
+                    println!(
+                        "CocoaDriver: FillRect at ({}, {}), size ({}x{}), color={:?}, selection_bg={}",
+                        x, y, width, height, color, is_selection_bg
+                    );
+                }
+                RenderCommand::SetCursorVisibility { visible } => {
+                    // This is part of RenderCommand enum, distinct from Driver::set_cursor_visibility
+                    println!("CocoaDriver: RenderCommand::SetCursorVisibility - {}", visible);
+                }
+                RenderCommand::SetWindowTitle { title } => {
+                     // This is part of RenderCommand enum, distinct from Driver::set_title
+                    println!("CocoaDriver: RenderCommand::SetWindowTitle - {}", title);
+                }
+                RenderCommand::RingBell => {
+                    // This is part of RenderCommand enum, distinct from Driver::bell
+                    println!("CocoaDriver: RenderCommand::RingBell");
+                }
+                RenderCommand::PresentFrame => {
+                     // This is part of RenderCommand enum, distinct from Driver::present
+                    println!("CocoaDriver: RenderCommand::PresentFrame");
+                }
             }
         }
+        Ok(())
+    }
+
+    fn present(&mut self) -> Result<()> {
+        println!("CocoaDriver: Presenting frame");
+        Ok(())
+    }
+
+    fn set_title(&mut self, title: &str) {
+        println!("CocoaDriver: Setting window title - {}", title);
+    }
+
+    fn bell(&mut self) {
+        println!("CocoaDriver: RingBell");
+    }
+
+    fn set_cursor_visibility(&mut self, visibility: CursorVisibility) {
+        println!("CocoaDriver: SetCursorVisibility - {:?}", visibility);
+    }
+
+    fn set_focus(&mut self, focus_state: FocusState) {
+        println!("CocoaDriver: SetFocus - {:?}", focus_state);
+    }
+
+    fn cleanup(&mut self) -> Result<()> {
+        println!("CocoaDriver: Cleanup");
         Ok(())
     }
 }

--- a/src/platform/console_platform.rs
+++ b/src/platform/console_platform.rs
@@ -265,6 +265,11 @@ impl Platform for ConsolePlatform {
     fn get_current_platform_state(&self) -> PlatformState {
         self.driver.get_platform_state()
     }
+
+    fn cleanup(&mut self) -> Result<()> {
+        log::info!("ConsolePlatform: cleanup() called. Cleaning up ConsoleDriver...");
+        self.driver.cleanup()
+    }
 }
 
 // Inherent methods

--- a/src/platform/linux_x11.rs
+++ b/src/platform/linux_x11.rs
@@ -331,6 +331,11 @@ impl Platform for LinuxX11Platform {
     fn get_current_platform_state(&self) -> PlatformState {
         self.driver.get_platform_state()
     }
+
+    fn cleanup(&mut self) -> Result<()> {
+        log::info!("LinuxX11Platform: cleanup() called. Cleaning up XDriver...");
+        self.driver.cleanup()
+    }
 }
 
 impl Drop for LinuxX11Platform {

--- a/src/platform/platform_trait.rs
+++ b/src/platform/platform_trait.rs
@@ -64,4 +64,9 @@ pub trait Platform {
     ///
     /// The current `PlatformState`.
     fn get_current_platform_state(&self) -> PlatformState;
+
+    /// Performs any necessary cleanup before the platform is dropped.
+    /// This includes releasing platform resources (e.g., closing display connections,
+    /// restoring terminal modes). This method should be idempotent.
+    fn cleanup(&mut self) -> Result<()>;
 }

--- a/src/renderer/tests.rs
+++ b/src/renderer/tests.rs
@@ -16,6 +16,7 @@ use std::sync::Mutex;
 
 // Mocking structures for testing the renderer's interaction with a Driver.
 #[derive(Debug, Clone, PartialEq)]
+#[allow(dead_code)] // Allow dead code for variants not explicitly constructed in tests
 enum MockDrawCommand {
     ClearAll {
         bg: Color,

--- a/src/term/emulator/input_handler.rs
+++ b/src/term/emulator/input_handler.rs
@@ -279,7 +279,8 @@ mod tests {
         let result = process_user_input_action(&mut emu, action);
         assert_eq!(result, Some(EmulatorAction::RequestRedraw));
 
-        let snapshot = emu.get_render_snapshot();
+        let snapshot_option = emu.get_render_snapshot();
+        let snapshot = snapshot_option.as_ref().expect("Snapshot was None");
         // Print the actual screen content for debugging
         for (r, line) in snapshot.lines.iter().enumerate() {
             let line_str: String = line
@@ -296,7 +297,7 @@ mod tests {
         }
         println!(
             "Actual cursor pos: {:?}",
-            snapshot.cursor_state.map(|cs| (cs.y, cs.x))
+            snapshot.cursor_state.as_ref().map(|cs| (cs.y, cs.x))
         );
 
         match snapshot.lines[0].cells[0] {

--- a/src/term/screen.rs
+++ b/src/term/screen.rs
@@ -179,10 +179,12 @@ impl Screen {
         self.scroll_bot
     }
 
+    /*
     /// Returns the current scrollback limit.
     pub fn scrollback_limit(&self) -> usize {
         self.scrollback_limit
     }
+    */
 
     /// Helper to get the glyph used for filling cleared areas.
     fn get_default_fill_glyph(&self) -> Glyph {
@@ -1017,7 +1019,7 @@ impl Screen {
     }
 }
 
-const SOME_REASONABLE_SLACK: usize = 20;
+// const SOME_REASONABLE_SLACK: usize = 20;
 
 #[cfg(test)]
 mod tests {

--- a/src/term/unicode.rs
+++ b/src/term/unicode.rs
@@ -46,37 +46,35 @@ impl LocaleInitializer {
 
     /// Internal method to calculate character display width.
     fn char_display_width_internal(&self, c: char) -> usize {
+        // Explicitly handle Zero-Width Joiner (U+200D) and other known zero-width characters first.
+        if c == '\u{200D}' || c == '\u{200B}' /* Zero Width Space */ {
+            return 0;
+        }
+
         let wc = c as c_uint;
         // SAFETY: Calling C's wcwidth. Locale is expected to be set by `new()`.
         let width_from_c = unsafe { wcwidth(wc) };
 
         match width_from_c {
             -1 => {
+                // For control characters, wcwidth might return -1. These should be 0 width.
+                // For other non-printable chars that wcwidth deems -1, also treat as 0 width.
+                // If it's a printable char for which wcwidth returns -1 (unlikely for common cases),
+                // defaulting to 1 might be an option, but 0 is safer for unhandled non-printables.
                 if c.is_control() {
-                    trace!(
-                        "wcwidth returned -1 for control char '{}' (U+{:X}), width is 0.",
-                        c,
-                        wc
-                    );
+                    trace!("wcwidth returned -1 for control char '{}' (U+{:X}), width is 0.", c, wc);
                     0
                 } else {
-                    trace!(
-                        "wcwidth returned -1 for char '{}' (U+{:X}), defaulting to width 1.",
-                        c,
-                        wc
-                    );
-                    1
+                    // This case is ambiguous: wcwidth says "not printable" but it's not a C0/C1 control char.
+                    // Could be other format effectors or unassigned. Defaulting to 0 is safer than 1.
+                    trace!("wcwidth returned -1 for non-control char '{}' (U+{:X}), width is 0.", c, wc);
+                    0
                 }
             }
             0 => {
-                trace!("wcwidth returned 0 for char '{}' (U+{:X}).", c, wc);
-                if c.is_control() {
-                     trace!("wcwidth returned 0 for control char '{}' (U+{:X}).", c, wc);
-                     0
-                } else {
-                     debug!("wcwidth returned 0 for non-control char '{}' (U+{:X}), defaulting to width 1.", c, wc);
-                     1
-                }
+                // wcwidth returning 0 typically means a non-spacing character (e.g., combining mark).
+                trace!("wcwidth returned 0 for char '{}' (U+{:X}), width is 0.", c, wc);
+                0
             }
             1 => 1,
             2 => 2,


### PR DESCRIPTION
This commit addresses several compilation errors and test failures throughout the codebase.

The key changes include:
- Corrected various import statements.
- Ensured `CocoaDriver` correctly implements the `Driver` trait.
- Handled `Option<RenderSnapshot>` appropriately in test files and `input_handler.rs`.
- Fixed the `map_key_event_to_action` function in `src/keys.rs` to correctly use its `Config` argument and updated its call sites. This resolved failures in `keys::tests`.
- Added a `cleanup()` method to the `Platform` trait and its implementations.
- Corrected the usage of the `CursorVisibility` enum in `src/platform/macos.rs`.
- Fixed a non-exhaustive pattern match in `src/platform/macos.rs`.
- Corrected the display width calculation for zero-width characters (like ZWJ) in `src/term/unicode.rs`, fixing the `test_zero_width_chars` test.
- Cleaned up various dead code warnings.

All tests are now passing.