### PR TITLE
⚡ Bolt: Replace `.sqrt().rsqrt()` with `.rsqrt()` to fix math error and improve performance

### DIFF
--- a/pixelflow-graphics/src/scene3d.rs
+++ b/pixelflow-graphics/src/scene3d.rs
@@ -598,7 +598,8 @@ impl<M: ManifoldCompat<Jet3, Output = Field>> Manifold<Jet3_4> for Reflect<M> {
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        // Use .rsqrt() directly instead of .sqrt().rsqrt() to compute x^(-1/2) correctly
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         // Normal components - evaluate at Jet3 construction boundary
         let nx = (cross_x * inv_n_len.clone()).constant();
@@ -686,7 +687,8 @@ impl<M: ManifoldCompat<Jet3, Output = Discrete>> Manifold<Jet3_4> for ColorRefle
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        // Use .rsqrt() directly instead of .sqrt().rsqrt() to compute x^(-1/2) correctly
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         // Normal components - evaluate at Jet3 construction boundary
         let nx = (cross_x * inv_n_len.clone()).constant();
@@ -793,7 +795,8 @@ where
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        // Use .rsqrt() directly instead of .sqrt().rsqrt() to compute x^(-1/2) correctly
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         let nx = (cross_x * inv_n_len.clone()).constant();
         let ny = (cross_y * inv_n_len.clone()).constant();
@@ -906,7 +909,8 @@ where
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        // Use .rsqrt() directly instead of .sqrt().rsqrt() to compute x^(-1/2) correctly
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         let nx = (cross_x * inv_n_len.clone()).constant();
         let ny = (cross_y * inv_n_len.clone()).constant();


### PR DESCRIPTION
### 💡 What
Replaced `.sqrt().rsqrt()` with `.rsqrt()` in `pixelflow-graphics/src/scene3d.rs`.

### 🎯 Why
When working with a squared vector length (`n_len_sq`), calculating the reciprocal length (to normalize the vector) should be `x^(-1/2)`. However, the original code called `n_len_sq.sqrt().rsqrt()`, which mathematically equates to `(x^(1/2))^(-1/2) = x^(-1/4)`. This introduces both a mathematical error (the resulting vector is not fully normalized) and a performance penalty from evaluating an extra, unnecessary square root.

### 📊 Impact
Corrects the mathematical logic ensuring that vectors are truly normalized to length 1. It also slightly improves performance by eliminating an unnecessary `sqrt()` evaluation, reducing AST node overhead.

### 🔬 Measurement
Verified via `cargo check` and `cargo test` on `pixelflow-graphics`. The changes directly fix a clear mathematical bug while keeping the SIMD evaluation efficient.

---
*PR created automatically by Jules for task [2189369502145502712](https://jules.google.com/task/2189369502145502712) started by @jppittman*