### PR TITLE
Refactor: Enforce test style guidelines in ansi_to_grid_integration.rs

### DIFF
--- a/core-term/tests/ansi_to_grid_integration.rs
+++ b/core-term/tests/ansi_to_grid_integration.rs
@@ -9,7 +9,7 @@ use core_term::ansi::commands::{AnsiCommand, C0Control, CsiCommand};
 use support::minimal_test_harness::MinimalTestHarness;
 
 #[test]
-fn test_single_character_print() {
+fn print_should_update_grid_when_single_character() {
     let mut harness = MinimalTestHarness::new();
 
     // TEST: Print a single character
@@ -34,7 +34,7 @@ fn test_single_character_print() {
 }
 
 #[test]
-fn test_multiple_characters() {
+fn print_should_update_grid_when_multiple_characters() {
     let mut harness = MinimalTestHarness::new();
 
     // TEST: Print multiple characters
@@ -47,7 +47,7 @@ fn test_multiple_characters() {
     ]);
 
     // VERIFY: Grid has "Hello"
-    let snapshot = harness.get_snapshot().unwrap();
+    let snapshot = harness.get_snapshot().expect("should get snapshot");
 
     let text: String = snapshot.lines[0]
         .cells
@@ -60,7 +60,7 @@ fn test_multiple_characters() {
 }
 
 #[test]
-fn test_newline_advances_row() {
+fn print_should_advance_row_when_newline() {
     let mut harness = MinimalTestHarness::new();
 
     // TEST: Print, newline, print again
@@ -71,14 +71,14 @@ fn test_newline_advances_row() {
     ]);
 
     // VERIFY: 'A' on row 0, 'B' on row 1
-    let snapshot = harness.get_snapshot().unwrap();
+    let snapshot = harness.get_snapshot().expect("should get snapshot");
 
     assert_eq!(snapshot.lines[0].cells[0].display_char(), 'A');
     assert_eq!(snapshot.lines[1].cells[0].display_char(), 'B');
 }
 
 #[test]
-fn test_cursor_position_command() {
+fn cursor_position_should_move_cursor_when_command_received() {
     let mut harness = MinimalTestHarness::new();
 
     // TEST: Move cursor to (5, 10), then print
@@ -88,14 +88,14 @@ fn test_cursor_position_command() {
     ]);
 
     // VERIFY: 'X' at position (9, 4) [0-indexed]
-    let snapshot = harness.get_snapshot().unwrap();
+    let snapshot = harness.get_snapshot().expect("should get snapshot");
 
     // CursorPosition is 1-indexed, grid is 0-indexed
     assert_eq!(snapshot.lines[4].cells[9].display_char(), 'X');
 }
 
 #[test]
-fn test_multiline_text() {
+fn print_should_update_grid_when_multiline_text() {
     let mut harness = MinimalTestHarness::new();
 
     // TEST: Print text with newlines
@@ -110,7 +110,7 @@ fn test_multiline_text() {
     }
 
     // VERIFY: Three lines of text
-    let snapshot = harness.get_snapshot().unwrap();
+    let snapshot = harness.get_snapshot().expect("should get snapshot");
 
     let line1: String = snapshot.lines[0]
         .cells
@@ -143,7 +143,7 @@ fn test_multiline_text() {
 // =============================================================================
 
 #[test]
-fn test_grid_checksum_changes_on_input() {
+fn inject_ansi_should_change_checksum_when_input_received() {
     let mut harness = MinimalTestHarness::new();
 
     // Get initial checksum (empty grid)
@@ -174,7 +174,7 @@ fn test_grid_checksum_changes_on_input() {
 }
 
 #[test]
-fn test_grid_checksum_stable_without_changes() {
+fn get_snapshot_should_return_stable_checksum_when_no_changes() {
     let mut harness = MinimalTestHarness::new();
 
     // Print a character
@@ -192,7 +192,7 @@ fn test_grid_checksum_stable_without_changes() {
 }
 
 #[test]
-fn test_multiple_characters_change_checksum() {
+fn print_should_update_grid_when_multiple_characters_change_checksum() {
     let mut harness = MinimalTestHarness::new();
 
     let mut checksums = Vec::new();
@@ -220,7 +220,7 @@ fn test_multiple_characters_change_checksum() {
 // =============================================================================
 
 #[test]
-fn test_bug_grid_changes_without_render_trigger() {
+fn interpret_input_should_change_grid_when_ansi_command_received() {
     // This test documents the ACTUAL BUG:
     // Grid state changes when ANSI commands are processed,
     // but send_frame() is never called, so the display doesn't update.


### PR DESCRIPTION
Updates `core-term/tests/ansi_to_grid_integration.rs` to adhere strictly to the "Mutant Hunter" user directives and `STYLE.md`.

* Renames tests to use the required `[method]_should_[outcome]_when_[condition]` behavior-driven convention.
* Replaces unidiomatic `.unwrap()` calls with `.expect("...")` to provide explicit context on panics and satisfy the "expect over unwrap" directive.
* Ensures no trivial whitespace/indentation changes are made in non-test source files.

---
*PR created automatically by Jules for task [1568380959640869414](https://jules.google.com/task/1568380959640869414) started by @jppittman*