### PR TITLE
Refactor: Avoid boolean arguments in ansi parser to enforce style rules

### DIFF
--- a/core-term/src/ansi/parser.rs
+++ b/core-term/src/ansi/parser.rs
@@ -13,6 +13,13 @@ const MAX_PARAMS: usize = 16;
 const MAX_INTERMEDIATES: usize = 2;
 const MAX_OSC_LEN: usize = 1024; // Limit OSC/DCS/PM/APC string length
 
+/// Indicates how to handle the String Terminator (ST)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StHandling {
+    Consume,
+    Preserve,
+}
+
 /// Represents the current state of the ANSI parser state machine.
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum State {
@@ -189,39 +196,39 @@ impl AnsiParser {
         self.state = State::Ground;
     }
 
-    fn dispatch_osc(&mut self, consume_st: bool) {
+    fn dispatch_osc(&mut self, st_handling: StHandling) {
         let data = mem::take(&mut self.string_buffer);
         trace!("Dispatching OSC: Data length {}", data.len());
         self.commands.push(AnsiCommand::Osc(data));
         self.clear_string_buffer();
-        if !consume_st { /* ST handled separately */ }
+        if st_handling == StHandling::Preserve { /* ST handled separately */ }
         self.state = State::Ground;
     }
 
-    fn dispatch_dcs(&mut self, consume_st: bool) {
+    fn dispatch_dcs(&mut self, st_handling: StHandling) {
         let data = mem::take(&mut self.string_buffer);
         trace!("Dispatching DCS: Data length {}", data.len());
         self.commands.push(AnsiCommand::Dcs(data));
         self.clear_string_buffer();
-        if !consume_st { /* ST handled separately */ }
+        if st_handling == StHandling::Preserve { /* ST handled separately */ }
         self.state = State::Ground;
     }
 
-    fn dispatch_pm(&mut self, consume_st: bool) {
+    fn dispatch_pm(&mut self, st_handling: StHandling) {
         let data = mem::take(&mut self.string_buffer);
         trace!("Dispatching PM: Data length {}", data.len());
         self.commands.push(AnsiCommand::Pm(data));
         self.clear_string_buffer();
-        if !consume_st { /* ST handled separately */ }
+        if st_handling == StHandling::Preserve { /* ST handled separately */ }
         self.state = State::Ground;
     }
 
-    fn dispatch_apc(&mut self, consume_st: bool) {
+    fn dispatch_apc(&mut self, st_handling: StHandling) {
         let data = mem::take(&mut self.string_buffer);
         trace!("Dispatching APC: Data length {}", data.len());
         self.commands.push(AnsiCommand::Apc(data));
         self.clear_string_buffer();
-        if !consume_st { /* ST handled separately */ }
+        if st_handling == StHandling::Preserve { /* ST handled separately */ }
         self.state = State::Ground;
     }
 
@@ -427,7 +434,7 @@ impl AnsiParser {
                     AnsiToken::C0Control(b)
                         if b == C0Control::BEL as u8 && self.state == State::OscString =>
                     {
-                        self.dispatch_osc(false)
+                        self.dispatch_osc(StHandling::Preserve)
                     }
                     AnsiToken::C0Control(b)
                         if b == C0Control::CAN as u8 || b == C0Control::SUB as u8 =>
@@ -447,10 +454,10 @@ impl AnsiParser {
             }
             State::EscInString => match token {
                 AnsiToken::Print('\\') => match self.string_state_origin {
-                    Some(State::OscString) => self.dispatch_osc(true),
-                    Some(State::DcsEntry) => self.dispatch_dcs(true),
-                    Some(State::PmString) => self.dispatch_pm(true),
-                    Some(State::ApcString) => self.dispatch_apc(true),
+                    Some(State::OscString) => self.dispatch_osc(StHandling::Consume),
+                    Some(State::DcsEntry) => self.dispatch_dcs(StHandling::Consume),
+                    Some(State::PmString) => self.dispatch_pm(StHandling::Consume),
+                    Some(State::ApcString) => self.dispatch_apc(StHandling::Consume),
                     _ => {
                         error!("EscInString state missing origin!");
                         self.dispatch_st_standalone();


### PR DESCRIPTION
### Description
This pull request enforces the core project style guideline regarding the avoidance of boolean arguments in function signatures. Specifically, the `docs/STYLE.md` dictates: "Avoid functions that take boolean arguments. They make the call site unclear. Prefer using enums or splitting the function into two separate functions."

**Changes Made:**
- Identified a clear violation in `core-term/src/ansi/parser.rs` where methods like `dispatch_osc`, `dispatch_dcs`, `dispatch_pm`, and `dispatch_apc` all took a `consume_st: bool` parameter.
- Refactored this by introducing a strongly typed `StHandling` enum (`Consume` or `Preserve`).
- Updated the aforementioned methods and all their callsites to pass the `StHandling` enum variants instead of plain `true`/`false`.

**Benefits:**
- Improves the readability and strict typing of the codebase.
- Eliminates "boolean blindness" at the callsites.
- Fully adheres to `docs/STYLE.md` without changing any existing logical behavior.

---
*PR created automatically by Jules for task [1521521134230034681](https://jules.google.com/task/1521521134230034681) started by @jppittman*