### PR TITLE
style: eliminate unused boolean arguments in `AnsiParser` dispatch methods

### DIFF
--- a/core-term/src/ansi/parser.rs
+++ b/core-term/src/ansi/parser.rs
@@ -189,39 +189,39 @@ impl AnsiParser {
         self.state = State::Ground;
     }
 
-    fn dispatch_osc(&mut self, consume_st: bool) {
+    fn dispatch_osc(&mut self) {
         let data = mem::take(&mut self.string_buffer);
         trace!("Dispatching OSC: Data length {}", data.len());
         self.commands.push(AnsiCommand::Osc(data));
         self.clear_string_buffer();
-        if !consume_st { /* ST handled separately */ }
+        // ST is handled separately, if present
         self.state = State::Ground;
     }
 
-    fn dispatch_dcs(&mut self, consume_st: bool) {
+    fn dispatch_dcs(&mut self) {
         let data = mem::take(&mut self.string_buffer);
         trace!("Dispatching DCS: Data length {}", data.len());
         self.commands.push(AnsiCommand::Dcs(data));
         self.clear_string_buffer();
-        if !consume_st { /* ST handled separately */ }
+        // ST is handled separately, if present
         self.state = State::Ground;
     }
 
-    fn dispatch_pm(&mut self, consume_st: bool) {
+    fn dispatch_pm(&mut self) {
         let data = mem::take(&mut self.string_buffer);
         trace!("Dispatching PM: Data length {}", data.len());
         self.commands.push(AnsiCommand::Pm(data));
         self.clear_string_buffer();
-        if !consume_st { /* ST handled separately */ }
+        // ST is handled separately, if present
         self.state = State::Ground;
     }
 
-    fn dispatch_apc(&mut self, consume_st: bool) {
+    fn dispatch_apc(&mut self) {
         let data = mem::take(&mut self.string_buffer);
         trace!("Dispatching APC: Data length {}", data.len());
         self.commands.push(AnsiCommand::Apc(data));
         self.clear_string_buffer();
-        if !consume_st { /* ST handled separately */ }
+        // ST is handled separately, if present
         self.state = State::Ground;
     }
 
@@ -427,7 +427,7 @@ impl AnsiParser {
                     AnsiToken::C0Control(b)
                         if b == C0Control::BEL as u8 && self.state == State::OscString =>
                     {
-                        self.dispatch_osc(false)
+                        self.dispatch_osc()
                     }
                     AnsiToken::C0Control(b)
                         if b == C0Control::CAN as u8 || b == C0Control::SUB as u8 =>
@@ -447,10 +447,10 @@ impl AnsiParser {
             }
             State::EscInString => match token {
                 AnsiToken::Print('\\') => match self.string_state_origin {
-                    Some(State::OscString) => self.dispatch_osc(true),
-                    Some(State::DcsEntry) => self.dispatch_dcs(true),
-                    Some(State::PmString) => self.dispatch_pm(true),
-                    Some(State::ApcString) => self.dispatch_apc(true),
+                    Some(State::OscString) => self.dispatch_osc(),
+                    Some(State::DcsEntry) => self.dispatch_dcs(),
+                    Some(State::PmString) => self.dispatch_pm(),
+                    Some(State::ApcString) => self.dispatch_apc(),
                     _ => {
                         error!("EscInString state missing origin!");
                         self.dispatch_st_standalone();

--- a/core-term/src/ansi/tests.rs
+++ b/core-term/src/ansi/tests.rs
@@ -1659,74 +1659,50 @@ mod mutation_tests {
     #[test]
     fn csi_cursor_up_no_param_defaults_to_1() {
         let cmds = process_bytes(b"\x1b[A");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::CursorUp(1))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::CursorUp(1))]);
     }
 
     #[test]
     fn csi_cursor_up_param_zero_is_coerced_to_1() {
         // param_or_1 applies max(1), so 0 -> 1
         let cmds = process_bytes(b"\x1b[0A");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::CursorUp(1))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::CursorUp(1))]);
     }
 
     #[test]
     fn csi_cursor_up_explicit_5() {
         let cmds = process_bytes(b"\x1b[5A");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::CursorUp(5))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::CursorUp(5))]);
     }
 
     #[test]
     fn csi_cursor_down_defaults_to_1() {
         let cmds = process_bytes(b"\x1b[B");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::CursorDown(1))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::CursorDown(1))]);
     }
 
     #[test]
     fn csi_cursor_forward_defaults_to_1() {
         let cmds = process_bytes(b"\x1b[C");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::CursorForward(1))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::CursorForward(1))]);
     }
 
     #[test]
     fn csi_cursor_backward_defaults_to_1() {
         let cmds = process_bytes(b"\x1b[D");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::CursorBackward(1))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::CursorBackward(1))]);
     }
 
     #[test]
     fn csi_cursor_next_line_defaults_to_1() {
         let cmds = process_bytes(b"\x1b[E");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::CursorNextLine(1))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::CursorNextLine(1))]);
     }
 
     #[test]
     fn csi_cursor_prev_line_defaults_to_1() {
         let cmds = process_bytes(b"\x1b[F");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::CursorPrevLine(1))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::CursorPrevLine(1))]);
     }
 
     #[test]
@@ -1778,37 +1754,25 @@ mod mutation_tests {
     #[test]
     fn csi_erase_in_display_no_param_defaults_to_0() {
         let cmds = process_bytes(b"\x1b[J");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::EraseInDisplay(0))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::EraseInDisplay(0))]);
     }
 
     #[test]
     fn csi_erase_in_display_explicit_2() {
         let cmds = process_bytes(b"\x1b[2J");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::EraseInDisplay(2))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::EraseInDisplay(2))]);
     }
 
     #[test]
     fn csi_erase_in_line_no_param_defaults_to_0() {
         let cmds = process_bytes(b"\x1b[K");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::EraseInLine(0))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::EraseInLine(0))]);
     }
 
     #[test]
     fn csi_erase_in_line_explicit_1() {
         let cmds = process_bytes(b"\x1b[1K");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::EraseInLine(1))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::EraseInLine(1))]);
     }
 
     // -----------------------------------------------------------------------
@@ -1887,7 +1851,11 @@ mod mutation_tests {
         if let Some(AnsiCommand::Csi(CsiCommand::SetGraphicsRendition(attrs))) = cmds.first() {
             // Checking len kills mutations that reduce MAX_PARAMS below 16.
             assert_eq!(attrs.len(), 16, "all 16 params must be retained");
-            assert_eq!(attrs[0], Attribute::Bold, "first of 16 params should be Bold");
+            assert_eq!(
+                attrs[0],
+                Attribute::Bold,
+                "first of 16 params should be Bold"
+            );
             assert_eq!(
                 attrs[1],
                 Attribute::Faint,
@@ -1903,8 +1871,7 @@ mod mutation_tests {
         // 16 zeros then ;7 (Reverse). The 17th param (7) must be ignored.
         // We send: ESC [ 0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;7m
         //          that's 16 zeros + 1 extra -> the 7 (Reverse) is the 17th and dropped.
-        let cmds =
-            process_bytes(b"\x1b[0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;7m");
+        let cmds = process_bytes(b"\x1b[0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;7m");
         if let Some(AnsiCommand::Csi(CsiCommand::SetGraphicsRendition(attrs))) = cmds.first() {
             // Every kept attribute should be Reset (0); Reverse (7) must NOT appear.
             assert!(
@@ -2080,28 +2047,19 @@ mod mutation_tests {
     #[test]
     fn csi_ctc_0_is_set_tab_stop() {
         let cmds = process_bytes(b"\x1b[0W");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::SetTabStop)]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::SetTabStop)]);
     }
 
     #[test]
     fn csi_ctc_2_clears_current_tab_stop() {
         let cmds = process_bytes(b"\x1b[2W");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::ClearTabStops(0))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::ClearTabStops(0))]);
     }
 
     #[test]
     fn csi_ctc_5_clears_all_tab_stops() {
         let cmds = process_bytes(b"\x1b[5W");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::ClearTabStops(3))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::ClearTabStops(3))]);
     }
 
     // -----------------------------------------------------------------------
@@ -2112,19 +2070,13 @@ mod mutation_tests {
     #[test]
     fn csi_s_uppercase_is_scroll_up() {
         let cmds = process_bytes(b"\x1b[3S");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::ScrollUp(3))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::ScrollUp(3))]);
     }
 
     #[test]
     fn csi_t_uppercase_is_scroll_down() {
         let cmds = process_bytes(b"\x1b[3T");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::ScrollDown(3))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::ScrollDown(3))]);
     }
 
     // -----------------------------------------------------------------------
@@ -2135,28 +2087,19 @@ mod mutation_tests {
     #[test]
     fn csi_at_is_insert_character() {
         let cmds = process_bytes(b"\x1b[2@");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::InsertCharacter(2))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::InsertCharacter(2))]);
     }
 
     #[test]
     fn csi_p_uppercase_is_delete_character() {
         let cmds = process_bytes(b"\x1b[2P");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::DeleteCharacter(2))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::DeleteCharacter(2))]);
     }
 
     #[test]
     fn csi_x_uppercase_is_erase_character() {
         let cmds = process_bytes(b"\x1b[2X");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::EraseCharacter(2))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::EraseCharacter(2))]);
     }
 
     // -----------------------------------------------------------------------
@@ -2166,19 +2109,13 @@ mod mutation_tests {
     #[test]
     fn csi_l_uppercase_is_insert_line() {
         let cmds = process_bytes(b"\x1b[4L");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::InsertLine(4))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::InsertLine(4))]);
     }
 
     #[test]
     fn csi_m_uppercase_is_delete_line() {
         let cmds = process_bytes(b"\x1b[4M");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::DeleteLine(4))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::DeleteLine(4))]);
     }
 
     // -----------------------------------------------------------------------

--- a/core-term/src/term/emulator/mouse.rs
+++ b/core-term/src/term/emulator/mouse.rs
@@ -57,9 +57,7 @@ fn should_report(modes: &DecPrivateModes, kind: MouseEventKind) -> bool {
         }
         MouseEventKind::Release => {
             // X10 mode does not report releases
-            modes.mouse_vt200_mode
-                || modes.mouse_button_event_mode
-                || modes.mouse_any_event_mode
+            modes.mouse_vt200_mode || modes.mouse_button_event_mode || modes.mouse_any_event_mode
         }
         MouseEventKind::Motion => {
             // Button-event mode reports motion only while a button is held,
@@ -82,7 +80,11 @@ fn button_base_code(button: MouseButton) -> u8 {
         MouseButton::ScrollDown => 65,
         MouseButton::Other(n) => {
             // Buttons 4+ map to codes 128+
-            if n >= 4 { 128 + n - 4 } else { n }
+            if n >= 4 {
+                128 + n - 4
+            } else {
+                n
+            }
         }
     }
 }
@@ -118,7 +120,11 @@ fn legacy_button_code(button: MouseButton, kind: MouseEventKind) -> u8 {
 /// Format: `ESC [ < Cb ; Cx ; Cy M` for press/motion, `ESC [ < Cb ; Cx ; Cy m` for release.
 /// Coordinates are 1-based.
 fn encode_sgr(button_code: u8, col: usize, row: usize, kind: MouseEventKind) -> Vec<u8> {
-    let suffix = if kind == MouseEventKind::Release { b'm' } else { b'M' };
+    let suffix = if kind == MouseEventKind::Release {
+        b'm'
+    } else {
+        b'M'
+    };
     // SGR uses 1-based coordinates
     let cx = col + 1;
     let cy = row + 1;
@@ -228,8 +234,7 @@ mod tests {
     fn sgr_middle_press() {
         let modes = modes_with_sgr();
         let result =
-            encode_mouse_event(&modes, MouseButton::Middle, 79, 23, MouseEventKind::Press)
-                .unwrap();
+            encode_mouse_event(&modes, MouseButton::Middle, 79, 23, MouseEventKind::Press).unwrap();
         assert_eq!(result, b"\x1b[<1;80;24M");
     }
 
@@ -263,9 +268,14 @@ mod tests {
     #[test]
     fn sgr_scroll_down() {
         let modes = modes_with_sgr();
-        let result =
-            encode_mouse_event(&modes, MouseButton::ScrollDown, 10, 5, MouseEventKind::Press)
-                .unwrap();
+        let result = encode_mouse_event(
+            &modes,
+            MouseButton::ScrollDown,
+            10,
+            5,
+            MouseEventKind::Press,
+        )
+        .unwrap();
         assert_eq!(result, b"\x1b[<65;11;6M");
     }
 
@@ -291,8 +301,7 @@ mod tests {
     fn legacy_right_release_uses_code_3() {
         let modes = modes_with_vt200();
         let result =
-            encode_mouse_event(&modes, MouseButton::Right, 5, 10, MouseEventKind::Release)
-                .unwrap();
+            encode_mouse_event(&modes, MouseButton::Right, 5, 10, MouseEventKind::Release).unwrap();
         // Legacy release always uses code 3 regardless of which button was released
         assert_eq!(result, vec![0x1b, b'[', b'M', 35, 38, 43]);
     }
@@ -300,8 +309,7 @@ mod tests {
     #[test]
     fn legacy_coords_overflow_returns_none() {
         let modes = modes_with_vt200();
-        let result =
-            encode_mouse_event(&modes, MouseButton::Left, 300, 10, MouseEventKind::Press);
+        let result = encode_mouse_event(&modes, MouseButton::Left, 300, 10, MouseEventKind::Press);
         assert_eq!(result, None);
     }
 
@@ -310,8 +318,7 @@ mod tests {
         let modes = modes_with_x10();
         let press = encode_mouse_event(&modes, MouseButton::Left, 0, 0, MouseEventKind::Press);
         assert!(press.is_some());
-        let release =
-            encode_mouse_event(&modes, MouseButton::Left, 0, 0, MouseEventKind::Release);
+        let release = encode_mouse_event(&modes, MouseButton::Left, 0, 0, MouseEventKind::Release);
         assert_eq!(release, None);
         let motion = encode_mouse_event(&modes, MouseButton::Left, 0, 0, MouseEventKind::Motion);
         assert_eq!(motion, None);
@@ -322,8 +329,7 @@ mod tests {
         let modes = modes_with_vt200();
         let press = encode_mouse_event(&modes, MouseButton::Left, 0, 0, MouseEventKind::Press);
         assert!(press.is_some());
-        let release =
-            encode_mouse_event(&modes, MouseButton::Left, 0, 0, MouseEventKind::Release);
+        let release = encode_mouse_event(&modes, MouseButton::Left, 0, 0, MouseEventKind::Release);
         assert!(release.is_some());
         let motion = encode_mouse_event(&modes, MouseButton::Left, 0, 0, MouseEventKind::Motion);
         assert_eq!(motion, None);
@@ -334,8 +340,7 @@ mod tests {
         let modes = modes_with_sgr();
         // SGR has no coordinate limit
         let result =
-            encode_mouse_event(&modes, MouseButton::Left, 500, 300, MouseEventKind::Press)
-                .unwrap();
+            encode_mouse_event(&modes, MouseButton::Left, 500, 300, MouseEventKind::Press).unwrap();
         assert_eq!(result, b"\x1b[<0;501;301M");
     }
 }


### PR DESCRIPTION
- Identifies the egregious violation: boolean parameters in the `AnsiParser`'s dispatch functions.
- Confirms these parameters are unused.
- Removes `consume_st: bool` from `dispatch_osc`, `dispatch_dcs`, `dispatch_pm`, and `dispatch_apc`.
- Updates `State::EscInString` and `C0Control::BEL` match arms to invoke these without arguments.
- Ensures all changes are extremely safe and comply with `docs/STYLE.md`.

---
*PR created automatically by Jules for task [13085648240432221576](https://jules.google.com/task/13085648240432221576) started by @jppittman*