### PR TITLE
refactor: replace magic numbers with mode constants in core-term tests

### DIFF
--- a/core-term/src/ansi/tests.rs
+++ b/core-term/src/ansi/tests.rs
@@ -88,7 +88,7 @@ fn it_should_process_dec_private_mode_reset_12_att610_cursor_blink() {
     let commands = process_bytes(bytes);
     assert_eq!(
         commands,
-        vec![AnsiCommand::Csi(CsiCommand::ResetModePrivate(12))],
+        vec![AnsiCommand::Csi(CsiCommand::ResetModePrivate(crate::term::modes::DecModeConstant::Att610CursorBlink as u16))],
         "Expected ResetModePrivate(12) for CSI ?12l"
     );
 }
@@ -99,7 +99,7 @@ fn it_should_process_dec_private_mode_set_25_text_cursor_enable() {
     let commands = process_bytes(bytes);
     assert_eq!(
         commands,
-        vec![AnsiCommand::Csi(CsiCommand::SetModePrivate(25))],
+        vec![AnsiCommand::Csi(CsiCommand::SetModePrivate(crate::term::modes::DecModeConstant::TextCursorEnable as u16))],
         "Expected SetModePrivate(25) for CSI ?25h"
     );
 }
@@ -110,7 +110,7 @@ fn it_should_process_dec_private_mode_reset_25_text_cursor_enable() {
     let commands = process_bytes(bytes);
     assert_eq!(
         commands,
-        vec![AnsiCommand::Csi(CsiCommand::ResetModePrivate(25))],
+        vec![AnsiCommand::Csi(CsiCommand::ResetModePrivate(crate::term::modes::DecModeConstant::TextCursorEnable as u16))],
         "Expected ResetModePrivate(25) for CSI ?25l"
     );
 }
@@ -160,7 +160,7 @@ fn it_should_process_dec_private_mode_bracketed_paste_2004() {
     let commands_set = process_bytes(bytes_set);
     assert_eq!(
         commands_set,
-        vec![AnsiCommand::Csi(CsiCommand::SetModePrivate(2004))],
+        vec![AnsiCommand::Csi(CsiCommand::SetModePrivate(crate::term::modes::DecModeConstant::BracketedPaste as u16))],
         "Expected SetModePrivate(2004) for CSI ?2004h"
     );
 
@@ -168,7 +168,7 @@ fn it_should_process_dec_private_mode_bracketed_paste_2004() {
     let commands_reset = process_bytes(bytes_reset);
     assert_eq!(
         commands_reset,
-        vec![AnsiCommand::Csi(CsiCommand::ResetModePrivate(2004))],
+        vec![AnsiCommand::Csi(CsiCommand::ResetModePrivate(crate::term::modes::DecModeConstant::BracketedPaste as u16))],
         "Expected ResetModePrivate(2004) for CSI ?2004l"
     );
 }
@@ -179,7 +179,7 @@ fn it_should_process_dec_private_mode_focus_event_1004() {
     let commands_set = process_bytes(bytes_set);
     assert_eq!(
         commands_set,
-        vec![AnsiCommand::Csi(CsiCommand::SetModePrivate(1004))],
+        vec![AnsiCommand::Csi(CsiCommand::SetModePrivate(crate::term::modes::DecModeConstant::FocusEvent as u16))],
         "Expected SetModePrivate(1004) for CSI ?1004h"
     );
 
@@ -187,7 +187,7 @@ fn it_should_process_dec_private_mode_focus_event_1004() {
     let commands_reset = process_bytes(bytes_reset);
     assert_eq!(
         commands_reset,
-        vec![AnsiCommand::Csi(CsiCommand::ResetModePrivate(1004))],
+        vec![AnsiCommand::Csi(CsiCommand::ResetModePrivate(crate::term::modes::DecModeConstant::FocusEvent as u16))],
         "Expected ResetModePrivate(1004) for CSI ?1004l"
     );
 }
@@ -198,7 +198,7 @@ fn it_should_process_dec_private_mode_uncommon_7727() {
     let commands = process_bytes(bytes);
     assert_eq!(
         commands,
-        vec![AnsiCommand::Csi(CsiCommand::ResetModePrivate(7727))],
+        vec![AnsiCommand::Csi(CsiCommand::ResetModePrivate(crate::term::modes::DecModeConstant::Unknown7727 as u16))],
         "Expected ResetModePrivate(7727) for CSI ?7727l"
     );
 }
@@ -290,7 +290,7 @@ fn it_should_process_csi_sequence_fragmented_across_intermediate_bytes() {
     let commands_frag2 = processor.process_bytes(b"25h");
     assert_eq!(
         commands_frag2,
-        vec![AnsiCommand::Csi(CsiCommand::SetModePrivate(25))],
+        vec![AnsiCommand::Csi(CsiCommand::SetModePrivate(crate::term::modes::DecModeConstant::TextCursorEnable as u16))],
         "After fragment 2 (25h)"
     );
 }

--- a/core-term/src/term/core_tests.rs
+++ b/core-term/src/term/core_tests.rs
@@ -519,7 +519,7 @@ fn it_should_move_cursor_down_keeping_column_on_line_feed_if_lnm_is_off() {
     let mut term = create_test_emulator(10, 3); // LNM is off by default
                                                 // Explicitly disable Linefeed/Newline Mode - testing that LF doesn't do CR
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Csi(
-        CsiCommand::ResetMode(20),
+        CsiCommand::ResetMode(crate::term::modes::StandardModeConstant::LinefeedNewlineMode as u16),
     )));
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('A'))); // Char 'A' at (0,0). Cursor at (0,1).
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Csi(
@@ -557,7 +557,7 @@ fn it_should_scroll_up_and_move_cursor_down_keeping_column_on_line_feed_at_botto
     let mut term = create_test_emulator(5, 2); // LNM is off by default
                                                // Explicitly disable Linefeed/Newline Mode - testing that LF doesn't do CR
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Csi(
-        CsiCommand::ResetMode(20),
+        CsiCommand::ResetMode(crate::term::modes::StandardModeConstant::LinefeedNewlineMode as u16),
     )));
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('1')));
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('2')));
@@ -585,9 +585,7 @@ fn it_should_scroll_up_and_move_cursor_down_keeping_column_on_line_feed_at_botto
 fn it_should_move_cursor_down_and_to_col_0_on_line_feed_if_lnm_is_on() {
     let mut term = create_test_emulator(10, 3);
     // Enable Linefeed/Newline Mode - testing that LF does CR+LF
-    term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Csi(CsiCommand::SetMode(
-        20,
-    ))));
+    term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Csi(CsiCommand::SetMode(crate::term::modes::StandardModeConstant::LinefeedNewlineMode as u16))));
 
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('A')));
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Csi(
@@ -623,9 +621,7 @@ fn it_should_move_cursor_down_and_to_col_0_on_line_feed_if_lnm_is_on() {
 fn it_should_scroll_and_move_to_col_0_on_line_feed_at_bottom_if_lnm_is_on() {
     let mut term = create_test_emulator(5, 2);
     // Enable Linefeed/Newline Mode - testing that LF does CR+LF
-    term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Csi(CsiCommand::SetMode(
-        20,
-    ))));
+    term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Csi(CsiCommand::SetMode(crate::term::modes::StandardModeConstant::LinefeedNewlineMode as u16))));
 
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('1')));
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('2')));
@@ -687,7 +683,7 @@ fn it_should_not_wrap_cursor_on_backspace_at_start_of_line() {
     let mut term = create_test_emulator(10, 2);
     // Explicitly disable Linefeed/Newline Mode - testing that LF doesn't do CR
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Csi(
-        CsiCommand::ResetMode(20),
+        CsiCommand::ResetMode(crate::term::modes::StandardModeConstant::LinefeedNewlineMode as u16),
     )));
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('L')));
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('1')));


### PR DESCRIPTION
This PR refactors test files in `core-term` to replace raw integers used as magic numbers in `CsiCommand::SetMode`, `CsiCommand::ResetMode`, `CsiCommand::SetModePrivate`, and `CsiCommand::ResetModePrivate` with explicitly typed enum constants (`StandardModeConstant` and `DecModeConstant`). This aligns the tests with the project's strict typing and idiomatic patterns as defined in `docs/STYLE.md`.

*   Replaced `20` with `StandardModeConstant::LinefeedNewlineMode`.
*   Replaced `25` with `DecModeConstant::TextCursorEnable`.
*   Replaced `2004` with `DecModeConstant::BracketedPaste`.
*   Replaced `1004` with `DecModeConstant::FocusEvent`.
*   Replaced `12` with `DecModeConstant::Att610CursorBlink`.
*   Replaced `7727` with `DecModeConstant::Unknown7727`.

---
*PR created automatically by Jules for task [13511487961133865504](https://jules.google.com/task/13511487961133865504) started by @jppittman*