### PR TITLE
⚡ Bolt: Optimized Surface evaluation with early exit

### DIFF
--- a/pixelflow-graphics/src/scene3d.rs
+++ b/pixelflow-graphics/src/scene3d.rs
@@ -373,56 +373,122 @@ impl<H: ManifoldCompat<Field, Output = Field>> Manifold<Jet3_4> for HeightFieldG
 //
 // Evaluates geometry to get t, computes hit point P = ray * t, then selects
 // between material (at P) and background based on hit validity.
-kernel!(pub struct Surface = |geometry: kernel, material: kernel, background: kernel| Jet3 -> Field {
-    // 1. Get distance t from geometry
-    let t = geometry;
+#[derive(Clone, Copy, ManifoldExpr)]
+pub struct Surface<G, M, B> {
+    pub geometry: G,
+    pub material: M,
+    pub background: B,
+}
 
-    // 2. Validate hit: t > 0, t < max, derivatives reasonable
-    let t_max = 1000000.0;
-    let deriv_max = 10000.0;
-    let valid_t = (V(t) > 0.0) & (V(t) < t_max);
-    let deriv_mag_sq = DX(t) * DX(t) + DY(t) * DY(t) + DZ(t) * DZ(t);
-    let valid_deriv = deriv_mag_sq < (deriv_max * deriv_max);
-    let mask = valid_t & valid_deriv;
+impl<G, M, B> Manifold<Jet3_4> for Surface<G, M, B>
+where
+    G: ManifoldCompat<Jet3, Output = Jet3>,
+    M: ManifoldCompat<Jet3, Output = Field>,
+    B: ManifoldCompat<Jet3, Output = Field>,
+{
+    type Output = Field;
 
-    // 3. Hit point: P = ray * t (always computed; Select short-circuits if mask is all-false)
-    let hx = X * t;
-    let hy = Y * t;
-    let hz = Z * t;
+    #[inline(always)]
+    fn eval(&self, p: Jet3_4) -> Field {
+        let (rx, ry, rz, w) = p;
 
-    // 4. Sample material at hit point, background at ray direction
-    let mat_val = material.at(hx, hy, hz, W);
-    let bg_val = background;
+        // 1. Get distance t from geometry
+        let t = self.geometry.eval_raw(rx, ry, rz, w);
 
-    // 5. Select based on hit validity (short-circuit avoids evaluating unused branch)
-    mask.select(mat_val, bg_val)
-});
+        // 2. Validate hit: t > 0, t < max, derivatives reasonable
+        let t_val = t.val;
+        let t_max = Field::from(1000000.0);
+        let deriv_max_sq = Field::from(10000.0 * 10000.0);
+        let zero = Field::from(0.0);
+
+        let valid_t = t_val.gt(zero) & t_val.lt(t_max);
+        let deriv_mag_sq = (t.dx * t.dx + t.dy * t.dy + t.dz * t.dz).constant();
+        let valid_deriv = deriv_mag_sq.lt(deriv_max_sq);
+        let mask = valid_t & valid_deriv;
+
+        // Optimization: Early exit for miss
+        if !mask.any() {
+            return self.background.eval_raw(rx, ry, rz, w);
+        }
+
+        // Optimization: Early exit for hit (skip background)
+        if mask.all() {
+            let hx = rx * t;
+            let hy = ry * t;
+            let hz = rz * t;
+            return self.material.eval_raw(hx, hy, hz, w);
+        }
+
+        // Mixed case: Evaluate both (but only active lanes matter)
+        let hx = rx * t;
+        let hy = ry * t;
+        let hz = rz * t;
+
+        let fg = self.material.eval_raw(hx, hy, hz, w);
+        let bg = self.background.eval_raw(rx, ry, rz, w);
+
+        <Field as Selectable>::select_raw(mask, fg, bg)
+    }
+}
 
 // Color Surface: geometry + material + background, outputs Discrete.
-kernel!(pub struct ColorSurface = |geometry: kernel, material: kernel, background: kernel| Jet3 -> Discrete {
-    // 1. Get distance t from geometry
-    let t = geometry;
+#[derive(Clone, Copy, ManifoldExpr)]
+pub struct ColorSurface<G, M, B> {
+    pub geometry: G,
+    pub material: M,
+    pub background: B,
+}
 
-    // 2. Validate hit: t > 0, t < max, derivatives reasonable
-    let t_max = 1000000.0;
-    let deriv_max = 10000.0;
-    let valid_t = (V(t) > 0.0) & (V(t) < t_max);
-    let deriv_mag_sq = DX(t) * DX(t) + DY(t) * DY(t) + DZ(t) * DZ(t);
-    let valid_deriv = deriv_mag_sq < (deriv_max * deriv_max);
-    let mask = valid_t & valid_deriv;
+impl<G, M, B> Manifold<Jet3_4> for ColorSurface<G, M, B>
+where
+    G: ManifoldCompat<Jet3, Output = Jet3>,
+    M: ManifoldCompat<Jet3, Output = Discrete>,
+    B: ManifoldCompat<Jet3, Output = Discrete>,
+{
+    type Output = Discrete;
 
-    // 3. Hit point: P = ray * t (always computed; Select short-circuits if mask is all-false)
-    let hx = X * t;
-    let hy = Y * t;
-    let hz = Z * t;
+    #[inline(always)]
+    fn eval(&self, p: Jet3_4) -> Discrete {
+        let (rx, ry, rz, w) = p;
 
-    // 4. Sample material at hit point, background at ray direction
-    let mat_val = material.at(hx, hy, hz, W);
-    let bg_val = background;
+        // 1. Get distance t from geometry
+        let t = self.geometry.eval_raw(rx, ry, rz, w);
 
-    // 5. Select based on hit validity (short-circuit avoids evaluating unused branch)
-    mask.select(mat_val, bg_val)
-});
+        // 2. Validate hit: t > 0, t < max, derivatives reasonable
+        let t_val = t.val;
+        let t_max = Field::from(1000000.0);
+        let deriv_max_sq = Field::from(10000.0 * 10000.0);
+        let zero = Field::from(0.0);
+
+        let valid_t = t_val.gt(zero) & t_val.lt(t_max);
+        let deriv_mag_sq = (t.dx * t.dx + t.dy * t.dy + t.dz * t.dz).constant();
+        let valid_deriv = deriv_mag_sq.lt(deriv_max_sq);
+        let mask = valid_t & valid_deriv;
+
+        // Optimization: Early exit for miss
+        if !mask.any() {
+            return self.background.eval_raw(rx, ry, rz, w);
+        }
+
+        // Optimization: Early exit for hit (skip background)
+        if mask.all() {
+            let hx = rx * t;
+            let hy = ry * t;
+            let hz = rz * t;
+            return self.material.eval_raw(hx, hy, hz, w);
+        }
+
+        // Mixed case: Evaluate both (but only active lanes matter)
+        let hx = rx * t;
+        let hy = ry * t;
+        let hz = rz * t;
+
+        let fg = self.material.eval_raw(hx, hy, hz, w);
+        let bg = self.background.eval_raw(rx, ry, rz, w);
+
+        <Discrete as Selectable>::select_raw(mask, fg, bg)
+    }
+}
 
 // ... SCENE COMPOSITION ...
 


### PR DESCRIPTION
This PR optimizes `Surface` and `ColorSurface` in `pixelflow-graphics/src/scene3d.rs` by replacing the `kernel!` macro invocation with a manual `Manifold` implementation.

Key improvements:
1.  **Early Exit on Miss:** If the ray misses geometry for all SIMD lanes (`!mask.any()`), the material evaluation is skipped entirely, and only the background is computed.
2.  **Early Exit on Hit:** If the ray hits geometry for all SIMD lanes (`mask.all()`), the background evaluation is skipped entirely.
3.  **Explicit Selection:** Uses `Selectable::select_raw` for blending in mixed SIMD lanes, ensuring correct behavior.

This addresses the "Conditional background evaluation" performance opportunity identified in the analysis, potentially yielding 10-15% speedup in scenes with significant empty space or full coverage.

The implementation correctly handles AST vs Value types by using `.constant()` where necessary for intermediate mask calculations.


---
*PR created automatically by Jules for task [9400950322606186424](https://jules.google.com/task/9400950322606186424) started by @jppittman*