### PR TITLE
Kill mutant and enforce naming conventions

### DIFF
--- a/pixelflow-graphics/tests/kernel_macro.rs
+++ b/pixelflow-graphics/tests/kernel_macro.rs
@@ -57,7 +57,7 @@ fn fields_close(a: Field, b: Field, epsilon: f32) -> bool {
 
 /// Test a kernel with one parameter.
 #[test]
-fn test_one_param_kernel() {
+fn kernel_should_evaluate_correctly_with_one_param() {
     // X offset by a parameter
     let offset_x = kernel!(|dx: f32| X + dx);
     let k = offset_x(10.0);
@@ -73,7 +73,7 @@ fn test_one_param_kernel() {
 
 /// Test a kernel with two parameters.
 #[test]
-fn test_two_param_kernel() {
+fn kernel_should_evaluate_correctly_with_two_params() {
     // Offset both X and Y
     let offset_xy = kernel!(|dx: f32, dy: f32| (X + dx) + (Y + dy));
     let k = offset_xy(10.0, 20.0);
@@ -89,7 +89,7 @@ fn test_two_param_kernel() {
 
 /// Test a kernel with no parameters.
 #[test]
-fn test_zero_param_kernel() {
+fn kernel_should_evaluate_correctly_with_zero_params() {
     // Simple distance from origin (no params)
     let dist = kernel!(|| (X * X + Y * Y).sqrt());
     let k = dist();
@@ -105,7 +105,7 @@ fn test_zero_param_kernel() {
 
 /// Test method chaining (ManifoldExt integration).
 #[test]
-fn test_method_chaining() {
+fn kernel_should_support_method_chaining() {
     // Clamped value using .max().min()
     let clamp = kernel!(|lo: f32, hi: f32| X.max(lo).min(hi));
     let k = clamp(0.0, 1.0);
@@ -134,7 +134,7 @@ fn test_method_chaining() {
 
 /// Test that kernels are Clone (not Copy, since they hold data).
 #[test]
-fn test_kernel_is_clone() {
+fn kernel_should_implement_clone() {
     let scale = kernel!(|factor: f32| X * factor);
     let k1 = scale(2.0);
     let k2 = k1.clone();
@@ -148,7 +148,7 @@ fn test_kernel_is_clone() {
 
 /// Test that different instantiations are independent.
 #[test]
-fn test_independent_instantiations() {
+fn kernel_instantiations_should_be_independent() {
     let scale = kernel!(|factor: f32| X * factor);
 
     let double = scale(2.0);
@@ -169,7 +169,7 @@ fn test_independent_instantiations() {
 
 /// Test sqrt method.
 #[test]
-fn test_sqrt() {
+fn sqrt_should_compute_square_root() {
     let root = kernel!(|val: f32| (X + val).sqrt());
     let k = root(7.0);
 
@@ -180,7 +180,7 @@ fn test_sqrt() {
 
 /// Test floor method.
 #[test]
-fn test_floor() {
+fn floor_should_round_down() {
     let floored = kernel!(|| X.floor());
     let k = floored();
 
@@ -193,7 +193,7 @@ fn test_floor() {
 
 /// Test abs method.
 #[test]
-fn test_abs() {
+fn abs_should_compute_absolute_value() {
     let absolute = kernel!(|offset: f32| (X - offset).abs());
     let k = absolute(5.0);
 
@@ -210,7 +210,7 @@ fn test_abs() {
 /// This is verified by the fact that the kernel compiles at all -
 /// if parameters were injected directly, the expression wouldn't be Copy.
 #[test]
-fn test_zst_expression_is_copy() {
+fn kernel_expression_should_be_copy() {
     // This kernel uses the parameter twice in the expression.
     // If the expression weren't Copy (ZST-based), this wouldn't compile
     // because the parameter would be moved on first use.
@@ -229,7 +229,7 @@ fn test_zst_expression_is_copy() {
 /// Test a kernel with three parameters.
 /// This demonstrates the new Let/Var binding system since Z/W slots only support 2.
 #[test]
-fn test_three_param_kernel() {
+fn kernel_should_support_three_params() {
     // Translate point by (dx, dy) and add z offset
     let translate_3d = kernel!(|dx: f32, dy: f32, dz: f32| (X + dx) + (Y + dy) + dz);
     let k = translate_3d(10.0, 20.0, 30.0);
@@ -246,7 +246,7 @@ fn test_three_param_kernel() {
 /// Test a kernel with four parameters.
 /// Demonstrates full 4-parameter support.
 #[test]
-fn test_four_param_kernel() {
+fn kernel_should_support_four_params() {
     // Combine all four parameters with coordinates
     let quad_combine = kernel!(|a: f32, b: f32, c: f32, d: f32| a + b + c + d + X + Y);
     let k = quad_combine(1.0, 2.0, 3.0, 4.0);
@@ -263,7 +263,7 @@ fn test_four_param_kernel() {
 /// Test a 4-parameter sphere SDF kernel.
 /// This is a practical example: signed distance from a sphere at (cx, cy, cz) with radius r.
 #[test]
-fn test_sphere_sdf_kernel() {
+fn kernel_should_implement_sphere_sdf_correctly() {
     // Sphere SDF: distance from center minus radius
     let sphere_sdf = kernel!(|cx: f32, cy: f32, cz: f32, r: f32| {
         let dx = X - cx;
@@ -295,7 +295,7 @@ fn test_sphere_sdf_kernel() {
 /// Test parameter ordering with 3 parameters.
 /// Verifies that parameters are correctly bound (first param deepest in stack).
 #[test]
-fn test_parameter_ordering_three() {
+fn kernel_should_bind_parameters_in_correct_order() {
     // Each parameter has a different multiplier to verify correct binding
     let order_test = kernel!(|a: f32, b: f32, c: f32| a * 100.0 + b * 10.0 + c);
     let k = order_test(1.0, 2.0, 3.0);
@@ -311,7 +311,7 @@ fn test_parameter_ordering_three() {
 
 /// Test that parameters can be used multiple times in 3+ param kernels.
 #[test]
-fn test_param_reuse_three() {
+fn kernel_should_allow_parameter_reuse() {
     // Use each parameter twice
     let reuse = kernel!(|a: f32, b: f32, c: f32| (a + a) + (b + b) + (c + c));
     let k = reuse(1.0, 2.0, 3.0);
@@ -343,7 +343,7 @@ fn jet3_4(x: f32, y: f32, z: f32, w: f32) -> Jet3_4 {
 
 /// Test a simple Jet3 kernel (domain inferred from output type).
 #[test]
-fn test_jet3_simple() {
+fn kernel_should_infer_jet3_output() {
     // X + Y with Jet3 output → domain is Jet3_4
     let add_xy = kernel!(|| -> Jet3 X + Y);
     let k = add_xy();
@@ -363,7 +363,7 @@ fn test_jet3_simple() {
 
 /// Test Jet3 kernel with parameters (sphere SDF).
 #[test]
-fn test_jet3_sphere_sdf() {
+fn kernel_should_compute_jet3_derivatives_correctly() {
     // Sphere SDF: distance from center minus radius
     // Using Jet3 for automatic differentiation (normals)
     let sphere_sdf = kernel!(|cx: f32, cy: f32, cz: f32, r: f32| -> Jet3 {
@@ -396,7 +396,7 @@ fn test_jet3_sphere_sdf() {
 /// Test basic kernel composition with a single manifold parameter.
 /// This is the core use case: composing a distance function with a circle SDF.
 #[test]
-fn test_simple_kernel_composition() {
+fn kernel_should_compose_with_other_kernels() {
     // Distance from a point (parametric)
     let dist = kernel!(|cx: f32, cy: f32| {
         let dx = X - cx;
@@ -429,7 +429,7 @@ fn test_simple_kernel_composition() {
 
 /// Test kernel composition with offset centers.
 #[test]
-fn test_kernel_composition_with_offset() {
+fn composed_kernel_should_handle_offsets() {
     let dist = kernel!(|cx: f32, cy: f32| {
         let dx = X - cx;
         let dy = Y - cy;
@@ -468,7 +468,7 @@ fn test_kernel_composition_with_offset() {
 /// 3. A different codegen strategy (e.g., leveled evaluation)
 #[test]
 #[ignore = "two-manifold params require ManifoldBind2 implementation"]
-fn test_two_manifold_params() {
+fn kernel_should_support_multiple_manifold_params() {
     // Test body commented out until ManifoldBind2 is implemented
     // See the original test for the intended behavior:
     //
@@ -479,7 +479,7 @@ fn test_two_manifold_params() {
 
 /// Test mixed manifold and scalar parameters.
 #[test]
-fn test_mixed_manifold_scalar_params() {
+fn kernel_should_support_mixed_params() {
     // Scale an SDF by a factor
     let scale_sdf = kernel!(|inner: kernel, factor: f32| inner * factor);
 
@@ -499,7 +499,7 @@ fn test_mixed_manifold_scalar_params() {
 
 /// Test chained kernel composition (three levels deep).
 #[test]
-fn test_chained_composition() {
+fn kernel_should_support_chained_composition() {
     // Basic X coordinate
     let get_x = kernel!(|| X);
 
@@ -522,7 +522,7 @@ fn test_chained_composition() {
 
 /// Test that composed kernels can be cloned (the inner kernel is owned).
 #[test]
-fn test_composed_kernel_ownership() {
+fn composed_kernel_should_own_inner_kernel() {
     let dist = kernel!(|cx: f32, cy: f32| {
         let dx = X - cx;
         let dy = Y - cy;
@@ -548,7 +548,7 @@ fn test_composed_kernel_ownership() {
 /// creating type mismatches with ZST expression tree types.
 /// With the annotation pass, literals become Var<N> references bound via Let.
 #[test]
-fn test_jet3_with_literals() {
+fn kernel_should_handle_literals_in_jet3() {
     // Inverse square root with literal numerator
     // This expression: 1.0 / (X*X + Y*Y + Z*Z).sqrt()
     // Tests that the literal 1.0 is properly handled in Jet3 mode
@@ -581,7 +581,7 @@ fn test_jet3_with_literals() {
 /// Test Jet3 kernel with multiple literals.
 /// Verifies that multiple literals each get their own Var<N> binding.
 #[test]
-fn test_jet3_multiple_literals() {
+fn kernel_should_handle_multiple_literals_in_jet3() {
     // Expression with multiple literals: 2.0 * X + 3.0
     let affine = kernel!(|| -> Jet3 2.0 * X + 3.0);
     let k = affine();
@@ -600,7 +600,7 @@ fn test_jet3_multiple_literals() {
 /// Test Jet3 kernel with literals AND parameters.
 /// Both literals and params become Var<N> - they should coexist correctly.
 #[test]
-fn test_jet3_literals_and_params() {
+fn kernel_should_handle_literals_and_params_in_jet3() {
     // offset + 2.0 * X - 0.5
     let kernel = kernel!(|offset: f32| -> Jet3 offset + 2.0 * X - 0.5);
     let k = kernel(10.0);
@@ -655,7 +655,7 @@ fn jet3_4_seeded(x: f32, y: f32, z: f32) -> Jet3_4 {
 
 /// Test GradientMag2D computes √(dx² + dy²) with single eval.
 #[test]
-fn test_gradient_mag_2d() {
+fn gradient_mag_2d_should_compute_magnitude() {
     // For f(x,y) = sqrt(x² + y²), the gradient is (x/r, y/r) where r = sqrt(x²+y²)
     // Gradient magnitude is always 1.0 for distance fields
     let dist =
@@ -673,7 +673,7 @@ fn test_gradient_mag_2d() {
 
 /// Test GradientMag3D computes √(dx² + dy² + dz²) with single eval.
 #[test]
-fn test_gradient_mag_3d() {
+fn gradient_mag_3d_should_compute_magnitude() {
     // For f(x,y,z) = sqrt(x² + y² + z²), gradient magnitude is 1.0
     let dist = (pixelflow_core::X * pixelflow_core::X
         + pixelflow_core::Y * pixelflow_core::Y
@@ -692,7 +692,7 @@ fn test_gradient_mag_3d() {
 
 /// Test Antialias2D computes val / √(dx² + dy²) with single eval.
 #[test]
-fn test_antialias_2d() {
+fn antialias_2d_should_compute_aa_factor() {
     // Circle SDF using kernel! macro (handles literal promotion)
     // At (2, 0): val = 1.0, gradient = (1, 0), so antialias = 1.0 / 1.0 = 1.0
     let circle_sdf = kernel!(|| -> Jet2 { (X * X + Y * Y).sqrt() - 1.0 });
@@ -709,7 +709,7 @@ fn test_antialias_2d() {
 
 /// Test Antialias3D computes val / √(dx² + dy² + dz²) with single eval.
 #[test]
-fn test_antialias_3d() {
+fn antialias_3d_should_compute_aa_factor() {
     // Sphere SDF using kernel! macro
     // At (2, 0, 0): val = 1.0, gradient = (1, 0, 0), so antialias = 1.0 / 1.0 = 1.0
     let sphere_sdf = kernel!(|| -> Jet3 { (X * X + Y * Y + Z * Z).sqrt() - 1.0 });
@@ -726,7 +726,7 @@ fn test_antialias_3d() {
 
 /// Test Normalized2D returns unit gradient vector with single eval.
 #[test]
-fn test_normalized_2d() {
+fn normalized_2d_should_return_unit_gradient() {
     // Distance field: sqrt(x² + y²)
     // At (3, 4): gradient = (3/5, 4/5) = (0.6, 0.8)
     let dist =
@@ -747,7 +747,7 @@ fn test_normalized_2d() {
 
 /// Test fused combinators with kernel-composed manifolds.
 #[test]
-fn test_fused_combinators_with_kernel_composition() {
+fn fused_combinators_should_work_with_composition() {
     // Create a circle SDF kernel
     let circle_sdf = kernel!(|cx: f32, cy: f32, r: f32| -> Jet2 {
         let dx = X - cx;
@@ -795,7 +795,7 @@ use pixelflow_core::{DX, DY, DZ, V};
 
 /// Test V accessor extracts the value component from Jet2.
 #[test]
-fn test_v_accessor() {
+fn v_accessor_should_extract_value() {
     // Distance from origin: sqrt(x² + y²)
     let dist =
         (pixelflow_core::X * pixelflow_core::X + pixelflow_core::Y * pixelflow_core::Y).sqrt();
@@ -813,7 +813,7 @@ fn test_v_accessor() {
 
 /// Test DX accessor extracts ∂f/∂x from Jet2.
 #[test]
-fn test_dx_accessor() {
+fn dx_accessor_should_extract_x_derivative() {
     // Distance from origin: sqrt(x² + y²)
     // ∂dist/∂x = x / sqrt(x² + y²) = x / dist
     let dist =
@@ -832,7 +832,7 @@ fn test_dx_accessor() {
 
 /// Test DY accessor extracts ∂f/∂y from Jet2.
 #[test]
-fn test_dy_accessor() {
+fn dy_accessor_should_extract_y_derivative() {
     // Distance from origin: sqrt(x² + y²)
     // ∂dist/∂y = y / sqrt(x² + y²) = y / dist
     let dist =
@@ -851,7 +851,7 @@ fn test_dy_accessor() {
 
 /// Test DZ accessor extracts ∂f/∂z from Jet3.
 #[test]
-fn test_dz_accessor() {
+fn dz_accessor_should_extract_z_derivative() {
     // 3D distance from origin: sqrt(x² + y² + z²)
     // ∂dist/∂z = z / sqrt(x² + y² + z²)
     let dist = (pixelflow_core::X * pixelflow_core::X
@@ -876,7 +876,7 @@ fn test_dz_accessor() {
 /// `(DX(sdf) * DX(sdf) + DY(sdf) * DY(sdf)).sqrt()` now work with ManifoldExt.
 /// CSE (Phase 6) will optimize away redundant evaluations.
 #[test]
-fn test_manual_gradient_magnitude() {
+fn manual_gradient_mag_should_match_fused() {
     // Distance from origin
     let dist =
         (pixelflow_core::X * pixelflow_core::X + pixelflow_core::Y * pixelflow_core::Y).sqrt();

--- a/pixelflow-graphics/tests/mutant_test.rs
+++ b/pixelflow-graphics/tests/mutant_test.rs
@@ -1,0 +1,127 @@
+//! Mutant Killing Tests
+//!
+//! These tests are designed to fail if specific logic bugs (mutants) are introduced.
+
+use pixelflow_core::jet::Jet3;
+use pixelflow_core::{Discrete, Field, Manifold, ManifoldCompat, ManifoldExt};
+use pixelflow_macros::{kernel, ManifoldExpr};
+
+type Field4 = (Field, Field, Field, Field);
+type Jet3_4 = (Jet3, Jet3, Jet3, Jet3);
+
+use pixelflow_graphics::render::color::Rgba8;
+use pixelflow_graphics::render::frame::Frame;
+use pixelflow_graphics::render::rasterizer::rasterize;
+use pixelflow_graphics::scene3d::{ScreenToDir, Surface};
+
+/// Sphere at given center with radius.
+#[derive(Clone, Copy, ManifoldExpr)]
+struct SphereAt {
+    center: (f32, f32, f32),
+    radius: f32,
+}
+
+impl Manifold<Jet3_4> for SphereAt {
+    type Output = Jet3;
+
+    #[inline]
+    fn eval(&self, p: Jet3_4) -> Jet3 {
+        let (rx, ry, rz, _w) = p;
+        let cx = Jet3::constant(Field::from(self.center.0));
+        let cy = Jet3::constant(Field::from(self.center.1));
+        let cz = Jet3::constant(Field::from(self.center.2));
+
+        let d_dot_c = rx * cx + ry * cy + rz * cz;
+        let c_sq = cx * cx + cy * cy + cz * cz;
+        let r_sq = Jet3::constant(Field::from(self.radius * self.radius));
+        let discriminant = d_dot_c * d_dot_c - (c_sq - r_sq);
+
+        let epsilon_sq = Jet3::constant(Field::from(0.0001));
+        d_dot_c - (discriminant + epsilon_sq).sqrt()
+    }
+}
+
+/// Convert grayscale Field to Discrete RGBA
+struct GrayToRgba<M> {
+    inner: M,
+}
+
+impl<M: ManifoldCompat<Field, Output = Field>> Manifold<Field4> for GrayToRgba<M> {
+    type Output = Discrete;
+
+    fn eval(&self, p: Field4) -> Discrete {
+        let (x, y, z, w) = p;
+        let gray = self.inner.eval_raw(x, y, z, w);
+        Discrete::pack(gray, gray, gray, Field::from(1.0))
+    }
+}
+
+/// Remap pixel coordinates to normalized screen coordinates.
+struct ScreenRemap<M> {
+    inner: M,
+    width: f32,
+    height: f32,
+}
+
+impl<M: ManifoldCompat<Field, Output = Field> + ManifoldExt> Manifold<Field4> for ScreenRemap<M> {
+    type Output = Field;
+
+    fn eval(&self, p: Field4) -> Field {
+        let (px, py, z, w) = p;
+        let width = Field::from(self.width);
+        let height = Field::from(self.height);
+
+        let scale = Field::from(2.0) / height;
+        let x = (px - width * Field::from(0.5)) * scale.clone();
+        let y = (height * Field::from(0.5) - py) * scale;
+
+        self.inner.eval_at(x, y, z, w)
+    }
+}
+
+/// Test that objects behind the camera are NOT rendered.
+///
+/// If the `valid_t` check (`t > 0`) in `Surface` is mutated to allow negative values,
+/// this test should fail because the sphere behind the camera would become visible.
+#[test]
+fn object_behind_camera_should_not_be_visible() {
+    const W: usize = 100;
+    const H: usize = 100;
+
+    // A white sphere at z = -4 (behind the camera).
+    // Camera looks towards +Z.
+    let white_mat = kernel!(|| 1.0)();
+    let black_bg = kernel!(|| 0.0)();
+
+    let scene = Surface {
+        geometry: SphereAt {
+            center: (0.0, 0.0, -4.0),
+            radius: 1.0,
+        },
+        // White material
+        material: white_mat,
+        // Black background
+        background: black_bg,
+    };
+
+    let screen = ScreenRemap {
+        inner: ScreenToDir { inner: scene },
+        width: W as f32,
+        height: H as f32,
+    };
+
+    let renderable = GrayToRgba { inner: screen };
+
+    let mut frame = Frame::<Rgba8>::new(W as u32, H as u32);
+    rasterize(&renderable, &mut frame, 1);
+
+    // Check the center pixel.
+    let center = &frame.data[(H / 2) * W + (W / 2)];
+
+    // Should be black (background), not white (sphere).
+    assert_eq!(
+        center.r(), 0,
+        "Center pixel should be black (background). Found r={}, meaning object behind camera was rendered.",
+        center.r()
+    );
+}

--- a/pixelflow-graphics/tests/pixel_contract.rs
+++ b/pixelflow-graphics/tests/pixel_contract.rs
@@ -6,7 +6,7 @@ use pixelflow_graphics::render::color::{Bgra8, Rgba8};
 use pixelflow_graphics::render::pixel::Pixel;
 
 #[test]
-fn test_rgba8_components() {
+fn rgba8_accessors_should_return_correct_values() {
     let rgba = Rgba8::new(0x11, 0x22, 0x33, 0x44);
     assert_eq!(rgba.r(), 0x11);
     assert_eq!(rgba.g(), 0x22);
@@ -15,7 +15,7 @@ fn test_rgba8_components() {
 }
 
 #[test]
-fn test_bgra8_components() {
+fn bgra8_accessors_should_return_correct_values() {
     let bgra = Bgra8::new(0x33, 0x22, 0x11, 0x44);
     assert_eq!(bgra.b(), 0x33);
     assert_eq!(bgra.g(), 0x22);
@@ -24,7 +24,7 @@ fn test_bgra8_components() {
 }
 
 #[test]
-fn test_swizzle_correctness() {
+fn bgra8_should_convert_from_rgba8_correctly() {
     let rgba = Rgba8::new(0x11, 0x22, 0x33, 0x44);
     let bgra = Bgra8::from(rgba);
 
@@ -35,7 +35,7 @@ fn test_swizzle_correctness() {
 }
 
 #[test]
-fn test_pixel_from_rgba_f32() {
+fn pixel_should_convert_from_f32_correctly() {
     let rgba = Rgba8::from_rgba(1.0, 0.5, 0.0, 1.0);
     assert_eq!(rgba.r(), 255);
     assert!(rgba.g() > 120 && rgba.g() < 140); // ~127
@@ -44,7 +44,7 @@ fn test_pixel_from_rgba_f32() {
 }
 
 #[test]
-fn test_pixel_from_u32() {
+fn pixel_should_convert_from_u32_correctly() {
     let packed: u32 = 0xFF332211; // ABGR in memory = RGBA little-endian
     let rgba = Rgba8::from_u32(packed);
     assert_eq!(rgba.to_u32(), packed);

--- a/pixelflow-graphics/tests/scene3d_test.rs
+++ b/pixelflow-graphics/tests/scene3d_test.rs
@@ -101,7 +101,7 @@ impl<M: ManifoldCompat<Field, Output = Field> + ManifoldExt> Manifold<Field4> fo
 /// - Surface<SphereAt, Reflect<world>, world>: sphere reflecting world
 /// - world = Surface<plane, Checker, Sky>: floor + sky
 #[test]
-fn test_chrome_unit_sphere() {
+fn scene_should_render_chrome_sphere_reflecting_world() {
     const W: usize = 400;
     const H: usize = 300;
 
@@ -142,10 +142,10 @@ fn test_chrome_unit_sphere() {
 
     // Save PPM
     let path = std::env::temp_dir().join("pixelflow_chrome_unit_sphere.ppm");
-    let mut file = File::create(&path).unwrap();
-    writeln!(file, "P6\n{} {}\n255", W, H).unwrap();
+    let mut file = File::create(&path).expect("Failed to create temporary file");
+    writeln!(file, "P6\n{} {}\n255", W, H).expect("Failed to write PPM header");
     for p in &frame.data {
-        file.write_all(&[p.r(), p.g(), p.b()]).unwrap();
+        file.write_all(&[p.r(), p.g(), p.b()]).expect("Failed to write pixel data");
     }
     println!("Saved: {}", path.display());
 
@@ -176,7 +176,7 @@ fn test_chrome_unit_sphere() {
 
 /// Test: Just the sky (no geometry)
 #[test]
-fn test_sky_only() {
+fn scene_should_render_sky_gradient() {
     const W: usize = 200;
     const H: usize = 150;
 
@@ -209,10 +209,10 @@ fn test_sky_only() {
 
     // Save
     let path = std::env::temp_dir().join("pixelflow_sky_only.ppm");
-    let mut file = File::create(&path).unwrap();
-    writeln!(file, "P6\n{} {}\n255", W, H).unwrap();
+    let mut file = File::create(&path).expect("Failed to create temporary file");
+    writeln!(file, "P6\n{} {}\n255", W, H).expect("Failed to write PPM header");
     for p in &frame.data {
-        file.write_all(&[p.r(), p.g(), p.b()]).unwrap();
+        file.write_all(&[p.r(), p.g(), p.b()]).expect("Failed to write pixel data");
     }
     println!("Saved: {}", path.display());
 
@@ -228,7 +228,7 @@ fn test_sky_only() {
 
 /// Test: Floor only (plane with checker pattern)
 #[test]
-fn test_floor_only() {
+fn scene_should_render_floor_checkerboard() {
     const W: usize = 400;
     const H: usize = 300;
 
@@ -252,10 +252,10 @@ fn test_floor_only() {
 
     // Save
     let path = std::env::temp_dir().join("pixelflow_floor_only.ppm");
-    let mut file = File::create(&path).unwrap();
-    writeln!(file, "P6\n{} {}\n255", W, H).unwrap();
+    let mut file = File::create(&path).expect("Failed to create temporary file");
+    writeln!(file, "P6\n{} {}\n255", W, H).expect("Failed to write PPM header");
     for p in &frame.data {
-        file.write_all(&[p.r(), p.g(), p.b()]).unwrap();
+        file.write_all(&[p.r(), p.g(), p.b()]).expect("Failed to write pixel data");
     }
     println!("Saved: {}", path.display());
 
@@ -276,7 +276,7 @@ fn test_floor_only() {
 /// Test: Color chrome sphere with blue sky (MULLET ARCHITECTURE)
 /// Geometry runs ONCE, colors flow as packed RGBA. 3x speedup!
 #[test]
-fn test_color_chrome_sphere() {
+fn scene_should_render_color_chrome_sphere() {
     const W: usize = 1920;
     const H: usize = 1080;
 
@@ -343,10 +343,10 @@ fn test_color_chrome_sphere() {
 
     // Save PPM
     let path = std::env::temp_dir().join("pixelflow_color_chrome.ppm");
-    let mut file = File::create(&path).unwrap();
-    writeln!(file, "P6\n{} {}\n255", W, H).unwrap();
+    let mut file = File::create(&path).expect("Failed to create temporary file");
+    writeln!(file, "P6\n{} {}\n255", W, H).expect("Failed to write PPM header");
     for p in &frame.data {
-        file.write_all(&[p.r(), p.g(), p.b()]).unwrap();
+        file.write_all(&[p.r(), p.g(), p.b()]).expect("Failed to write pixel data");
     }
     println!("Saved: {}", path.display());
 
@@ -368,7 +368,7 @@ fn test_color_chrome_sphere() {
 /// Test: Compare 3-channel vs mullet rendering to ensure they match.
 /// This verifies the mullet architecture produces identical results.
 #[test]
-fn test_mullet_vs_3channel_comparison() {
+fn mullet_architecture_should_match_3channel_rendering() {
     const W: usize = 200;
     const H: usize = 150;
 
@@ -608,7 +608,7 @@ fn test_mullet_vs_3channel_comparison() {
 
 /// Benchmark: Compare work-stealing vs single-threaded at 1080p
 #[test]
-fn test_work_stealing_benchmark() {
+fn parallel_rendering_should_match_sequential() {
     const W: usize = 1920;
     const H: usize = 1080;
 


### PR DESCRIPTION
Added a regression test to ensure objects behind the camera are not rendered, effectively killing a potential mutant in the ray validity check. Renamed tests in `pixelflow-graphics` to follow the project's naming convention (`[method]_should_[outcome]`). Removed temporary debug code.

---
*PR created automatically by Jules for task [5506281153385872025](https://jules.google.com/task/5506281153385872025) started by @jppittman*