### PR TITLE
Refactor functions to eliminate boolean arguments

### DIFF
--- a/actor-scheduler/src/lib.rs
+++ b/actor-scheduler/src/lib.rs
@@ -1247,7 +1247,7 @@ mod tests {
             mgmt_count: usize,
         }
 
-        impl SchedulerHandler<i32, String, bool> for CountingHandler {
+        impl SchedulerHandler<i32, String, ()> for CountingHandler {
             fn handle_data(&mut self, _: i32) -> HandlerResult {
                 self.data_count += 1;
                 Ok(())
@@ -1256,7 +1256,7 @@ mod tests {
                 self.ctrl_count += 1;
                 Ok(())
             }
-            fn handle_management(&mut self, _: bool) -> HandlerResult {
+            fn handle_management(&mut self, _: ()) -> HandlerResult {
                 self.mgmt_count += 1;
                 Ok(())
             }
@@ -1280,7 +1280,7 @@ mod tests {
         tx.send(Message::Data(1)).unwrap();
         tx.send(Message::Data(2)).unwrap();
         tx.send(Message::Control("test".to_string())).unwrap();
-        tx.send(Message::Management(true)).unwrap();
+        tx.send(Message::Management(())).unwrap();
 
         thread::sleep(Duration::from_millis(50));
         drop(tx);

--- a/core-term/src/ansi/commands.rs
+++ b/core-term/src/ansi/commands.rs
@@ -1,3 +1,9 @@
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum CsiType {
+    Private,
+    Standard,
+}
 // src/ansi/commands.rs
 
 //! Defines the `AnsiCommand` enum representing parsed ANSI escape sequences
@@ -600,9 +606,10 @@ impl AnsiCommand {
     pub(crate) fn from_csi(
         params: Vec<u16>,
         intermediates: Vec<u8>,
-        is_private: bool,
+        csi_type: CsiType,
         final_byte: u8,
     ) -> Option<Self> {
+        let is_private = csi_type == CsiType::Private;
         let param_or = |idx: usize, default: u16| params.get(idx).copied().unwrap_or(default);
         let param_or_1 = |idx: usize| param_or(idx, 1).max(1);
 

--- a/core-term/src/ansi/parser.rs
+++ b/core-term/src/ansi/parser.rs
@@ -1,3 +1,9 @@
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ConsumeSt {
+    Yes,
+    No,
+}
 // src/ansi/parser.rs
 
 //! ANSI escape sequence parser.
@@ -158,7 +164,7 @@ impl AnsiParser {
         if let Some(command) = AnsiCommand::from_csi(
             params_vec,
             intermediates_vec,
-            is_private_csi_flag,
+            if is_private_csi_flag { super::commands::CsiType::Private } else { super::commands::CsiType::Standard },
             final_byte,
         ) {
             // Check if the command is the specific Unsupported variant we want to remap
@@ -189,39 +195,39 @@ impl AnsiParser {
         self.state = State::Ground;
     }
 
-    fn dispatch_osc(&mut self, consume_st: bool) {
+    fn dispatch_osc(&mut self, consume_st: ConsumeSt) {
         let data = mem::take(&mut self.string_buffer);
         trace!("Dispatching OSC: Data length {}", data.len());
         self.commands.push(AnsiCommand::Osc(data));
         self.clear_string_buffer();
-        if !consume_st { /* ST handled separately */ }
+        if consume_st == ConsumeSt::No { /* ST handled separately */ }
         self.state = State::Ground;
     }
 
-    fn dispatch_dcs(&mut self, consume_st: bool) {
+    fn dispatch_dcs(&mut self, consume_st: ConsumeSt) {
         let data = mem::take(&mut self.string_buffer);
         trace!("Dispatching DCS: Data length {}", data.len());
         self.commands.push(AnsiCommand::Dcs(data));
         self.clear_string_buffer();
-        if !consume_st { /* ST handled separately */ }
+        if consume_st == ConsumeSt::No { /* ST handled separately */ }
         self.state = State::Ground;
     }
 
-    fn dispatch_pm(&mut self, consume_st: bool) {
+    fn dispatch_pm(&mut self, consume_st: ConsumeSt) {
         let data = mem::take(&mut self.string_buffer);
         trace!("Dispatching PM: Data length {}", data.len());
         self.commands.push(AnsiCommand::Pm(data));
         self.clear_string_buffer();
-        if !consume_st { /* ST handled separately */ }
+        if consume_st == ConsumeSt::No { /* ST handled separately */ }
         self.state = State::Ground;
     }
 
-    fn dispatch_apc(&mut self, consume_st: bool) {
+    fn dispatch_apc(&mut self, consume_st: ConsumeSt) {
         let data = mem::take(&mut self.string_buffer);
         trace!("Dispatching APC: Data length {}", data.len());
         self.commands.push(AnsiCommand::Apc(data));
         self.clear_string_buffer();
-        if !consume_st { /* ST handled separately */ }
+        if consume_st == ConsumeSt::No { /* ST handled separately */ }
         self.state = State::Ground;
     }
 
@@ -427,7 +433,7 @@ impl AnsiParser {
                     AnsiToken::C0Control(b)
                         if b == C0Control::BEL as u8 && self.state == State::OscString =>
                     {
-                        self.dispatch_osc(false)
+                        self.dispatch_osc(ConsumeSt::No)
                     }
                     AnsiToken::C0Control(b)
                         if b == C0Control::CAN as u8 || b == C0Control::SUB as u8 =>
@@ -447,10 +453,10 @@ impl AnsiParser {
             }
             State::EscInString => match token {
                 AnsiToken::Print('\\') => match self.string_state_origin {
-                    Some(State::OscString) => self.dispatch_osc(true),
-                    Some(State::DcsEntry) => self.dispatch_dcs(true),
-                    Some(State::PmString) => self.dispatch_pm(true),
-                    Some(State::ApcString) => self.dispatch_apc(true),
+                    Some(State::OscString) => self.dispatch_osc(ConsumeSt::Yes),
+                    Some(State::DcsEntry) => self.dispatch_dcs(ConsumeSt::Yes),
+                    Some(State::PmString) => self.dispatch_pm(ConsumeSt::Yes),
+                    Some(State::ApcString) => self.dispatch_apc(ConsumeSt::Yes),
                     _ => {
                         error!("EscInString state missing origin!");
                         self.dispatch_st_standalone();

--- a/pixelflow-compiler/src/codegen/leveled.rs
+++ b/pixelflow-compiler/src/codegen/leveled.rs
@@ -1,9 +1,4 @@
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub enum JetWrapperMode {
-    UseWrapper,
-    NoWrapper,
-}
 //! # Leveled (BFS) Code Generation
 //!
 //! Emits code by evaluating expression trees level-by-level (breadth-first).
@@ -50,6 +45,12 @@ use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
 use crate::annotate::AnnotatedExpr;
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum JetWrapperMode {
+    UseWrapper,
+    NoWrapper,
+}
 use crate::ast::{BinaryOp, UnaryOp, ParamKind};
 use crate::sema::AnalyzedKernel;
 use crate::symbol::SymbolKind;

--- a/pixelflow-compiler/src/codegen/leveled.rs
+++ b/pixelflow-compiler/src/codegen/leveled.rs
@@ -1,3 +1,9 @@
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum JetWrapperMode {
+    UseWrapper,
+    NoWrapper,
+}
 //! # Leveled (BFS) Code Generation
 //!
 //! Emits code by evaluating expression trees level-by-level (breadth-first).
@@ -453,7 +459,7 @@ pub fn analyze_deps(
 pub fn emit_leveled(
     analyzed: &AnalyzedKernel,
     annotated: &AnnotatedExpr,
-    use_jet_wrapper: bool,
+    wrapper_mode: JetWrapperMode,
 ) -> TokenStream {
     let mut builder = LevelBuilder::new(analyzed);
     let root = builder.build(annotated);
@@ -481,7 +487,7 @@ pub fn emit_leveled(
 }
 
 /// Emit code for a single node
-fn emit_node(node: &LeveledNode, use_jet_wrapper: bool) -> TokenStream {
+fn emit_node(node: &LeveledNode, wrapper_mode: JetWrapperMode) -> TokenStream {
     match &node.kind {
         LeveledNodeKind::Param { name, kind } => {
             let name_ident = format_ident!("{}", name);
@@ -491,7 +497,7 @@ fn emit_node(node: &LeveledNode, use_jet_wrapper: bool) -> TokenStream {
                     quote! { #name_ident.eval(__p) }
                 }
                 ParamKind::Scalar(_) => {
-                    if use_jet_wrapper {
+                    if wrapper_mode == JetWrapperMode::UseWrapper {
                         quote! { __ScalarType::from_f32(#name_ident) }
                     } else {
                         quote! { ::pixelflow_core::Field::from(#name_ident) }
@@ -502,7 +508,7 @@ fn emit_node(node: &LeveledNode, use_jet_wrapper: bool) -> TokenStream {
 
         LeveledNodeKind::Literal { value } => {
             let lit = *value as f32;
-            if use_jet_wrapper {
+            if wrapper_mode == JetWrapperMode::UseWrapper {
                 quote! { __ScalarType::from_f32(#lit) }
             } else {
                 quote! { ::pixelflow_core::Field::from(#lit) }

--- a/pixelflow-ir/src/backend/emit/aarch64.rs
+++ b/pixelflow-ir/src/backend/emit/aarch64.rs
@@ -1,7 +1,14 @@
+
 //! ARM64/NEON instruction encoding.
 //!
 //! Each function emits raw machine code bytes for one instruction (or a small fixed sequence).
 //! These are the "atoms" that compound operations are built from.
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum AdrType {
+    Adr,
+    Adrp,
+}
 
 use super::Reg;
 use crate::kind::OpKind;
@@ -385,8 +392,8 @@ pub fn emit_adr_x17_placeholder(code: &mut Vec<u8>) -> usize {
 
 /// Patch a previously emitted `ADR X17` placeholder at `adr_pos` to point to `target_pos`.
 /// If `is_adrp` is true, assumes 8 bytes are reserved and patches `ADRP X17` + `ADD X17`.
-pub fn patch_adr_or_adrp(code: &mut [u8], adr_pos: usize, target_pos: usize, is_adrp: bool) {
-    if is_adrp {
+pub fn patch_adr_or_adrp(code: &mut [u8], adr_pos: usize, target_pos: usize, adr_type: AdrType) {
+    if adr_type == AdrType::Adrp {
         assert!(
             adr_pos + 8 <= code.len(),
             "patch_adr_or_adrp: adr_pos {} + 8 exceeds code length {}",

--- a/pixelflow-ir/src/backend/emit/mod.rs
+++ b/pixelflow-ir/src/backend/emit/mod.rs
@@ -840,7 +840,8 @@ pub fn compile_dag_with_ctx(expr: &Expr, ctx: EmitCtx) -> Result<CompileResult, 
         for &bits in &pool.entries {
             aarch64::emit_pool_entry(&mut code, bits);
         }
-        aarch64::patch_adr_or_adrp(&mut code, adr_pos, pool_start, needs_adrp);
+        let adr_type = if needs_adrp { aarch64::AdrType::Adrp } else { aarch64::AdrType::Adr };
+        aarch64::patch_adr_or_adrp(&mut code, adr_pos, pool_start, adr_type);
     }
 
     let exec = unsafe { executable::ExecutableCode::from_code(&code)? };

--- a/pixelflow-runtime/src/platform/macos/cocoa.rs
+++ b/pixelflow-runtime/src/platform/macos/cocoa.rs
@@ -136,10 +136,15 @@ impl NSApplication {
         }
     }
 
-    pub fn activate_ignoring_other_apps(&self, ignore: bool) {
+    pub fn activate_ignoring_other_apps(&self) {
         unsafe {
-            let val = if ignore { YES } else { NO };
-            sys::send_1::<(), BOOL>(self.0, sys::sel(b"activateIgnoringOtherApps:\0"), val);
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"activateIgnoringOtherApps:\0"), YES);
+        }
+    }
+
+    pub fn activate_respecting_other_apps(&self) {
+        unsafe {
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"activateIgnoringOtherApps:\0"), NO);
         }
     }
 

--- a/pixelflow-runtime/src/platform/macos/platform.rs
+++ b/pixelflow-runtime/src/platform/macos/platform.rs
@@ -45,7 +45,7 @@ impl MetalOps {
             app.set_activation_policy(NS_APPLICATION_ACTIVATION_POLICY_REGULAR);
 
             app.finish_launching();
-            app.activate_ignoring_other_apps(true);
+            app.activate_ignoring_other_apps();
 
             app
         };

--- a/pixelflow-search/src/nnue/factored.rs
+++ b/pixelflow-search/src/nnue/factored.rs
@@ -1,3 +1,11 @@
+
+#[derive(Clone, Copy)]
+pub struct RuleFlags {
+    pub commutative: bool,
+    pub associative: bool,
+    pub creates_sharing: bool,
+    pub expensive_op: bool,
+}
 //! # Factored Embedding NNUE Architecture
 //!
 //! An O(ops) alternative to the O(ops²) HalfEP feature encoding.
@@ -171,11 +179,8 @@ impl RuleFeatures {
         category: f32,
         lhs_nodes: usize,
         depth_delta: i8,
-        commutative: bool,
-        associative: bool,
-        creates_sharing: bool,
         match_rate: f32,
-        expensive_op: bool,
+        flags: RuleFlags,
     ) {
         self.features[rule_idx] = [
             category,

--- a/pixelflow-search/src/nnue/factored.rs
+++ b/pixelflow-search/src/nnue/factored.rs
@@ -6,42 +6,42 @@ pub struct RuleFlags {
     pub creates_sharing: bool,
     pub expensive_op: bool,
 }
-//! # Factored Embedding NNUE Architecture
-//!
-//! An O(ops) alternative to the O(ops²) HalfEP feature encoding.
-//!
-//! ## The Problem
-//!
-//! HalfEP features encode all (perspective_op, descendant_op, depth, path) tuples:
-//! - 42 ops → 42² × 8 × 256 = 3.6M possible features
-//! - Feature space grows quadratically with operation count
-//! - Training requires O(GB) of memory for weight matrices
-//!
-//! ## The Solution: Edge-based Factored Embeddings
-//!
-//! Instead of one-hot encoding each (parent, child) pair, we learn dense
-//! embeddings for each operation and accumulate them edge-by-edge:
-//!
-//! ```text
-//! For each parent→child edge in the expression tree:
-//!     accumulator[0..K]  += E[parent_op]   // "what's above"
-//!     accumulator[K..2K] += E[child_op]    // "what's below"
-//! ```
-//!
-//! Key insight: **Position encodes role**. Parent ops contribute to the first
-//! half of the accumulator, child ops to the second half. This ensures that
-//! `Mul→Add` (FMA-eligible) produces a different vector than `Add→Mul` (not FMA).
-//!
-//! ## Complexity
-//!
-//! | Metric | HalfEP | Factored | Improvement |
-//! |--------|--------|----------|-------------|
-//! | Feature space | O(ops²) | O(ops) | O(ops) |
-//! | Weight memory | ~1GB | ~10KB | 100,000× |
-//! | Accumulator build | O(nodes²) | O(edges) | O(nodes) |
-//! | Incremental update | O(subtree²) | O(Δedges × K) | O(subtree) |
+// # Factored Embedding NNUE Architecture
+//
+// An O(ops) alternative to the O(ops²) HalfEP feature encoding.
+//
+// ## The Problem
+//
+// HalfEP features encode all (perspective_op, descendant_op, depth, path) tuples:
+// - 42 ops → 42² × 8 × 256 = 3.6M possible features
+// - Feature space grows quadratically with operation count
+// - Training requires O(GB) of memory for weight matrices
+//
+// ## The Solution: Edge-based Factored Embeddings
+//
+// Instead of one-hot encoding each (parent, child) pair, we learn dense
+// embeddings for each operation and accumulate them edge-by-edge:
+//
+// ```text
+// For each parent→child edge in the expression tree:
+//     accumulator[0..K]  += E[parent_op]   // "what's above"
+//     accumulator[K..2K] += E[child_op]    // "what's below"
+// ```
+//
+// Key insight: **Position encodes role**. Parent ops contribute to the first
+// half of the accumulator, child ops to the second half. This ensures that
+// `Mul→Add` (FMA-eligible) produces a different vector than `Add→Mul` (not FMA).
+//
+// ## Complexity
+//
+// | Metric | HalfEP | Factored | Improvement |
+// |--------|--------|----------|-------------|
+// | Feature space | O(ops²) | O(ops) | O(ops) |
+// | Weight memory | ~1GB | ~10KB | 100,000× |
+// | Accumulator build | O(nodes²) | O(edges) | O(nodes) |
+// | Incremental update | O(subtree²) | O(Δedges × K) | O(subtree) |
 
-#![allow(dead_code)] // Prototype code
+#[allow(dead_code)]
 
 extern crate alloc;
 
@@ -186,11 +186,11 @@ impl RuleFeatures {
             category,
             lhs_nodes as f32 / 10.0,
             depth_delta as f32,
-            if commutative { 1.0 } else { 0.0 },
-            if associative { 1.0 } else { 0.0 },
-            if creates_sharing { 1.0 } else { 0.0 },
+            if flags.commutative { 1.0 } else { 0.0 },
+            if flags.associative { 1.0 } else { 0.0 },
+            if flags.creates_sharing { 1.0 } else { 0.0 },
             match_rate.clamp(0.0, 1.0),
-            if expensive_op { 1.0 } else { 0.0 },
+            if flags.expensive_op { 1.0 } else { 0.0 },
         ];
     }
 }

--- a/pixelflow-search/src/nnue/factored.rs
+++ b/pixelflow-search/src/nnue/factored.rs
@@ -1,45 +1,38 @@
 
-#[derive(Clone, Copy)]
-pub struct RuleFlags {
-    pub commutative: bool,
-    pub associative: bool,
-    pub creates_sharing: bool,
-    pub expensive_op: bool,
-}
-// # Factored Embedding NNUE Architecture
-//
-// An O(ops) alternative to the O(ops²) HalfEP feature encoding.
-//
-// ## The Problem
-//
-// HalfEP features encode all (perspective_op, descendant_op, depth, path) tuples:
-// - 42 ops → 42² × 8 × 256 = 3.6M possible features
-// - Feature space grows quadratically with operation count
-// - Training requires O(GB) of memory for weight matrices
-//
-// ## The Solution: Edge-based Factored Embeddings
-//
-// Instead of one-hot encoding each (parent, child) pair, we learn dense
-// embeddings for each operation and accumulate them edge-by-edge:
-//
-// ```text
-// For each parent→child edge in the expression tree:
-//     accumulator[0..K]  += E[parent_op]   // "what's above"
-//     accumulator[K..2K] += E[child_op]    // "what's below"
-// ```
-//
-// Key insight: **Position encodes role**. Parent ops contribute to the first
-// half of the accumulator, child ops to the second half. This ensures that
-// `Mul→Add` (FMA-eligible) produces a different vector than `Add→Mul` (not FMA).
-//
-// ## Complexity
-//
-// | Metric | HalfEP | Factored | Improvement |
-// |--------|--------|----------|-------------|
-// | Feature space | O(ops²) | O(ops) | O(ops) |
-// | Weight memory | ~1GB | ~10KB | 100,000× |
-// | Accumulator build | O(nodes²) | O(edges) | O(nodes) |
-// | Incremental update | O(subtree²) | O(Δedges × K) | O(subtree) |
+//! # Factored Embedding NNUE Architecture
+//!
+//! An O(ops) alternative to the O(ops²) HalfEP feature encoding.
+//!
+//! ## The Problem
+//!
+//! HalfEP features encode all (perspective_op, descendant_op, depth, path) tuples:
+//! - 42 ops → 42² × 8 × 256 = 3.6M possible features
+//! - Feature space grows quadratically with operation count
+//! - Training requires O(GB) of memory for weight matrices
+//!
+//! ## The Solution: Edge-based Factored Embeddings
+//!
+//! Instead of one-hot encoding each (parent, child) pair, we learn dense
+//! embeddings for each operation and accumulate them edge-by-edge:
+//!
+//! ```text
+//! For each parent→child edge in the expression tree:
+//!     accumulator[0..K]  += E[parent_op]   // "what's above"
+//!     accumulator[K..2K] += E[child_op]    // "what's below"
+//! ```
+//!
+//! Key insight: **Position encodes role**. Parent ops contribute to the first
+//! half of the accumulator, child ops to the second half. This ensures that
+//! `Mul→Add` (FMA-eligible) produces a different vector than `Add→Mul` (not FMA).
+//!
+//! ## Complexity
+//!
+//! | Metric | HalfEP | Factored | Improvement |
+//! |--------|--------|----------|-------------|
+//! | Feature space | O(ops²) | O(ops) | O(ops) |
+//! | Weight memory | ~1GB | ~10KB | 100,000× |
+//! | Accumulator build | O(nodes²) | O(edges) | O(nodes) |
+//! | Incremental update | O(subtree²) | O(Δedges × K) | O(subtree) |
 
 #[allow(dead_code)]
 
@@ -51,6 +44,14 @@ use libm::sqrtf;
 pub use pixelflow_ir::OpKind;
 use pixelflow_ir::Expr;
 
+
+#[derive(Clone, Copy)]
+pub struct RuleFlags {
+    pub commutative: bool,
+    pub associative: bool,
+    pub creates_sharing: bool,
+    pub expensive_op: bool,
+}
 // ============================================================================
 // Constants
 // ============================================================================

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,18 @@
+1. **Analyze target document:**
+   Read `docs/STYLE.md` to identify style guidelines, particularly the strict rule against boolean arguments.
+
+2. **Develop style enforcer tool:**
+   Create a Python script (`~/self_created_tools/style_enforcer.py`) to randomly sample `.rs` files and detect boolean arguments in function signatures.
+
+3. **Iteratively identify and fix violations:**
+   - Run the style enforcer to find a violation.
+   - For each violation, replace the boolean argument with an enum (or separate functions, per the style guide).
+   - Update call sites.
+   - Run `cargo check` to ensure fixes don't break the build (ignoring pre-existing errors in `pixelflow-ir`).
+
+4. **Review changes:**
+   Check the modifications using `git diff` to ensure they accurately fix the style violation without introducing logical errors.
+
+5. **Pre-commit and submit:**
+   - Run `pre_commit_instructions` tool to verify required pre-commit steps.
+   - Commit changes and submit the PR.


### PR DESCRIPTION
Refactored functions across the codebase to remove boolean arguments, as mandated by `docs/STYLE.md`. Boolean arguments make call sites unclear; this PR enforces clarity by introducing semantically meaningful enums (`ConsumeSt`, `JetWrapperMode`, `AdrType`, `CsiType`), a dedicated parameter struct (`RuleFlags`), and by splitting functions into separate positive/negative implementations (e.g., `activate_ignoring_other_apps` vs `activate_respecting_other_apps`).

---
*PR created automatically by Jules for task [13324080828335263355](https://jules.google.com/task/13324080828335263355) started by @jppittman*