### PR TITLE
Refactor AnsiParser to remove unused `consume_st` parameter

### DIFF
--- a/core-term/src/ansi/parser.rs
+++ b/core-term/src/ansi/parser.rs
@@ -189,39 +189,35 @@ impl AnsiParser {
         self.state = State::Ground;
     }
 
-    fn dispatch_osc(&mut self, consume_st: bool) {
+    fn dispatch_osc(&mut self) {
         let data = mem::take(&mut self.string_buffer);
         trace!("Dispatching OSC: Data length {}", data.len());
         self.commands.push(AnsiCommand::Osc(data));
         self.clear_string_buffer();
-        if !consume_st { /* ST handled separately */ }
         self.state = State::Ground;
     }
 
-    fn dispatch_dcs(&mut self, consume_st: bool) {
+    fn dispatch_dcs(&mut self) {
         let data = mem::take(&mut self.string_buffer);
         trace!("Dispatching DCS: Data length {}", data.len());
         self.commands.push(AnsiCommand::Dcs(data));
         self.clear_string_buffer();
-        if !consume_st { /* ST handled separately */ }
         self.state = State::Ground;
     }
 
-    fn dispatch_pm(&mut self, consume_st: bool) {
+    fn dispatch_pm(&mut self) {
         let data = mem::take(&mut self.string_buffer);
         trace!("Dispatching PM: Data length {}", data.len());
         self.commands.push(AnsiCommand::Pm(data));
         self.clear_string_buffer();
-        if !consume_st { /* ST handled separately */ }
         self.state = State::Ground;
     }
 
-    fn dispatch_apc(&mut self, consume_st: bool) {
+    fn dispatch_apc(&mut self) {
         let data = mem::take(&mut self.string_buffer);
         trace!("Dispatching APC: Data length {}", data.len());
         self.commands.push(AnsiCommand::Apc(data));
         self.clear_string_buffer();
-        if !consume_st { /* ST handled separately */ }
         self.state = State::Ground;
     }
 
@@ -427,7 +423,7 @@ impl AnsiParser {
                     AnsiToken::C0Control(b)
                         if b == C0Control::BEL as u8 && self.state == State::OscString =>
                     {
-                        self.dispatch_osc(false)
+                        self.dispatch_osc()
                     }
                     AnsiToken::C0Control(b)
                         if b == C0Control::CAN as u8 || b == C0Control::SUB as u8 =>
@@ -447,10 +443,10 @@ impl AnsiParser {
             }
             State::EscInString => match token {
                 AnsiToken::Print('\\') => match self.string_state_origin {
-                    Some(State::OscString) => self.dispatch_osc(true),
-                    Some(State::DcsEntry) => self.dispatch_dcs(true),
-                    Some(State::PmString) => self.dispatch_pm(true),
-                    Some(State::ApcString) => self.dispatch_apc(true),
+                    Some(State::OscString) => self.dispatch_osc(),
+                    Some(State::DcsEntry) => self.dispatch_dcs(),
+                    Some(State::PmString) => self.dispatch_pm(),
+                    Some(State::ApcString) => self.dispatch_apc(),
                     _ => {
                         error!("EscInString state missing origin!");
                         self.dispatch_st_standalone();


### PR DESCRIPTION
Fix STYLE.md violation for boolean parameters in AnsiParser.

---
*PR created automatically by Jules for task [13585340224780120879](https://jules.google.com/task/13585340224780120879) started by @jppittman*