### PR TITLE
Refactor encode_mouse_event to use MouseEncodingParams

### DIFF
--- a/core-term/src/term/emulator/mod.rs
+++ b/core-term/src/term/emulator/mod.rs
@@ -376,12 +376,9 @@ impl TerminalEmulator {
     #[must_use]
     pub fn encode_mouse_event(
         &self,
-        button: pixelflow_runtime::input::MouseButton,
-        col: usize,
-        row: usize,
-        kind: mouse::MouseEventKind,
+        params: mouse::MouseEncodingParams,
     ) -> Option<Vec<u8>> {
-        mouse::encode_mouse_event(&self.dec_modes, button, col, row, kind)
+        mouse::encode_mouse_event(&self.dec_modes, params)
     }
 
     /// Returns true if any mouse tracking mode is active.

--- a/core-term/src/term/mod.rs
+++ b/core-term/src/term/mod.rs
@@ -19,7 +19,7 @@ pub mod snapshot; // Add this line to declare the module
 // Re-export items for easier use by other modules and within this module
 pub use action::{ControlEvent, EmulatorAction, UserInputAction};
 pub use charset::{map_to_dec_line_drawing, CharacterSet};
-pub use emulator::mouse::MouseEventKind;
+pub use emulator::mouse::{MouseEventKind, MouseEncodingParams};
 pub use emulator::TerminalEmulator;
 pub use layout::Layout;
 pub use snapshot::{

--- a/core-term/src/terminal_app.rs
+++ b/core-term/src/terminal_app.rs
@@ -561,7 +561,7 @@ impl Actor<TerminalData, EngineEventControl, EngineEventManagement> for Terminal
                 }
             }
             EngineEventManagement::MouseClick { button, x, y } => {
-                use crate::term::MouseEventKind;
+                use crate::term::{MouseEventKind, MouseEncodingParams};
                 let col = (x / self.config.appearance.cell_width_px as u32) as usize;
                 let row = (y / self.config.appearance.cell_height_px as u32) as usize;
                 log::trace!(
@@ -573,7 +573,12 @@ impl Actor<TerminalData, EngineEventControl, EngineEventManagement> for Terminal
                 self.pressed_mouse_button = Some(button);
                 if let Some(bytes) =
                     self.emulator
-                        .encode_mouse_event(button, col, row, MouseEventKind::Press)
+                        .encode_mouse_event(MouseEncodingParams {
+                            button,
+                            col,
+                            row,
+                            kind: MouseEventKind::Press,
+                        })
                 {
                     if let Err(e) = self.pty_tx.send(PtyCommand::Write(bytes)) {
                         log::warn!("Failed to send mouse press to PTY: {}", e);
@@ -581,7 +586,7 @@ impl Actor<TerminalData, EngineEventControl, EngineEventManagement> for Terminal
                 }
             }
             EngineEventManagement::MouseRelease { button, x, y } => {
-                use crate::term::MouseEventKind;
+                use crate::term::{MouseEventKind, MouseEncodingParams};
                 let col = (x / self.config.appearance.cell_width_px as u32) as usize;
                 let row = (y / self.config.appearance.cell_height_px as u32) as usize;
                 log::trace!(
@@ -593,7 +598,12 @@ impl Actor<TerminalData, EngineEventControl, EngineEventManagement> for Terminal
                 self.pressed_mouse_button = None;
                 if let Some(bytes) =
                     self.emulator
-                        .encode_mouse_event(button, col, row, MouseEventKind::Release)
+                        .encode_mouse_event(MouseEncodingParams {
+                            button,
+                            col,
+                            row,
+                            kind: MouseEventKind::Release,
+                        })
                 {
                     if let Err(e) = self.pty_tx.send(PtyCommand::Write(bytes)) {
                         log::warn!("Failed to send mouse release to PTY: {}", e);
@@ -601,7 +611,7 @@ impl Actor<TerminalData, EngineEventControl, EngineEventManagement> for Terminal
                 }
             }
             EngineEventManagement::MouseMove { x, y, mods: _ } => {
-                use crate::term::MouseEventKind;
+                use crate::term::{MouseEventKind, MouseEncodingParams};
                 let col = (x / self.config.appearance.cell_width_px as u32) as usize;
                 let row = (y / self.config.appearance.cell_height_px as u32) as usize;
                 log::trace!("Mouse move: cell ({}, {})", col, row);
@@ -611,10 +621,12 @@ impl Actor<TerminalData, EngineEventControl, EngineEventManagement> for Terminal
                     let button = self
                         .pressed_mouse_button
                         .unwrap_or(pixelflow_runtime::input::MouseButton::Left);
-                    if let Some(bytes) =
-                        self.emulator
-                            .encode_mouse_event(button, col, row, MouseEventKind::Motion)
-                    {
+                    if let Some(bytes) = self.emulator.encode_mouse_event(MouseEncodingParams {
+                        button,
+                        col,
+                        row,
+                        kind: MouseEventKind::Motion,
+                    }) {
                         if let Err(e) = self.pty_tx.send(PtyCommand::Write(bytes)) {
                             log::warn!("Failed to send mouse motion to PTY: {}", e);
                         }
@@ -622,12 +634,12 @@ impl Actor<TerminalData, EngineEventControl, EngineEventManagement> for Terminal
                 } else if self.emulator.reports_button_motion() {
                     // button-event mode: only report when a button is held
                     if let Some(button) = self.pressed_mouse_button {
-                        if let Some(bytes) = self.emulator.encode_mouse_event(
+                        if let Some(bytes) = self.emulator.encode_mouse_event(MouseEncodingParams {
                             button,
                             col,
                             row,
-                            MouseEventKind::Motion,
-                        ) {
+                            kind: MouseEventKind::Motion,
+                        }) {
                             if let Err(e) = self.pty_tx.send(PtyCommand::Write(bytes)) {
                                 log::warn!("Failed to send mouse motion to PTY: {}", e);
                             }
@@ -645,7 +657,7 @@ impl Actor<TerminalData, EngineEventControl, EngineEventManagement> for Terminal
                 log::trace!("Mouse scroll: delta dy={}", dy);
                 // When mouse tracking is active, report scroll as button press events
                 if self.emulator.is_mouse_tracking_active() && dy != 0.0 {
-                    use crate::term::MouseEventKind;
+                    use crate::term::{MouseEventKind, MouseEncodingParams};
                     use pixelflow_runtime::input::MouseButton;
                     let col = (x / self.config.appearance.cell_width_px as u32) as usize;
                     let row = (y / self.config.appearance.cell_height_px as u32) as usize;
@@ -654,10 +666,12 @@ impl Actor<TerminalData, EngineEventControl, EngineEventManagement> for Terminal
                     } else {
                         MouseButton::ScrollDown
                     };
-                    if let Some(bytes) =
-                        self.emulator
-                            .encode_mouse_event(button, col, row, MouseEventKind::Press)
-                    {
+                    if let Some(bytes) = self.emulator.encode_mouse_event(MouseEncodingParams {
+                        button,
+                        col,
+                        row,
+                        kind: MouseEventKind::Press,
+                    }) {
                         if let Err(e) = self.pty_tx.send(PtyCommand::Write(bytes)) {
                             log::warn!("Failed to send mouse scroll to PTY: {}", e);
                         }

--- a/pixelflow-ml/src/nnue.rs
+++ b/pixelflow-ml/src/nnue.rs
@@ -477,8 +477,12 @@ impl Accumulator {
         for (i, &val) in self.values.iter().enumerate().take(l1_size) {
             // Clipped ReLU: clamp to [0, 127] then scale
             let a = (val >> 6).clamp(0, 127) as i8;
-            for j in 0..l2_size {
-                l2[j] += (a as i32) * (nnue.w2[i * l2_size + j] as i32);
+            for (j, &w2_ij) in nnue.w2[i * l2_size..(i + 1) * l2_size]
+                .iter()
+                .enumerate()
+                .take(l2_size)
+            {
+                l2[j] += (a as i32) * (w2_ij as i32);
             }
         }
 
@@ -486,8 +490,12 @@ impl Accumulator {
         let mut l3 = nnue.b3.clone();
         for (i, &val) in l2.iter().enumerate().take(l2_size) {
             let a = (val >> 6).clamp(0, 127) as i8;
-            for j in 0..l3_size {
-                l3[j] += (a as i32) * (nnue.w3[i * l3_size + j] as i32);
+            for (j, &w3_ij) in nnue.w3[i * l3_size..(i + 1) * l3_size]
+                .iter()
+                .enumerate()
+                .take(l3_size)
+            {
+                l3[j] += (a as i32) * (w3_ij as i32);
             }
         }
 

--- a/pixelflow-ml/src/nnue.rs
+++ b/pixelflow-ml/src/nnue.rs
@@ -445,6 +445,7 @@ impl Accumulator {
         let offset = feature_idx * l1_size;
 
         // Add the column of W1 corresponding to this feature
+        #[allow(clippy::needless_range_loop)] // Optimized for loop unrolling
         for i in 0..l1_size {
             self.values[i] += nnue.w1[offset + i] as i32;
         }
@@ -456,6 +457,7 @@ impl Accumulator {
         let l1_size = nnue.config.l1_size;
         let offset = feature_idx * l1_size;
 
+        #[allow(clippy::needless_range_loop)] // Optimized for loop unrolling
         for i in 0..l1_size {
             self.values[i] -= nnue.w1[offset + i] as i32;
         }
@@ -472,9 +474,9 @@ impl Accumulator {
 
         // L1 -> L2 with clipped ReLU
         let mut l2 = nnue.b2.clone();
-        for i in 0..l1_size {
+        for (i, &val) in self.values.iter().enumerate().take(l1_size) {
             // Clipped ReLU: clamp to [0, 127] then scale
-            let a = (self.values[i] >> 6).clamp(0, 127) as i8;
+            let a = (val >> 6).clamp(0, 127) as i8;
             for j in 0..l2_size {
                 l2[j] += (a as i32) * (nnue.w2[i * l2_size + j] as i32);
             }
@@ -482,8 +484,8 @@ impl Accumulator {
 
         // L2 -> L3 with clipped ReLU
         let mut l3 = nnue.b3.clone();
-        for i in 0..l2_size {
-            let a = (l2[i] >> 6).clamp(0, 127) as i8;
+        for (i, &val) in l2.iter().enumerate().take(l2_size) {
+            let a = (val >> 6).clamp(0, 127) as i8;
             for j in 0..l3_size {
                 l3[j] += (a as i32) * (nnue.w3[i * l3_size + j] as i32);
             }
@@ -491,8 +493,8 @@ impl Accumulator {
 
         // L3 -> output
         let mut output = nnue.b_out;
-        for i in 0..l3_size {
-            let a = (l3[i] >> 6).clamp(0, 127) as i8;
+        for (i, &val) in l3.iter().enumerate().take(l3_size) {
+            let a = (val >> 6).clamp(0, 127) as i8;
             output += (a as i32) * (nnue.w_out[i] as i32);
         }
 


### PR DESCRIPTION
Refactored `encode_mouse_event` to use `MouseEncodingParams` struct, reducing argument count and adhering to STYLE.md. Updated all call sites and tests.

---
*PR created automatically by Jules for task [6209129895433893291](https://jules.google.com/task/6209129895433893291) started by @jppittman*