### PR TITLE
⚡ Bolt: Optimize normal vector normalization by avoiding redundant sqrt

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2025-12-28 - Rasterizer Inner Loop Hoisting
 **Learning:** The inner loop of `execute_stripe` was re-evaluating `Field::sequential(start)` on every iteration, which involves multiple SIMD instructions (broadcast/load + add).
 **Action:** Hoisted the initialization of `xs` out of the loop and updated it incrementally using a pre-computed `step` vector. This reduced the inner loop overhead significantly, yielding a ~34% improvement in rasterization throughput.
+
+## 2025-12-28 - Avoid Redundant AST Nodes in Inverse Length
+**Learning:** When computing reciprocal square root in `pixelflow-graphics`, chaining `.sqrt().rsqrt()` produces a mathematically incorrect calculation (effectively `x^(-1/4)` instead of `x^(-1/2)`) and creates unnecessary AST node evaluation overhead.
+**Action:** Always compute reciprocal square root directly using `.rsqrt()` on the squared length to preserve correctness and performance.

--- a/pixelflow-graphics/src/scene3d.rs
+++ b/pixelflow-graphics/src/scene3d.rs
@@ -598,7 +598,7 @@ impl<M: ManifoldCompat<Jet3, Output = Field>> Manifold<Jet3_4> for Reflect<M> {
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         // Normal components - evaluate at Jet3 construction boundary
         let nx = (cross_x * inv_n_len.clone()).constant();
@@ -686,7 +686,7 @@ impl<M: ManifoldCompat<Jet3, Output = Discrete>> Manifold<Jet3_4> for ColorRefle
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         // Normal components - evaluate at Jet3 construction boundary
         let nx = (cross_x * inv_n_len.clone()).constant();
@@ -793,7 +793,7 @@ where
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         let nx = (cross_x * inv_n_len.clone()).constant();
         let ny = (cross_y * inv_n_len.clone()).constant();
@@ -906,7 +906,7 @@ where
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         let nx = (cross_x * inv_n_len.clone()).constant();
         let ny = (cross_y * inv_n_len.clone()).constant();


### PR DESCRIPTION
💡 What: Replaced 4 occurrences of `n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt()` with `n_len_sq.max(Field::from(1e-10)).rsqrt()` in `pixelflow-graphics/src/scene3d.rs`.
🎯 Why: Chaining `.sqrt().rsqrt()` is mathematically incorrect (computes `x^(-1/4)` instead of `x^(-1/2)`) for normalizing normal vectors and incurs the performance overhead of evaluating an unnecessary `Sqrt` AST node per pixel.
📊 Impact: Fixes a bug in the graphics rendering logic and eliminates one `Sqrt` AST node evaluation per pixel in a hot path.
🔬 Measurement: Verify using `cargo check -p pixelflow-graphics`. Tests covering reflection logic should remain correct.

---
*PR created automatically by Jules for task [17706171484370885611](https://jules.google.com/task/17706171484370885611) started by @jppittman*