### PR TITLE
refactor(tests): Enforce Mutant Hunter naming conventions and semantic assertions

### DIFF
--- a/pixelflow-core/src/algebra.rs
+++ b/pixelflow-core/src/algebra.rs
@@ -513,7 +513,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_f32_algebra() {
+    fn f32_should_satisfy_ring_operations_and_comparisons() {
         // Ring operations
         assert_eq!(f32::zero(), 0.0);
         assert_eq!(f32::one(), 1.0);
@@ -537,7 +537,7 @@ mod tests {
     // Transcendental tests only run on scalar fallback platforms
     #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
     #[test]
-    fn test_f32_transcendental() {
+    fn f32_should_compute_transcendental_functions_within_epsilon() {
         let epsilon = 1e-6;
 
         assert!((4.0f32.sqrt() - 2.0).abs() < epsilon);
@@ -558,26 +558,26 @@ mod tests {
     }
 
     #[test]
-    fn test_bool_algebra() {
-        assert_eq!(bool::zero(), false);
-        assert_eq!(bool::one(), true);
+    fn bool_should_satisfy_boolean_ring_operations() {
+        assert!(!bool::zero());
+        assert!(bool::one());
 
         // Boolean ring (OR/AND)
-        assert_eq!(false.add(false), false);
-        assert_eq!(false.add(true), true);
-        assert_eq!(true.add(false), true);
-        assert_eq!(true.add(true), true);
+        assert!(!false.add(false));
+        assert!(false.add(true));
+        assert!(true.add(false));
+        assert!(true.add(true));
 
-        assert_eq!(false.mul(false), false);
-        assert_eq!(false.mul(true), false);
-        assert_eq!(true.mul(true), true);
+        assert!(!false.mul(false));
+        assert!(!false.mul(true));
+        assert!(true.mul(true));
 
-        assert_eq!(true.neg(), false);
-        assert_eq!(false.neg(), true);
+        assert!(!true.neg());
+        assert!(false.neg());
     }
 
     #[test]
-    fn test_u32_algebra() {
+    fn u32_should_satisfy_ring_and_wrapping_operations() {
         assert_eq!(u32::zero(), 0);
         assert_eq!(u32::one(), 1);
         assert_eq!(2u32.add(3), 5);

--- a/pixelflow-graphics/src/subdivision.rs
+++ b/pixelflow-graphics/src/subdivision.rs
@@ -465,7 +465,7 @@ mod tests {
     use std::io::Cursor;
 
     #[test]
-    fn test_regular_patch() {
+    fn patch_should_be_extraordinary_when_all_corners_have_valence_1() {
         let obj = "
 v 0.0 0.0 0.0
 v 1.0 0.0 0.0
@@ -482,7 +482,7 @@ f 1 2 3 4
     }
 
     #[test]
-    fn test_limit_eval() {
+    fn eval_limit_should_produce_ast_nodes_when_evaluated_at_center() {
         let obj = "
 v 0.0 0.0 0.0
 v 1.0 0.0 0.0
@@ -505,11 +505,11 @@ f 1 2 3 4
 
         // For bilinear fallback, center should be roughly (0.5, 0.5, 0.0)
         // We can't easily check SIMD Field values in tests, so this is a smoke test
-        assert_eq!(patch.is_extraordinary(), true);
+        assert!(patch.is_extraordinary());
     }
 
     #[test]
-    fn test_surface_stats() {
+    fn stats_should_return_correct_patch_count_when_mesh_has_two_faces() {
         let obj = "
 v 0.0 0.0 0.0
 v 1.0 0.0 0.0

--- a/pixelflow-graphics/tests/scene3d_test.rs
+++ b/pixelflow-graphics/tests/scene3d_test.rs
@@ -101,7 +101,7 @@ impl<M: ManifoldCompat<Field, Output = Field> + ManifoldExt> Manifold<Field4> fo
 /// - Surface<SphereAt, Reflect<world>, world>: sphere reflecting world
 /// - world = Surface<plane, Checker, Sky>: floor + sky
 #[test]
-fn test_chrome_unit_sphere() {
+fn scene3d_should_render_chrome_unit_sphere() {
     const W: usize = 400;
     const H: usize = 300;
 
@@ -174,7 +174,7 @@ fn test_chrome_unit_sphere() {
 
 /// Test: Just the sky (no geometry)
 #[test]
-fn test_sky_only() {
+fn scene3d_should_render_sky_gradient_when_sky_only() {
     const W: usize = 200;
     const H: usize = 150;
 
@@ -226,7 +226,7 @@ fn test_sky_only() {
 
 /// Test: Floor only (plane with checker pattern)
 #[test]
-fn test_floor_only() {
+fn scene3d_should_render_checker_floor_when_floor_only() {
     const W: usize = 400;
     const H: usize = 300;
 
@@ -274,7 +274,7 @@ fn test_floor_only() {
 /// Test: Color chrome sphere with blue sky (MULLET ARCHITECTURE)
 /// Geometry runs ONCE, colors flow as packed RGBA. 3x speedup!
 #[test]
-fn test_color_chrome_sphere() {
+fn scene3d_should_render_chrome_sphere_with_color_cube() {
     const W: usize = 1920;
     const H: usize = 1080;
 
@@ -364,7 +364,7 @@ fn test_color_chrome_sphere() {
 /// Test: Compare 3-channel vs mullet rendering to ensure they match.
 /// This verifies the mullet architecture produces identical results.
 #[test]
-fn test_mullet_vs_3channel_comparison() {
+fn scene3d_should_match_mullet_and_3channel_rendering() {
     const W: usize = 200;
     const H: usize = 150;
 
@@ -600,7 +600,7 @@ fn test_mullet_vs_3channel_comparison() {
 
 /// Benchmark: Compare work-stealing vs single-threaded at 1080p
 #[test]
-fn test_work_stealing_benchmark() {
+fn scene3d_should_run_work_stealing_benchmark() {
     const W: usize = 1920;
     const H: usize = 1080;
 


### PR DESCRIPTION
This PR applies strict "Mutant Hunter" testing standards to `algebra.rs`, `subdivision.rs`, and `scene3d_test.rs`.
    
    **Changes made:**
    *   **Naming Conventions:** Renamed test functions to eliminate generic `test_` prefixes, replacing them with descriptive names (e.g., `scene3d_should_render_chrome_unit_sphere`, `bool_should_satisfy_boolean_ring_operations`).
    *   **Assertion Semantics:** Removed boolean equality checks (e.g., `assert_eq!(patch.is_extraordinary(), true)`) and replaced them with direct semantic assertions (e.g., `assert!(patch.is_extraordinary())`) following the Style Guide's "No Boolean Args" directive.
    *   Verified changes pass the relevant module unit tests via `cargo test --workspace`.

---
*PR created automatically by Jules for task [6581489473626080447](https://jules.google.com/task/6581489473626080447) started by @jppittman*