### PR TITLE
⚡ Bolt: Initialize vectors with capacity in render loop to avoid heap allocations

### DIFF
--- a/core-term/src/terminal_app.rs
+++ b/core-term/src/terminal_app.rs
@@ -288,11 +288,11 @@ impl TerminalApp {
         let default_bg = self.config.colors.background;
 
         // Build 2-level BSP: Vertical (Rows) -> Horizontal (Cells)
-        let mut row_items = Vec::new();
+        let mut row_items = Vec::with_capacity(rows);
 
         for row in 0..rows {
             let line = &snapshot.lines[row];
-            let mut cell_items = Vec::new();
+            let mut cell_items = Vec::with_capacity(cols);
 
             for col in 0..cols {
                 let glyph = &line.cells[col];


### PR DESCRIPTION
💡 What: Changed `Vec::new()` to `Vec::with_capacity(rows)` and `Vec::with_capacity(cols)` for `row_items` and `cell_items` inside the hot rendering loop in `core-term/src/terminal_app.rs`.
🎯 Why: In `core-term/src/terminal_app.rs`, vectors representing the rendering grid were initialized empty and pushed to row-by-row and cell-by-cell. Since we know the exact number of rows and columns from the terminal snapshot dimensions, dynamically resizing vectors via `.push()` incurs unnecessary heap reallocations on the critical rendering path.
📊 Impact: Eliminates O(log N) dynamic memory re-allocations per row and per frame rendering, making rendering marginally faster and producing less memory fragmentation.
🔬 Measurement: Verify by checking CPU profiling over time in the core-term render loop, or observe lower allocator activity during the render process.

---
*PR created automatically by Jules for task [16768807679765241163](https://jules.google.com/task/16768807679765241163) started by @jppittman*