### PR TITLE
refactor: apply MouseEncodingParams to encode_mouse_event

### DIFF
--- a/core-term/src/term/emulator/mod.rs
+++ b/core-term/src/term/emulator/mod.rs
@@ -376,12 +376,9 @@ impl TerminalEmulator {
     #[must_use]
     pub fn encode_mouse_event(
         &self,
-        button: pixelflow_runtime::input::MouseButton,
-        col: usize,
-        row: usize,
-        kind: mouse::MouseEventKind,
+        params: mouse::MouseEncodingParams,
     ) -> Option<Vec<u8>> {
-        mouse::encode_mouse_event(&self.dec_modes, button, col, row, kind)
+        mouse::encode_mouse_event(&self.dec_modes, params)
     }
 
     /// Returns true if any mouse tracking mode is active.

--- a/core-term/src/term/mod.rs
+++ b/core-term/src/term/mod.rs
@@ -19,7 +19,7 @@ pub mod snapshot; // Add this line to declare the module
 // Re-export items for easier use by other modules and within this module
 pub use action::{ControlEvent, EmulatorAction, UserInputAction};
 pub use charset::{map_to_dec_line_drawing, CharacterSet};
-pub use emulator::mouse::MouseEventKind;
+pub use emulator::mouse::{MouseEventKind, MouseEncodingParams};
 pub use emulator::TerminalEmulator;
 pub use layout::Layout;
 pub use snapshot::{

--- a/core-term/src/terminal_app.rs
+++ b/core-term/src/terminal_app.rs
@@ -561,7 +561,7 @@ impl Actor<TerminalData, EngineEventControl, EngineEventManagement> for Terminal
                 }
             }
             EngineEventManagement::MouseClick { button, x, y } => {
-                use crate::term::MouseEventKind;
+
                 let col = (x / self.config.appearance.cell_width_px as u32) as usize;
                 let row = (y / self.config.appearance.cell_height_px as u32) as usize;
                 log::trace!(
@@ -573,7 +573,7 @@ impl Actor<TerminalData, EngineEventControl, EngineEventManagement> for Terminal
                 self.pressed_mouse_button = Some(button);
                 if let Some(bytes) =
                     self.emulator
-                        .encode_mouse_event(button, col, row, MouseEventKind::Press)
+                        .encode_mouse_event(crate::term::MouseEncodingParams { button, col, row, kind: crate::term::MouseEventKind::Press })
                 {
                     if let Err(e) = self.pty_tx.send(PtyCommand::Write(bytes)) {
                         log::warn!("Failed to send mouse press to PTY: {}", e);
@@ -581,7 +581,7 @@ impl Actor<TerminalData, EngineEventControl, EngineEventManagement> for Terminal
                 }
             }
             EngineEventManagement::MouseRelease { button, x, y } => {
-                use crate::term::MouseEventKind;
+
                 let col = (x / self.config.appearance.cell_width_px as u32) as usize;
                 let row = (y / self.config.appearance.cell_height_px as u32) as usize;
                 log::trace!(
@@ -593,7 +593,7 @@ impl Actor<TerminalData, EngineEventControl, EngineEventManagement> for Terminal
                 self.pressed_mouse_button = None;
                 if let Some(bytes) =
                     self.emulator
-                        .encode_mouse_event(button, col, row, MouseEventKind::Release)
+                        .encode_mouse_event(crate::term::MouseEncodingParams { button, col, row, kind: crate::term::MouseEventKind::Release })
                 {
                     if let Err(e) = self.pty_tx.send(PtyCommand::Write(bytes)) {
                         log::warn!("Failed to send mouse release to PTY: {}", e);
@@ -601,7 +601,7 @@ impl Actor<TerminalData, EngineEventControl, EngineEventManagement> for Terminal
                 }
             }
             EngineEventManagement::MouseMove { x, y, mods: _ } => {
-                use crate::term::MouseEventKind;
+
                 let col = (x / self.config.appearance.cell_width_px as u32) as usize;
                 let row = (y / self.config.appearance.cell_height_px as u32) as usize;
                 log::trace!("Mouse move: cell ({}, {})", col, row);
@@ -613,7 +613,7 @@ impl Actor<TerminalData, EngineEventControl, EngineEventManagement> for Terminal
                         .unwrap_or(pixelflow_runtime::input::MouseButton::Left);
                     if let Some(bytes) =
                         self.emulator
-                            .encode_mouse_event(button, col, row, MouseEventKind::Motion)
+                            .encode_mouse_event(crate::term::MouseEncodingParams { button, col, row, kind: crate::term::MouseEventKind::Motion })
                     {
                         if let Err(e) = self.pty_tx.send(PtyCommand::Write(bytes)) {
                             log::warn!("Failed to send mouse motion to PTY: {}", e);
@@ -623,10 +623,7 @@ impl Actor<TerminalData, EngineEventControl, EngineEventManagement> for Terminal
                     // button-event mode: only report when a button is held
                     if let Some(button) = self.pressed_mouse_button {
                         if let Some(bytes) = self.emulator.encode_mouse_event(
-                            button,
-                            col,
-                            row,
-                            MouseEventKind::Motion,
+                            crate::term::MouseEncodingParams { button, col, row, kind: crate::term::MouseEventKind::Motion }
                         ) {
                             if let Err(e) = self.pty_tx.send(PtyCommand::Write(bytes)) {
                                 log::warn!("Failed to send mouse motion to PTY: {}", e);
@@ -645,7 +642,7 @@ impl Actor<TerminalData, EngineEventControl, EngineEventManagement> for Terminal
                 log::trace!("Mouse scroll: delta dy={}", dy);
                 // When mouse tracking is active, report scroll as button press events
                 if self.emulator.is_mouse_tracking_active() && dy != 0.0 {
-                    use crate::term::MouseEventKind;
+
                     use pixelflow_runtime::input::MouseButton;
                     let col = (x / self.config.appearance.cell_width_px as u32) as usize;
                     let row = (y / self.config.appearance.cell_height_px as u32) as usize;
@@ -656,7 +653,7 @@ impl Actor<TerminalData, EngineEventControl, EngineEventManagement> for Terminal
                     };
                     if let Some(bytes) =
                         self.emulator
-                            .encode_mouse_event(button, col, row, MouseEventKind::Press)
+                            .encode_mouse_event(crate::term::MouseEncodingParams { button, col, row, kind: crate::term::MouseEventKind::Press })
                     {
                         if let Err(e) = self.pty_tx.send(PtyCommand::Write(bytes)) {
                             log::warn!("Failed to send mouse scroll to PTY: {}", e);


### PR DESCRIPTION
Refactored `encode_mouse_event` to use a `MouseEncodingParams` struct, adhering to internal code styling rules that limit functions to fewer than 4 arguments. Also patched a minor clippy warning related to discarding the result of a `write!` macro.

---
*PR created automatically by Jules for task [14771055803208074901](https://jules.google.com/task/14771055803208074901) started by @jppittman*