### PR TITLE
⚡ Bolt: [style compliance] Replace boolean parameters with semantic enums and explicit methods in macos platform layer

### DIFF
--- a/pixelflow-runtime/src/platform/macos/cocoa.rs
+++ b/pixelflow-runtime/src/platform/macos/cocoa.rs
@@ -115,7 +115,21 @@ impl NSRect {
     }
 }
 
+
+// --- Enums ---
+
+pub enum EventDequeue {
+    Dequeue,
+    Peek,
+}
+
+pub enum WindowDeferral {
+    Defer,
+    Immediate,
+}
+
 // --- Wrappers ---
+
 
 /// Wrapper for NSApplication
 #[derive(Copy, Clone)]
@@ -136,10 +150,15 @@ impl NSApplication {
         }
     }
 
-    pub fn activate_ignoring_other_apps(&self, ignore: bool) {
+    pub fn activate_ignoring_other_apps(&self) {
         unsafe {
-            let val = if ignore { YES } else { NO };
-            sys::send_1::<(), BOOL>(self.0, sys::sel(b"activateIgnoringOtherApps:\0"), val);
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"activateIgnoringOtherApps:\0"), YES);
+        }
+    }
+
+    pub fn activate_normally(&self) {
+        unsafe {
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"activateIgnoringOtherApps:\0"), NO);
         }
     }
 
@@ -156,9 +175,12 @@ impl NSApplication {
     }
 
     // nextEventMatchingMask:untilDate:inMode:dequeue:
-    pub fn next_event(&self, mask: u64, date: Id, mode: Id, dequeue: bool) -> NSEvent {
+    pub fn next_event(&self, mask: u64, date: Id, mode: Id, dequeue: EventDequeue) -> NSEvent {
         unsafe {
-            let d = if dequeue { YES } else { NO };
+            let d = match dequeue {
+                EventDequeue::Dequeue => YES,
+                EventDequeue::Peek => NO,
+            };
             let ptr: Id = sys::send_4(
                 self.0,
                 sys::sel(b"nextEventMatchingMask:untilDate:inMode:dequeue:\0"),
@@ -190,10 +212,13 @@ impl NSWindow {
         rect: NSRect,
         style_mask: u64,
         backing: u64,
-        defer: bool,
+        defer: WindowDeferral,
     ) -> Self {
         unsafe {
-            let d = if defer { YES } else { NO };
+            let d = match defer {
+                WindowDeferral::Defer => YES,
+                WindowDeferral::Immediate => NO,
+            };
             let ptr: Id = sys::send_4(
                 self.0,
                 sys::sel(b"initWithContentRect:styleMask:backing:defer:\0"),
@@ -266,10 +291,15 @@ impl NSView {
         }
     }
 
-    pub fn set_wants_layer(&self, wants: bool) {
+    pub fn enable_layer(&self) {
         unsafe {
-            let val = if wants { YES } else { NO };
-            sys::send_1::<(), BOOL>(self.0, sys::sel(b"setWantsLayer:\0"), val);
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"setWantsLayer:\0"), YES);
+        }
+    }
+
+    pub fn disable_layer(&self) {
+        unsafe {
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"setWantsLayer:\0"), NO);
         }
     }
 

--- a/pixelflow-runtime/src/platform/macos/platform.rs
+++ b/pixelflow-runtime/src/platform/macos/platform.rs
@@ -2,7 +2,7 @@ use crate::api::private::{EngineActorHandle, EngineData, WindowId};
 use crate::display::messages::{DisplayControl, DisplayData, DisplayEvent, DisplayMgmt, Window};
 use crate::display::ops::PlatformOps;
 use crate::error::RuntimeError;
-use crate::platform::macos::cocoa::{self, event_type, NSApplication, NSPasteboard};
+use crate::platform::macos::cocoa::{self, event_type, EventDequeue, NSApplication, NSPasteboard};
 use crate::platform::macos::events;
 use crate::platform::macos::sys;
 use crate::platform::macos::window::MacWindow;
@@ -45,7 +45,7 @@ impl MetalOps {
             app.set_activation_policy(NS_APPLICATION_ACTIVATION_POLICY_REGULAR);
 
             app.finish_launching();
-            app.activate_ignoring_other_apps(true);
+            app.activate_ignoring_other_apps();
 
             app
         };
@@ -102,7 +102,11 @@ impl PlatformOps for MetalOps {
             }
             DisplayControl::SetVisible { id, visible } => {
                 if let Some(win) = self.windows.get_mut(&id) {
-                    win.set_visible(visible);
+                    if visible {
+                        win.show();
+                    } else {
+                        win.hide();
+                    }
                 }
             }
             DisplayControl::RequestRedraw { id } => {
@@ -164,7 +168,7 @@ impl PlatformOps for MetalOps {
             }
             DisplayMgmt::Destroy { id } => {
                 if let Some(mut win) = self.windows.remove(&id) {
-                    win.set_visible(false);
+                    win.hide();
                     // Drop closes it implicitly or we call close
                     // win.window.close(); // If we expose it
                     self.window_map.remove(&(win.window.0 as usize));
@@ -217,7 +221,7 @@ impl PlatformOps for MetalOps {
                 u64::MAX,
                 until_date,
                 mode,
-                true, // dequeue
+                EventDequeue::Dequeue,
             );
 
             // Release mode string

--- a/pixelflow-runtime/src/platform/macos/window.rs
+++ b/pixelflow-runtime/src/platform/macos/window.rs
@@ -1,6 +1,6 @@
 use crate::api::public::WindowDescriptor;
 use crate::error::RuntimeError;
-use crate::platform::macos::cocoa::{NSPoint, NSRect, NSSize, NSView, NSWindow};
+use crate::platform::macos::cocoa::{WindowDeferral, NSPoint, NSRect, NSSize, NSView, NSWindow};
 use crate::platform::macos::sys::{self, Id, BOOL, YES};
 use std::ffi::c_void;
 
@@ -24,7 +24,7 @@ impl MacWindow {
         // NSBackingStoreBuffered = 2
         let backing = 2;
 
-        let window = NSWindow::alloc().init_with_content_rect(rect, style_mask, backing, false);
+        let window = NSWindow::alloc().init_with_content_rect(rect, style_mask, backing, WindowDeferral::Immediate);
         window.set_title(&desc.title);
 
         let view = NSView::alloc().init_with_frame(rect);
@@ -60,7 +60,7 @@ impl MacWindow {
             sys::send_1::<(), Id>(view.0, sys::sel(b"setLayer:\0"), layer);
 
             // [view setWantsLayer: YES]
-            view.set_wants_layer(true);
+            view.enable_layer();
         }
 
         window.set_content_view(view);
@@ -122,13 +122,13 @@ impl MacWindow {
         }
     }
 
-    pub fn set_visible(&mut self, visible: bool) {
-        if visible {
-            self.window.make_key_and_order_front();
-        } else {
-            unsafe {
-                sys::send::<()>(self.window.0, sys::sel(b"orderOut:\0"));
-            }
+    pub fn show(&mut self) {
+        self.window.make_key_and_order_front();
+    }
+
+    pub fn hide(&mut self) {
+        unsafe {
+            sys::send::<()>(self.window.0, sys::sel(b"orderOut:\0"));
         }
     }
 


### PR DESCRIPTION
What:
Refactored several Cocoa-related functions in `pixelflow-runtime/src/platform/macos/` to accept explicit semantic enums or use individual explicitly-named methods rather than taking boolean arguments.
- Replaced `activate_ignoring_other_apps(ignore: bool)` with `activate_ignoring_other_apps()` and `activate_normally()`.
- Replaced `set_wants_layer(wants: bool)` with `enable_layer()` and `disable_layer()`.
- Replaced `next_event(..., dequeue: bool)` with `next_event(..., dequeue: EventDequeue)`.
- Replaced `init_with_content_rect(..., defer: bool)` with `init_with_content_rect(..., defer: WindowDeferral)`.
- Replaced `set_visible(visible: bool)` on `MacWindow` with `show()` and `hide()`.

Why:
These changes strictly enforce the `docs/STYLE.md` guideline against boolean arguments ("boolean blindness") for cleaner, self-documenting code. Explicit intentions make the Cocoa bindings and platform abstractions far easier to read.

Impact:
Provides safer and significantly more readable type signatures in `pixelflow-runtime`.

Measurement:
Code compiles locally with expected semantics preserved. Existing unit tests (`cargo check -p pixelflow-runtime` / `cargo test`) will continue to pass.

---
*PR created automatically by Jules for task [4016314024008129715](https://jules.google.com/task/4016314024008129715) started by @jppittman*