### PR TITLE
⚡ Bolt: Replace .sqrt().rsqrt() with .rsqrt() in scene3d.rs

### DIFF
--- a/pixelflow-graphics/src/scene3d.rs
+++ b/pixelflow-graphics/src/scene3d.rs
@@ -598,7 +598,7 @@ impl<M: ManifoldCompat<Jet3, Output = Field>> Manifold<Jet3_4> for Reflect<M> {
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         // Normal components - evaluate at Jet3 construction boundary
         let nx = (cross_x * inv_n_len.clone()).constant();
@@ -686,7 +686,7 @@ impl<M: ManifoldCompat<Jet3, Output = Discrete>> Manifold<Jet3_4> for ColorRefle
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         // Normal components - evaluate at Jet3 construction boundary
         let nx = (cross_x * inv_n_len.clone()).constant();
@@ -793,7 +793,7 @@ where
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         let nx = (cross_x * inv_n_len.clone()).constant();
         let ny = (cross_y * inv_n_len.clone()).constant();
@@ -906,7 +906,7 @@ where
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         let nx = (cross_x * inv_n_len.clone()).constant();
         let ny = (cross_y * inv_n_len.clone()).constant();


### PR DESCRIPTION
💡 **What**: The optimization implemented
Replaced four occurrences of `.sqrt().rsqrt()` with `.rsqrt()` across normal vector reconstruction algorithms within `Reflect` and `ColorReflect` structs in `pixelflow-graphics/src/scene3d.rs`.

🎯 **Why**: The performance problem it solves
Because `.rsqrt()` explicitly represents $1/\sqrt{x}$, chaining `.sqrt().rsqrt()` resulted in $1/\sqrt{\sqrt{x}}$, or $x^{-1/4}$, which is a mathematical error when trying to compute the inverse length $1/\|N\|$ of a vector. Furthermore, `.sqrt()` evaluates to a very computationally expensive and costly AST node in the graphics kernel. 

📊 **Impact**: Expected performance improvement
Significantly reduces AST evaluation times and hardware overhead inside the hot-loop ray reflection rendering step by removing an unnecessary ~14 cycle `sqrt` operation per lane, utilizing the fast inverse square root Newton-Raphson approximation immediately.

🔬 **Measurement**: How to verify the improvement
Inspect `perf` metrics or evaluate raytracer performance times for materials with reflections before and after the patch. The mathematical behavior is now corrected, meaning shading algorithms behave consistently with correct vector normals.

---
*PR created automatically by Jules for task [7559312343427608868](https://jules.google.com/task/7559312343427608868) started by @jppittman*