### PR TITLE
Enforce STYLE.md: Remove boolean arguments from macOS platform bindings

### DIFF
--- a/pixelflow-runtime/src/platform/macos/cocoa.rs
+++ b/pixelflow-runtime/src/platform/macos/cocoa.rs
@@ -6,6 +6,19 @@
 use super::sys::{self, Id, BOOL, NO, YES};
 use std::ffi::c_void;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EventDequeue {
+    Dequeue,
+    Peek,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WindowDeferral {
+    Defer,
+    Immediate,
+}
+
+
 // --- Helpers ---
 
 /// Convert Rust string to NSString id.
@@ -136,10 +149,15 @@ impl NSApplication {
         }
     }
 
-    pub fn activate_ignoring_other_apps(&self, ignore: bool) {
+    pub fn activate_ignoring_other_apps(&self) {
         unsafe {
-            let val = if ignore { YES } else { NO };
-            sys::send_1::<(), BOOL>(self.0, sys::sel(b"activateIgnoringOtherApps:\0"), val);
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"activateIgnoringOtherApps:\0"), YES);
+        }
+    }
+
+    pub fn activate_normally(&self) {
+        unsafe {
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"activateIgnoringOtherApps:\0"), NO);
         }
     }
 
@@ -156,9 +174,9 @@ impl NSApplication {
     }
 
     // nextEventMatchingMask:untilDate:inMode:dequeue:
-    pub fn next_event(&self, mask: u64, date: Id, mode: Id, dequeue: bool) -> NSEvent {
+    pub fn next_event(&self, mask: u64, date: Id, mode: Id, dequeue: EventDequeue) -> NSEvent {
         unsafe {
-            let d = if dequeue { YES } else { NO };
+            let d = if dequeue == EventDequeue::Dequeue { YES } else { NO };
             let ptr: Id = sys::send_4(
                 self.0,
                 sys::sel(b"nextEventMatchingMask:untilDate:inMode:dequeue:\0"),
@@ -190,10 +208,10 @@ impl NSWindow {
         rect: NSRect,
         style_mask: u64,
         backing: u64,
-        defer: bool,
+        defer: WindowDeferral,
     ) -> Self {
         unsafe {
-            let d = if defer { YES } else { NO };
+            let d = if defer == WindowDeferral::Defer { YES } else { NO };
             let ptr: Id = sys::send_4(
                 self.0,
                 sys::sel(b"initWithContentRect:styleMask:backing:defer:\0"),
@@ -266,10 +284,15 @@ impl NSView {
         }
     }
 
-    pub fn set_wants_layer(&self, wants: bool) {
+    pub fn enable_layer(&self) {
         unsafe {
-            let val = if wants { YES } else { NO };
-            sys::send_1::<(), BOOL>(self.0, sys::sel(b"setWantsLayer:\0"), val);
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"setWantsLayer:\0"), YES);
+        }
+    }
+
+    pub fn disable_layer(&self) {
+        unsafe {
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"setWantsLayer:\0"), NO);
         }
     }
 

--- a/pixelflow-runtime/src/platform/macos/platform.rs
+++ b/pixelflow-runtime/src/platform/macos/platform.rs
@@ -45,7 +45,7 @@ impl MetalOps {
             app.set_activation_policy(NS_APPLICATION_ACTIVATION_POLICY_REGULAR);
 
             app.finish_launching();
-            app.activate_ignoring_other_apps(true);
+            app.activate_ignoring_other_apps();
 
             app
         };
@@ -102,7 +102,7 @@ impl PlatformOps for MetalOps {
             }
             DisplayControl::SetVisible { id, visible } => {
                 if let Some(win) = self.windows.get_mut(&id) {
-                    win.set_visible(visible);
+                    if visible { win.show(); } else { win.hide(); }
                 }
             }
             DisplayControl::RequestRedraw { id } => {
@@ -164,7 +164,7 @@ impl PlatformOps for MetalOps {
             }
             DisplayMgmt::Destroy { id } => {
                 if let Some(mut win) = self.windows.remove(&id) {
-                    win.set_visible(false);
+                    win.hide();
                     // Drop closes it implicitly or we call close
                     // win.window.close(); // If we expose it
                     self.window_map.remove(&(win.window.0 as usize));
@@ -217,7 +217,7 @@ impl PlatformOps for MetalOps {
                 u64::MAX,
                 until_date,
                 mode,
-                true, // dequeue
+                crate::platform::macos::cocoa::EventDequeue::Dequeue,
             );
 
             // Release mode string

--- a/pixelflow-runtime/src/platform/macos/window.rs
+++ b/pixelflow-runtime/src/platform/macos/window.rs
@@ -24,7 +24,7 @@ impl MacWindow {
         // NSBackingStoreBuffered = 2
         let backing = 2;
 
-        let window = NSWindow::alloc().init_with_content_rect(rect, style_mask, backing, false);
+        let window = NSWindow::alloc().init_with_content_rect(rect, style_mask, backing, crate::platform::macos::cocoa::WindowDeferral::Immediate);
         window.set_title(&desc.title);
 
         let view = NSView::alloc().init_with_frame(rect);
@@ -60,7 +60,7 @@ impl MacWindow {
             sys::send_1::<(), Id>(view.0, sys::sel(b"setLayer:\0"), layer);
 
             // [view setWantsLayer: YES]
-            view.set_wants_layer(true);
+            view.enable_layer();
         }
 
         window.set_content_view(view);
@@ -122,13 +122,13 @@ impl MacWindow {
         }
     }
 
-    pub fn set_visible(&mut self, visible: bool) {
-        if visible {
-            self.window.make_key_and_order_front();
-        } else {
-            unsafe {
-                sys::send::<()>(self.window.0, sys::sel(b"orderOut:\0"));
-            }
+    pub fn show(&mut self) {
+        self.window.make_key_and_order_front();
+    }
+
+    pub fn hide(&mut self) {
+        unsafe {
+            sys::send::<()>(self.window.0, sys::sel(b"orderOut:\0"));
         }
     }
 


### PR DESCRIPTION
This PR enforces the `docs/STYLE.md` guideline regarding boolean arguments by replacing ambiguous boolean parameters with descriptive semantic enums (`EventDequeue`, `WindowDeferral`) and splitting boolean state toggles into explicit, intention-revealing methods (`show()`, `hide()`, `enable_layer()`, `disable_layer()`, `activate_ignoring_other_apps()`, `activate_normally()`). This change prevents "boolean blindness" and significantly improves the readability of the macOS platform Cocoa bindings.

---
*PR created automatically by Jules for task [12655369116791203249](https://jules.google.com/task/12655369116791203249) started by @jppittman*