### PR TITLE
Refactor magic numbers in scene3d.rs and update kernel macros

### DIFF
--- a/pixelflow-graphics/src/scene3d.rs
+++ b/pixelflow-graphics/src/scene3d.rs
@@ -40,6 +40,12 @@ const CURVATURE_SCALE_FACTOR: f32 = 2.0;
 /// Epsilon for sphere intersection to avoid self-intersection artifacts.
 const SPHERE_EPSILON: f32 = 0.0001;
 
+/// Maximum ray distance for intersection checks.
+const MAX_RAY_DISTANCE: f32 = 1_000_000.0;
+
+/// Maximum derivative magnitude for valid hits (filters out singularities/edge artifacts).
+const MAX_DERIVATIVE_MAGNITUDE: f32 = 10_000.0;
+
 // ============================================================================
 // LIFT: Field manifold → Jet3 manifold (explicit conversion)
 // ============================================================================
@@ -378,8 +384,8 @@ kernel!(pub struct Surface = |geometry: kernel, material: kernel, background: ke
     let t = geometry;
 
     // 2. Validate hit: t > 0, t < max, derivatives reasonable
-    let t_max = 1000000.0;
-    let deriv_max = 10000.0;
+    let t_max = MAX_RAY_DISTANCE;
+    let deriv_max = MAX_DERIVATIVE_MAGNITUDE;
     let valid_t = (V(t) > 0.0) & (V(t) < t_max);
     let deriv_mag_sq = DX(t) * DX(t) + DY(t) * DY(t) + DZ(t) * DZ(t);
     let valid_deriv = deriv_mag_sq < (deriv_max * deriv_max);
@@ -404,8 +410,8 @@ kernel!(pub struct ColorSurface = |geometry: kernel, material: kernel, backgroun
     let t = geometry;
 
     // 2. Validate hit: t > 0, t < max, derivatives reasonable
-    let t_max = 1000000.0;
-    let deriv_max = 10000.0;
+    let t_max = MAX_RAY_DISTANCE;
+    let deriv_max = MAX_DERIVATIVE_MAGNITUDE;
     let valid_t = (V(t) > 0.0) & (V(t) < t_max);
     let deriv_mag_sq = DX(t) * DX(t) + DY(t) * DY(t) + DZ(t) * DZ(t);
     let valid_deriv = deriv_mag_sq < (deriv_max * deriv_max);
@@ -530,8 +536,8 @@ where
 // Mask manifold for geometry hit detection.
 kernel!(pub struct GeometryMask = |geometry: kernel| Jet3 -> Field {
     let t = geometry;
-    let t_max = 1000000.0;
-    let deriv_max = 10000.0;
+    let t_max = MAX_RAY_DISTANCE;
+    let deriv_max = MAX_DERIVATIVE_MAGNITUDE;
 
     // Valid if: t > 0, t < max, derivatives reasonable
     let valid_t = (V(t) > 0.0) & (V(t) < t_max);

--- a/pixelflow-macros/src/codegen/emitter.rs
+++ b/pixelflow-macros/src/codegen/emitter.rs
@@ -828,8 +828,8 @@ impl<'a> CodeEmitter<'a> {
                                 quote! { #name }
                             }
                         }
-                        SymbolKind::Local => {
-                            // Locals emitted as-is
+                        SymbolKind::Local | SymbolKind::Constant => {
+                            // Locals and Constants emitted as-is
                             quote! { #name }
                         }
                     },

--- a/pixelflow-macros/src/codegen/leveled.rs
+++ b/pixelflow-macros/src/codegen/leveled.rs
@@ -317,6 +317,10 @@ impl<'a> LevelBuilder<'a> {
                             // Local variables - conservatively Varying
                             (LeveledNodeKind::Local { name }, Deps::Varying)
                         }
+                        SymbolKind::Constant => {
+                            // Constants - effectively literals
+                            (LeveledNodeKind::Local { name }, Deps::Const)
+                        }
                     },
                     None => (LeveledNodeKind::Local { name }, Deps::Varying),
                 }

--- a/pixelflow-macros/src/sema.rs
+++ b/pixelflow-macros/src/sema.rs
@@ -179,6 +179,18 @@ impl SemanticAnalyzer {
                     return Ok(SymbolKind::Local); // Treat as external/captured
                 }
 
+                // Check for constants (ALL_CAPS) - allow external constants
+                // Heuristic: Must be all uppercase/numeric/underscore, start with letter, length > 1
+                // (Single letters could be local variables or loop indices, except intrinsics which are handled above)
+                if name.len() > 1
+                    && name
+                        .chars()
+                        .all(|c| c.is_uppercase() || c.is_numeric() || c == '_')
+                    && !name.chars().next().unwrap().is_numeric()
+                {
+                    return Ok(SymbolKind::Constant);
+                }
+
                 // For named kernels, undefined symbols are errors
                 let suggestion = self.find_similar_symbol(&name);
                 let msg = match suggestion {

--- a/pixelflow-macros/src/symbol.rs
+++ b/pixelflow-macros/src/symbol.rs
@@ -52,6 +52,10 @@ pub enum SymbolKind {
     /// Local variable introduced by `let`.
     /// Scoped to the containing block.
     Local,
+
+    /// External constant (heuristically identified by uppercase naming).
+    /// Emitted as-is, bypassing symbol table restrictions.
+    Constant,
 }
 
 /// A symbol in the symbol table.


### PR DESCRIPTION
Replaced magic numbers `1_000_000.0` and `10_000.0` with named constants in `pixelflow-graphics/src/scene3d.rs`. To support this within the `kernel!` macro DSL, `pixelflow-macros` was updated to recognize and emit external constants (identified by uppercase naming heuristic). This aligns the codebase with `STYLE.md`.

---
*PR created automatically by Jules for task [2447617887469099160](https://jules.google.com/task/2447617887469099160) started by @jppittman*