### PR TITLE
Update CLAUDE.md to reflect current repository state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,56 +25,61 @@
 
 ## Workspace Structure
 
-The repository is organized as a Cargo workspace with 11 member crates:
+The repository is organized as a Cargo workspace with 11 member crates (plus `pixelflow-ir` as a non-workspace path dependency):
 
 ```
 core-term/                  # Repository root
-├── pixelflow-core/         # SIMD algebra (no_std)
+├── pixelflow-core/         # SIMD algebra (edition 2024)
 ├── pixelflow-graphics/     # Colors, fonts, rendering
-├── pixelflow-ir/           # Shared IR and backend abstraction
-├── pixelflow-macros/       # Proc-macro compiler frontend
-├── pixelflow-ml/           # Experimental: ML as graphics
-├── pixelflow-nnue/         # NNUE neural network for instruction selection
+├── pixelflow-ir/           # Shared IR (NOT a workspace member, path dependency only)
+├── pixelflow-macros/       # Proc-macro compiler frontend (edition 2024)
+├── pixelflow-ml/           # ML for graphics & compiler optimization (edition 2024)
+├── pixelflow-nnue/         # NNUE neural network for instruction selection (edition 2024)
 ├── pixelflow-runtime/      # Platform drivers and runtime
-├── pixelflow-search/       # E-graph optimization and rewrite search
+├── pixelflow-search/       # E-graph optimization and rewrite search (edition 2024)
 ├── actor-scheduler/        # Priority channels
 ├── actor-scheduler-macros/ # Proc macros for actors
 ├── core-term/              # Terminal application
-├── xtask/                  # Build automation
-├── docs/                   # Architecture documentation
-├── assets/                 # Fonts, resources
-├── scripts/                # Development scripts
-├── .github/workflows/      # CI/CD automation
-├── .claude/                # Claude Code configuration + table of contents
-├── .agent/                 # Agent rules and configuration
-└── .jules/                 # Jules AI configuration
+├── xtask/                  # Build automation + codegen
+├── docs/                   # Architecture documentation + design docs
+├── assets/                 # Fonts (Noto Sans Mono), icons
+├── scripts/                # Development scripts (Python + shell)
+├── .github/workflows/      # CI/CD automation (9 workflows)
+├── .claude/                # Claude Code configuration + agent context files
+├── .agent/                 # Agent rules (core.md, splats.md)
+├── .jules/                 # Jules AI configuration (bolt.md)
+└── .githooks/              # Git hooks (pre-commit, pre-push, post-commit, etc.)
 ```
 
 ### Special Directories
 
-- **`.claude/`** - Claude Code (Anthropic) configuration and documentation index
-- **`.agent/`** - AI agent rules (core.md, splats.md) for automated development
-- **`.jules/`** - Jules AI assistant configuration
-- **`.githooks/`** - Git hooks for pre-commit checks and automation
+- **`.claude/`** - Claude Code (Anthropic) configuration, `DOCS_TOC.md`, and `agents/` with 11 domain-specific context files
+- **`.agent/`** - AI agent rules (`rules/core.md`, `rules/splats.md`) for automated development
+- **`.jules/`** - Jules AI assistant configuration (`bolt.md`)
+- **`.githooks/`** - Git hooks: `pre-commit`, `pre-push`, `post-commit`, `post-checkout`, `post-merge`
 
 These directories configure AI assistants to understand project conventions and constraints.
 
+### Non-Workspace Crate
+
+`pixelflow-ir` exists as a directory with its own `Cargo.toml` but is **not** listed in the workspace `members`. It is consumed as a path dependency by `pixelflow-macros`, `pixelflow-ml`, `pixelflow-nnue`, and `pixelflow-search`. See `PIXELFLOW_IR_STATUS.md` for details.
+
 ### Key Crate Details
 
-| Crate | Purpose |
-|-------|---------|
-| `pixelflow-core` | `no_std` SIMD algebra. `Field`, `Manifold`, coordinate variables. Multi-backend (AVX-512/SSE2/NEON/scalar). |
-| `pixelflow-ir` | Shared IR (intermediate representation) and backend abstraction. Op traits, OpKind enum, backend execution traits. |
-| `pixelflow-macros` | Proc-macro compiler frontend: `kernel!` macro, lexer, parser, semantic analysis, code generation. |
-| `pixelflow-graphics` | Font loading, colors (`Rgba8`, `Color`), rasterization, antialiasing. |
-| `pixelflow-ml` | Experimental: Linear attention as spherical harmonics. Research on neural rendering. |
-| `pixelflow-nnue` | NNUE neural network for instruction selection, inspired by Stockfish. HalfEP feature encoding. |
-| `pixelflow-runtime` | Display drivers (macOS Cocoa, X11, headless, Metal, Web WASM), input handling, vsync. |
-| `pixelflow-search` | E-graph optimization framework. Rewrite rules, saturation, cost extraction, NNUE-guided search. |
-| `actor-scheduler` | Priority channels with `troupe!` macro for actor groups. Lock-free concurrency. |
-| `actor-scheduler-macros` | Procedural macros for actor system. |
-| `core-term` | Terminal application, PTY management, ANSI processing. First PixelFlow consumer. |
-| `xtask` | Build tooling for bundling macOS app and running development tasks. |
+| Crate | Purpose | Edition |
+|-------|---------|---------|
+| `pixelflow-core` | SIMD algebra. `Field`, `Manifold`, coordinate variables, ops. Multi-backend (AVX-512/SSE2/NEON/scalar). | 2024 |
+| `pixelflow-ir` | Shared IR. Op traits, OpKind enum, Expr tree, backend execution traits. **Not a workspace member.** | 2021 |
+| `pixelflow-macros` | Proc-macro compiler: `kernel!` macro, lexer, parser, sema, AST optimization, codegen. | 2024 |
+| `pixelflow-graphics` | Font loading (TTF, SDF), colors (`Rgba8`, `Color`), rasterization, antialiasing, shapes, animation. | 2021 |
+| `pixelflow-ml` | Neural networks for graphics & compiler optimization. NNUE training, HCE extraction, e-graph training. | 2024 |
+| `pixelflow-nnue` | NNUE neural network for instruction selection, inspired by Stockfish. HalfEP features, factored networks. | 2024 |
+| `pixelflow-runtime` | Display drivers (macOS Cocoa, headless, Metal, Web WASM), input handling, vsync, render pool. | 2021 |
+| `pixelflow-search` | E-graph optimization framework. Rewrite rules, saturation, cost extraction, NNUE-guided search. | 2024 |
+| `actor-scheduler` | Priority channels with `troupe!` macro. Kubelet, lifecycle, SPSC queues, sharded dispatch. | 2021 |
+| `actor-scheduler-macros` | Procedural macros for actor system. | 2021 |
+| `core-term` | Terminal application: PTY management, ANSI processing, terminal emulator, key translation. | 2021 |
+| `xtask` | Build tooling: macOS app bundling (`bundle-run`), codegen tasks. | 2021 |
 
 ## Core Concepts
 
@@ -150,8 +155,10 @@ This prevents silent failures - all errors must be explicitly handled.
 
 ### Toolchain
 
+- **Rust stable** toolchain (configured in `rust-toolchain.toml`)
 - SIMD backend auto-detected at compile time via `build.rs` and target features
 - Platform features automatically selected based on OS (macOS Cocoa, Linux X11, Web WASM)
+- Build scripts (`build.rs`) exist in: `pixelflow-core`, `pixelflow-runtime`, `core-term`
 
 ### CI & Automation
 
@@ -164,6 +171,7 @@ The repository includes several GitHub Actions workflows:
 
 2. **Gemini AI Integration** - Automated code review and triage
    - `gemini-dispatch.yml` - Routes tasks to appropriate workflows
+   - `gemini-invoke.yml` - Invokes Gemini for specific tasks
    - `gemini-review.yml` - AI-powered code review on PRs
    - `gemini-triage.yml` - Issue triage and labeling
    - `gemini-scheduled-triage.yml` - Periodic maintenance tasks
@@ -212,70 +220,134 @@ if status_code == 4 { ... }                 // Bad
 | `pixelflow-core/src/lib.rs` | Field, Manifold, SIMD type selection, re-exports |
 | `pixelflow-core/src/manifold.rs` | Core Manifold trait and dimensional hierarchy |
 | `pixelflow-core/src/ext.rs` | Manifold methods for ergonomic postfix notation |
+| `pixelflow-core/src/variables.rs` | Coordinate variables (X, Y, Z, W) - the symbol table |
+| `pixelflow-core/src/algebra.rs` | Algebraic structures and laws |
+| `pixelflow-core/src/ops/` | Operation types: `base`, `binary`, `unary`, `compare`, `trig`, `logic`, `derivative`, `vector` |
 | `pixelflow-core/src/combinators/at.rs` | Struct version of contramap |
 | `pixelflow-core/src/combinators/select.rs` | Struct version of conditional |
-| `pixelflow-core/src/backend/` | SIMD backend implementations (AVX-512, SSE2, NEON, scalar) |
-| `pixelflow-core/src/combinators/` | Six eigenshaders: Warp, Grade, Lerp, Select, Fix, Compute |
-| `pixelflow-core/src/jet/` | Automatic differentiation for antialiasing |
+| `pixelflow-core/src/combinators/` | Combinators: at, map, select, fix, computed, binding, block, shift, pack, project, context, spherical, texture, with_gradient |
+| `pixelflow-core/src/backend/` | SIMD backend implementations: `x86.rs` (AVX-512/SSE2), `arm.rs` (NEON), `scalar.rs`, `wasm.rs`, `fastmath.rs` |
+| `pixelflow-core/src/jet/` | Automatic differentiation: `jet2.rs`, `jet2h.rs`, `jet3.rs`, `path_jet.rs` |
+| `pixelflow-core/src/storage.rs` | Storage abstractions for SIMD data |
+| `pixelflow-core/src/numeric.rs` | Numeric trait definitions |
+| `pixelflow-core/src/mask.rs` | SIMD mask operations |
+| `pixelflow-core/src/zst.rs` | Zero-sized type utilities |
+| `pixelflow-core/src/domain.rs` | Domain abstractions |
+| `pixelflow-core/src/dual.rs` | Dual number support |
+| `pixelflow-core/src/generated_kernels.rs` | Auto-generated kernel implementations |
 
-### Compiler Stack (New)
+### Compiler Stack
 
 | Path | Purpose |
 |------|---------|
 | `pixelflow-macros/src/lib.rs` | `kernel!` and `kernel_raw!` proc-macros, compiler entry points |
 | `pixelflow-macros/src/lexer.rs` | Token stream processing (delegated to syn) |
 | `pixelflow-macros/src/parser.rs` | AST construction from closure syntax |
+| `pixelflow-macros/src/ast.rs` | AST node definitions |
 | `pixelflow-macros/src/sema.rs` | Semantic analysis, symbol resolution, type validation |
+| `pixelflow-macros/src/symbol.rs` | Symbol table management |
 | `pixelflow-macros/src/optimize.rs` | AST optimization (constant folding, FMA fusion, algebraic simplification) |
-| `pixelflow-macros/src/codegen/` | Code generation: struct + Manifold impl emission |
+| `pixelflow-macros/src/fold.rs` | AST fold/visitor infrastructure |
+| `pixelflow-macros/src/ir_bridge.rs` | Bridge between macro AST and shared IR |
+| `pixelflow-macros/src/rewrite_rules.rs` | Rewrite rule definitions for optimization |
+| `pixelflow-macros/src/cost_builder.rs` | Cost model construction |
+| `pixelflow-macros/src/manifold_expr.rs` | Manifold expression types |
+| `pixelflow-macros/src/codegen/` | Code generation: `emitter.rs`, `struct_emitter.rs`, `binding.rs`, `leveled.rs`, `util.rs` |
 | `pixelflow-ir/src/lib.rs` | Shared IR: Op trait, OpKind enum, Expr tree |
-| `pixelflow-ir/src/backend/` | Backend-specific lowering (x86, ARM, WASM, scalar) |
-| `pixelflow-search/src/egraph/` | E-graph data structure, saturation, rewrite rules |
-| `pixelflow-search/src/egraph/extract.rs` | Cost-based extraction from saturated e-graphs |
+| `pixelflow-ir/src/ops.rs` | Operation unit structs |
+| `pixelflow-ir/src/kind.rs` | OpKind enum |
+| `pixelflow-ir/src/expr.rs` | Expression tree |
+| `pixelflow-ir/src/traits.rs` | Backend trait definitions |
+| `pixelflow-ir/src/features.rs` | Feature encoding for cost model |
+| `pixelflow-ir/src/math.rs` | Math utilities |
+| `pixelflow-ir/src/backend/` | Backend-specific lowering: `x86.rs`, `arm.rs`, `wasm.rs`, `scalar.rs`, `fastmath.rs` |
+| `pixelflow-search/src/egraph/` | E-graph: `graph.rs`, `node.rs`, `ops.rs`, `saturate.rs`, `rewrite.rs`, `rules.rs`, `extract.rs`, `cost.rs`, `deps.rs`, `codegen.rs`, `algebra.rs`, `best_first.rs`, `guided.rs`, `nnue_adapter.rs` |
+| `pixelflow-search/src/domain/` | Domain-specific algebra: `algebra.rs` |
+| `pixelflow-search/src/model.rs` | Cost model |
 | `pixelflow-nnue/src/lib.rs` | NNUE network for cost estimation, HalfEP features |
+| `pixelflow-nnue/src/factored.rs` | Factored NNUE network variant |
 
 ### Graphics & Rendering
 
 | Path | Purpose |
 |------|---------|
-| `pixelflow-graphics/src/render/` | Rasterization, color spaces, antialiasing |
-| `pixelflow-graphics/src/fonts/` | Glyph loading, caching, and SDF generation |
+| `pixelflow-graphics/src/lib.rs` | Re-exports and module declarations |
+| `pixelflow-graphics/src/render/` | Rasterization engine: `aa.rs`, `color.rs`, `discrete.rs`, `frame.rs`, `pixel.rs`, `rasterizer/` (actor, parallel, messages) |
+| `pixelflow-graphics/src/fonts/` | Font system: `loader.rs`, `cache.rs`, `combinators.rs`, `text.rs`, `ttf.rs`, `ttf_curve_analytical.rs` |
 | `pixelflow-graphics/src/scene3d.rs` | 3D scene graph and transformations |
+| `pixelflow-graphics/src/shapes.rs` | Shape primitives |
+| `pixelflow-graphics/src/animation.rs` | Animation support |
+| `pixelflow-graphics/src/mesh.rs` | Mesh data structures |
+| `pixelflow-graphics/src/patch.rs` | Patch-based rendering |
+| `pixelflow-graphics/src/image.rs` | Image handling |
+| `pixelflow-graphics/src/transform.rs` | Geometric transformations |
+| `pixelflow-graphics/src/spatial_bsp.rs` | BSP tree for spatial queries |
+| `pixelflow-graphics/src/subdiv/` | Subdivision surfaces: `coeffs.rs` |
+| `pixelflow-graphics/src/baked.rs` | Pre-baked rendering data |
 
 ### Runtime & Platform
 
 | Path | Purpose |
 |------|---------|
-| `pixelflow-runtime/src/display/drivers/` | Display driver implementations (X11, headless, Metal, Web) |
-| `pixelflow-runtime/src/platform/macos/` | macOS Cocoa integration (window, events, objc bindings) |
-| `pixelflow-runtime/src/platform/linux.rs` | Linux platform abstractions |
+| `pixelflow-runtime/src/lib.rs` | Runtime entry point, module declarations |
+| `pixelflow-runtime/src/display/drivers/` | Display drivers: `headless.rs`, `metal.rs`, `web/` (no standalone X11 driver - X11 handled via platform layer) |
+| `pixelflow-runtime/src/display/` | Display abstractions: `driver.rs`, `messages.rs`, `ops.rs`, `platform.rs` |
+| `pixelflow-runtime/src/platform/macos/` | macOS Cocoa: `cocoa.rs`, `events.rs`, `objc.rs`, `platform.rs`, `sys.rs`, `window.rs` |
+| `pixelflow-runtime/src/platform/linux/` | Linux platform: `platform.rs`, `events.rs`, `window.rs` |
+| `pixelflow-runtime/src/platform/waker.rs` | Cross-platform thread waking |
+| `pixelflow-runtime/src/api/` | Public and private API surfaces: `public.rs`, `private.rs` |
 | `pixelflow-runtime/src/engine_troupe.rs` | Actor-based render orchestration |
 | `pixelflow-runtime/src/vsync_actor.rs` | Vsync coordination actor |
+| `pixelflow-runtime/src/render_pool.rs` | Render thread pool management |
+| `pixelflow-runtime/src/frame.rs` | Frame buffer management |
+| `pixelflow-runtime/src/config.rs` | Runtime configuration |
+| `pixelflow-runtime/src/input.rs` | Input event handling |
+| `pixelflow-runtime/src/testing/` | Test infrastructure: `mock_engine.rs` |
 
 ### Actor System
 
 | Path | Purpose |
 |------|---------|
 | `actor-scheduler/src/lib.rs` | Priority channel implementation (Control/Management/Data lanes) |
+| `actor-scheduler/src/kubelet.rs` | Actor lifecycle management (kubelet pattern) |
+| `actor-scheduler/src/lifecycle.rs` | Actor lifecycle states and transitions |
+| `actor-scheduler/src/service.rs` | Service abstractions |
+| `actor-scheduler/src/registry.rs` | Actor registry |
+| `actor-scheduler/src/spsc.rs` | Single-producer single-consumer queue |
+| `actor-scheduler/src/sharded.rs` | Sharded dispatch |
+| `actor-scheduler/src/params.rs` | Configuration parameters |
+| `actor-scheduler/src/error.rs` | Error types |
 | `actor-scheduler-macros/src/lib.rs` | Troupe macro for actor group management |
 
 ### Terminal Application
 
 | Path | Purpose |
 |------|---------|
-| `core-term/src/term/` | Terminal emulator state machine and grid |
-| `core-term/src/ansi/` | ANSI escape sequence parser |
-| `core-term/src/io/` | PTY actors and event monitoring (kqueue/epoll) |
+| `core-term/src/main.rs` | Application entry point |
 | `core-term/src/terminal_app.rs` | Top-level terminal application actor |
-| `core-term/src/surface/` | Terminal rendering surface |
+| `core-term/src/config.rs` | Terminal configuration |
+| `core-term/src/keys.rs` | Key binding definitions |
+| `core-term/src/messages.rs` | Inter-actor message types |
+| `core-term/src/color.rs` | Terminal color handling |
+| `core-term/src/glyph.rs` | Glyph rendering bridge |
+| `core-term/src/term/` | Terminal emulator: `screen.rs`, `cursor.rs`, `modes.rs`, `layout.rs`, `action.rs`, `charset.rs`, `snapshot.rs`, `unicode.rs` |
+| `core-term/src/term/emulator/` | Emulator handlers: `ansi_handler.rs`, `char_processor.rs`, `cursor_handler.rs`, `input_handler.rs`, `key_translator.rs`, `mode_handler.rs`, `osc_handler.rs`, `screen_ops.rs`, `methods.rs` |
+| `core-term/src/ansi/` | ANSI parser: `lexer.rs`, `parser.rs`, `commands.rs` |
+| `core-term/src/io/` | PTY I/O: `pty.rs`, `traits.rs`, `kqueue.rs` (macOS), `epoll.rs` (Linux) |
+| `core-term/src/io/event_monitor_actor/` | Event monitor: `read_thread/`, `write_thread/`, `parser_thread/` |
+| `core-term/src/surface/` | Terminal rendering surface: `manifold.rs`, `terminal.rs` |
 
 ### Build & Development
 
 | Path | Purpose |
 |------|---------|
 | `xtask/src/main.rs` | Build tasks (bundle-run for macOS app packaging) |
+| `xtask/src/codegen.rs` | Code generation tasks |
 | `Cargo.toml` | Workspace definition and build profiles |
-| `rust-toolchain.toml` | Rust nightly pinning |
+| `rust-toolchain.toml` | Rust stable toolchain pinning |
+| `pixelflow-core/build.rs` | SIMD backend detection (CPU feature probing) |
+| `pixelflow-runtime/build.rs` | Platform feature detection (X11 pkg-config) |
+| `core-term/build.rs` | Terminal build configuration |
 
 ## Architecture Documentation
 
@@ -283,16 +355,39 @@ if status_code == 4 { ... }                 // Bad
 
 Detailed design docs in `docs/`:
 - `STYLE.md` - Coding style guide and conventions
-- `.claude/`  - Includes Claude's auto-generated repo TOC
 - `AUTODIFF_RENDERING.md` - Automatic differentiation for antialiasing
 - `MESSAGE_CUJ_COVERAGE.md` - Message passing critical user journeys
+- `COMPILER_ANALYSIS.md` - Compiler pipeline analysis
+- `COMPILER_OPPORTUNITIES.md` - Optimization opportunities
+- `EGRAPH_SEARCH_INTEGRATION.md` - E-graph search integration details
+- `FLAT_CONTEXT_TUPLE_PROTOTYPE.md` - Context representation prototype
+- `GNN_REWRITE_GUIDANCE_VISION.md` - GNN-guided rewrite vision
+- `KERNEL_PARAM_LIMIT_INVESTIGATION.md` - Kernel parameter limit analysis
+- `NNUE_INTEGRATION_STATUS.md` - NNUE neural network integration status
+- `lample_charton_2019_symbolic_math.md` - Symbolic math reference notes
 - `gemini/` - Gemini AI integration documentation
+
+Design documents in `docs/designs/`:
+- `compiler-architecture-2026.md` - Compiler architecture roadmap
+- `nnue-training-pipeline.md` - NNUE training pipeline design
+- `actor-scheduler-supervisor-migration.md` - Supervisor migration plan
+
+Templates in `docs/templates/`:
+- `DESIGN_DOC.md` - Template for new design documents
+
+Reference PDFs in `docs/`:
+- `fop-conal.pdf`, `type-class-morphisms-long.pdf`, `2425_deep_learning_for_symbolic_mat.pdf`
 
 ### Top-Level Documentation
 
 - `README.md` - Project overview, philosophy, getting started
 - `CLAUDE.md` - This file: AI assistant development guide
+- `GEMINI.md` - Gemini AI assistant guide
+- `PERFORMANCE.md` - Performance benchmarks and targets
+- `PERFORMANCE_ANALYSIS.md` - Detailed performance analysis
+- `PIXELFLOW_IR_STATUS.md` - Status of pixelflow-ir crate (non-workspace member)
 - `LICENSE.md` - Apache license
+- `.claude/DOCS_TOC.md` - Auto-generated documentation table of contents
 
 ### Agent Context Files
 
@@ -410,10 +505,10 @@ See `pixelflow-core/src/backend/` for implementation details.
 - **Platform code:** `pixelflow-runtime/src/platform/macos/`
 
 ### Linux
-- **Display driver:** X11 via `pixelflow-runtime/src/display/drivers/x11.rs`
-- **PTY I/O:** epoll-based async I/O
-- **Dependencies:** Requires X11 development headers (libx11-dev, libxft-dev, etc.)
-- **Platform code:** `pixelflow-runtime/src/platform/linux.rs`
+- **Display driver:** X11 via the `x11` crate (feature-gated with `display_x11`), integrated through platform layer
+- **PTY I/O:** epoll-based async I/O (`core-term/src/io/epoll.rs`)
+- **Dependencies:** Requires X11 development headers (libx11-dev, libxft-dev, etc.), detected via `pkg-config` in `build.rs`
+- **Platform code:** `pixelflow-runtime/src/platform/linux/` (directory: `platform.rs`, `events.rs`, `window.rs`)
 
 ### Web (WASM)
 - **Driver:** `pixelflow-runtime/src/display/drivers/web/`
@@ -468,31 +563,45 @@ Inspired by Stockfish's NNUE, uses HalfEP (Half-Expression-Position) features:
 
 Incremental updates: only features for modified subtrees change, making evaluation O(rewrite_size).
 
-## Experimental: pixelflow-ml
+## pixelflow-ml: Neural Networks for Graphics & Compiler Optimization
 
-The `pixelflow-ml` crate explores a deep mathematical connection:
+The `pixelflow-ml` crate has evolved from a research crate into a practical training and evaluation framework.
 
-**Linear Attention IS Harmonic Global Illumination**
+### Core Insight
 
-### The Insight
-
-Both linear attention (transformers) and spherical harmonic lighting solve the same problem:
+**Linear Attention IS Harmonic Global Illumination** - both solve the same problem:
 - Compress infinite/quadratic interactions into finite/linear operations
 - Project onto orthogonal basis functions (φ for attention, Y_lm for SH)
 - Compute via efficient inner products instead of exhaustive summation
 
+### Architecture
+
+| Module | Purpose |
+|--------|---------|
+| `lib.rs` | Core types, mathematical exposition |
+| `layer.rs` | Neural network layer definitions |
+| `nnue.rs` | NNUE network implementation |
+| `nnue_trainer.rs` | NNUE training loop |
+| `evaluator.rs` | Expression evaluation |
+| `hce_extractor.rs` | Hand-crafted evaluation feature extraction |
+| `nonlinear_eval.rs` | Non-linear evaluation functions |
+| `graphics.rs` | Graphics integration (SH features) |
+| `benchmark.rs` | Benchmarking utilities |
+| `training/` | Training infrastructure: `backprop.rs`, `data_gen.rs`, `egraph.rs`, `factored.rs`, `features.rs` |
+
+### Feature Flags
+
+- `graphics` (default) - Enable graphics integration, requires `pixelflow-core`
+- `std` - Enable std for benchmarking and training data generation
+- `training` - Enable training data generation (implies `std`)
+- `egraph-training` - Enable e-graph training examples (requires `pixelflow-search`, `pixelflow-nnue`)
+
 ### Current Status
 
-- **Experimental research crate** - API unstable
-- Depends only on `pixelflow-core` (pure algebra)
+- Edition 2024, API stabilizing
+- Depends on `pixelflow-ir` (always), `pixelflow-core` (optional via `graphics` feature)
 - Uses `libm` for `no_std` compatibility
-- Edition 2024 (latest Rust features)
-
-### Use Cases
-
-- Neural rendering with SH-inspired feature maps
-- Fast approximation of global illumination in PixelFlow scenes
-- Exploration of attention mechanisms as graphics primitives
+- Extensive benchmarks: `hce_bench`, `expr_perf`, `manifold_hce_validation`, `nnue_training_suite`, `generated_kernels`
 
 See `pixelflow-ml/src/lib.rs` for detailed mathematical exposition.
 
@@ -554,6 +663,39 @@ See `pixelflow-ml/src/lib.rs` for detailed mathematical exposition.
 - Use Manifold composition instead of exposing internals
 - Changes to public API require architectural discussion
 
+## Feature Flags
+
+Key feature flags across the workspace:
+
+| Crate | Feature | Purpose |
+|-------|---------|---------|
+| `pixelflow-runtime` | `display_cocoa` | macOS Cocoa display driver |
+| `pixelflow-runtime` | `display_x11` | Linux X11 display driver (pulls in `x11` crate) |
+| `pixelflow-runtime` | `display_headless` | Headless driver for CI/testing |
+| `pixelflow-runtime` | `display_web` | WebAssembly display driver |
+| `pixelflow-ir` | `std`, `alloc` | Standard library and allocator support (both default) |
+| `pixelflow-ml` | `graphics` (default) | Graphics integration with `pixelflow-core` |
+| `pixelflow-ml` | `training` | Training data generation (implies `std`) |
+| `pixelflow-ml` | `egraph-training` | E-graph training examples (implies `std`, requires `pixelflow-search`, `pixelflow-nnue`) |
+| `pixelflow-nnue` | `std` (default) | Standard library support |
+| `pixelflow-nnue` | `training` | NNUE training support |
+| `pixelflow-search` | `std` (default) | Standard library support |
+| `pixelflow-graphics` | `serde` | Serialization support |
+| `core-term` | `profiling` | Flamegraph profiling via `pprof` |
+| `core-term` | `display_cocoa` | Force Cocoa driver |
+| `core-term` | `display_x11` | Force X11 driver |
+| `core-term` | `display_headless` | Force headless driver |
+
+Platform auto-detection: `core-term/Cargo.toml` uses `[target.'cfg(...)'.dependencies]` to automatically select the right display driver per platform. Feature flags are only needed for manual override.
+
+## Scripts
+
+Development scripts in `scripts/`:
+- `compute_log2_coefficients.py` - Compute polynomial coefficients for fast log2 approximation
+- `compute_log2_simple.py` - Simplified log2 coefficient computation
+- `fit_log2_polynomial.py` - Polynomial fitting for log2
+- `gen-docs-toc.sh` - Generate documentation table of contents
+
 ## Quick Reference
 
 ### Most Common Commands
@@ -566,12 +708,16 @@ cargo run --release -p core-term  # Run terminal directly
 cargo xtask bundle-run            # Build and run macOS app
 
 # Performance
-cargo bench -p pixelflow-core     # Benchmark core algebra
+cargo bench -p pixelflow-core     # Benchmark core algebra (core_benches)
+cargo bench -p pixelflow-macros   # Benchmark macro compilation (macro_bench)
+cargo bench -p pixelflow-ml       # ML benchmarks (hce_bench, expr_perf, manifold_hce_validation, nnue_training_suite, generated_kernels)
+cargo bench -p core-term          # Terminal benchmarks (ansi_parser, keybinding_benchmark)
 cargo xtask bundle-run --features profiling  # Profile with flamegraph
 
 # Platform-specific
-cargo build --features display_x11     # Force X11 (Linux)
-cargo build --features display_cocoa   # Force Cocoa (macOS)
+cargo build -p core-term --features display_x11       # Force X11 (Linux)
+cargo build -p core-term --features display_cocoa      # Force Cocoa (macOS)
+cargo build -p core-term --features display_headless   # Force headless (CI)
 ```
 
 ### Key Concepts Cheat Sheet
@@ -592,46 +738,94 @@ cargo build --features display_cocoa   # Force Cocoa (macOS)
 pixelflow-core/src/
   lib.rs              - Re-exports, Field definition
   manifold.rs         - Core trait
-  backend/            - SIMD implementations (avx512, sse2, neon, scalar)
-  combinators/        - Six eigenshaders
-  jet/                - Automatic differentiation
+  variables.rs        - Coordinate variables (symbol table)
+  algebra.rs          - Algebraic structures
+  ops/                - Operation types (base, binary, unary, compare, trig, logic, derivative, vector)
+  backend/            - SIMD implementations (x86, arm, scalar, wasm, fastmath)
+  combinators/        - at, map, select, fix, computed, binding, block, shift, pack, project, etc.
+  jet/                - Automatic differentiation (jet2, jet2h, jet3, path_jet)
+  storage.rs          - SIMD storage abstractions
+  numeric.rs          - Numeric traits
+  mask.rs             - SIMD mask operations
+  zst.rs              - Zero-sized type utilities
 
 pixelflow-macros/src/
   lib.rs              - kernel! macro entry point
+  ast.rs              - AST node definitions
   parser.rs           - AST construction
   sema.rs             - Semantic analysis
+  symbol.rs           - Symbol table
   optimize.rs         - AST optimization
-  codegen/            - Rust code emission
+  fold.rs             - AST visitor/fold
+  ir_bridge.rs        - Bridge to shared IR
+  rewrite_rules.rs    - Optimization rewrite rules
+  cost_builder.rs     - Cost model construction
+  codegen/            - Code emission (emitter, struct_emitter, binding, leveled, util)
 
-pixelflow-ir/src/
+pixelflow-ir/src/      (NOT a workspace member)
   lib.rs              - IR types and re-exports
   ops.rs              - Operation unit structs
   kind.rs             - OpKind enum
-  backend/            - Target-specific lowering
+  expr.rs             - Expression tree
+  traits.rs           - Backend traits
+  features.rs         - Feature encoding
+  backend/            - Target-specific lowering (x86, arm, wasm, scalar, fastmath)
 
 pixelflow-search/src/
   egraph/             - E-graph optimization
     graph.rs          - Core e-graph structure
+    node.rs           - E-graph nodes
     saturate.rs       - Rewrite saturation
     extract.rs        - Cost-based extraction
+    rules.rs          - Rewrite rule definitions
+    guided.rs         - NNUE-guided search
+    best_first.rs     - Best-first search strategy
+    nnue_adapter.rs   - NNUE adapter
+  domain/             - Domain-specific algebra
 
 pixelflow-nnue/src/
   lib.rs              - NNUE network, HalfEP features
+  factored.rs         - Factored NNUE variant
 
 pixelflow-graphics/src/
-  render/             - Rasterization engine
-  fonts/              - Glyph loading & SDF
+  render/             - Rasterization engine (aa, color, discrete, frame, pixel, rasterizer/)
+  fonts/              - Font system (loader, cache, combinators, text, ttf, ttf_curve_analytical)
   scene3d.rs          - 3D scene graph
+  shapes.rs           - Shape primitives
+  animation.rs        - Animation support
+  mesh.rs             - Mesh structures
+  spatial_bsp.rs      - BSP spatial queries
 
 pixelflow-runtime/src/
-  display/drivers/    - X11, headless, Metal, Web
-  platform/macos/     - Cocoa integration
+  display/drivers/    - headless, Metal, Web (no standalone X11 driver)
+  display/            - driver, messages, ops, platform abstractions
+  platform/macos/     - Cocoa integration (cocoa, events, objc, platform, sys, window)
+  platform/linux/     - Linux platform (platform, events, window)
+  api/                - Public and private API surfaces
   engine_troupe.rs    - Render actor orchestration
+  vsync_actor.rs      - Vsync coordination
+  render_pool.rs      - Render thread pool
+  testing/            - Mock engine for tests
+
+pixelflow-ml/src/
+  lib.rs              - Core types, math exposition
+  training/           - Training infrastructure (backprop, data_gen, egraph, factored, features)
+  nnue.rs             - NNUE implementation
+  hce_extractor.rs    - Hand-crafted evaluation extraction
 
 core-term/src/
-  term/               - Terminal state machine
-  ansi/               - Escape sequence parser
-  io/                 - PTY actors
+  main.rs             - Entry point
+  terminal_app.rs     - Top-level actor
+  term/               - Terminal state machine (screen, cursor, modes, layout, emulator/)
+  term/emulator/      - Handlers (ansi, char, cursor, input, key_translator, mode, osc, screen_ops)
+  ansi/               - Escape sequence parser (lexer, parser, commands)
+  io/                 - PTY actors (pty, kqueue, epoll, event_monitor_actor/)
+  surface/            - Rendering surface (manifold, terminal)
+  config.rs           - Configuration
+  keys.rs             - Key bindings
+  messages.rs         - Message types
+  color.rs            - Color handling
+  glyph.rs            - Glyph bridge
 ```
 
 ### When to Use Which Tool
@@ -658,5 +852,5 @@ core-term/src/
     3c. variables.rs is the symbol table
 4. **Minimal public API** - Composition over exposure
 5. **Zero allocations** - No per-frame heap allocation
-6. **No copies of unknown sized types** pixelflow language types are copy iff they are provably zero sized 
-6. **Platform on main thread** - Especially macOS Cocoa
+6. **No copies of unknown sized types** pixelflow language types are copy iff they are provably zero sized
+7. **Platform on main thread** - Especially macOS Cocoa


### PR DESCRIPTION
Major corrections and additions:
- Fix pixelflow-ir status: not a workspace member, clarify as path dependency
- Fix rust-toolchain.toml: stable, not nightly
- Fix Linux platform path: directory not single file
- Remove phantom X11 display driver reference (no x11.rs exists)
- Fix duplicate architecture principle numbering (two #6s)
- Remove stale "(New)" from Compiler Stack heading
- Add edition info (2024 vs 2021) to crate details table

New content:
- Complete source file listings for all crates (pixelflow-core ops/,
  pixelflow-macros ast/fold/symbol, actor-scheduler modules,
  core-term emulator handlers, pixelflow-runtime api/testing)
- Feature Flags reference table across all crates
- Scripts section documenting Python/shell utilities
- All docs/ files including designs/, templates/, and reference PDFs
- All top-level docs (GEMINI.md, PERFORMANCE.md, PIXELFLOW_IR_STATUS.md)
- Missing CI workflow (gemini-invoke.yml)
- Benchmark commands for all crates with named benchmarks
- pixelflow-ml architecture table and training infrastructure docs
- build.rs locations for all three crates that have them
- Complete .githooks listing (5 hooks)

https://claude.ai/code/session_018MbCMxGcfL3qapqPMJtMPi