### PR TITLE
Refactor magic numbers in scene3d.rs to constants

### DIFF
--- a/pixelflow-graphics/src/scene3d.rs
+++ b/pixelflow-graphics/src/scene3d.rs
@@ -31,6 +31,12 @@ type PathJet4 = (PathJet<Jet3>, PathJet<Jet3>, PathJet<Jet3>, PathJet<Jet3>);
 /// Epsilon for normalizing vectors to avoid division by zero.
 const NORMALIZATION_EPSILON: f32 = 1e-10;
 
+/// Maximum ray distance for intersection tests.
+const MAX_RAY_DISTANCE: f32 = 1_000_000.0;
+
+/// Maximum derivative magnitude for valid hits (anti-aliasing limit).
+const MAX_DERIVATIVE_MAGNITUDE: f32 = 10_000.0;
+
 /// Minimum cosine of incidence angle to avoid infinite curvature scaling at grazing angles.
 const MIN_INCIDENCE_COSINE: f32 = 0.1;
 
@@ -373,56 +379,96 @@ impl<H: ManifoldCompat<Field, Output = Field>> Manifold<Jet3_4> for HeightFieldG
 //
 // Evaluates geometry to get t, computes hit point P = ray * t, then selects
 // between material (at P) and background based on hit validity.
-kernel!(pub struct Surface = |geometry: kernel, material: kernel, background: kernel| Jet3 -> Field {
-    // 1. Get distance t from geometry
-    let t = geometry;
+#[derive(Clone, Copy, ManifoldExpr)]
+pub struct Surface<G, M, B> {
+    pub geometry: G,
+    pub material: M,
+    pub background: B,
+}
 
-    // 2. Validate hit: t > 0, t < max, derivatives reasonable
-    let t_max = 1000000.0;
-    let deriv_max = 10000.0;
-    let valid_t = (V(t) > 0.0) & (V(t) < t_max);
-    let deriv_mag_sq = DX(t) * DX(t) + DY(t) * DY(t) + DZ(t) * DZ(t);
-    let valid_deriv = deriv_mag_sq < (deriv_max * deriv_max);
-    let mask = valid_t & valid_deriv;
+impl<G, M, B> Manifold<Jet3_4> for Surface<G, M, B>
+where
+    G: ManifoldCompat<Jet3, Output = Jet3>,
+    M: ManifoldCompat<Jet3, Output = Field>,
+    B: ManifoldCompat<Jet3, Output = Field>,
+{
+    type Output = Field;
 
-    // 3. Hit point: P = ray * t (always computed; Select short-circuits if mask is all-false)
-    let hx = X * t;
-    let hy = Y * t;
-    let hz = Z * t;
+    #[inline]
+    fn eval(&self, p: Jet3_4) -> Field {
+        let (rx, ry, rz, w) = p;
+        let t = self.geometry.eval_raw(rx, ry, rz, w);
 
-    // 4. Sample material at hit point, background at ray direction
-    let mat_val = material.at(hx, hy, hz, W);
-    let bg_val = background;
+        let t_max = Field::from(MAX_RAY_DISTANCE);
+        let deriv_max = Field::from(MAX_DERIVATIVE_MAGNITUDE);
 
-    // 5. Select based on hit validity (short-circuit avoids evaluating unused branch)
-    mask.select(mat_val, bg_val)
-});
+        // Valid if: t > 0, t < max, derivatives reasonable
+        let zero = Field::from(0.0);
+        let valid_t = t.val.gt(zero) & t.val.lt(t_max);
+
+        let deriv_mag_sq = (t.dx * t.dx + t.dy * t.dy + t.dz * t.dz).constant();
+        let valid_deriv = deriv_mag_sq.lt((deriv_max * deriv_max).constant());
+        let mask = valid_t & valid_deriv;
+
+        // Hit point P = ray * t
+        let hx = rx * t;
+        let hy = ry * t;
+        let hz = rz * t;
+
+        // Sample material at hit point, background at ray direction
+        let mat_val = self.material.eval_raw(hx, hy, hz, w);
+        let bg_val = self.background.eval_raw(rx, ry, rz, w);
+
+        // Select
+        mask.select(mat_val, bg_val).constant()
+    }
+}
 
 // Color Surface: geometry + material + background, outputs Discrete.
-kernel!(pub struct ColorSurface = |geometry: kernel, material: kernel, background: kernel| Jet3 -> Discrete {
-    // 1. Get distance t from geometry
-    let t = geometry;
+#[derive(Clone, Copy, ManifoldExpr)]
+pub struct ColorSurface<G, M, B> {
+    pub geometry: G,
+    pub material: M,
+    pub background: B,
+}
 
-    // 2. Validate hit: t > 0, t < max, derivatives reasonable
-    let t_max = 1000000.0;
-    let deriv_max = 10000.0;
-    let valid_t = (V(t) > 0.0) & (V(t) < t_max);
-    let deriv_mag_sq = DX(t) * DX(t) + DY(t) * DY(t) + DZ(t) * DZ(t);
-    let valid_deriv = deriv_mag_sq < (deriv_max * deriv_max);
-    let mask = valid_t & valid_deriv;
+impl<G, M, B> Manifold<Jet3_4> for ColorSurface<G, M, B>
+where
+    G: ManifoldCompat<Jet3, Output = Jet3>,
+    M: ManifoldCompat<Jet3, Output = Discrete>,
+    B: ManifoldCompat<Jet3, Output = Discrete>,
+{
+    type Output = Discrete;
 
-    // 3. Hit point: P = ray * t (always computed; Select short-circuits if mask is all-false)
-    let hx = X * t;
-    let hy = Y * t;
-    let hz = Z * t;
+    #[inline]
+    fn eval(&self, p: Jet3_4) -> Discrete {
+        let (rx, ry, rz, w) = p;
+        let t = self.geometry.eval_raw(rx, ry, rz, w);
 
-    // 4. Sample material at hit point, background at ray direction
-    let mat_val = material.at(hx, hy, hz, W);
-    let bg_val = background;
+        let t_max = Field::from(MAX_RAY_DISTANCE);
+        let deriv_max = Field::from(MAX_DERIVATIVE_MAGNITUDE);
 
-    // 5. Select based on hit validity (short-circuit avoids evaluating unused branch)
-    mask.select(mat_val, bg_val)
-});
+        // Valid if: t > 0, t < max, derivatives reasonable
+        let zero = Field::from(0.0);
+        let valid_t = t.val.gt(zero) & t.val.lt(t_max);
+
+        let deriv_mag_sq = (t.dx * t.dx + t.dy * t.dy + t.dz * t.dz).constant();
+        let valid_deriv = deriv_mag_sq.lt((deriv_max * deriv_max).constant());
+        let mask = valid_t & valid_deriv;
+
+        // Hit point P = ray * t
+        let hx = rx * t;
+        let hy = ry * t;
+        let hz = rz * t;
+
+        // Sample material at hit point, background at ray direction
+        let mat_val = self.material.eval_raw(hx, hy, hz, w);
+        let bg_val = self.background.eval_raw(rx, ry, rz, w);
+
+        // Select
+        Discrete::select(mask, mat_val, bg_val)
+    }
+}
 
 // ... SCENE COMPOSITION ...
 
@@ -528,18 +574,35 @@ where
 }
 
 // Mask manifold for geometry hit detection.
-kernel!(pub struct GeometryMask = |geometry: kernel| Jet3 -> Field {
-    let t = geometry;
-    let t_max = 1000000.0;
-    let deriv_max = 10000.0;
+#[derive(Clone, Copy, ManifoldExpr)]
+pub struct GeometryMask<G> {
+    pub geometry: G,
+}
 
-    // Valid if: t > 0, t < max, derivatives reasonable
-    let valid_t = (V(t) > 0.0) & (V(t) < t_max);
-    let deriv_mag_sq = DX(t) * DX(t) + DY(t) * DY(t) + DZ(t) * DZ(t);
-    let valid_deriv = deriv_mag_sq < (deriv_max * deriv_max);
+impl<G> Manifold<Jet3_4> for GeometryMask<G>
+where
+    G: ManifoldCompat<Jet3, Output = Jet3>,
+{
+    type Output = Field;
 
-    valid_t & valid_deriv
-});
+    #[inline]
+    fn eval(&self, p: Jet3_4) -> Field {
+        let (rx, ry, rz, w) = p;
+        let t = self.geometry.eval_raw(rx, ry, rz, w);
+
+        let t_max = Field::from(MAX_RAY_DISTANCE);
+        let deriv_max = Field::from(MAX_DERIVATIVE_MAGNITUDE);
+
+        // Valid if: t > 0, t < max, derivatives reasonable
+        let zero = Field::from(0.0);
+        let valid_t = t.val.gt(zero) & t.val.lt(t_max);
+
+        let deriv_mag_sq = (t.dx * t.dx + t.dy * t.dy + t.dz * t.dz).constant();
+        let valid_deriv = deriv_mag_sq.lt((deriv_max * deriv_max).constant());
+
+        valid_t & valid_deriv
+    }
+}
 
 impl<G, M> Scene for SceneObject<G, M>
 where


### PR DESCRIPTION
Replaced magic numbers in `pixelflow-graphics/src/scene3d.rs` with named constants.
Refactored `Surface`, `ColorSurface`, and `GeometryMask` to use manual `Manifold` implementations instead of the `kernel!` macro, enabling the use of constants and resolving scope issues.
Ensured type safety and correctness of manifold evaluations.

---
*PR created automatically by Jules for task [9914686742575878380](https://jules.google.com/task/9914686742575878380) started by @jppittman*