### PR TITLE
Refactor `MacWindow::set_visible` to avoid boolean argument

### DIFF
--- a/pixelflow-runtime/src/platform/macos/platform.rs
+++ b/pixelflow-runtime/src/platform/macos/platform.rs
@@ -102,7 +102,11 @@ impl PlatformOps for MetalOps {
             }
             DisplayControl::SetVisible { id, visible } => {
                 if let Some(win) = self.windows.get_mut(&id) {
-                    win.set_visible(visible);
+                    if visible {
+                        win.show();
+                    } else {
+                        win.hide();
+                    }
                 }
             }
             DisplayControl::RequestRedraw { id } => {
@@ -164,7 +168,7 @@ impl PlatformOps for MetalOps {
             }
             DisplayMgmt::Destroy { id } => {
                 if let Some(mut win) = self.windows.remove(&id) {
-                    win.set_visible(false);
+                    win.hide();
                     // Drop closes it implicitly or we call close
                     // win.window.close(); // If we expose it
                     self.window_map.remove(&(win.window.0 as usize));

--- a/pixelflow-runtime/src/platform/macos/window.rs
+++ b/pixelflow-runtime/src/platform/macos/window.rs
@@ -122,13 +122,13 @@ impl MacWindow {
         }
     }
 
-    pub fn set_visible(&mut self, visible: bool) {
-        if visible {
-            self.window.make_key_and_order_front();
-        } else {
-            unsafe {
-                sys::send::<()>(self.window.0, sys::sel(b"orderOut:\0"));
-            }
+    pub fn show(&mut self) {
+        self.window.make_key_and_order_front();
+    }
+
+    pub fn hide(&mut self) {
+        unsafe {
+            sys::send::<()>(self.window.0, sys::sel(b"orderOut:\0"));
         }
     }
 

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,12 @@
+1. **Target:** `pixelflow-runtime/src/platform/macos/window.rs`
+   - `MacWindow::set_visible(&mut self, visible: bool)` uses a boolean argument `visible`.
+2. **Analysis:**
+   - This explicitly violates the `STYLE.md` guideline against boolean arguments: "Avoid functions that take boolean arguments. They make the call site unclear... Prefer using enums or splitting the function into two separate functions."
+   - The method logic is simple: if `visible` is true, it shows the window; if false, it hides it. This is a perfect candidate for splitting into `show()` and `hide()`.
+3. **Execution:**
+   - Replace `pub fn set_visible(&mut self, visible: bool)` in `MacWindow` with `pub fn show(&mut self)` and `pub fn hide(&mut self)`.
+   - Update `pixelflow-runtime/src/platform/macos/platform.rs` which calls this method to use the new methods based on the `visible` boolean it receives from `DisplayControl::SetVisible`.
+4. **Pre-commit step:**
+   - Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+5. **Submit:**
+   - Commit and submit.


### PR DESCRIPTION
Replaced `set_visible(&mut self, visible: bool)` with `show(&mut self)`
and `hide(&mut self)` in `pixelflow-runtime/src/platform/macos/window.rs`
to comply with `STYLE.md` guidelines against boolean arguments.
Updated the call sites in `pixelflow-runtime/src/platform/macos/platform.rs`
to use the new methods based on the `DisplayControl::SetVisible` boolean flag.

---
*PR created automatically by Jules for task [4423015385339029813](https://jules.google.com/task/4423015385339029813) started by @jppittman*