### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/pixelflow-graphics/src/scene3d.rs
+++ b/pixelflow-graphics/src/scene3d.rs
@@ -598,7 +598,7 @@ impl<M: ManifoldCompat<Jet3, Output = Field>> Manifold<Jet3_4> for Reflect<M> {
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         // Normal components - evaluate at Jet3 construction boundary
         let nx = (cross_x * inv_n_len.clone()).constant();
@@ -686,7 +686,7 @@ impl<M: ManifoldCompat<Jet3, Output = Discrete>> Manifold<Jet3_4> for ColorRefle
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         // Normal components - evaluate at Jet3 construction boundary
         let nx = (cross_x * inv_n_len.clone()).constant();
@@ -793,7 +793,7 @@ where
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         let nx = (cross_x * inv_n_len.clone()).constant();
         let ny = (cross_y * inv_n_len.clone()).constant();
@@ -906,7 +906,7 @@ where
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         let nx = (cross_x * inv_n_len.clone()).constant();
         let ny = (cross_y * inv_n_len.clone()).constant();


### PR DESCRIPTION
### 💡 What
Replaced `.sqrt().rsqrt()` with `.rsqrt()` for inverse length calculations in `pixelflow-graphics/src/scene3d.rs`.

### 🎯 Why
The codebase intended to calculate $1/\sqrt{x}$ (the reciprocal square root) for vector normalization, but accidentally calculated $1/\sqrt{\sqrt{x}} = x^{-1/4}$ by chaining the methods. Calling `.rsqrt()` directly corrects this mathematical error and improves performance by eliminating an unnecessary `sqrt` AST node (and resulting JIT instruction).

### 📊 Impact
Removes an expensive and redundant `sqrt` operation per normalized vector, slightly reducing JIT overhead and improving execution speed. More importantly, it correctly normalizes vectors which were previously slightly off.

### 🔬 Measurement
Verify by checking the assembly for normal reconstruction or by rendering a scene and ensuring lighting/reflection directions are mathematically accurate. Unit tests for `scene3d.rs` will also now test mathematically correct normalization logic.

---
*PR created automatically by Jules for task [14132210031745838245](https://jules.google.com/task/14132210031745838245) started by @jppittman*