### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/pixelflow-graphics/src/scene3d.rs
+++ b/pixelflow-graphics/src/scene3d.rs
@@ -598,7 +598,7 @@ impl<M: ManifoldCompat<Jet3, Output = Field>> Manifold<Jet3_4> for Reflect<M> {
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         // Normal components - evaluate at Jet3 construction boundary
         let nx = (cross_x * inv_n_len.clone()).constant();
@@ -686,7 +686,7 @@ impl<M: ManifoldCompat<Jet3, Output = Discrete>> Manifold<Jet3_4> for ColorRefle
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         // Normal components - evaluate at Jet3 construction boundary
         let nx = (cross_x * inv_n_len.clone()).constant();
@@ -793,7 +793,7 @@ where
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         let nx = (cross_x * inv_n_len.clone()).constant();
         let ny = (cross_y * inv_n_len.clone()).constant();
@@ -906,7 +906,7 @@ where
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         let nx = (cross_x * inv_n_len.clone()).constant();
         let ny = (cross_y * inv_n_len.clone()).constant();


### PR DESCRIPTION
What:
Replaced `.sqrt().rsqrt()` with `.rsqrt()` for Jet3 length normalization in `pixelflow-graphics/src/scene3d.rs`.

Why:
The `rsqrt` instruction inherently computes `1 / sqrt(x)`. Doing `.sqrt().rsqrt()` computes `1 / sqrt(sqrt(x))`, which is mathematically incorrect (`x^(-1/4)` instead of `x^(-1/2)`), introduces errors, and incurs redundant AST evaluation overhead by stacking unnecessary nodes.

Impact:
Fixes a subtle math bug causing skewed normal vectors during reflection.
Improves performance in the critical rendering loop by removing a redundant `sqrt` operation (~14 CPU cycles) from the AST graph, allowing `rsqrt` to execute natively.

Measurement:
Can be verified by rendering the scene examples; normal calculations for reflection will now be mathematically accurate, and rendering should see a slight performance boost.

---
*PR created automatically by Jules for task [11929199587146885471](https://jules.google.com/task/11929199587146885471) started by @jppittman*