### PR TITLE
⚡ Bolt: Performance improvement and math fix for vector normalizations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,6 @@
 ## 2025-12-28 - Rasterizer Inner Loop Hoisting
 **Learning:** The inner loop of `execute_stripe` was re-evaluating `Field::sequential(start)` on every iteration, which involves multiple SIMD instructions (broadcast/load + add).
 **Action:** Hoisted the initialization of `xs` out of the loop and updated it incrementally using a pre-computed `step` vector. This reduced the inner loop overhead significantly, yielding a ~34% improvement in rasterization throughput.
+## 2024-05-17 - `.sqrt().rsqrt()` is an anti-pattern
+**Learning:** In `pixelflow-graphics`, computing the inverse length using `.sqrt().rsqrt()` on a `Field` type (AST node) incorrectly computes `x^(-1/4)` instead of the intended `x^(-1/2)`. It also introduces redundant AST node evaluation overhead.
+**Action:** Always use `.rsqrt()` directly on the squared value instead of `.sqrt().rsqrt()`.

--- a/pixelflow-graphics/src/scene3d.rs
+++ b/pixelflow-graphics/src/scene3d.rs
@@ -598,7 +598,10 @@ impl<M: ManifoldCompat<Jet3, Output = Field>> Manifold<Jet3_4> for Reflect<M> {
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        // ⚡ Bolt: Performance optimization & Math fix
+        // Using .rsqrt() directly on the squared length computes x^(-1/2) correctly
+        // and saves an expensive .sqrt() call vs the previous .sqrt().rsqrt() which computed x^(-1/4).
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         // Normal components - evaluate at Jet3 construction boundary
         let nx = (cross_x * inv_n_len.clone()).constant();
@@ -686,7 +689,10 @@ impl<M: ManifoldCompat<Jet3, Output = Discrete>> Manifold<Jet3_4> for ColorRefle
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        // ⚡ Bolt: Performance optimization & Math fix
+        // Using .rsqrt() directly on the squared length computes x^(-1/2) correctly
+        // and saves an expensive .sqrt() call vs the previous .sqrt().rsqrt() which computed x^(-1/4).
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         // Normal components - evaluate at Jet3 construction boundary
         let nx = (cross_x * inv_n_len.clone()).constant();
@@ -793,7 +799,10 @@ where
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        // ⚡ Bolt: Performance optimization & Math fix
+        // Using .rsqrt() directly on the squared length computes x^(-1/2) correctly
+        // and saves an expensive .sqrt() call vs the previous .sqrt().rsqrt() which computed x^(-1/4).
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         let nx = (cross_x * inv_n_len.clone()).constant();
         let ny = (cross_y * inv_n_len.clone()).constant();
@@ -906,7 +915,10 @@ where
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        // ⚡ Bolt: Performance optimization & Math fix
+        // Using .rsqrt() directly on the squared length computes x^(-1/2) correctly
+        // and saves an expensive .sqrt() call vs the previous .sqrt().rsqrt() which computed x^(-1/4).
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         let nx = (cross_x * inv_n_len.clone()).constant();
         let ny = (cross_y * inv_n_len.clone()).constant();


### PR DESCRIPTION
**💡 What:** Removed a redundant `.sqrt()` call before `.rsqrt()` across four different vector normalization implementations in `pixelflow-graphics/src/scene3d.rs` and added code comments. Also logged this learning to `.jules/bolt.md`.
**🎯 Why:** Since `rsqrt(x)` computes the reciprocal square root ($1/\sqrt{x}$), calling it directly on the squared normal length (`n_len_sq`) yields the inverse length needed to normalize the vector correctly. The original code (`.sqrt().rsqrt()`) computed $1/\sqrt{\sqrt{x}} = x^{-0.25}$ instead of $x^{-0.5}$, making it incorrect and mathematically slower.
**📊 Impact:** Ensures the inverse length calculates $x^{-0.5}$ rather than $x^{-0.25}$, increasing mathematical correctness and saving expensive computational operations (a single `.sqrt()` operation on `Field` or `Jet3`).
**🔬 Measurement:** View the diff and benchmark the `pixelflow-graphics` normal computations.

---
*PR created automatically by Jules for task [10900985809663221163](https://jules.google.com/task/10900985809663221163) started by @jppittman*