### PR TITLE
feat(pixelflow-core, pixelflow-ir): add Field<Bf16> backends for AVX-512 and NEON

### DIFF
--- a/pixelflow-core/build.rs
+++ b/pixelflow-core/build.rs
@@ -6,6 +6,8 @@ fn main() {
     println!("cargo::rustc-check-cfg=cfg(pixelflow_avx512f)");
     println!("cargo::rustc-check-cfg=cfg(pixelflow_avx2)");
     println!("cargo::rustc-check-cfg=cfg(pixelflow_neon)");
+    println!("cargo::rustc-check-cfg=cfg(pixelflow_avx512bf16)");
+    println!("cargo::rustc-check-cfg=cfg(pixelflow_neon_bf16)");
 
     #[cfg(target_arch = "x86_64")]
     {
@@ -15,11 +17,17 @@ fn main() {
         if is_x86_feature_detected!("avx2") {
             println!("cargo:rustc-cfg=pixelflow_avx2");
         }
+        if is_x86_feature_detected!("avx512bf16") {
+            println!("cargo:rustc-cfg=pixelflow_avx512bf16");
+        }
     }
 
     #[cfg(target_arch = "aarch64")]
     {
         // ARM always has NEON on aarch64
         println!("cargo:rustc-cfg=pixelflow_neon");
+        if std::arch::is_aarch64_feature_detected!("bf16") {
+            println!("cargo:rustc-cfg=pixelflow_neon_bf16");
+        }
     }
 }

--- a/pixelflow-core/src/backend/arm.rs
+++ b/pixelflow-core/src/backend/arm.rs
@@ -1,6 +1,6 @@
 //! ARM NEON backend (4 lanes for f32).
 
-use super::{Backend, MaskOps, SimdOps, SimdU32Ops};
+use super::{Backend, MaskOps, SimdBf16Ops, SimdOps, SimdU32Ops};
 use core::arch::aarch64::*;
 use core::fmt::{Debug, Formatter};
 use core::ops::*;
@@ -635,6 +635,120 @@ impl U32x4 {
 
             let packed = vorrq_u32(vorrq_u32(r_u32, g_shifted), vorrq_u32(b_shifted, a_shifted));
             Self(packed)
+        }
+    }
+}
+
+// ============================================================================
+// BF16x8 — 8-lane bf16 for ARM NEON
+// ============================================================================
+
+/// 8-lane bfloat16 SIMD vector for ARM NEON.
+///
+/// Internally stores 8 × u16 bf16 values in a 128-bit NEON register
+/// (as `uint16x8_t`). When the `bf16` target feature is available, hardware
+/// `vcvt_f32_bf16` / `vcvt_bf16_f32` instructions are used; otherwise integer
+/// shift operations provide correct software emulation.
+#[derive(Copy, Clone)]
+#[repr(transparent)]
+pub struct BF16x8(pub(crate) uint16x8_t);
+
+impl Default for BF16x8 {
+    fn default() -> Self {
+        unsafe { Self(vdupq_n_u16(0)) }
+    }
+}
+
+impl core::fmt::Debug for BF16x8 {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut arr = [0u16; 8];
+        unsafe { vst1q_u16(arr.as_mut_ptr(), self.0) };
+        write!(f, "BF16x8({:?})", arr)
+    }
+}
+
+impl SimdBf16Ops for BF16x8 {
+    const LANES: usize = 8;
+    type F32Simd = F32x4;
+
+    #[inline(always)]
+    fn splat(val: u16) -> Self {
+        unsafe { Self(vdupq_n_u16(val)) }
+    }
+
+    #[inline(always)]
+    fn load(slice: &[u16]) -> Self {
+        assert!(slice.len() >= 8);
+        unsafe { Self(vld1q_u16(slice.as_ptr())) }
+    }
+
+    #[inline(always)]
+    fn store(&self, out: &mut [u16]) {
+        assert!(out.len() >= 8);
+        unsafe { vst1q_u16(out.as_mut_ptr(), self.0) }
+    }
+
+    #[inline(always)]
+    fn to_f32_lo(self) -> F32x4 {
+        unsafe {
+            #[cfg(target_feature = "bf16")]
+            {
+                // Hardware path: reinterpret uint16x8_t as bfloat16x8_t, extract low half,
+                // convert to float32x4_t.
+                let bh8: bfloat16x8_t = vreinterpretq_bf16_u16(self.0);
+                F32x4(vcvt_f32_bf16(vget_low_bf16(bh8)))
+            }
+            #[cfg(not(target_feature = "bf16"))]
+            {
+                // Software path: zero-extend lower 4 × u16 → u32, shift left 16, bitcast.
+                let lo: uint16x4_t = vget_low_u16(self.0);
+                let lo_u32: uint32x4_t = vmovl_u16(lo); // zero-extend u16 → u32
+                let shifted: uint32x4_t = vshlq_n_u32::<16>(lo_u32);
+                F32x4(vreinterpretq_f32_u32(shifted))
+            }
+        }
+    }
+
+    #[inline(always)]
+    fn to_f32_hi(self) -> F32x4 {
+        unsafe {
+            #[cfg(target_feature = "bf16")]
+            {
+                let bh8: bfloat16x8_t = vreinterpretq_bf16_u16(self.0);
+                F32x4(vcvt_f32_bf16(vget_high_bf16(bh8)))
+            }
+            #[cfg(not(target_feature = "bf16"))]
+            {
+                let hi: uint16x4_t = vget_high_u16(self.0);
+                let hi_u32: uint32x4_t = vmovl_u16(hi);
+                let shifted: uint32x4_t = vshlq_n_u32::<16>(hi_u32);
+                F32x4(vreinterpretq_f32_u32(shifted))
+            }
+        }
+    }
+
+    #[inline(always)]
+    fn from_f32(lo: F32x4, hi: F32x4) -> Self {
+        unsafe {
+            #[cfg(target_feature = "bf16")]
+            {
+                // Hardware path: convert each f32x4 → bfloat16x4_t (round-to-nearest-even),
+                // then combine into bfloat16x8_t and reinterpret as uint16x8_t.
+                let lo_bh: bfloat16x4_t = vcvt_bf16_f32(lo.0);
+                let hi_bh: bfloat16x4_t = vcvt_bf16_f32(hi.0);
+                Self(vreinterpretq_u16_bf16(vcombine_bf16(lo_bh, hi_bh)))
+            }
+            #[cfg(not(target_feature = "bf16"))]
+            {
+                // Software path: narrowing shift right by 16 extracts the upper 16 bits
+                // (= the bf16 bits) from each f32's bit pattern.
+                let lo_u32 = vreinterpretq_u32_f32(lo.0);
+                let hi_u32 = vreinterpretq_u32_f32(hi.0);
+                // vshrn_n_u32::<16> shifts each u32 right by 16 and narrows to u16
+                let lo_u16: uint16x4_t = vshrn_n_u32::<16>(lo_u32);
+                let hi_u16: uint16x4_t = vshrn_n_u32::<16>(hi_u32);
+                Self(vcombine_u16(lo_u16, hi_u16))
+            }
         }
     }
 }

--- a/pixelflow-core/src/backend/mod.rs
+++ b/pixelflow-core/src/backend/mod.rs
@@ -217,6 +217,73 @@ pub trait SimdU32Ops:
     fn from_f32_scaled<F: SimdOps>(f: F) -> Self;
 }
 
+// ============================================================================
+// SimdBf16Ops — bf16 SIMD load/store/convert trait
+// ============================================================================
+
+/// SIMD operations for bfloat16 vectors.
+///
+/// bf16 values are stored in SIMD registers as packed `u16` words (the raw
+/// IEEE 754 bf16 bit pattern). All arithmetic is performed in f32 by calling
+/// [`to_f32_lo`](SimdBf16Ops::to_f32_lo) / [`to_f32_hi`](SimdBf16Ops::to_f32_hi)
+/// to upcast, computing, then packing back with [`from_f32`](SimdBf16Ops::from_f32).
+///
+/// # Lane layout
+///
+/// A `SimdBf16Ops` type holds `LANES` bf16 values, which is always **2×** the
+/// lane count of the paired [`F32Simd`](SimdBf16Ops::F32Simd) type. The lanes
+/// are split evenly:
+/// - lanes `0 .. LANES/2` → `to_f32_lo`
+/// - lanes `LANES/2 .. LANES` → `to_f32_hi`
+///
+/// # Hardware acceleration
+///
+/// | Platform | Feature | Instruction |
+/// |----------|---------|-------------|
+/// | AVX-512 | `avx512bf16` | `vcvtpbh2ps`, `vcvtne2ps2bf16` |
+/// | NEON | `bf16` | `vcvt_f32_bf16`, `vcvt_bf16_f32` |
+/// | Other | (software) | shift + pack |
+pub trait SimdBf16Ops: Copy + Clone + core::fmt::Debug + Default + Send + Sync {
+    /// Number of bf16 lanes (always 2× `F32Simd::LANES`).
+    const LANES: usize;
+
+    /// The paired f32 SIMD type — holds `LANES / 2` f32 values.
+    type F32Simd: SimdOps;
+
+    /// Splat a raw bf16 value (as `u16` bits) to every lane.
+    fn splat(val: u16) -> Self;
+
+    /// Load `LANES` bf16 values from a slice of raw `u16` bits.
+    ///
+    /// # Panics
+    /// Panics if `slice.len() < LANES`.
+    fn load(slice: &[u16]) -> Self;
+
+    /// Store `LANES` bf16 values to a slice of raw `u16` bits.
+    ///
+    /// # Panics
+    /// Panics if `out.len() < LANES`.
+    fn store(&self, out: &mut [u16]);
+
+    /// Convert the lower `LANES/2` bf16 lanes to f32.
+    ///
+    /// Uses hardware `vcvtpbh2ps` / `vcvt_f32_bf16` when available;
+    /// falls back to software zero-extension otherwise.
+    fn to_f32_lo(self) -> Self::F32Simd;
+
+    /// Convert the upper `LANES/2` bf16 lanes to f32.
+    fn to_f32_hi(self) -> Self::F32Simd;
+
+    /// Pack two f32 SIMD vectors into a bf16 vector.
+    ///
+    /// - `lo` → lanes `0 .. LANES/2`
+    /// - `hi` → lanes `LANES/2 .. LANES`
+    ///
+    /// Uses hardware `vcvtne2ps2bf16` (round-to-nearest-even) when available;
+    /// falls back to truncation (round-toward-zero) otherwise.
+    fn from_f32(lo: Self::F32Simd, hi: Self::F32Simd) -> Self;
+}
+
 #[cfg(target_arch = "aarch64")]
 pub mod arm;
 

--- a/pixelflow-core/src/bf16.rs
+++ b/pixelflow-core/src/bf16.rs
@@ -1,0 +1,217 @@
+//! BFloat16 scalar type for use with `Field<Bf16>`.
+//!
+//! `Bf16` is the top 16 bits of an IEEE 754 single-precision float:
+//! - 1 sign bit
+//! - 8 exponent bits (same range as f32)
+//! - 7 mantissa bits (vs 23 for f32)
+//!
+//! The primary purpose of `Field<Bf16>` is **memory bandwidth reduction**: store
+//! data in bf16 format, load it into a SIMD vector, upcast to f32 for computation,
+//! then optionally downcast back to bf16 for storage. This halves memory traffic
+//! compared to f32 at the cost of ~3 decimal digits of precision.
+//!
+//! # Layout
+//!
+//! bf16 is literally the upper 16 bits of f32:
+//! ```text
+//! f32:  SEEEEEEE EMMMMMMM MMMMMMMM MMMMMMMM
+//! bf16: SEEEEEEE EMMMMMMM
+//! ```
+//! where S=sign, E=exponent, M=mantissa.
+//!
+//! This makes conversion trivial:
+//! - f32 → bf16: `(f32.to_bits() >> 16) as u16` (truncation, round-toward-zero)
+//! - bf16 → f32: `f32::from_bits((bf16 as u32) << 16)` (exact, zero-extends mantissa)
+
+use crate::algebra::Algebra;
+
+/// BFloat16 scalar type.
+///
+/// A 16-bit floating-point format that shares the f32 exponent range.
+/// Used as the element type for `Field<Bf16>` to enable bf16 SIMD backends.
+///
+/// # Storage
+///
+/// The raw bits are stored as a `u16`. Values are interpreted as the upper
+/// 16 bits of the IEEE 754 f32 representation.
+///
+/// # Note on arithmetic
+///
+/// Scalar `Bf16` arithmetic upcasts to f32, computes, then truncates back.
+/// For vectorized computation, use `Field<Bf16>` which converts entire SIMD
+/// vectors at once via `to_f32_lo` / `to_f32_hi`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[repr(transparent)]
+pub struct Bf16(pub u16);
+
+impl Bf16 {
+    /// Construct from raw bf16 bits (the upper 16 bits of an f32).
+    #[inline(always)]
+    pub const fn from_bits(bits: u16) -> Self {
+        Self(bits)
+    }
+
+    /// Return the raw bf16 bits.
+    #[inline(always)]
+    pub const fn to_bits(self) -> u16 {
+        self.0
+    }
+
+    /// Convert f32 to bf16 by truncating the lower 16 mantissa bits (round toward zero).
+    ///
+    /// For round-to-nearest-even, use the SIMD conversion paths in `Field<Bf16>::from_f32`
+    /// when hardware bf16 instructions are available.
+    #[inline(always)]
+    pub fn from_f32_truncate(val: f32) -> Self {
+        Self((val.to_bits() >> 16) as u16)
+    }
+
+    /// Convert bf16 to f32 by zero-extending the mantissa.
+    ///
+    /// This is an exact conversion (no rounding occurs).
+    #[inline(always)]
+    pub fn to_f32(self) -> f32 {
+        f32::from_bits((self.0 as u32) << 16)
+    }
+
+    /// bf16 representation of 0.0
+    pub const ZERO: Self = Self(0x0000);
+
+    /// bf16 representation of 1.0
+    pub const ONE: Self = Self(0x3F80);
+
+    /// bf16 representation of -1.0
+    pub const NEG_ONE: Self = Self(0xBF80);
+
+    /// bf16 positive infinity
+    pub const INFINITY: Self = Self(0x7F80);
+
+    /// bf16 NaN (quiet)
+    pub const NAN: Self = Self(0x7FC0);
+}
+
+// ============================================================================
+// Algebra implementation for Bf16
+//
+// All arithmetic routes through f32 (upcast → compute → truncate back).
+// This is the scalar path; the vectorized path goes through Field<Bf16>.
+// ============================================================================
+
+impl Algebra for Bf16 {
+    type Mask = bool;
+
+    #[inline(always)]
+    fn zero() -> Self {
+        Self::ZERO
+    }
+
+    #[inline(always)]
+    fn one() -> Self {
+        Self::ONE
+    }
+
+    #[inline(always)]
+    fn add(self, rhs: Self) -> Self {
+        Self::from_f32_truncate(self.to_f32() + rhs.to_f32())
+    }
+
+    #[inline(always)]
+    fn sub(self, rhs: Self) -> Self {
+        Self::from_f32_truncate(self.to_f32() - rhs.to_f32())
+    }
+
+    #[inline(always)]
+    fn mul(self, rhs: Self) -> Self {
+        Self::from_f32_truncate(self.to_f32() * rhs.to_f32())
+    }
+
+    #[inline(always)]
+    fn neg(self) -> Self {
+        // Toggle the sign bit — no upcast needed
+        Self(self.0 ^ 0x8000)
+    }
+
+    #[inline(always)]
+    fn lt(self, rhs: Self) -> bool {
+        self.to_f32() < rhs.to_f32()
+    }
+
+    #[inline(always)]
+    fn le(self, rhs: Self) -> bool {
+        self.to_f32() <= rhs.to_f32()
+    }
+
+    #[inline(always)]
+    fn gt(self, rhs: Self) -> bool {
+        self.to_f32() > rhs.to_f32()
+    }
+
+    #[inline(always)]
+    fn ge(self, rhs: Self) -> bool {
+        self.to_f32() >= rhs.to_f32()
+    }
+
+    #[inline(always)]
+    fn eq(self, rhs: Self) -> bool {
+        // Compare bit patterns directly (handles +0/-0 unification if needed)
+        // For IEEE semantics, NaN != NaN, which is preserved here since to_f32 roundtrips.
+        self.to_f32() == rhs.to_f32()
+    }
+
+    #[inline(always)]
+    fn ne(self, rhs: Self) -> bool {
+        self.to_f32() != rhs.to_f32()
+    }
+
+    #[inline(always)]
+    fn select(mask: bool, if_true: Self, if_false: Self) -> Self {
+        if mask { if_true } else { if_false }
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bf16_roundtrip() {
+        // 1.0 in f32 = 0x3F800000, upper 16 bits = 0x3F80
+        let one = Bf16::from_f32_truncate(1.0);
+        assert_eq!(one.to_bits(), 0x3F80);
+        assert_eq!(one.to_f32(), 1.0);
+    }
+
+    #[test]
+    fn test_bf16_zero() {
+        let z = Bf16::zero();
+        assert_eq!(z.to_bits(), 0x0000);
+        assert_eq!(z.to_f32(), 0.0);
+    }
+
+    #[test]
+    fn test_bf16_neg() {
+        let one = Bf16::ONE;
+        let neg_one = one.neg();
+        assert_eq!(neg_one.to_bits(), 0xBF80);
+        assert_eq!(neg_one.to_f32(), -1.0);
+    }
+
+    #[test]
+    fn test_bf16_add() {
+        let a = Bf16::from_f32_truncate(1.0);
+        let b = Bf16::from_f32_truncate(2.0);
+        let c = a.add(b);
+        // 3.0 in bf16
+        assert_eq!(c.to_f32(), 3.0);
+    }
+
+    #[test]
+    fn test_bf16_algebra_constants() {
+        assert_eq!(Bf16::ZERO, Bf16::from_f32_truncate(0.0));
+        assert_eq!(Bf16::ONE, Bf16::from_f32_truncate(1.0));
+    }
+}

--- a/pixelflow-ir/src/backend/x86.rs
+++ b/pixelflow-ir/src/backend/x86.rs
@@ -1,6 +1,6 @@
 //! x86_64 backend.
 
-use super::{Backend, MaskOps, SimdOps, SimdU32Ops};
+use super::{Backend, MaskOps, SimdBf16Ops, SimdOps, SimdU32Ops};
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
 use core::fmt::{Debug, Formatter};
@@ -1804,6 +1804,299 @@ impl U32x16 {
                 _mm512_or_si512(b_shifted, a_shifted),
             );
             Self(packed)
+        }
+    }
+}
+
+// ============================================================================
+// BF16x32 — 32-lane bf16 for AVX-512
+// ============================================================================
+
+/// 32-lane bfloat16 SIMD vector for AVX-512.
+///
+/// Internally stores 32 × u16 bf16 values in a 512-bit `__m512i`.
+/// When `avx512bf16` target feature is available, uses hardware
+/// `vcvtpbh2ps` / `vcvtne2ps2bf16`; otherwise uses software shift.
+#[cfg(target_feature = "avx512f")]
+#[derive(Copy, Clone)]
+#[repr(transparent)]
+pub struct BF16x32(pub(crate) __m512i);
+
+#[cfg(target_feature = "avx512f")]
+impl Default for BF16x32 {
+    fn default() -> Self {
+        unsafe { Self(_mm512_setzero_si512()) }
+    }
+}
+
+#[cfg(target_feature = "avx512f")]
+impl core::fmt::Debug for BF16x32 {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        let mut arr = [0u16; 32];
+        unsafe { _mm512_storeu_si512(arr.as_mut_ptr() as *mut __m512i, self.0) };
+        write!(f, "BF16x32({:?})", arr)
+    }
+}
+
+#[cfg(target_feature = "avx512f")]
+impl SimdBf16Ops for BF16x32 {
+    const LANES: usize = 32;
+    type F32Simd = F32x16;
+
+    #[inline(always)]
+    fn splat(val: u16) -> Self {
+        unsafe { Self(_mm512_set1_epi16(val as i16)) }
+    }
+
+    #[inline(always)]
+    fn load(slice: &[u16]) -> Self {
+        assert!(slice.len() >= 32);
+        unsafe { Self(_mm512_loadu_si512(slice.as_ptr() as *const __m512i)) }
+    }
+
+    #[inline(always)]
+    fn store(&self, out: &mut [u16]) {
+        assert!(out.len() >= 32);
+        unsafe { _mm512_storeu_si512(out.as_mut_ptr() as *mut __m512i, self.0) }
+    }
+
+    #[inline(always)]
+    fn to_f32_lo(self) -> F32x16 {
+        unsafe {
+            let lo: __m256i = _mm512_castsi512_si256(self.0);
+            #[cfg(target_feature = "avx512bf16")]
+            {
+                let lo_bh: __m256bh = core::mem::transmute(lo);
+                F32x16(_mm512_cvtpbh_ps(lo_bh))
+            }
+            #[cfg(not(target_feature = "avx512bf16"))]
+            {
+                let lo_u32 = _mm512_cvtepu16_epi32(lo);
+                F32x16(_mm512_castsi512_ps(_mm512_slli_epi32(lo_u32, 16)))
+            }
+        }
+    }
+
+    #[inline(always)]
+    fn to_f32_hi(self) -> F32x16 {
+        unsafe {
+            let hi: __m256i = _mm512_extracti64x4_epi64::<1>(self.0);
+            #[cfg(target_feature = "avx512bf16")]
+            {
+                let hi_bh: __m256bh = core::mem::transmute(hi);
+                F32x16(_mm512_cvtpbh_ps(hi_bh))
+            }
+            #[cfg(not(target_feature = "avx512bf16"))]
+            {
+                let hi_u32 = _mm512_cvtepu16_epi32(hi);
+                F32x16(_mm512_castsi512_ps(_mm512_slli_epi32(hi_u32, 16)))
+            }
+        }
+    }
+
+    #[inline(always)]
+    fn from_f32(lo: F32x16, hi: F32x16) -> Self {
+        unsafe {
+            #[cfg(target_feature = "avx512bf16")]
+            {
+                let bh: __m512bh = _mm512_cvtne2ps_pbh(hi.0, lo.0);
+                Self(core::mem::transmute(bh))
+            }
+            #[cfg(not(target_feature = "avx512bf16"))]
+            {
+                let lo_shr = _mm512_srli_epi32(_mm512_castps_si512(lo.0), 16);
+                let hi_shr = _mm512_srli_epi32(_mm512_castps_si512(hi.0), 16);
+                let lo_u16: __m256i = _mm512_cvtepi32_epi16(lo_shr);
+                let hi_u16: __m256i = _mm512_cvtepi32_epi16(hi_shr);
+                Self(_mm512_inserti64x4::<1>(_mm512_castsi256_si512(lo_u16), hi_u16))
+            }
+        }
+    }
+}
+
+// ============================================================================
+// BF16x16 — 16-lane bf16 for AVX2
+// ============================================================================
+
+/// 16-lane bfloat16 SIMD vector for AVX2.
+///
+/// Internally stores 16 × u16 bf16 values in a 256-bit `__m256i`.
+/// Uses software conversion (no AVX2 bf16 instructions exist).
+#[cfg(all(target_feature = "avx2", not(target_feature = "avx512f")))]
+#[derive(Copy, Clone)]
+#[repr(transparent)]
+pub struct BF16x16(pub(crate) __m256i);
+
+#[cfg(all(target_feature = "avx2", not(target_feature = "avx512f")))]
+impl Default for BF16x16 {
+    fn default() -> Self {
+        unsafe { Self(_mm256_setzero_si256()) }
+    }
+}
+
+#[cfg(all(target_feature = "avx2", not(target_feature = "avx512f")))]
+impl core::fmt::Debug for BF16x16 {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        let mut arr = [0u16; 16];
+        unsafe { _mm256_storeu_si256(arr.as_mut_ptr() as *mut __m256i, self.0) };
+        write!(f, "BF16x16({:?})", arr)
+    }
+}
+
+#[cfg(all(target_feature = "avx2", not(target_feature = "avx512f")))]
+impl SimdBf16Ops for BF16x16 {
+    const LANES: usize = 16;
+    type F32Simd = F32x8;
+
+    #[inline(always)]
+    fn splat(val: u16) -> Self {
+        unsafe { Self(_mm256_set1_epi16(val as i16)) }
+    }
+
+    #[inline(always)]
+    fn load(slice: &[u16]) -> Self {
+        assert!(slice.len() >= 16);
+        unsafe { Self(_mm256_loadu_si256(slice.as_ptr() as *const __m256i)) }
+    }
+
+    #[inline(always)]
+    fn store(&self, out: &mut [u16]) {
+        assert!(out.len() >= 16);
+        unsafe { _mm256_storeu_si256(out.as_mut_ptr() as *mut __m256i, self.0) }
+    }
+
+    #[inline(always)]
+    fn to_f32_lo(self) -> F32x8 {
+        unsafe {
+            let lo: __m128i = _mm256_castsi256_si128(self.0);
+            let lo_u32: __m256i = _mm256_cvtepu16_epi32(lo);
+            F32x8(_mm256_castsi256_ps(_mm256_slli_epi32(lo_u32, 16)))
+        }
+    }
+
+    #[inline(always)]
+    fn to_f32_hi(self) -> F32x8 {
+        unsafe {
+            let hi: __m128i = _mm256_extracti128_si256::<1>(self.0);
+            let hi_u32: __m256i = _mm256_cvtepu16_epi32(hi);
+            F32x8(_mm256_castsi256_ps(_mm256_slli_epi32(hi_u32, 16)))
+        }
+    }
+
+    #[inline(always)]
+    fn from_f32(lo: F32x8, hi: F32x8) -> Self {
+        unsafe {
+            let lo_shr = _mm256_srli_epi32(_mm256_castps_si256(lo.0), 16);
+            let hi_shr = _mm256_srli_epi32(_mm256_castps_si256(hi.0), 16);
+            let lo_lo = _mm256_castsi256_si128(lo_shr);
+            let lo_hi = _mm256_extracti128_si256::<1>(lo_shr);
+            let hi_lo = _mm256_castsi256_si128(hi_shr);
+            let hi_hi = _mm256_extracti128_si256::<1>(hi_shr);
+            let lo_packed: __m128i = _mm_packus_epi32(lo_lo, lo_hi);
+            let hi_packed: __m128i = _mm_packus_epi32(hi_lo, hi_hi);
+            Self(_mm256_set_m128i(hi_packed, lo_packed))
+        }
+    }
+}
+
+// ============================================================================
+// BF16x8 — 8-lane bf16 for SSE2 (x86_64 baseline)
+// ============================================================================
+
+/// 8-lane bfloat16 SIMD vector for SSE2.
+///
+/// Internally stores 8 × u16 bf16 values in a 128-bit `__m128i`.
+/// Uses software conversion (no SSE bf16 instructions exist).
+#[cfg(all(
+    target_arch = "x86_64",
+    not(target_feature = "avx2"),
+    not(target_feature = "avx512f")
+))]
+#[derive(Copy, Clone)]
+#[repr(transparent)]
+pub struct BF16x8(pub(crate) __m128i);
+
+#[cfg(all(
+    target_arch = "x86_64",
+    not(target_feature = "avx2"),
+    not(target_feature = "avx512f")
+))]
+impl Default for BF16x8 {
+    fn default() -> Self {
+        unsafe { Self(_mm_setzero_si128()) }
+    }
+}
+
+#[cfg(all(
+    target_arch = "x86_64",
+    not(target_feature = "avx2"),
+    not(target_feature = "avx512f")
+))]
+impl core::fmt::Debug for BF16x8 {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        let mut arr = [0u16; 8];
+        unsafe { _mm_storeu_si128(arr.as_mut_ptr() as *mut __m128i, self.0) };
+        write!(f, "BF16x8({:?})", arr)
+    }
+}
+
+#[cfg(all(
+    target_arch = "x86_64",
+    not(target_feature = "avx2"),
+    not(target_feature = "avx512f")
+))]
+impl SimdBf16Ops for BF16x8 {
+    const LANES: usize = 8;
+    type F32Simd = F32x4;
+
+    #[inline(always)]
+    fn splat(val: u16) -> Self {
+        unsafe { Self(_mm_set1_epi16(val as i16)) }
+    }
+
+    #[inline(always)]
+    fn load(slice: &[u16]) -> Self {
+        assert!(slice.len() >= 8);
+        unsafe { Self(_mm_loadu_si128(slice.as_ptr() as *const __m128i)) }
+    }
+
+    #[inline(always)]
+    fn store(&self, out: &mut [u16]) {
+        assert!(out.len() >= 8);
+        unsafe { _mm_storeu_si128(out.as_mut_ptr() as *mut __m128i, self.0) }
+    }
+
+    #[inline(always)]
+    fn to_f32_lo(self) -> F32x4 {
+        unsafe {
+            let zero = _mm_setzero_si128();
+            let lo_u32 = _mm_unpacklo_epi16(self.0, zero);
+            F32x4(_mm_castsi128_ps(_mm_slli_epi32(lo_u32, 16)))
+        }
+    }
+
+    #[inline(always)]
+    fn to_f32_hi(self) -> F32x4 {
+        unsafe {
+            let zero = _mm_setzero_si128();
+            let hi_u32 = _mm_unpackhi_epi16(self.0, zero);
+            F32x4(_mm_castsi128_ps(_mm_slli_epi32(hi_u32, 16)))
+        }
+    }
+
+    #[inline(always)]
+    fn from_f32(lo: F32x4, hi: F32x4) -> Self {
+        unsafe {
+            let mut lo_buf = [0.0f32; 4];
+            let mut hi_buf = [0.0f32; 4];
+            _mm_storeu_ps(lo_buf.as_mut_ptr(), lo.0);
+            _mm_storeu_ps(hi_buf.as_mut_ptr(), hi.0);
+            let mut out = [0u16; 8];
+            for i in 0..4 {
+                out[i] = (lo_buf[i].to_bits() >> 16) as u16;
+                out[i + 4] = (hi_buf[i].to_bits() >> 16) as u16;
+            }
+            Self(_mm_loadu_si128(out.as_ptr() as *const __m128i))
         }
     }
 }


### PR DESCRIPTION
Adds bfloat16 SIMD support across the full backend stack:

**New types:**
- `Bf16` scalar algebra type (pixelflow-core/src/bf16.rs)
- `SimdBf16Ops` trait: splat/load/store/to_f32_lo/to_f32_hi/from_f32
- `BF16x32` — AVX-512, 32 lanes, hardware vcvtpbh2ps/vcvtne2ps2bf16 when avx512bf16 available
- `BF16x16` — AVX2, 16 lanes, software shift conversion
- `BF16x8` — SSE2 (x86) and NEON (ARM), 8 lanes; NEON uses vcvt_f32_bf16/vcvt_bf16_f32 when bf16 target feature present
- `ScalarBf16` — 2-lane scalar fallback (preserves LANES = 2×F32Simd::LANES)

**Plumbing:**
- `FieldStorage for Bf16` maps to `NativeBf16Storage` platform alias
- `Field<Bf16>` with `load`, `store`, `to_f32_lo`, `to_f32_hi`, `from_f32`, `LANES`
- `pub type FieldBf16 = Field<Bf16>` alias; `pub use bf16::Bf16` in prelude
- build.rs: detects `avx512bf16` → `pixelflow_avx512bf16`, ARM `bf16` → `pixelflow_neon_bf16`

**Mirrored to pixelflow-ir:**
- `SimdBf16Ops` trait in backend/mod.rs
- `BF16x32/16/8` in backend/x86.rs
- `BF16x8` in backend/arm.rs
- `ScalarBf16` in backend/scalar.rs

All bf16↔f32 conversion: hardware round-to-nearest-even (when available),
software truncation fallback via bit shifts.

https://claude.ai/code/session_014gf3EuBykm52Rt6KNgPiRT