### PR TITLE
⚡ Bolt: Replace .sqrt().rsqrt() with .rsqrt() in scene3d.rs

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2025-12-28 - Rasterizer Inner Loop Hoisting
 **Learning:** The inner loop of `execute_stripe` was re-evaluating `Field::sequential(start)` on every iteration, which involves multiple SIMD instructions (broadcast/load + add).
 **Action:** Hoisted the initialization of `xs` out of the loop and updated it incrementally using a pre-computed `step` vector. This reduced the inner loop overhead significantly, yielding a ~34% improvement in rasterization throughput.
+
+## 2025-12-28 - Avoid .sqrt().rsqrt() Chaining
+**Learning:** When calculating the reciprocal square root of a value, chaining `.sqrt().rsqrt()` mathematically calculates $x^{-1/4}$ rather than the intended $x^{-1/2}$, while simultaneously increasing overhead by chaining two SIMD math operations.
+**Action:** Always compute reciprocal square root directly using `.rsqrt()` without an intermediate `.sqrt()` step.

--- a/pixelflow-graphics/src/scene3d.rs
+++ b/pixelflow-graphics/src/scene3d.rs
@@ -598,7 +598,7 @@ impl<M: ManifoldCompat<Jet3, Output = Field>> Manifold<Jet3_4> for Reflect<M> {
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         // Normal components - evaluate at Jet3 construction boundary
         let nx = (cross_x * inv_n_len.clone()).constant();
@@ -686,7 +686,7 @@ impl<M: ManifoldCompat<Jet3, Output = Discrete>> Manifold<Jet3_4> for ColorRefle
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         // Normal components - evaluate at Jet3 construction boundary
         let nx = (cross_x * inv_n_len.clone()).constant();
@@ -793,7 +793,7 @@ where
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         let nx = (cross_x * inv_n_len.clone()).constant();
         let ny = (cross_y * inv_n_len.clone()).constant();
@@ -906,7 +906,7 @@ where
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         let nx = (cross_x * inv_n_len.clone()).constant();
         let ny = (cross_y * inv_n_len.clone()).constant();


### PR DESCRIPTION
💡 **What:** Replaced four occurrences of `.sqrt().rsqrt()` chaining with direct calls to `.rsqrt()` in the normal calculation paths within `pixelflow-graphics/src/scene3d.rs`.

🎯 **Why:** The existing code contained a subtle bug and an anti-pattern: chaining `.sqrt().rsqrt()` computes $1 / \sqrt{\sqrt{x}} = x^{-1/4}$, whereas the algorithm requires the inverse length $1 / \sqrt{x} = x^{-1/2}$. Furthermore, calculating a square root and then its reciprocal square root requires executing two expensive SIMD approximations in succession, drastically increasing overhead.

📊 **Impact:**
1. **Mathematical correctness:** Restores correct geometric reflection modeling by ensuring proper normalization of the normal vector.
2. **Performance:** Eliminates the intermediate `sqrt` node from the AST structure entirely. Since `sqrt` generally costs ~14 cycles and `rsqrt` ~4 cycles in SIMD mode, this optimization saves ~14 SIMD ALU cycles *per* normal vector construction, heavily optimizing paths evaluating Householder reflections in full color pipelines.

🔬 **Measurement:**
- Verify standard performance metrics using existing benchmark targets (e.g., `manifold_simple/distance`).
- Run `cargo check -p pixelflow-graphics` to ensure code safely constructs without macro interference. Note: the `scene3d.rs` code contains pre-existing compiler errors within its `kernel!` macros which are structurally disconnected from this change.

---
*PR created automatically by Jules for task [1726308939651630742](https://jules.google.com/task/1726308939651630742) started by @jppittman*