### PR TITLE
Refactor `MacWindow::set_visible` to use `show()` and `hide()`

### DIFF
--- a/pixelflow-runtime/src/platform/macos/platform.rs
+++ b/pixelflow-runtime/src/platform/macos/platform.rs
@@ -102,7 +102,11 @@ impl PlatformOps for MetalOps {
             }
             DisplayControl::SetVisible { id, visible } => {
                 if let Some(win) = self.windows.get_mut(&id) {
-                    win.set_visible(visible);
+                    if visible {
+                        win.show();
+                    } else {
+                        win.hide();
+                    }
                 }
             }
             DisplayControl::RequestRedraw { id } => {
@@ -164,7 +168,7 @@ impl PlatformOps for MetalOps {
             }
             DisplayMgmt::Destroy { id } => {
                 if let Some(mut win) = self.windows.remove(&id) {
-                    win.set_visible(false);
+                    win.hide();
                     // Drop closes it implicitly or we call close
                     // win.window.close(); // If we expose it
                     self.window_map.remove(&(win.window.0 as usize));

--- a/pixelflow-runtime/src/platform/macos/window.rs
+++ b/pixelflow-runtime/src/platform/macos/window.rs
@@ -122,13 +122,13 @@ impl MacWindow {
         }
     }
 
-    pub fn set_visible(&mut self, visible: bool) {
-        if visible {
-            self.window.make_key_and_order_front();
-        } else {
-            unsafe {
-                sys::send::<()>(self.window.0, sys::sel(b"orderOut:\0"));
-            }
+    pub fn show(&mut self) {
+        self.window.make_key_and_order_front();
+    }
+
+    pub fn hide(&mut self) {
+        unsafe {
+            sys::send::<()>(self.window.0, sys::sel(b"orderOut:\0"));
         }
     }
 


### PR DESCRIPTION
This change fixes an egregious style violation in the codebase where a boolean argument was used to control visibility. As per `docs/STYLE.md`, functions should avoid boolean arguments to keep the call site clear. 

The `MacWindow::set_visible(visible: bool)` method has been split into `MacWindow::show()` and `MacWindow::hide()`, and its usage in `platform.rs` has been updated accordingly. This logic is safe and fully equivalent to the original `if visible` branching logic.

---
*PR created automatically by Jules for task [3255305995358377899](https://jules.google.com/task/3255305995358377899) started by @jppittman*