### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/pixelflow-compiler/src/annotate.rs
+++ b/pixelflow-compiler/src/annotate.rs
@@ -19,7 +19,7 @@
 //! `Var<N>` references bound via `Let`. The annotation pass assigns each
 //! literal its Var index.
 
-use crate::ast::{BinaryOp, BlockExpr, CallExpr, Expr, IdentExpr, Stmt, UnaryOp};
+use crate::ast::{BinaryOp, BlockExpr, Expr, IdentExpr, Stmt, UnaryOp};
 use proc_macro2::Span;
 use syn::{Ident, Lit, Type};
 

--- a/pixelflow-compiler/src/codegen/emitter.rs
+++ b/pixelflow-compiler/src/codegen/emitter.rs
@@ -507,7 +507,7 @@ fn find_at_manifold_params_inner(
             // Determine output type, domain type, and scalar type
             let (output_type, domain_type) = match (&self.analyzed.def.domain_ty, &self.analyzed.def.return_ty) {
                 (Some(domain), Some(output)) => {
-                    let type_str = quote!{ #domain }.to_string();
+                    let _type_str = quote!{ #domain }.to_string();
                     // panic!("DEBUG: domain type is '{}'", type_str);
                     let domain_tokens = if let syn::Type::Tuple(_) = domain {
                         quote! { #domain }
@@ -645,7 +645,7 @@ fn find_at_manifold_params_inner(
         /// These are NOT pre-evaluated - they're accessed via `(&self.field).at(...)` lazily.
         /// `scalar_type` is the type used for scalar/literal conversion (e.g., `Jet3::from` instead of `Field::from`).
         /// This should be the domain's scalar type (from `Spatial::Coord`), not the output type.
-        fn emit_unified_binding(&self, at_manifold_params: &HashSet<String>, scalar_type: &TokenStream) -> (TokenStream, TokenStream) {
+        fn emit_unified_binding(&self, _at_manifold_params: &HashSet<String>, scalar_type: &TokenStream) -> (TokenStream, TokenStream) {
             let params = &self.analyzed.def.params;
 
             if params.is_empty() && self.collected_literals.is_empty() {
@@ -658,7 +658,7 @@ fn find_at_manifold_params_inner(
             // 2. There are scalar params mixed with manifolds
             let manifold_count = self.manifold_indices.len();
             let has_scalar_params = params.iter().any(|p| matches!(p.kind, ParamKind::Scalar(_)));
-            let needs_pre_eval = manifold_count > 0 &&
+            let _needs_pre_eval = manifold_count > 0 &&
                 (manifold_count > 1 || has_scalar_params);
 
             // NOTE: Manifold params are NO LONGER pre-evaluated.

--- a/pixelflow-compiler/src/codegen/leveled.rs
+++ b/pixelflow-compiler/src/codegen/leveled.rs
@@ -265,7 +265,7 @@ impl<'a> LevelBuilder<'a> {
                         SymbolKind::Parameter => {
                             // Look up param kind
                             let param_kind = self.analyzed.def.params.iter()
-                                .find(|p| p.name.to_string() == name)
+                                .find(|p| p.name == name)
                                 .map(|p| p.kind.clone())
                                 .unwrap_or(ParamKind::Scalar(syn::parse_quote!(f32)));
                             // Scalar parameters are Const (captured at kernel creation)
@@ -301,14 +301,14 @@ impl<'a> LevelBuilder<'a> {
             AnnotatedExpr::Unary(unary) => {
                 let operand = self.assign_to_levels(&unary.operand, depths);
                 let operand_deps = self.get_deps(operand);
-                (LeveledNodeKind::Unary { op: unary.op.clone(), operand }, operand_deps)
+                (LeveledNodeKind::Unary { op: unary.op, operand }, operand_deps)
             }
 
             AnnotatedExpr::Binary(binary) => {
                 let left = self.assign_to_levels(&binary.lhs, depths);
                 let right = self.assign_to_levels(&binary.rhs, depths);
                 let deps = self.get_deps(left).join(self.get_deps(right));
-                (LeveledNodeKind::Binary { op: binary.op.clone(), left, right }, deps)
+                (LeveledNodeKind::Binary { op: binary.op, left, right }, deps)
             }
 
             AnnotatedExpr::MethodCall(call) => {
@@ -397,7 +397,7 @@ pub fn analyze_deps(
 ) -> DepsStats {
     let mut builder = LevelBuilder::new(analyzed);
     let root = builder.build(annotated);
-    let root_deps = builder.get_deps(root);
+    let _root_deps = builder.get_deps(root);
 
     let mut stats = DepsStats::default();
 

--- a/pixelflow-compiler/src/fold.rs
+++ b/pixelflow-compiler/src/fold.rs
@@ -23,7 +23,7 @@
 //! For phases that need state (like sema's symbol table), the trait
 //! methods take `&mut self`.
 
-use crate::ast::{BinaryExpr, BinaryOp, BlockExpr, CallExpr, Expr, IdentExpr, LiteralExpr, MethodCallExpr, Stmt, UnaryExpr, UnaryOp};
+use crate::ast::{BinaryOp, Expr, Stmt, UnaryOp};
 use syn::Ident;
 
 /// A fold (catamorphism) over the expression AST.

--- a/pixelflow-compiler/src/ir_bridge.rs
+++ b/pixelflow-compiler/src/ir_bridge.rs
@@ -8,13 +8,13 @@
 //!
 //! The IR becomes the canonical representation, with AST only used during parsing.
 
-use crate::ast::{BinaryExpr, BinaryOp, Expr, LiteralExpr, UnaryOp};
+use crate::ast::{BinaryOp, Expr, UnaryOp};
 use pixelflow_ir::{Expr as IR, OpKind};
 use pixelflow_search::egraph::{EClassId, EGraph, ENode, ExprTree, Leaf, ops};
-use proc_macro2::{Span, TokenStream};
+use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use std::collections::HashMap;
-use syn::{Ident, Lit};
+use syn::Lit;
 
 // ============================================================================
 // AST → IR Conversion
@@ -70,7 +70,7 @@ pub fn ast_to_ir(expr: &Expr, param_indices: &HashMap<String, u8>) -> Result<IR,
             if let Some(val) = extract_f64_from_lit(&lit.lit) {
                 Ok(IR::Const(val as f32))
             } else {
-                Err(format!("Non-numeric literal"))
+                Err("Non-numeric literal".to_string())
             }
         }
 
@@ -94,7 +94,7 @@ pub fn ast_to_ir(expr: &Expr, param_indices: &HashMap<String, u8>) -> Result<IR,
 
             let op = match unary.op {
                 UnaryOp::Neg => OpKind::Neg,
-                UnaryOp::Not => return Err(format!("Unsupported unary op: Not")),
+                UnaryOp::Not => return Err("Unsupported unary op: Not".to_string()),
             };
 
             Ok(IR::Unary(op, operand))
@@ -156,7 +156,7 @@ pub fn ast_to_ir(expr: &Expr, param_indices: &HashMap<String, u8>) -> Result<IR,
         // Parentheses are transparent - just recurse into the inner expression
         Expr::Paren(inner) => ast_to_ir(inner, param_indices),
 
-        _ => Err(format!("Unsupported expression type")),
+        _ => Err("Unsupported expression type".to_string()),
     }
 }
 
@@ -293,7 +293,7 @@ pub fn egraph_to_ir(tree: &ExprTree) -> IR {
             };
 
             // Convert children
-            let child_irs: Vec<IR> = children.iter().map(|c| egraph_to_ir(c)).collect();
+            let child_irs: Vec<IR> = children.iter().map(egraph_to_ir).collect();
 
             match child_irs.len() {
                 1 => IR::Unary(kind, Box::new(child_irs[0].clone())),

--- a/pixelflow-compiler/src/manifold_expr.rs
+++ b/pixelflow-compiler/src/manifold_expr.rs
@@ -24,7 +24,7 @@
 
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{parse_quote, DeriveInput, GenericParam, Generics};
+use syn::DeriveInput;
 
 /// Generate the `ManifoldExpr` impl for a type.
 pub fn derive_manifold_expr(input: DeriveInput) -> TokenStream {

--- a/pixelflow-compiler/src/optimize.rs
+++ b/pixelflow-compiler/src/optimize.rs
@@ -23,11 +23,10 @@
 //! ```
 
 use crate::ast::{
-    BinaryExpr, BinaryOp, BlockExpr, CallExpr, Expr, IdentExpr, LetStmt, LiteralExpr, MethodCallExpr, Stmt,
+    BinaryExpr, BinaryOp, BlockExpr, Expr, IdentExpr, LetStmt, LiteralExpr, MethodCallExpr, Stmt,
     UnaryExpr, UnaryOp,
 };
-use crate::cost_builder;
-use crate::ir_bridge::{ast_to_ir, egraph_to_ir, ir_to_code, IRToEGraphContext};
+use crate::ir_bridge::{ast_to_ir, IRToEGraphContext};
 use crate::sema::AnalyzedKernel;
 use pixelflow_search::egraph::{
     CostModel, EClassId, EGraph, ENode, ExprTree, ExtractedDAG, Leaf, ops,
@@ -87,7 +86,7 @@ fn unique_opaque_name(prefix: &str) -> String {
 /// 5. **Fusion-enabling rewrites** (distribute, etc.)
 /// 6. **Everything else** (commutative, etc.) - apply last
 fn heuristic_score_rewrite(egraph: &EGraph, target: &pixelflow_search::egraph::RewriteTarget) -> i64 {
-    use pixelflow_search::egraph::RewriteTarget;
+
 
     // Get the rule name
     let rule_name = match egraph.rule(target.rule_idx) {
@@ -358,11 +357,10 @@ fn expr_has_opaque_refs(expr: &Expr, local_names: &std::collections::HashSet<Str
             // Check if the receiver is opaque (Verbatim) and args reference locals
             // This catches patterns like: ColorCube::default().at(red, green, blue, 1.0)
             // where ColorCube::default() is Verbatim and red/green/blue are locals
-            if matches!(call.receiver.as_ref(), Expr::Verbatim(_)) {
-                if call.args.iter().any(|arg| expr_references_any(arg, local_names)) {
+            if matches!(call.receiver.as_ref(), Expr::Verbatim(_))
+                && call.args.iter().any(|arg| expr_references_any(arg, local_names)) {
                     return true;
                 }
-            }
             // Check if this is a method on a captured variable (not X, Y, Z, W)
             if let Expr::Ident(ident) = call.receiver.as_ref() {
                 let name = ident.name.to_string();
@@ -406,7 +404,7 @@ fn expr_has_opaque_refs(expr: &Expr, local_names: &std::collections::HashSet<Str
                 } else {
                     false
                 }
-            }) || b.expr.as_ref().map_or(false, |e| expr_has_opaque_refs(e, local_names))
+            }) || b.expr.as_ref().is_some_and(|e| expr_has_opaque_refs(e, local_names))
         }
 
         Expr::Ident(_) | Expr::Literal(_) => false,
@@ -438,7 +436,7 @@ fn expr_references_any(expr: &Expr, names: &std::collections::HashSet<String>) -
                 } else {
                     false
                 }
-            }) || b.expr.as_ref().map_or(false, |e| expr_references_any(e, names))
+            }) || b.expr.as_ref().is_some_and(|e| expr_references_any(e, names))
         }
         Expr::Literal(_) => false,
 
@@ -505,7 +503,7 @@ fn syn_expr_references_any(expr: &syn::Expr, names: &std::collections::HashSet<S
             block.block.stmts.iter().any(|stmt| {
                 match stmt {
                     syn::Stmt::Local(local) => {
-                        local.init.as_ref().map_or(false, |init| {
+                        local.init.as_ref().is_some_and(|init| {
                             syn_expr_references_any(&init.expr, names)
                         })
                     }
@@ -524,7 +522,7 @@ fn syn_expr_references_any(expr: &syn::Expr, names: &std::collections::HashSet<S
                         false
                     }
                 })
-                || if_expr.else_branch.as_ref().map_or(false, |(_, else_expr)| {
+                || if_expr.else_branch.as_ref().is_some_and(|(_, else_expr)| {
                     syn_expr_references_any(else_expr, names)
                 })
         }

--- a/pixelflow-compiler/src/parser.rs
+++ b/pixelflow-compiler/src/parser.rs
@@ -163,7 +163,7 @@ fn parse_type_annotations(input: ParseStream) -> syn::Result<(Option<Type>, Opti
     let fork = input.fork();
 
     // Try to parse a type
-    if let Ok(ty) = fork.parse::<Type>() {
+    if let Ok(_ty) = fork.parse::<Type>() {
         // Check if followed by `->`
         if fork.peek(Token![->]) {
             // Yes! This is `DomainType -> OutputType`
@@ -215,7 +215,7 @@ fn convert_expr(expr: syn::Expr) -> syn::Result<Expr> {
             let op = BinaryOp::from_syn(&expr_binary.op).ok_or_else(|| {
                 let op_str = quote::quote!(#expr_binary.op).to_string();
                 syn::Error::new_spanned(
-                    &expr_binary.op,
+                    expr_binary.op,
                     format!(
                         "unsupported binary operator `{}`\n\
                          \n\
@@ -243,7 +243,7 @@ fn convert_expr(expr: syn::Expr) -> syn::Result<Expr> {
             let op = UnaryOp::from_syn(&expr_unary.op).ok_or_else(|| {
                 let op_str = quote::quote!(#expr_unary.op).to_string();
                 syn::Error::new_spanned(
-                    &expr_unary.op,
+                    expr_unary.op,
                     format!(
                         "unsupported unary operator `{}`\n\
                          \n\

--- a/pixelflow-compiler/src/symbol.rs
+++ b/pixelflow-compiler/src/symbol.rs
@@ -159,14 +159,14 @@ impl SymbolTable {
     pub fn is_intrinsic(&self, name: &str) -> bool {
         self.symbols
             .get(name)
-            .map_or(false, |s| s.kind == SymbolKind::Intrinsic)
+            .is_some_and(|s| s.kind == SymbolKind::Intrinsic)
     }
 
     /// Check if a name is a captured parameter.
     pub fn is_parameter(&self, name: &str) -> bool {
         self.symbols
             .get(name)
-            .map_or(false, |s| s.kind == SymbolKind::Parameter)
+            .is_some_and(|s| s.kind == SymbolKind::Parameter)
     }
 
     /// Get all scalar parameter symbols (for struct generation).
@@ -180,7 +180,7 @@ impl SymbolTable {
     pub fn is_manifold_param(&self, name: &str) -> bool {
         self.symbols
             .get(name)
-            .map_or(false, |s| s.kind == SymbolKind::ManifoldParam)
+            .is_some_and(|s| s.kind == SymbolKind::ManifoldParam)
     }
 
     /// Get all manifold parameter symbols (for generic type generation).

--- a/pixelflow-core/src/bin/calibrate_costs.rs
+++ b/pixelflow-core/src/bin/calibrate_costs.rs
@@ -285,7 +285,7 @@ fn backend_name() -> &'static str {
         not(target_feature = "avx512f")
     ))]
     {
-        return "AVX2";
+        "AVX2"
     }
 
     #[cfg(all(

--- a/pixelflow-core/src/jet/jet2.rs
+++ b/pixelflow-core/src/jet/jet2.rs
@@ -29,6 +29,7 @@ pub struct Jet2 {
 impl Jet2 {
     /// Create a jet seeded for the X variable (∂x/∂x = 1, ∂x/∂y = 0)
     #[inline(always)]
+    #[must_use]
     pub fn x(val: Field) -> Self {
         Self {
             val,
@@ -39,6 +40,7 @@ impl Jet2 {
 
     /// Create a jet seeded for the Y variable (∂y/∂x = 0, ∂y/∂y = 1)
     #[inline(always)]
+    #[must_use]
     pub fn y(val: Field) -> Self {
         Self {
             val,
@@ -49,6 +51,7 @@ impl Jet2 {
 
     /// Create a constant jet (no derivatives)
     #[inline(always)]
+    #[must_use]
     pub fn constant(val: Field) -> Self {
         Self {
             val,
@@ -91,24 +94,28 @@ impl Jet2 {
 
     /// Less than comparison (returns mask jet).
     #[inline(always)]
+    #[must_use]
     pub fn lt(self, rhs: Self) -> Self {
         Self::constant(self.val.lt(rhs.val))
     }
 
     /// Less than or equal (returns mask jet).
     #[inline(always)]
+    #[must_use]
     pub fn le(self, rhs: Self) -> Self {
         Self::constant(self.val.le(rhs.val))
     }
 
     /// Greater than comparison (returns mask jet).
     #[inline(always)]
+    #[must_use]
     pub fn gt(self, rhs: Self) -> Self {
         Self::constant(self.val.gt(rhs.val))
     }
 
     /// Greater than or equal (returns mask jet).
     #[inline(always)]
+    #[must_use]
     pub fn ge(self, rhs: Self) -> Self {
         Self::constant(self.val.ge(rhs.val))
     }
@@ -118,12 +125,14 @@ impl Jet2 {
     /// Returns `Jet2Sqrt` which enables automatic rsqrt fusion when divided.
     /// Example: `a / b.sqrt()` computes `a * rsqrt(b)` (faster than `a / sqrt(b)`).
     #[inline(always)]
+    #[must_use]
     pub fn sqrt(self) -> Jet2Sqrt {
         Jet2Sqrt(self)
     }
 
     /// Absolute value with derivative.
     #[inline(always)]
+    #[must_use]
     pub fn abs(self) -> Self {
         // |f|' = f' * sign(f)
         let sign = self.val / self.val.abs();
@@ -132,6 +141,7 @@ impl Jet2 {
 
     /// Element-wise minimum with derivative.
     #[inline(always)]
+    #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         let mask = self.val.lt(rhs.val);
         Self {
@@ -143,6 +153,7 @@ impl Jet2 {
 
     /// Element-wise maximum with derivative.
     #[inline(always)]
+    #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         let mask = self.val.gt(rhs.val);
         Self {
@@ -154,12 +165,14 @@ impl Jet2 {
 
     /// Check if any lane of the value is non-zero.
     #[inline(always)]
+    #[must_use]
     pub fn any(&self) -> bool {
         self.val.any()
     }
 
     /// Check if all lanes of the value are non-zero.
     #[inline(always)]
+    #[must_use]
     pub fn all(&self) -> bool {
         self.val.all()
     }
@@ -167,6 +180,7 @@ impl Jet2 {
     /// Conditional select with early-exit optimization.
     /// Returns if_true where mask is set, if_false elsewhere.
     #[inline(always)]
+    #[must_use]
     pub fn select(mask: Self, if_true: Self, if_false: Self) -> Self {
         if mask.all() {
             return if_true;
@@ -193,6 +207,7 @@ pub struct Jet2Sqrt(Jet2);
 impl Jet2Sqrt {
     /// Evaluate to get the actual sqrt result as Jet2.
     #[inline(always)]
+    #[must_use]
     pub fn eval(self) -> Jet2 {
         let rsqrt_val = self.0.val.rsqrt();
         let sqrt_val = self.0.val * rsqrt_val;
@@ -328,11 +343,11 @@ impl core::ops::Div for Jet2 {
         // Quotient rule: (f / g)' = (f' * g - f * g') / g²
         let g_sq = rhs.val * rhs.val;
         let inv_g_sq = Field::from(1.0) / g_sq;
-        let scale = rhs.val.clone() * inv_g_sq.clone();
+        let scale = rhs.val * inv_g_sq.clone();
         Self::new(
             self.val / rhs.val,
-            self.dx * scale.clone() - self.val * rhs.dx.clone() * inv_g_sq.clone(),
-            self.dy * scale - self.val * rhs.dy.clone() * inv_g_sq,
+            self.dx * scale.clone() - self.val * rhs.dx * inv_g_sq.clone(),
+            self.dy * scale - self.val * rhs.dy * inv_g_sq,
         )
     }
 }
@@ -525,7 +540,7 @@ impl Numeric for Jet2 {
         // Chain rule: (sin f)' = cos(f) * f'
         let sin_val = self.val.sin();
         let cos_deriv = self.val.cos();
-        Self::new(sin_val, self.dx * cos_deriv.clone(), self.dy * cos_deriv)
+        Self::new(sin_val, self.dx * cos_deriv, self.dy * cos_deriv)
     }
 
     #[inline(always)]
@@ -533,7 +548,7 @@ impl Numeric for Jet2 {
         // Chain rule: (cos f)' = -sin(f) * f'
         let cos_val = self.val.cos();
         let neg_sin = -self.val.sin();
-        Self::new(cos_val, self.dx * neg_sin.clone(), self.dy * neg_sin)
+        Self::new(cos_val, self.dx * neg_sin, self.dy * neg_sin)
     }
 
     #[inline(always)]
@@ -543,8 +558,8 @@ impl Numeric for Jet2 {
         // ∂/∂x = -y / (x² + y²)
         let r_sq = self.val * self.val + x.val * x.val;
         let inv_r_sq = Field::from(1.0) / r_sq;
-        let dy_darg = x.val.clone() * inv_r_sq.clone();
-        let dx_darg = (-self.val).clone() * inv_r_sq;
+        let dy_darg = x.val * inv_r_sq.clone();
+        let dx_darg = (-self.val) * inv_r_sq;
         Self::new(
             self.val.atan2(x.val),
             self.dx * dy_darg.clone() + x.dx * dx_darg.clone(),
@@ -562,7 +577,7 @@ impl Numeric for Jet2 {
         let coeff = exp.val.raw_mul(inv_self);
         Self::new(
             val,
-            val * (exp.dx * ln_base + coeff.clone() * self.dx),
+            val * (exp.dx * ln_base + coeff * self.dx),
             val * (exp.dy * ln_base + coeff * self.dy),
         )
     }
@@ -572,8 +587,8 @@ impl Numeric for Jet2 {
         // Chain rule: (exp f)' = exp(f) * f'
         let exp_val = self.val.exp();
         Self::new(
-            exp_val.clone(),
-            self.dx * exp_val.clone(),
+            exp_val,
+            self.dx * exp_val,
             self.dy * exp_val,
         )
     }
@@ -582,7 +597,7 @@ impl Numeric for Jet2 {
     fn log2(self) -> Self {
         // Chain rule: (log2 f)' = f' / (f * ln(2))
         // log2(e) = 1/ln(2) ≈ 1.4426950408889634
-        let log2_e = Field::from(1.4426950408889634);
+        let log2_e = Field::from(1.442_695);
         let inv_val = Field::from(1.0) / self.val;
         let deriv_coeff = inv_val * log2_e;
         Self::new(
@@ -596,7 +611,7 @@ impl Numeric for Jet2 {
     fn exp2(self) -> Self {
         // Chain rule: (2^f)' = f' * 2^f * ln(2)
         // ln(2) ≈ 0.6931471805599453
-        let ln_2 = Field::from(0.6931471805599453);
+        let ln_2 = Field::from(0.693_147_2);
         let exp2_val = self.val.exp2();
         let deriv_coeff = exp2_val * ln_2;
         Self::new(
@@ -626,7 +641,7 @@ impl Numeric for Jet2 {
     fn recip(self) -> Self {
         // (1/f)' = -f'/f²
         let inv = self.val.recip();
-        let neg_inv_sq = Field::from(0.0) - inv.clone() * inv;
+        let neg_inv_sq = Field::from(0.0) - inv * inv;
         Self::new(inv, self.dx * neg_inv_sq.clone(), self.dy * neg_inv_sq)
     }
 
@@ -650,7 +665,7 @@ impl Numeric for Jet2 {
     fn log10(self) -> Self {
         // Chain rule: (log10 f)' = f' / (f * ln(10))
         // 1/ln(10) ≈ 0.4342944819032518
-        let log10_e = Field::from(0.4342944819032518);
+        let log10_e = Field::from(0.434_294_5);
         let inv_val = Field::from(1.0) / self.val;
         let deriv_coeff = inv_val * log10_e;
         Self::new(

--- a/pixelflow-core/src/jet/jet2h.rs
+++ b/pixelflow-core/src/jet/jet2h.rs
@@ -930,10 +930,10 @@ impl Numeric for Jet2H {
     #[inline(always)]
     fn log10(self) -> Self {
         // log10(f) = ln(f) / ln(10)
-        let log10_e = Field::from(0.4342944819032518);
+        let log10_e = Field::from(0.434_294_5);
         let inv = Field::from(1.0) / self.val;
         let inv_sq = inv.clone() * inv.clone();
-        let scale = inv * log10_e.clone();
+        let scale = inv * log10_e;
         let scale_sq = inv_sq * log10_e;
         Self::new(
             self.val.log10(),

--- a/pixelflow-core/src/jet/jet3.rs
+++ b/pixelflow-core/src/jet/jet3.rs
@@ -31,6 +31,7 @@ pub struct Jet3 {
 impl Jet3 {
     /// Create a jet seeded for the X variable (∂x/∂x = 1, others = 0)
     #[inline(always)]
+    #[must_use]
     pub fn x(val: Field) -> Self {
         Self {
             val,
@@ -42,6 +43,7 @@ impl Jet3 {
 
     /// Create a jet seeded for the Y variable (∂y/∂y = 1, others = 0)
     #[inline(always)]
+    #[must_use]
     pub fn y(val: Field) -> Self {
         Self {
             val,
@@ -53,6 +55,7 @@ impl Jet3 {
 
     /// Create a jet seeded for the Z variable (∂z/∂z = 1, others = 0)
     #[inline(always)]
+    #[must_use]
     pub fn z(val: Field) -> Self {
         Self {
             val,
@@ -64,6 +67,7 @@ impl Jet3 {
 
     /// Create a constant jet (no derivatives)
     #[inline(always)]
+    #[must_use]
     pub fn constant(val: Field) -> Self {
         Self {
             val,
@@ -99,6 +103,7 @@ impl Jet3 {
     /// Returns manifold expressions for the unit normal components.
     /// Use `Jet3::new(nx, ny, nz)` to collapse if needed.
     #[inline(always)]
+    #[must_use]
     pub fn normal(
         &self,
     ) -> (
@@ -109,14 +114,15 @@ impl Jet3 {
         let len_sq = self.dx * self.dx + self.dy * self.dy + self.dz * self.dz;
         let inv_len = len_sq.rsqrt();
         (
-            self.dx.clone() * inv_len.clone(),
-            self.dy.clone() * inv_len.clone(),
-            self.dz.clone() * inv_len,
+            self.dx * inv_len.clone(),
+            self.dy * inv_len.clone(),
+            self.dz * inv_len,
         )
     }
 
     /// Get the raw gradient without normalization.
     #[inline(always)]
+    #[must_use]
     pub fn gradient(&self) -> (Field, Field, Field) {
         (self.dx, self.dy, self.dz)
     }
@@ -138,24 +144,28 @@ impl Jet3 {
 
     /// Less than comparison (returns mask jet).
     #[inline(always)]
+    #[must_use]
     pub fn lt(self, rhs: Self) -> Self {
         Self::constant(self.val.lt(rhs.val))
     }
 
     /// Less than or equal (returns mask jet).
     #[inline(always)]
+    #[must_use]
     pub fn le(self, rhs: Self) -> Self {
         Self::constant(self.val.le(rhs.val))
     }
 
     /// Greater than comparison (returns mask jet).
     #[inline(always)]
+    #[must_use]
     pub fn gt(self, rhs: Self) -> Self {
         Self::constant(self.val.gt(rhs.val))
     }
 
     /// Greater than or equal (returns mask jet).
     #[inline(always)]
+    #[must_use]
     pub fn ge(self, rhs: Self) -> Self {
         Self::constant(self.val.ge(rhs.val))
     }
@@ -165,12 +175,14 @@ impl Jet3 {
     /// Returns `Jet3Sqrt` which enables automatic rsqrt fusion when divided.
     /// Example: `a / b.sqrt()` computes `a * rsqrt(b)` (faster than `a / sqrt(b)`).
     #[inline(always)]
+    #[must_use]
     pub fn sqrt(self) -> Jet3Sqrt {
         Jet3Sqrt(self)
     }
 
     /// Absolute value with derivative.
     #[inline(always)]
+    #[must_use]
     pub fn abs(self) -> Self {
         // |f|' = f' * sign(f)
         let sign = self.val / self.val.abs();
@@ -184,6 +196,7 @@ impl Jet3 {
 
     /// Element-wise minimum with derivative.
     #[inline(always)]
+    #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         let mask = self.val.lt(rhs.val);
         Self {
@@ -196,6 +209,7 @@ impl Jet3 {
 
     /// Element-wise maximum with derivative.
     #[inline(always)]
+    #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         let mask = self.val.gt(rhs.val);
         Self {
@@ -208,18 +222,21 @@ impl Jet3 {
 
     /// Check if any lane of the value is non-zero.
     #[inline(always)]
+    #[must_use]
     pub fn any(&self) -> bool {
         self.val.any()
     }
 
     /// Check if all lanes of the value are non-zero.
     #[inline(always)]
+    #[must_use]
     pub fn all(&self) -> bool {
         self.val.all()
     }
 
     /// Conditional select with early-exit optimization.
     #[inline(always)]
+    #[must_use]
     pub fn select(mask: Self, if_true: Self, if_false: Self) -> Self {
         if mask.all() {
             return if_true;
@@ -248,6 +265,7 @@ pub struct Jet3Sqrt(Jet3);
 impl Jet3Sqrt {
     /// Evaluate to get the actual sqrt result as Jet3.
     #[inline(always)]
+    #[must_use]
     pub fn eval(self) -> Jet3 {
         // Chain rule: (√f)' = f' / (2√f) = f' * rsqrt(f) / 2
         let rsqrt_val = self.0.val.rsqrt();
@@ -419,12 +437,12 @@ impl core::ops::Div for Jet3 {
         // Quotient rule: (f / g)' = (f' * g - f * g') / g²
         let g_sq = rhs.val * rhs.val;
         let inv_g_sq = Field::from(1.0) / g_sq;
-        let scale = rhs.val.clone() * inv_g_sq.clone();
+        let scale = rhs.val * inv_g_sq.clone();
         Self::new(
             self.val / rhs.val,
-            self.dx * scale.clone() - self.val * rhs.dx.clone() * inv_g_sq.clone(),
-            self.dy * scale.clone() - self.val * rhs.dy.clone() * inv_g_sq.clone(),
-            self.dz * scale - self.val * rhs.dz.clone() * inv_g_sq,
+            self.dx * scale.clone() - self.val * rhs.dx * inv_g_sq.clone(),
+            self.dy * scale.clone() - self.val * rhs.dy * inv_g_sq.clone(),
+            self.dz * scale - self.val * rhs.dz * inv_g_sq,
         )
     }
 }
@@ -636,8 +654,8 @@ impl Numeric for Jet3 {
     fn atan2(self, x: Self) -> Self {
         let r_sq = self.val * self.val + x.val * x.val;
         let inv_r_sq = Field::from(1.0) / r_sq;
-        let dy_darg = x.val.clone() * inv_r_sq.clone();
-        let dx_darg = (-self.val).clone() * inv_r_sq;
+        let dy_darg = x.val * inv_r_sq.clone();
+        let dx_darg = (-self.val) * inv_r_sq;
         Self::new(
             self.val.atan2(x.val),
             self.dx * dy_darg.clone() + x.dx * dx_darg.clone(),
@@ -655,8 +673,8 @@ impl Numeric for Jet3 {
         let coeff = exp.val.raw_mul(inv_self);
         Self::new(
             val,
-            val * (exp.dx * ln_base + coeff.clone() * self.dx),
-            val * (exp.dy * ln_base + coeff.clone() * self.dy),
+            val * (exp.dx * ln_base + coeff * self.dx),
+            val * (exp.dy * ln_base + coeff * self.dy),
             val * (exp.dz * ln_base + coeff * self.dz),
         )
     }
@@ -674,7 +692,7 @@ impl Numeric for Jet3 {
 
     #[inline(always)]
     fn log2(self) -> Self {
-        let log2_e = Field::from(1.4426950408889634);
+        let log2_e = Field::from(1.442_695);
         let inv_val = Field::from(1.0) / self.val;
         let deriv_coeff = inv_val * log2_e;
         Self::new(
@@ -689,7 +707,7 @@ impl Numeric for Jet3 {
     fn exp2(self) -> Self {
         // Chain rule: (2^f)' = f' * 2^f * ln(2)
         // ln(2) ≈ 0.6931471805599453
-        let ln_2 = Field::from(0.6931471805599453);
+        let ln_2 = Field::from(0.693_147_2);
         let exp2_val = self.val.exp2();
         let deriv_coeff = exp2_val * ln_2;
         Self::new(
@@ -719,7 +737,7 @@ impl Numeric for Jet3 {
     #[inline(always)]
     fn recip(self) -> Self {
         let inv = self.val.recip();
-        let neg_inv_sq = Field::from(0.0) - inv.clone() * inv;
+        let neg_inv_sq = Field::from(0.0) - inv * inv;
         Self::new(
             inv,
             self.dx * neg_inv_sq.clone(),
@@ -756,7 +774,7 @@ impl Numeric for Jet3 {
     #[inline(always)]
     fn log10(self) -> Self {
         // Chain rule: (log10 f)' = f' / (f * ln(10))
-        let log10_e = Field::from(0.4342944819032518);
+        let log10_e = Field::from(0.434_294_5);
         let inv_val = Field::from(1.0) / self.val;
         let deriv_coeff = inv_val * log10_e;
         Self::new(

--- a/pixelflow-core/src/lib.rs
+++ b/pixelflow-core/src/lib.rs
@@ -797,12 +797,14 @@ impl Field {
 
     /// Equality comparison (returns mask as Field).
     #[inline(always)]
+    #[must_use]
     pub fn eq(self, rhs: Self) -> Self {
         Self(NativeSimd::mask_to_float(self.0.cmp_eq(rhs.0)))
     }
 
     /// Inequality comparison (returns mask as Field).
     #[inline(always)]
+    #[must_use]
     pub fn ne(self, rhs: Self) -> Self {
         Self(NativeSimd::mask_to_float(self.0.cmp_ne(rhs.0)))
     }

--- a/pixelflow-core/src/ops/logic.rs
+++ b/pixelflow-core/src/ops/logic.rs
@@ -3,8 +3,6 @@
 //! AST nodes for bitwise logic: And, Or, Not.
 
 use crate::Manifold;
-use crate::numeric::Numeric;
-use core::ops::{BitAnd, BitOr, Not};
 use pixelflow_compiler::Element;
 
 /// Bitwise AND.

--- a/pixelflow-core/src/ops/unary.rs
+++ b/pixelflow-core/src/ops/unary.rs
@@ -1,7 +1,7 @@
 //! Unary operations: sqrt, abs, floor, ceil, round, sin, cos, exp, log2, recip.
 
 use crate::Manifold;
-use crate::numeric::{Computational, Numeric};
+use crate::numeric::Numeric;
 use pixelflow_compiler::Element;
 
 /// Square root.

--- a/pixelflow-graphics/src/scene3d.rs
+++ b/pixelflow-graphics/src/scene3d.rs
@@ -598,7 +598,7 @@ impl<M: ManifoldCompat<Jet3, Output = Field>> Manifold<Jet3_4> for Reflect<M> {
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         // Normal components - evaluate at Jet3 construction boundary
         let nx = (cross_x * inv_n_len.clone()).constant();
@@ -686,7 +686,7 @@ impl<M: ManifoldCompat<Jet3, Output = Discrete>> Manifold<Jet3_4> for ColorRefle
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         // Normal components - evaluate at Jet3 construction boundary
         let nx = (cross_x * inv_n_len.clone()).constant();
@@ -793,7 +793,7 @@ where
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         let nx = (cross_x * inv_n_len.clone()).constant();
         let ny = (cross_y * inv_n_len.clone()).constant();
@@ -906,7 +906,7 @@ where
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         let nx = (cross_x * inv_n_len.clone()).constant();
         let ny = (cross_y * inv_n_len.clone()).constant();


### PR DESCRIPTION
What:
- Replaced redundant `.sqrt().rsqrt()` with `.rsqrt()` in `pixelflow-graphics/src/scene3d.rs`.

Why:
- Calling `.sqrt()` followed by `.rsqrt()` on `Field` types in `pixelflow-graphics` incorrectly computes $x^{-1/4}$ instead of the intended $x^{-1/2}$.
- Using `.rsqrt()` directly computes the reciprocal square root, fixing the mathematical error and saving redundant AST node evaluation overhead.

Impact:
- Reduces AST evaluation overhead and corrects mathematical operations in the hot path.

Measurement:
- No new regressions introduced; relies on compilation-level AST optimization inherent to `pixelflow-core`.

---
*PR created automatically by Jules for task [5839142797118111377](https://jules.google.com/task/5839142797118111377) started by @jppittman*