### PR TITLE
⚡ Bolt: Pre-allocate vectors in terminal rendering hot path

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2025-12-28 - Rasterizer Inner Loop Hoisting
 **Learning:** The inner loop of `execute_stripe` was re-evaluating `Field::sequential(start)` on every iteration, which involves multiple SIMD instructions (broadcast/load + add).
 **Action:** Hoisted the initialization of `xs` out of the loop and updated it incrementally using a pre-computed `step` vector. This reduced the inner loop overhead significantly, yielding a ~34% improvement in rasterization throughput.
+
+## 2025-12-28 - Pre-allocate vectors in terminal rendering hot path
+**Learning:** During the 2-level BSP tree building in `core-term`'s rendering loop (`terminal_app.rs`), vectors for rows and cells were initialized with `Vec::new()`, leading to continuous expensive heap reallocations on every render frame for known dimensions (rows/cols).
+**Action:** In rendering hot paths or tight loops, always initialize dynamically growing vectors with their known target dimensions using `Vec::with_capacity(size)` instead of `Vec::new()` to prevent unnecessary allocations.

--- a/core-term/src/io/kqueue.rs
+++ b/core-term/src/io/kqueue.rs
@@ -50,7 +50,7 @@ impl EventMonitor {
         flags: KqueueFlags,
     ) -> Result<()> {
         let fd = source.as_raw_fd();
-        let mut changes = Vec::new();
+        let mut changes = Vec::with_capacity(2);
 
         // Add read filter if requested
         if flags.contains(KqueueFlags::EPOLLIN) {
@@ -113,7 +113,7 @@ impl EventMonitor {
 
     pub fn delete<S: std::os::unix::io::AsRawFd>(&self, source: &S) -> Result<()> {
         let fd = source.as_raw_fd();
-        let mut changes = Vec::new();
+        let mut changes = Vec::with_capacity(2);
 
         // Delete both read and write filters
         for filter in [libc::EVFILT_READ, libc::EVFILT_WRITE] {

--- a/core-term/src/terminal_app.rs
+++ b/core-term/src/terminal_app.rs
@@ -288,11 +288,11 @@ impl TerminalApp {
         let default_bg = self.config.colors.background;
 
         // Build 2-level BSP: Vertical (Rows) -> Horizontal (Cells)
-        let mut row_items = Vec::new();
+        let mut row_items = Vec::with_capacity(rows);
 
         for row in 0..rows {
             let line = &snapshot.lines[row];
-            let mut cell_items = Vec::new();
+            let mut cell_items = Vec::with_capacity(cols);
 
             for col in 0..cols {
                 let glyph = &line.cells[col];


### PR DESCRIPTION
**💡 What**: Modified `core-term/src/terminal_app.rs` to replace dynamically growing vectors initialized with `Vec::new()` with pre-allocated vectors using `Vec::with_capacity(size)` during the 2-level BSP layout tree construction.
**🎯 Why**: The layout engine inside the main rendering loop repeatedly recreates row and cell tracking collections. With known dimensions from the terminal snapshot (`rows` and `cols`), relying on dynamic growth triggered continuous and completely avoidable heap memory reallocations on every render frame.
**📊 Impact**: Eliminates multiple redundant memory allocations per frame iteration in a critical hot path. The size of the row and cell lists are completely known beforehand, thereby eliminating the O(log N) cost of dynamic array expansions under continuous scrolling text or heavy TUI output.
**🔬 Measurement**: Expected terminal emulator performance to run cooler and significantly faster, maintaining consistent high FPS while rendering heavy text output or large applications. Can be measured and profiled directly via CPU performance monitors.

---
*PR created automatically by Jules for task [820599048145047902](https://jules.google.com/task/820599048145047902) started by @jppittman*