### PR TITLE
Refactor `core-term/src/ansi/parser.rs` boolean blindness

### DIFF
--- a/core-term/src/ansi/parser.rs
+++ b/core-term/src/ansi/parser.rs
@@ -29,6 +29,12 @@ enum State {
     EscIntermediate,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConsumeSt {
+    Yes,
+    No,
+}
+
 /// The ANSI parser structure.
 ///
 /// Manages the state transitions and parameter accumulation for parsing
@@ -189,39 +195,39 @@ impl AnsiParser {
         self.state = State::Ground;
     }
 
-    fn dispatch_osc(&mut self, consume_st: bool) {
+    fn dispatch_osc(&mut self, consume_st: ConsumeSt) {
         let data = mem::take(&mut self.string_buffer);
         trace!("Dispatching OSC: Data length {}", data.len());
         self.commands.push(AnsiCommand::Osc(data));
         self.clear_string_buffer();
-        if !consume_st { /* ST handled separately */ }
+        if consume_st == ConsumeSt::No { /* ST handled separately */ }
         self.state = State::Ground;
     }
 
-    fn dispatch_dcs(&mut self, consume_st: bool) {
+    fn dispatch_dcs(&mut self, consume_st: ConsumeSt) {
         let data = mem::take(&mut self.string_buffer);
         trace!("Dispatching DCS: Data length {}", data.len());
         self.commands.push(AnsiCommand::Dcs(data));
         self.clear_string_buffer();
-        if !consume_st { /* ST handled separately */ }
+        if consume_st == ConsumeSt::No { /* ST handled separately */ }
         self.state = State::Ground;
     }
 
-    fn dispatch_pm(&mut self, consume_st: bool) {
+    fn dispatch_pm(&mut self, consume_st: ConsumeSt) {
         let data = mem::take(&mut self.string_buffer);
         trace!("Dispatching PM: Data length {}", data.len());
         self.commands.push(AnsiCommand::Pm(data));
         self.clear_string_buffer();
-        if !consume_st { /* ST handled separately */ }
+        if consume_st == ConsumeSt::No { /* ST handled separately */ }
         self.state = State::Ground;
     }
 
-    fn dispatch_apc(&mut self, consume_st: bool) {
+    fn dispatch_apc(&mut self, consume_st: ConsumeSt) {
         let data = mem::take(&mut self.string_buffer);
         trace!("Dispatching APC: Data length {}", data.len());
         self.commands.push(AnsiCommand::Apc(data));
         self.clear_string_buffer();
-        if !consume_st { /* ST handled separately */ }
+        if consume_st == ConsumeSt::No { /* ST handled separately */ }
         self.state = State::Ground;
     }
 
@@ -427,7 +433,7 @@ impl AnsiParser {
                     AnsiToken::C0Control(b)
                         if b == C0Control::BEL as u8 && self.state == State::OscString =>
                     {
-                        self.dispatch_osc(false)
+                        self.dispatch_osc(ConsumeSt::No)
                     }
                     AnsiToken::C0Control(b)
                         if b == C0Control::CAN as u8 || b == C0Control::SUB as u8 =>
@@ -447,10 +453,10 @@ impl AnsiParser {
             }
             State::EscInString => match token {
                 AnsiToken::Print('\\') => match self.string_state_origin {
-                    Some(State::OscString) => self.dispatch_osc(true),
-                    Some(State::DcsEntry) => self.dispatch_dcs(true),
-                    Some(State::PmString) => self.dispatch_pm(true),
-                    Some(State::ApcString) => self.dispatch_apc(true),
+                    Some(State::OscString) => self.dispatch_osc(ConsumeSt::Yes),
+                    Some(State::DcsEntry) => self.dispatch_dcs(ConsumeSt::Yes),
+                    Some(State::PmString) => self.dispatch_pm(ConsumeSt::Yes),
+                    Some(State::ApcString) => self.dispatch_apc(ConsumeSt::Yes),
                     _ => {
                         error!("EscInString state missing origin!");
                         self.dispatch_st_standalone();


### PR DESCRIPTION
Replaced boolean parameter in parser dispatch methods with `ConsumeSt` enum.

---
*PR created automatically by Jules for task [6181358249650196295](https://jules.google.com/task/6181358249650196295) started by @jppittman*