### PR TITLE
⚡ Bolt: Optimize Color::eval by bypassing float conversion

### DIFF
--- a/pixelflow-core/src/lib.rs
+++ b/pixelflow-core/src/lib.rs
@@ -1600,6 +1600,13 @@ impl From<i32> for Field {
     }
 }
 
+impl From<u32> for Field<u32> {
+    #[inline(always)]
+    fn from(val: u32) -> Self {
+        Self(NativeU32Simd::splat(val))
+    }
+}
+
 // ============================================================================
 // Operator Implementations (AST-building)
 // ============================================================================
@@ -1973,6 +1980,17 @@ pub const PARALLELISM: usize = NativeSimd::LANES;
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_discrete_from_u32() {
+        let val = 0xAABBCCDD;
+        let d = Discrete::from(val);
+        let mut out = [0u32; PARALLELISM];
+        d.store(&mut out);
+        for i in 0..PARALLELISM {
+            assert_eq!(out[i], val, "Lane {} mismatch", i);
+        }
+    }
 
     #[test]
     fn test_gather_behavior() {

--- a/pixelflow-graphics/src/render/color.rs
+++ b/pixelflow-graphics/src/render/color.rs
@@ -83,18 +83,11 @@ impl pixelflow_core::Manifold<Field4> for NamedColor {
     type Output = pixelflow_core::Discrete;
 
     #[inline(always)]
-    fn eval(&self, p: Field4) -> pixelflow_core::Discrete {
-        let (x, y, z, w) = p;
-        let (r, g, b) = self.to_rgb();
-        // Use RGBA ColorCube terminal object directly
-        RgbaColorCube::default()
-            .at(
-                Field::from(r as f32 / 255.0),
-                Field::from(g as f32 / 255.0),
-                Field::from(b as f32 / 255.0),
-                Field::from(1.0),
-            )
-            .eval_raw(x, y, z, w)
+    fn eval(&self, _p: Field4) -> pixelflow_core::Discrete {
+        // Fast path: direct integer splat (avoiding f32 conversions)
+        // NamedColor -> Color -> u32 (PALETTE lookup) -> Discrete
+        let val: u32 = Color::Named(*self).into();
+        pixelflow_core::Discrete::from(val)
     }
 }
 
@@ -147,17 +140,10 @@ impl pixelflow_core::Manifold<Field4> for Color {
     type Output = pixelflow_core::Discrete;
 
     #[inline(always)]
-    fn eval(&self, p: Field4) -> pixelflow_core::Discrete {
-        let (x, y, z, w) = p;
-        let (r, g, b, a) = self.to_f32_rgba();
-        RgbaColorCube::default()
-            .at(
-                Field::from(r),
-                Field::from(g),
-                Field::from(b),
-                Field::from(a),
-            )
-            .eval_raw(x, y, z, w)
+    fn eval(&self, _p: Field4) -> pixelflow_core::Discrete {
+        // Fast path: direct integer splat
+        let val: u32 = (*self).into();
+        pixelflow_core::Discrete::from(val)
     }
 }
 


### PR DESCRIPTION
**Performance Optimization for Color Evaluation**

Identified that `Color::eval` and `NamedColor::eval` were performing unnecessary round-trip conversions:
1.  Looking up a packed `u32` color from the palette.
2.  Unpacking it to `f32` components (0.0-1.0).
3.  Creating constant `Field`s for each component.
4.  Passing them to `RgbaColorCube`.
5.  Re-packing them via `Discrete::pack` (which clamps, scales by 255, and bit-shifts back to `u32`).

This change implements a direct path:
1.  Look up packed `u32` color.
2.  Splat it directly to `Discrete` (Field<u32>).

This removes significant overhead for every constant color evaluated in the scene graph.

**Changes:**
*   `pixelflow-core/src/lib.rs`: Added `impl From<u32> for Field<u32>`.
*   `pixelflow-graphics/src/render/color.rs`: Updated `eval` methods to use the fast path.


---
*PR created automatically by Jules for task [13778591362812316916](https://jules.google.com/task/13778591362812316916) started by @jppittman*