### PR TITLE
Refactor `AnsiParser` to replace boolean `consume_st` with strictly-typed `ConsumeSt` enum

### DIFF
--- a/core-term/src/ansi/parser.rs
+++ b/core-term/src/ansi/parser.rs
@@ -13,12 +13,6 @@ const MAX_PARAMS: usize = 16;
 const MAX_INTERMEDIATES: usize = 2;
 const MAX_OSC_LEN: usize = 1024; // Limit OSC/DCS/PM/APC string length
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ConsumeSt {
-    Consume,
-    Keep,
-}
-
 /// Represents the current state of the ANSI parser state machine.
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum State {
@@ -195,39 +189,39 @@ impl AnsiParser {
         self.state = State::Ground;
     }
 
-    fn dispatch_osc(&mut self, consume_st: ConsumeSt) {
+    fn dispatch_osc(&mut self, consume_st: bool) {
         let data = mem::take(&mut self.string_buffer);
         trace!("Dispatching OSC: Data length {}", data.len());
         self.commands.push(AnsiCommand::Osc(data));
         self.clear_string_buffer();
-        if consume_st == ConsumeSt::Keep { /* ST handled separately */ }
+        if !consume_st { /* ST handled separately */ }
         self.state = State::Ground;
     }
 
-    fn dispatch_dcs(&mut self, consume_st: ConsumeSt) {
+    fn dispatch_dcs(&mut self, consume_st: bool) {
         let data = mem::take(&mut self.string_buffer);
         trace!("Dispatching DCS: Data length {}", data.len());
         self.commands.push(AnsiCommand::Dcs(data));
         self.clear_string_buffer();
-        if consume_st == ConsumeSt::Keep { /* ST handled separately */ }
+        if !consume_st { /* ST handled separately */ }
         self.state = State::Ground;
     }
 
-    fn dispatch_pm(&mut self, consume_st: ConsumeSt) {
+    fn dispatch_pm(&mut self, consume_st: bool) {
         let data = mem::take(&mut self.string_buffer);
         trace!("Dispatching PM: Data length {}", data.len());
         self.commands.push(AnsiCommand::Pm(data));
         self.clear_string_buffer();
-        if consume_st == ConsumeSt::Keep { /* ST handled separately */ }
+        if !consume_st { /* ST handled separately */ }
         self.state = State::Ground;
     }
 
-    fn dispatch_apc(&mut self, consume_st: ConsumeSt) {
+    fn dispatch_apc(&mut self, consume_st: bool) {
         let data = mem::take(&mut self.string_buffer);
         trace!("Dispatching APC: Data length {}", data.len());
         self.commands.push(AnsiCommand::Apc(data));
         self.clear_string_buffer();
-        if consume_st == ConsumeSt::Keep { /* ST handled separately */ }
+        if !consume_st { /* ST handled separately */ }
         self.state = State::Ground;
     }
 
@@ -433,7 +427,7 @@ impl AnsiParser {
                     AnsiToken::C0Control(b)
                         if b == C0Control::BEL as u8 && self.state == State::OscString =>
                     {
-                        self.dispatch_osc(ConsumeSt::Keep)
+                        self.dispatch_osc(false)
                     }
                     AnsiToken::C0Control(b)
                         if b == C0Control::CAN as u8 || b == C0Control::SUB as u8 =>
@@ -453,10 +447,10 @@ impl AnsiParser {
             }
             State::EscInString => match token {
                 AnsiToken::Print('\\') => match self.string_state_origin {
-                    Some(State::OscString) => self.dispatch_osc(ConsumeSt::Consume),
-                    Some(State::DcsEntry) => self.dispatch_dcs(ConsumeSt::Consume),
-                    Some(State::PmString) => self.dispatch_pm(ConsumeSt::Consume),
-                    Some(State::ApcString) => self.dispatch_apc(ConsumeSt::Consume),
+                    Some(State::OscString) => self.dispatch_osc(true),
+                    Some(State::DcsEntry) => self.dispatch_dcs(true),
+                    Some(State::PmString) => self.dispatch_pm(true),
+                    Some(State::ApcString) => self.dispatch_apc(true),
                     _ => {
                         error!("EscInString state missing origin!");
                         self.dispatch_st_standalone();

--- a/core-term/src/ansi/parser.rs
+++ b/core-term/src/ansi/parser.rs
@@ -13,6 +13,12 @@ const MAX_PARAMS: usize = 16;
 const MAX_INTERMEDIATES: usize = 2;
 const MAX_OSC_LEN: usize = 1024; // Limit OSC/DCS/PM/APC string length
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConsumeSt {
+    Consume,
+    Keep,
+}
+
 /// Represents the current state of the ANSI parser state machine.
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum State {
@@ -189,39 +195,39 @@ impl AnsiParser {
         self.state = State::Ground;
     }
 
-    fn dispatch_osc(&mut self, consume_st: bool) {
+    fn dispatch_osc(&mut self, consume_st: ConsumeSt) {
         let data = mem::take(&mut self.string_buffer);
         trace!("Dispatching OSC: Data length {}", data.len());
         self.commands.push(AnsiCommand::Osc(data));
         self.clear_string_buffer();
-        if !consume_st { /* ST handled separately */ }
+        if consume_st == ConsumeSt::Keep { /* ST handled separately */ }
         self.state = State::Ground;
     }
 
-    fn dispatch_dcs(&mut self, consume_st: bool) {
+    fn dispatch_dcs(&mut self, consume_st: ConsumeSt) {
         let data = mem::take(&mut self.string_buffer);
         trace!("Dispatching DCS: Data length {}", data.len());
         self.commands.push(AnsiCommand::Dcs(data));
         self.clear_string_buffer();
-        if !consume_st { /* ST handled separately */ }
+        if consume_st == ConsumeSt::Keep { /* ST handled separately */ }
         self.state = State::Ground;
     }
 
-    fn dispatch_pm(&mut self, consume_st: bool) {
+    fn dispatch_pm(&mut self, consume_st: ConsumeSt) {
         let data = mem::take(&mut self.string_buffer);
         trace!("Dispatching PM: Data length {}", data.len());
         self.commands.push(AnsiCommand::Pm(data));
         self.clear_string_buffer();
-        if !consume_st { /* ST handled separately */ }
+        if consume_st == ConsumeSt::Keep { /* ST handled separately */ }
         self.state = State::Ground;
     }
 
-    fn dispatch_apc(&mut self, consume_st: bool) {
+    fn dispatch_apc(&mut self, consume_st: ConsumeSt) {
         let data = mem::take(&mut self.string_buffer);
         trace!("Dispatching APC: Data length {}", data.len());
         self.commands.push(AnsiCommand::Apc(data));
         self.clear_string_buffer();
-        if !consume_st { /* ST handled separately */ }
+        if consume_st == ConsumeSt::Keep { /* ST handled separately */ }
         self.state = State::Ground;
     }
 
@@ -427,7 +433,7 @@ impl AnsiParser {
                     AnsiToken::C0Control(b)
                         if b == C0Control::BEL as u8 && self.state == State::OscString =>
                     {
-                        self.dispatch_osc(false)
+                        self.dispatch_osc(ConsumeSt::Keep)
                     }
                     AnsiToken::C0Control(b)
                         if b == C0Control::CAN as u8 || b == C0Control::SUB as u8 =>
@@ -447,10 +453,10 @@ impl AnsiParser {
             }
             State::EscInString => match token {
                 AnsiToken::Print('\\') => match self.string_state_origin {
-                    Some(State::OscString) => self.dispatch_osc(true),
-                    Some(State::DcsEntry) => self.dispatch_dcs(true),
-                    Some(State::PmString) => self.dispatch_pm(true),
-                    Some(State::ApcString) => self.dispatch_apc(true),
+                    Some(State::OscString) => self.dispatch_osc(ConsumeSt::Consume),
+                    Some(State::DcsEntry) => self.dispatch_dcs(ConsumeSt::Consume),
+                    Some(State::PmString) => self.dispatch_pm(ConsumeSt::Consume),
+                    Some(State::ApcString) => self.dispatch_apc(ConsumeSt::Consume),
                     _ => {
                         error!("EscInString state missing origin!");
                         self.dispatch_st_standalone();

--- a/pixelflow-graphics/src/scene3d.rs
+++ b/pixelflow-graphics/src/scene3d.rs
@@ -365,7 +365,7 @@ kernel!(pub struct Surface = |geometry: kernel, material: kernel, background: ke
     let valid_t = (V(t) > 0.0) & (V(t) < t_max);
     let deriv_mag_sq = DX(t) * DX(t) + DY(t) * DY(t) + DZ(t) * DZ(t);
     let valid_deriv = deriv_mag_sq < (deriv_max * deriv_max);
-    let mask = valid_t & valid_deriv;
+    let mask = valid_t.clone() & valid_deriv.clone();
 
     // 3. Hit point: P = ray * t (always computed; Select short-circuits if mask is all-false)
     let hx = X * t;
@@ -391,7 +391,7 @@ kernel!(pub struct ColorSurface = |geometry: kernel, material: kernel, backgroun
     let valid_t = (V(t) > 0.0) & (V(t) < t_max);
     let deriv_mag_sq = DX(t) * DX(t) + DY(t) * DY(t) + DZ(t) * DZ(t);
     let valid_deriv = deriv_mag_sq < (deriv_max * deriv_max);
-    let mask = valid_t & valid_deriv;
+    let mask = valid_t.clone() & valid_deriv.clone();
 
     // 3. Hit point: P = ray * t (always computed; Select short-circuits if mask is all-false)
     let hx = X * t;


### PR DESCRIPTION
Replaced the boolean argument `consume_st` in `dispatch_osc`, `dispatch_dcs`, `dispatch_pm`, and `dispatch_apc` with a strongly-typed enum `ConsumeSt { Consume, Keep }` to resolve boolean blindness and adhere to the strict typing guidelines in `STYLE.md`. Update call sites appropriately.

---
*PR created automatically by Jules for task [16765552081551682254](https://jules.google.com/task/16765552081551682254) started by @jppittman*