### PR TITLE
Refactor mouse event encoding to adhere to argument count style guidelines

### DIFF
--- a/core-term/src/ansi/tests.rs
+++ b/core-term/src/ansi/tests.rs
@@ -1659,74 +1659,50 @@ mod mutation_tests {
     #[test]
     fn csi_cursor_up_no_param_defaults_to_1() {
         let cmds = process_bytes(b"\x1b[A");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::CursorUp(1))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::CursorUp(1))]);
     }
 
     #[test]
     fn csi_cursor_up_param_zero_is_coerced_to_1() {
         // param_or_1 applies max(1), so 0 -> 1
         let cmds = process_bytes(b"\x1b[0A");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::CursorUp(1))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::CursorUp(1))]);
     }
 
     #[test]
     fn csi_cursor_up_explicit_5() {
         let cmds = process_bytes(b"\x1b[5A");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::CursorUp(5))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::CursorUp(5))]);
     }
 
     #[test]
     fn csi_cursor_down_defaults_to_1() {
         let cmds = process_bytes(b"\x1b[B");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::CursorDown(1))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::CursorDown(1))]);
     }
 
     #[test]
     fn csi_cursor_forward_defaults_to_1() {
         let cmds = process_bytes(b"\x1b[C");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::CursorForward(1))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::CursorForward(1))]);
     }
 
     #[test]
     fn csi_cursor_backward_defaults_to_1() {
         let cmds = process_bytes(b"\x1b[D");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::CursorBackward(1))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::CursorBackward(1))]);
     }
 
     #[test]
     fn csi_cursor_next_line_defaults_to_1() {
         let cmds = process_bytes(b"\x1b[E");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::CursorNextLine(1))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::CursorNextLine(1))]);
     }
 
     #[test]
     fn csi_cursor_prev_line_defaults_to_1() {
         let cmds = process_bytes(b"\x1b[F");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::CursorPrevLine(1))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::CursorPrevLine(1))]);
     }
 
     #[test]
@@ -1778,37 +1754,25 @@ mod mutation_tests {
     #[test]
     fn csi_erase_in_display_no_param_defaults_to_0() {
         let cmds = process_bytes(b"\x1b[J");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::EraseInDisplay(0))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::EraseInDisplay(0))]);
     }
 
     #[test]
     fn csi_erase_in_display_explicit_2() {
         let cmds = process_bytes(b"\x1b[2J");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::EraseInDisplay(2))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::EraseInDisplay(2))]);
     }
 
     #[test]
     fn csi_erase_in_line_no_param_defaults_to_0() {
         let cmds = process_bytes(b"\x1b[K");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::EraseInLine(0))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::EraseInLine(0))]);
     }
 
     #[test]
     fn csi_erase_in_line_explicit_1() {
         let cmds = process_bytes(b"\x1b[1K");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::EraseInLine(1))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::EraseInLine(1))]);
     }
 
     // -----------------------------------------------------------------------
@@ -1887,7 +1851,11 @@ mod mutation_tests {
         if let Some(AnsiCommand::Csi(CsiCommand::SetGraphicsRendition(attrs))) = cmds.first() {
             // Checking len kills mutations that reduce MAX_PARAMS below 16.
             assert_eq!(attrs.len(), 16, "all 16 params must be retained");
-            assert_eq!(attrs[0], Attribute::Bold, "first of 16 params should be Bold");
+            assert_eq!(
+                attrs[0],
+                Attribute::Bold,
+                "first of 16 params should be Bold"
+            );
             assert_eq!(
                 attrs[1],
                 Attribute::Faint,
@@ -1903,8 +1871,7 @@ mod mutation_tests {
         // 16 zeros then ;7 (Reverse). The 17th param (7) must be ignored.
         // We send: ESC [ 0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;7m
         //          that's 16 zeros + 1 extra -> the 7 (Reverse) is the 17th and dropped.
-        let cmds =
-            process_bytes(b"\x1b[0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;7m");
+        let cmds = process_bytes(b"\x1b[0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;7m");
         if let Some(AnsiCommand::Csi(CsiCommand::SetGraphicsRendition(attrs))) = cmds.first() {
             // Every kept attribute should be Reset (0); Reverse (7) must NOT appear.
             assert!(
@@ -2080,28 +2047,19 @@ mod mutation_tests {
     #[test]
     fn csi_ctc_0_is_set_tab_stop() {
         let cmds = process_bytes(b"\x1b[0W");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::SetTabStop)]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::SetTabStop)]);
     }
 
     #[test]
     fn csi_ctc_2_clears_current_tab_stop() {
         let cmds = process_bytes(b"\x1b[2W");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::ClearTabStops(0))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::ClearTabStops(0))]);
     }
 
     #[test]
     fn csi_ctc_5_clears_all_tab_stops() {
         let cmds = process_bytes(b"\x1b[5W");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::ClearTabStops(3))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::ClearTabStops(3))]);
     }
 
     // -----------------------------------------------------------------------
@@ -2112,19 +2070,13 @@ mod mutation_tests {
     #[test]
     fn csi_s_uppercase_is_scroll_up() {
         let cmds = process_bytes(b"\x1b[3S");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::ScrollUp(3))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::ScrollUp(3))]);
     }
 
     #[test]
     fn csi_t_uppercase_is_scroll_down() {
         let cmds = process_bytes(b"\x1b[3T");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::ScrollDown(3))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::ScrollDown(3))]);
     }
 
     // -----------------------------------------------------------------------
@@ -2135,28 +2087,19 @@ mod mutation_tests {
     #[test]
     fn csi_at_is_insert_character() {
         let cmds = process_bytes(b"\x1b[2@");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::InsertCharacter(2))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::InsertCharacter(2))]);
     }
 
     #[test]
     fn csi_p_uppercase_is_delete_character() {
         let cmds = process_bytes(b"\x1b[2P");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::DeleteCharacter(2))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::DeleteCharacter(2))]);
     }
 
     #[test]
     fn csi_x_uppercase_is_erase_character() {
         let cmds = process_bytes(b"\x1b[2X");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::EraseCharacter(2))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::EraseCharacter(2))]);
     }
 
     // -----------------------------------------------------------------------
@@ -2166,19 +2109,13 @@ mod mutation_tests {
     #[test]
     fn csi_l_uppercase_is_insert_line() {
         let cmds = process_bytes(b"\x1b[4L");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::InsertLine(4))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::InsertLine(4))]);
     }
 
     #[test]
     fn csi_m_uppercase_is_delete_line() {
         let cmds = process_bytes(b"\x1b[4M");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::DeleteLine(4))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::DeleteLine(4))]);
     }
 
     // -----------------------------------------------------------------------

--- a/core-term/src/term/emulator/mod.rs
+++ b/core-term/src/term/emulator/mod.rs
@@ -39,7 +39,7 @@ mod input_handler;
 mod key_translator;
 mod methods;
 mod mode_handler;
-pub(crate) mod mouse;
+pub mod mouse;
 mod osc_handler;
 mod screen_ops;
 
@@ -374,14 +374,8 @@ impl TerminalEmulator {
     ///
     /// Coordinates `col` and `row` are 0-based cell positions.
     #[must_use]
-    pub fn encode_mouse_event(
-        &self,
-        button: pixelflow_runtime::input::MouseButton,
-        col: usize,
-        row: usize,
-        kind: mouse::MouseEventKind,
-    ) -> Option<Vec<u8>> {
-        mouse::encode_mouse_event(&self.dec_modes, button, col, row, kind)
+    pub fn encode_mouse_event(&self, params: mouse::MouseEncodingParams) -> Option<Vec<u8>> {
+        mouse::encode_mouse_event(&self.dec_modes, params)
     }
 
     /// Returns true if any mouse tracking mode is active.

--- a/core-term/src/term/emulator/mouse.rs
+++ b/core-term/src/term/emulator/mouse.rs
@@ -19,6 +19,13 @@ pub enum MouseEventKind {
     Motion,
 }
 
+pub struct MouseEncodingParams {
+    pub button: MouseButton,
+    pub col: usize,
+    pub row: usize,
+    pub kind: MouseEventKind,
+}
+
 /// Encode a mouse event as terminal escape sequence bytes.
 ///
 /// Returns `None` if no mouse tracking mode is active, or if the current mode
@@ -27,22 +34,19 @@ pub enum MouseEventKind {
 /// Coordinates `col` and `row` are 0-based cell positions.
 pub(crate) fn encode_mouse_event(
     modes: &DecPrivateModes,
-    button: MouseButton,
-    col: usize,
-    row: usize,
-    kind: MouseEventKind,
+    params: MouseEncodingParams,
 ) -> Option<Vec<u8>> {
     // Determine if the current tracking mode reports this event kind
-    if !should_report(modes, kind) {
+    if !should_report(modes, params.kind) {
         return None;
     }
 
     if modes.mouse_sgr_mode {
-        let button_code = sgr_button_code(button, kind);
-        Some(encode_sgr(button_code, col, row, kind))
+        let button_code = sgr_button_code(params.button, params.kind);
+        Some(encode_sgr(button_code, &params))
     } else {
-        let button_code = legacy_button_code(button, kind);
-        encode_legacy(button_code, col, row)
+        let button_code = legacy_button_code(params.button, params.kind);
+        encode_legacy(button_code, params.col, params.row)
     }
 }
 
@@ -57,9 +61,7 @@ fn should_report(modes: &DecPrivateModes, kind: MouseEventKind) -> bool {
         }
         MouseEventKind::Release => {
             // X10 mode does not report releases
-            modes.mouse_vt200_mode
-                || modes.mouse_button_event_mode
-                || modes.mouse_any_event_mode
+            modes.mouse_vt200_mode || modes.mouse_button_event_mode || modes.mouse_any_event_mode
         }
         MouseEventKind::Motion => {
             // Button-event mode reports motion only while a button is held,
@@ -82,7 +84,11 @@ fn button_base_code(button: MouseButton) -> u8 {
         MouseButton::ScrollDown => 65,
         MouseButton::Other(n) => {
             // Buttons 4+ map to codes 128+
-            if n >= 4 { 128 + n - 4 } else { n }
+            if n >= 4 {
+                128 + n - 4
+            } else {
+                n
+            }
         }
     }
 }
@@ -117,11 +123,15 @@ fn legacy_button_code(button: MouseButton, kind: MouseEventKind) -> u8 {
 ///
 /// Format: `ESC [ < Cb ; Cx ; Cy M` for press/motion, `ESC [ < Cb ; Cx ; Cy m` for release.
 /// Coordinates are 1-based.
-fn encode_sgr(button_code: u8, col: usize, row: usize, kind: MouseEventKind) -> Vec<u8> {
-    let suffix = if kind == MouseEventKind::Release { b'm' } else { b'M' };
+fn encode_sgr(button_code: u8, params: &MouseEncodingParams) -> Vec<u8> {
+    let suffix = if params.kind == MouseEventKind::Release {
+        b'm'
+    } else {
+        b'M'
+    };
     // SGR uses 1-based coordinates
-    let cx = col + 1;
-    let cy = row + 1;
+    let cx = params.col + 1;
+    let cy = params.row + 1;
     // Max realistic: "\x1b[<999;99999;99999M" = ~22 bytes
     let mut buf = Vec::with_capacity(24);
     let _ = write!(buf, "\x1b[<{};{};{}", button_code, cx, cy);
@@ -185,15 +195,31 @@ mod tests {
     #[test]
     fn no_mode_returns_none() {
         let modes = DecPrivateModes::default();
-        let result = encode_mouse_event(&modes, MouseButton::Left, 5, 10, MouseEventKind::Press);
+        let result = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Left,
+                col: 5,
+                row: 10,
+                kind: MouseEventKind::Press,
+            },
+        );
         assert_eq!(result, None);
     }
 
     #[test]
     fn sgr_left_press() {
         let modes = modes_with_sgr();
-        let result =
-            encode_mouse_event(&modes, MouseButton::Left, 5, 10, MouseEventKind::Press).unwrap();
+        let result = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Left,
+                col: 5,
+                row: 10,
+                kind: MouseEventKind::Press,
+            },
+        )
+        .unwrap();
         // SGR: ESC[<0;6;11M (1-based coords)
         assert_eq!(result, b"\x1b[<0;6;11M");
     }
@@ -201,8 +227,16 @@ mod tests {
     #[test]
     fn sgr_left_release() {
         let modes = modes_with_sgr();
-        let result =
-            encode_mouse_event(&modes, MouseButton::Left, 5, 10, MouseEventKind::Release).unwrap();
+        let result = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Left,
+                col: 5,
+                row: 10,
+                kind: MouseEventKind::Release,
+            },
+        )
+        .unwrap();
         // SGR release uses lowercase 'm', button code preserved
         assert_eq!(result, b"\x1b[<0;6;11m");
     }
@@ -210,16 +244,32 @@ mod tests {
     #[test]
     fn sgr_right_press() {
         let modes = modes_with_sgr();
-        let result =
-            encode_mouse_event(&modes, MouseButton::Right, 0, 0, MouseEventKind::Press).unwrap();
+        let result = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Right,
+                col: 0,
+                row: 0,
+                kind: MouseEventKind::Press,
+            },
+        )
+        .unwrap();
         assert_eq!(result, b"\x1b[<2;1;1M");
     }
 
     #[test]
     fn sgr_right_release() {
         let modes = modes_with_sgr();
-        let result =
-            encode_mouse_event(&modes, MouseButton::Right, 3, 7, MouseEventKind::Release).unwrap();
+        let result = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Right,
+                col: 3,
+                row: 7,
+                kind: MouseEventKind::Release,
+            },
+        )
+        .unwrap();
         // SGR preserves button identity on release
         assert_eq!(result, b"\x1b[<2;4;8m");
     }
@@ -227,17 +277,32 @@ mod tests {
     #[test]
     fn sgr_middle_press() {
         let modes = modes_with_sgr();
-        let result =
-            encode_mouse_event(&modes, MouseButton::Middle, 79, 23, MouseEventKind::Press)
-                .unwrap();
+        let result = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Middle,
+                col: 79,
+                row: 23,
+                kind: MouseEventKind::Press,
+            },
+        )
+        .unwrap();
         assert_eq!(result, b"\x1b[<1;80;24M");
     }
 
     #[test]
     fn sgr_motion_left() {
         let modes = modes_with_any_event_sgr();
-        let result =
-            encode_mouse_event(&modes, MouseButton::Left, 10, 5, MouseEventKind::Motion).unwrap();
+        let result = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Left,
+                col: 10,
+                row: 5,
+                kind: MouseEventKind::Motion,
+            },
+        )
+        .unwrap();
         // Motion adds 32 to button code: 0 + 32 = 32
         assert_eq!(result, b"\x1b[<32;11;6M");
     }
@@ -245,8 +310,16 @@ mod tests {
     #[test]
     fn sgr_motion_right() {
         let modes = modes_with_button_event_sgr();
-        let result =
-            encode_mouse_event(&modes, MouseButton::Right, 10, 5, MouseEventKind::Motion).unwrap();
+        let result = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Right,
+                col: 10,
+                row: 5,
+                kind: MouseEventKind::Motion,
+            },
+        )
+        .unwrap();
         // Motion adds 32 to button code: 2 + 32 = 34
         assert_eq!(result, b"\x1b[<34;11;6M");
     }
@@ -254,26 +327,48 @@ mod tests {
     #[test]
     fn sgr_scroll_up() {
         let modes = modes_with_sgr();
-        let result =
-            encode_mouse_event(&modes, MouseButton::ScrollUp, 10, 5, MouseEventKind::Press)
-                .unwrap();
+        let result = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::ScrollUp,
+                col: 10,
+                row: 5,
+                kind: MouseEventKind::Press,
+            },
+        )
+        .unwrap();
         assert_eq!(result, b"\x1b[<64;11;6M");
     }
 
     #[test]
     fn sgr_scroll_down() {
         let modes = modes_with_sgr();
-        let result =
-            encode_mouse_event(&modes, MouseButton::ScrollDown, 10, 5, MouseEventKind::Press)
-                .unwrap();
+        let result = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::ScrollDown,
+                col: 10,
+                row: 5,
+                kind: MouseEventKind::Press,
+            },
+        )
+        .unwrap();
         assert_eq!(result, b"\x1b[<65;11;6M");
     }
 
     #[test]
     fn legacy_left_press() {
         let modes = modes_with_vt200();
-        let result =
-            encode_mouse_event(&modes, MouseButton::Left, 5, 10, MouseEventKind::Press).unwrap();
+        let result = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Left,
+                col: 5,
+                row: 10,
+                kind: MouseEventKind::Press,
+            },
+        )
+        .unwrap();
         // Legacy: ESC[M + (0+32) + (5+33) + (10+33)
         assert_eq!(result, vec![0x1b, b'[', b'M', 32, 38, 43]);
     }
@@ -281,8 +376,16 @@ mod tests {
     #[test]
     fn legacy_left_release_uses_code_3() {
         let modes = modes_with_vt200();
-        let result =
-            encode_mouse_event(&modes, MouseButton::Left, 5, 10, MouseEventKind::Release).unwrap();
+        let result = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Left,
+                col: 5,
+                row: 10,
+                kind: MouseEventKind::Release,
+            },
+        )
+        .unwrap();
         // Legacy release: button code = 3, so Cb = 3 + 32 = 35
         assert_eq!(result, vec![0x1b, b'[', b'M', 35, 38, 43]);
     }
@@ -290,9 +393,16 @@ mod tests {
     #[test]
     fn legacy_right_release_uses_code_3() {
         let modes = modes_with_vt200();
-        let result =
-            encode_mouse_event(&modes, MouseButton::Right, 5, 10, MouseEventKind::Release)
-                .unwrap();
+        let result = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Right,
+                col: 5,
+                row: 10,
+                kind: MouseEventKind::Release,
+            },
+        )
+        .unwrap();
         // Legacy release always uses code 3 regardless of which button was released
         assert_eq!(result, vec![0x1b, b'[', b'M', 35, 38, 43]);
     }
@@ -300,32 +410,85 @@ mod tests {
     #[test]
     fn legacy_coords_overflow_returns_none() {
         let modes = modes_with_vt200();
-        let result =
-            encode_mouse_event(&modes, MouseButton::Left, 300, 10, MouseEventKind::Press);
+        let result = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Left,
+                col: 300,
+                row: 10,
+                kind: MouseEventKind::Press,
+            },
+        );
         assert_eq!(result, None);
     }
 
     #[test]
     fn x10_reports_press_only() {
         let modes = modes_with_x10();
-        let press = encode_mouse_event(&modes, MouseButton::Left, 0, 0, MouseEventKind::Press);
+        let press = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Left,
+                col: 0,
+                row: 0,
+                kind: MouseEventKind::Press,
+            },
+        );
         assert!(press.is_some());
-        let release =
-            encode_mouse_event(&modes, MouseButton::Left, 0, 0, MouseEventKind::Release);
+        let release = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Left,
+                col: 0,
+                row: 0,
+                kind: MouseEventKind::Release,
+            },
+        );
         assert_eq!(release, None);
-        let motion = encode_mouse_event(&modes, MouseButton::Left, 0, 0, MouseEventKind::Motion);
+        let motion = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Left,
+                col: 0,
+                row: 0,
+                kind: MouseEventKind::Motion,
+            },
+        );
         assert_eq!(motion, None);
     }
 
     #[test]
     fn vt200_reports_press_and_release() {
         let modes = modes_with_vt200();
-        let press = encode_mouse_event(&modes, MouseButton::Left, 0, 0, MouseEventKind::Press);
+        let press = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Left,
+                col: 0,
+                row: 0,
+                kind: MouseEventKind::Press,
+            },
+        );
         assert!(press.is_some());
-        let release =
-            encode_mouse_event(&modes, MouseButton::Left, 0, 0, MouseEventKind::Release);
+        let release = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Left,
+                col: 0,
+                row: 0,
+                kind: MouseEventKind::Release,
+            },
+        );
         assert!(release.is_some());
-        let motion = encode_mouse_event(&modes, MouseButton::Left, 0, 0, MouseEventKind::Motion);
+        let motion = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Left,
+                col: 0,
+                row: 0,
+                kind: MouseEventKind::Motion,
+            },
+        );
         assert_eq!(motion, None);
     }
 
@@ -333,9 +496,16 @@ mod tests {
     fn sgr_large_coordinates() {
         let modes = modes_with_sgr();
         // SGR has no coordinate limit
-        let result =
-            encode_mouse_event(&modes, MouseButton::Left, 500, 300, MouseEventKind::Press)
-                .unwrap();
+        let result = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Left,
+                col: 500,
+                row: 300,
+                kind: MouseEventKind::Press,
+            },
+        )
+        .unwrap();
         assert_eq!(result, b"\x1b[<0;501;301M");
     }
 }

--- a/core-term/src/term/mod.rs
+++ b/core-term/src/term/mod.rs
@@ -19,6 +19,7 @@ pub mod snapshot; // Add this line to declare the module
 // Re-export items for easier use by other modules and within this module
 pub use action::{ControlEvent, EmulatorAction, UserInputAction};
 pub use charset::{map_to_dec_line_drawing, CharacterSet};
+pub use emulator::mouse::MouseEncodingParams;
 pub use emulator::mouse::MouseEventKind;
 pub use emulator::TerminalEmulator;
 pub use layout::Layout;

--- a/core-term/src/terminal_app.rs
+++ b/core-term/src/terminal_app.rs
@@ -5,6 +5,7 @@ use crate::glyph::Glyph;
 use crate::io::traits::PtySender;
 use crate::io::PtyCommand;
 use crate::messages::TerminalData;
+use crate::term::MouseEncodingParams;
 use crate::term::TerminalEmulator;
 use actor_scheduler::{
     Actor, ActorBuilder, ActorHandle, ActorStatus, HandlerError, HandlerResult, Message,
@@ -571,10 +572,12 @@ impl Actor<TerminalData, EngineEventControl, EngineEventManagement> for Terminal
                     row
                 );
                 self.pressed_mouse_button = Some(button);
-                if let Some(bytes) =
-                    self.emulator
-                        .encode_mouse_event(button, col, row, MouseEventKind::Press)
-                {
+                if let Some(bytes) = self.emulator.encode_mouse_event(MouseEncodingParams {
+                    button: button,
+                    col: col,
+                    row: row,
+                    kind: MouseEventKind::Press,
+                }) {
                     if let Err(e) = self.pty_tx.send(PtyCommand::Write(bytes)) {
                         log::warn!("Failed to send mouse press to PTY: {}", e);
                     }
@@ -591,10 +594,12 @@ impl Actor<TerminalData, EngineEventControl, EngineEventManagement> for Terminal
                     row
                 );
                 self.pressed_mouse_button = None;
-                if let Some(bytes) =
-                    self.emulator
-                        .encode_mouse_event(button, col, row, MouseEventKind::Release)
-                {
+                if let Some(bytes) = self.emulator.encode_mouse_event(MouseEncodingParams {
+                    button: button,
+                    col: col,
+                    row: row,
+                    kind: MouseEventKind::Release,
+                }) {
                     if let Err(e) = self.pty_tx.send(PtyCommand::Write(bytes)) {
                         log::warn!("Failed to send mouse release to PTY: {}", e);
                     }
@@ -611,10 +616,12 @@ impl Actor<TerminalData, EngineEventControl, EngineEventManagement> for Terminal
                     let button = self
                         .pressed_mouse_button
                         .unwrap_or(pixelflow_runtime::input::MouseButton::Left);
-                    if let Some(bytes) =
-                        self.emulator
-                            .encode_mouse_event(button, col, row, MouseEventKind::Motion)
-                    {
+                    if let Some(bytes) = self.emulator.encode_mouse_event(MouseEncodingParams {
+                        button: button,
+                        col: col,
+                        row: row,
+                        kind: MouseEventKind::Motion,
+                    }) {
                         if let Err(e) = self.pty_tx.send(PtyCommand::Write(bytes)) {
                             log::warn!("Failed to send mouse motion to PTY: {}", e);
                         }
@@ -622,12 +629,12 @@ impl Actor<TerminalData, EngineEventControl, EngineEventManagement> for Terminal
                 } else if self.emulator.reports_button_motion() {
                     // button-event mode: only report when a button is held
                     if let Some(button) = self.pressed_mouse_button {
-                        if let Some(bytes) = self.emulator.encode_mouse_event(
-                            button,
-                            col,
-                            row,
-                            MouseEventKind::Motion,
-                        ) {
+                        if let Some(bytes) = self.emulator.encode_mouse_event(MouseEncodingParams {
+                            button: button,
+                            col: col,
+                            row: row,
+                            kind: MouseEventKind::Motion,
+                        }) {
                             if let Err(e) = self.pty_tx.send(PtyCommand::Write(bytes)) {
                                 log::warn!("Failed to send mouse motion to PTY: {}", e);
                             }
@@ -654,10 +661,12 @@ impl Actor<TerminalData, EngineEventControl, EngineEventManagement> for Terminal
                     } else {
                         MouseButton::ScrollDown
                     };
-                    if let Some(bytes) =
-                        self.emulator
-                            .encode_mouse_event(button, col, row, MouseEventKind::Press)
-                    {
+                    if let Some(bytes) = self.emulator.encode_mouse_event(MouseEncodingParams {
+                        button: button,
+                        col: col,
+                        row: row,
+                        kind: MouseEventKind::Press,
+                    }) {
                         if let Err(e) = self.pty_tx.send(PtyCommand::Write(bytes)) {
                             log::warn!("Failed to send mouse scroll to PTY: {}", e);
                         }


### PR DESCRIPTION
This addresses a style violation described in `docs/STYLE.md` where `encode_mouse_event` and `encode_sgr` functions took more than the recommended number of arguments. Introduced a `MouseEncodingParams` struct to properly encapsulate mouse event parameters and maintain code clarity. Call sites and unit tests were updated to utilize the new struct. Temporary scripting artifacts used during the refactoring process were removed prior to submission.

---
*PR created automatically by Jules for task [5949852251106215256](https://jules.google.com/task/5949852251106215256) started by @jppittman*