### PR TITLE
Refactor ansi parser to use explicit ConsumeSt enum

### DIFF
--- a/core-term/src/ansi/parser.rs
+++ b/core-term/src/ansi/parser.rs
@@ -13,6 +13,13 @@ const MAX_PARAMS: usize = 16;
 const MAX_INTERMEDIATES: usize = 2;
 const MAX_OSC_LEN: usize = 1024; // Limit OSC/DCS/PM/APC string length
 
+/// Whether to consume the string terminator (ST) or let it be handled separately.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConsumeSt {
+    Consume,
+    Keep,
+}
+
 /// Represents the current state of the ANSI parser state machine.
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum State {
@@ -189,39 +196,39 @@ impl AnsiParser {
         self.state = State::Ground;
     }
 
-    fn dispatch_osc(&mut self, consume_st: bool) {
+    fn dispatch_osc(&mut self, consume_st: ConsumeSt) {
         let data = mem::take(&mut self.string_buffer);
         trace!("Dispatching OSC: Data length {}", data.len());
         self.commands.push(AnsiCommand::Osc(data));
         self.clear_string_buffer();
-        if !consume_st { /* ST handled separately */ }
+        if consume_st == ConsumeSt::Keep { /* ST handled separately */ }
         self.state = State::Ground;
     }
 
-    fn dispatch_dcs(&mut self, consume_st: bool) {
+    fn dispatch_dcs(&mut self, consume_st: ConsumeSt) {
         let data = mem::take(&mut self.string_buffer);
         trace!("Dispatching DCS: Data length {}", data.len());
         self.commands.push(AnsiCommand::Dcs(data));
         self.clear_string_buffer();
-        if !consume_st { /* ST handled separately */ }
+        if consume_st == ConsumeSt::Keep { /* ST handled separately */ }
         self.state = State::Ground;
     }
 
-    fn dispatch_pm(&mut self, consume_st: bool) {
+    fn dispatch_pm(&mut self, consume_st: ConsumeSt) {
         let data = mem::take(&mut self.string_buffer);
         trace!("Dispatching PM: Data length {}", data.len());
         self.commands.push(AnsiCommand::Pm(data));
         self.clear_string_buffer();
-        if !consume_st { /* ST handled separately */ }
+        if consume_st == ConsumeSt::Keep { /* ST handled separately */ }
         self.state = State::Ground;
     }
 
-    fn dispatch_apc(&mut self, consume_st: bool) {
+    fn dispatch_apc(&mut self, consume_st: ConsumeSt) {
         let data = mem::take(&mut self.string_buffer);
         trace!("Dispatching APC: Data length {}", data.len());
         self.commands.push(AnsiCommand::Apc(data));
         self.clear_string_buffer();
-        if !consume_st { /* ST handled separately */ }
+        if consume_st == ConsumeSt::Keep { /* ST handled separately */ }
         self.state = State::Ground;
     }
 
@@ -427,7 +434,7 @@ impl AnsiParser {
                     AnsiToken::C0Control(b)
                         if b == C0Control::BEL as u8 && self.state == State::OscString =>
                     {
-                        self.dispatch_osc(false)
+                        self.dispatch_osc(ConsumeSt::Keep)
                     }
                     AnsiToken::C0Control(b)
                         if b == C0Control::CAN as u8 || b == C0Control::SUB as u8 =>
@@ -447,10 +454,10 @@ impl AnsiParser {
             }
             State::EscInString => match token {
                 AnsiToken::Print('\\') => match self.string_state_origin {
-                    Some(State::OscString) => self.dispatch_osc(true),
-                    Some(State::DcsEntry) => self.dispatch_dcs(true),
-                    Some(State::PmString) => self.dispatch_pm(true),
-                    Some(State::ApcString) => self.dispatch_apc(true),
+                    Some(State::OscString) => self.dispatch_osc(ConsumeSt::Consume),
+                    Some(State::DcsEntry) => self.dispatch_dcs(ConsumeSt::Consume),
+                    Some(State::PmString) => self.dispatch_pm(ConsumeSt::Consume),
+                    Some(State::ApcString) => self.dispatch_apc(ConsumeSt::Consume),
                     _ => {
                         error!("EscInString state missing origin!");
                         self.dispatch_st_standalone();

--- a/pixelflow-graphics/src/scene3d.rs
+++ b/pixelflow-graphics/src/scene3d.rs
@@ -15,6 +15,7 @@
 
 use pixelflow_core::jet::Jet3;
 use pixelflow_core::*;
+use pixelflow_core::{Field, Discrete, Manifold, ManifoldCompat, ManifoldExt};
 use pixelflow_compiler::{kernel, ManifoldExpr};
 
 /// The standard 4D Field domain type.
@@ -362,18 +363,11 @@ kernel!(pub struct Surface = |geometry: kernel, material: kernel, background: ke
     // 2. Validate hit: t > 0, t < max, derivatives reasonable
     let t_max = 1000000.0;
     let deriv_max = 10000.0;
-    let valid_t = (V(t) > 0.0) & (V(t) < t_max);
-    let deriv_mag_sq = DX(t) * DX(t) + DY(t) * DY(t) + DZ(t) * DZ(t);
-    let valid_deriv = deriv_mag_sq < (deriv_max * deriv_max);
-    let mask = valid_t & valid_deriv;
+    let mask = ((V(t) > 0.0) & (V(t) < t_max)) & ((DX(t) * DX(t) + DY(t) * DY(t) + DZ(t) * DZ(t)) < (deriv_max * deriv_max));
 
     // 3. Hit point: P = ray * t (always computed; Select short-circuits if mask is all-false)
-    let hx = X * t;
-    let hy = Y * t;
-    let hz = Z * t;
-
     // 4. Sample material at hit point, background at ray direction
-    let mat_val = material.at(hx, hy, hz, W);
+    let mat_val = material.at(X * t, Y * t, Z * t, W);
     let bg_val = background;
 
     // 5. Select based on hit validity (short-circuit avoids evaluating unused branch)
@@ -388,18 +382,11 @@ kernel!(pub struct ColorSurface = |geometry: kernel, material: kernel, backgroun
     // 2. Validate hit: t > 0, t < max, derivatives reasonable
     let t_max = 1000000.0;
     let deriv_max = 10000.0;
-    let valid_t = (V(t) > 0.0) & (V(t) < t_max);
-    let deriv_mag_sq = DX(t) * DX(t) + DY(t) * DY(t) + DZ(t) * DZ(t);
-    let valid_deriv = deriv_mag_sq < (deriv_max * deriv_max);
-    let mask = valid_t & valid_deriv;
+    let mask = ((V(t) > 0.0) & (V(t) < t_max)) & ((DX(t) * DX(t) + DY(t) * DY(t) + DZ(t) * DZ(t)) < (deriv_max * deriv_max));
 
     // 3. Hit point: P = ray * t (always computed; Select short-circuits if mask is all-false)
-    let hx = X * t;
-    let hy = Y * t;
-    let hz = Z * t;
-
     // 4. Sample material at hit point, background at ray direction
-    let mat_val = material.at(hx, hy, hz, W);
+    let mat_val = material.at(X * t, Y * t, Z * t, W);
     let bg_val = background;
 
     // 5. Select based on hit validity (short-circuit avoids evaluating unused branch)
@@ -418,7 +405,7 @@ kernel!(pub struct ColorSurface = |geometry: kernel, material: kernel, backgroun
 /// "First hit in scene graph wins" - not distance-based, but priority-based.
 pub trait Scene {
     /// Mask manifold: evaluates to positive where ray hits this scene.
-    type Mask: ManifoldCompat<Jet3, Output = Field>;
+    type Mask: ManifoldCompat<Jet3, Output = Jet3>;
     /// Color manifold: evaluates to the color at the hit point.
     type Color: ManifoldCompat<Jet3, Output = Discrete>;
 
@@ -510,17 +497,13 @@ where
 }
 
 /// Mask manifold for geometry hit detection.
-kernel!(pub struct GeometryMask = |geometry: kernel| Jet3 -> Field {
+kernel!(pub struct GeometryMask = |geometry: kernel| Jet3 -> Jet3 {
     let t = geometry;
     let t_max = 1000000.0;
     let deriv_max = 10000.0;
 
     // Valid if: t > 0, t < max, derivatives reasonable
-    let valid_t = (V(t) > 0.0) & (V(t) < t_max);
-    let deriv_mag_sq = DX(t) * DX(t) + DY(t) * DY(t) + DZ(t) * DZ(t);
-    let valid_deriv = deriv_mag_sq < (deriv_max * deriv_max);
-
-    valid_t & valid_deriv
+    ((V(t) > 0.0) & (V(t) < t_max)) & ((DX(t) * DX(t) + DY(t) * DY(t) + DZ(t) * DZ(t)) < (deriv_max * deriv_max))
 });
 
 impl<G, M> Scene for SceneObject<G, M>
@@ -652,7 +635,7 @@ impl<M: ManifoldCompat<Jet3, Output = Field>> Manifold<Jet3_4> for Reflect<M> {
         let r_z = d_jet_z - k * n_jet_z;
 
         // Recurse with curved reflected rays
-        self.inner.eval(r_x, r_y, r_z, w)
+        self.inner.eval((r_x, r_y, r_z, w))
     }
 }
 

--- a/pixelflow-graphics/src/scene3d.rs
+++ b/pixelflow-graphics/src/scene3d.rs
@@ -15,7 +15,6 @@
 
 use pixelflow_core::jet::Jet3;
 use pixelflow_core::*;
-use pixelflow_core::{Field, Discrete, Manifold, ManifoldCompat, ManifoldExt};
 use pixelflow_compiler::{kernel, ManifoldExpr};
 
 /// The standard 4D Field domain type.
@@ -363,11 +362,18 @@ kernel!(pub struct Surface = |geometry: kernel, material: kernel, background: ke
     // 2. Validate hit: t > 0, t < max, derivatives reasonable
     let t_max = 1000000.0;
     let deriv_max = 10000.0;
-    let mask = ((V(t) > 0.0) & (V(t) < t_max)) & ((DX(t) * DX(t) + DY(t) * DY(t) + DZ(t) * DZ(t)) < (deriv_max * deriv_max));
+    let valid_t = (V(t) > 0.0) & (V(t) < t_max);
+    let deriv_mag_sq = DX(t) * DX(t) + DY(t) * DY(t) + DZ(t) * DZ(t);
+    let valid_deriv = deriv_mag_sq < (deriv_max * deriv_max);
+    let mask = valid_t & valid_deriv;
 
     // 3. Hit point: P = ray * t (always computed; Select short-circuits if mask is all-false)
+    let hx = X * t;
+    let hy = Y * t;
+    let hz = Z * t;
+
     // 4. Sample material at hit point, background at ray direction
-    let mat_val = material.at(X * t, Y * t, Z * t, W);
+    let mat_val = material.at(hx, hy, hz, W);
     let bg_val = background;
 
     // 5. Select based on hit validity (short-circuit avoids evaluating unused branch)
@@ -382,11 +388,18 @@ kernel!(pub struct ColorSurface = |geometry: kernel, material: kernel, backgroun
     // 2. Validate hit: t > 0, t < max, derivatives reasonable
     let t_max = 1000000.0;
     let deriv_max = 10000.0;
-    let mask = ((V(t) > 0.0) & (V(t) < t_max)) & ((DX(t) * DX(t) + DY(t) * DY(t) + DZ(t) * DZ(t)) < (deriv_max * deriv_max));
+    let valid_t = (V(t) > 0.0) & (V(t) < t_max);
+    let deriv_mag_sq = DX(t) * DX(t) + DY(t) * DY(t) + DZ(t) * DZ(t);
+    let valid_deriv = deriv_mag_sq < (deriv_max * deriv_max);
+    let mask = valid_t & valid_deriv;
 
     // 3. Hit point: P = ray * t (always computed; Select short-circuits if mask is all-false)
+    let hx = X * t;
+    let hy = Y * t;
+    let hz = Z * t;
+
     // 4. Sample material at hit point, background at ray direction
-    let mat_val = material.at(X * t, Y * t, Z * t, W);
+    let mat_val = material.at(hx, hy, hz, W);
     let bg_val = background;
 
     // 5. Select based on hit validity (short-circuit avoids evaluating unused branch)
@@ -405,7 +418,7 @@ kernel!(pub struct ColorSurface = |geometry: kernel, material: kernel, backgroun
 /// "First hit in scene graph wins" - not distance-based, but priority-based.
 pub trait Scene {
     /// Mask manifold: evaluates to positive where ray hits this scene.
-    type Mask: ManifoldCompat<Jet3, Output = Jet3>;
+    type Mask: ManifoldCompat<Jet3, Output = Field>;
     /// Color manifold: evaluates to the color at the hit point.
     type Color: ManifoldCompat<Jet3, Output = Discrete>;
 
@@ -497,13 +510,17 @@ where
 }
 
 /// Mask manifold for geometry hit detection.
-kernel!(pub struct GeometryMask = |geometry: kernel| Jet3 -> Jet3 {
+kernel!(pub struct GeometryMask = |geometry: kernel| Jet3 -> Field {
     let t = geometry;
     let t_max = 1000000.0;
     let deriv_max = 10000.0;
 
     // Valid if: t > 0, t < max, derivatives reasonable
-    ((V(t) > 0.0) & (V(t) < t_max)) & ((DX(t) * DX(t) + DY(t) * DY(t) + DZ(t) * DZ(t)) < (deriv_max * deriv_max))
+    let valid_t = (V(t) > 0.0) & (V(t) < t_max);
+    let deriv_mag_sq = DX(t) * DX(t) + DY(t) * DY(t) + DZ(t) * DZ(t);
+    let valid_deriv = deriv_mag_sq < (deriv_max * deriv_max);
+
+    valid_t & valid_deriv
 });
 
 impl<G, M> Scene for SceneObject<G, M>
@@ -635,7 +652,7 @@ impl<M: ManifoldCompat<Jet3, Output = Field>> Manifold<Jet3_4> for Reflect<M> {
         let r_z = d_jet_z - k * n_jet_z;
 
         // Recurse with curved reflected rays
-        self.inner.eval((r_x, r_y, r_z, w))
+        self.inner.eval(r_x, r_y, r_z, w)
     }
 }
 


### PR DESCRIPTION
As requested by the StyleEnforcer guidelines (`docs/STYLE.md`), refactored the `AnsiParser` string dispatch methods (`dispatch_osc`, `dispatch_dcs`, `dispatch_pm`, `dispatch_apc`) to use an explicit enum (`ConsumeSt`) rather than a boolean parameter (`consume_st: bool`). This makes the call sites clearer (e.g. `self.dispatch_osc(ConsumeSt::Keep)` instead of `self.dispatch_osc(false)`) and eliminates boolean blindness. Verified the changes with `cargo test -p core-term`.

---
*PR created automatically by Jules for task [4858096320365022047](https://jules.google.com/task/4858096320365022047) started by @jppittman*