### PR TITLE
Refactor core-term tests to adhere to STYLE.md conventions

### DIFF
--- a/core-term/src/term/core_tests.rs
+++ b/core-term/src/term/core_tests.rs
@@ -231,8 +231,8 @@ fn it_should_print_a_single_multibyte_unicode_character() {
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('世')));
     let snapshot = term.get_render_snapshot().expect("Snapshot was None");
     assert_screen_state(&snapshot, &["世        "], Some((0, 2)));
-    let glyph_1_wrapper = get_glyph_from_snapshot(&snapshot, 0, 0).unwrap();
-    let glyph_2_wrapper = get_glyph_from_snapshot(&snapshot, 0, 1).unwrap();
+    let glyph_1_wrapper = get_glyph_from_snapshot(&snapshot, 0, 0).expect("Glyph should exist at snapshot");
+    let glyph_2_wrapper = get_glyph_from_snapshot(&snapshot, 0, 1).expect("Glyph should exist at snapshot");
     match glyph_1_wrapper {
         Glyph::WidePrimary(cell) => assert_eq!(cell.c, '世'),
         other => panic!("Expected WidePrimary '世' at (0,0), got {:?}", other),
@@ -256,8 +256,8 @@ fn it_should_print_multiple_multibyte_unicode_characters() {
     let snapshot = term.get_render_snapshot().expect("Snapshot was None");
     assert_screen_state(&snapshot, &["你好      "], Some((0, 4)));
 
-    let char1_glyph1 = get_glyph_from_snapshot(&snapshot, 0, 0).unwrap();
-    let char1_glyph2 = get_glyph_from_snapshot(&snapshot, 0, 1).unwrap();
+    let char1_glyph1 = get_glyph_from_snapshot(&snapshot, 0, 0).expect("Glyph should exist at snapshot");
+    let char1_glyph2 = get_glyph_from_snapshot(&snapshot, 0, 1).expect("Glyph should exist at snapshot");
     match char1_glyph1 {
         Glyph::WidePrimary(cell) => assert_eq!(cell.c, '你'),
         _ => panic!("Expected WidePrimary at (0,0)"),
@@ -267,8 +267,8 @@ fn it_should_print_multiple_multibyte_unicode_characters() {
         "Expected WideSpacer at (0,1)"
     );
 
-    let char2_glyph1 = get_glyph_from_snapshot(&snapshot, 0, 2).unwrap();
-    let char2_glyph2 = get_glyph_from_snapshot(&snapshot, 0, 3).unwrap();
+    let char2_glyph1 = get_glyph_from_snapshot(&snapshot, 0, 2).expect("Glyph should exist at snapshot");
+    let char2_glyph2 = get_glyph_from_snapshot(&snapshot, 0, 3).expect("Glyph should exist at snapshot");
     match char2_glyph1 {
         Glyph::WidePrimary(cell) => assert_eq!(cell.c, '好'),
         _ => panic!("Expected WidePrimary at (0,2)"),
@@ -288,14 +288,14 @@ fn it_should_handle_mixed_ascii_and_multibyte_unicode_characters() {
     let snapshot = term.get_render_snapshot().expect("Snapshot was None");
     assert_screen_state(&snapshot, &["A世B      "], Some((0, 4)));
 
-    let glyph_a = get_glyph_from_snapshot(&snapshot, 0, 0).unwrap();
+    let glyph_a = get_glyph_from_snapshot(&snapshot, 0, 0).expect("Glyph should exist at snapshot");
     match glyph_a {
         Glyph::Single(cell) => assert_eq!(cell.c, 'A'),
         _ => panic!("Expected Single 'A' at (0,0)"),
     }
 
-    let glyph_uni_1 = get_glyph_from_snapshot(&snapshot, 0, 1).unwrap();
-    let glyph_uni_2 = get_glyph_from_snapshot(&snapshot, 0, 2).unwrap();
+    let glyph_uni_1 = get_glyph_from_snapshot(&snapshot, 0, 1).expect("Glyph should exist at snapshot");
+    let glyph_uni_2 = get_glyph_from_snapshot(&snapshot, 0, 2).expect("Glyph should exist at snapshot");
     match glyph_uni_1 {
         Glyph::WidePrimary(cell) => assert_eq!(cell.c, '世'),
         _ => panic!("Expected WidePrimary '世' at (0,1)"),
@@ -305,7 +305,7 @@ fn it_should_handle_mixed_ascii_and_multibyte_unicode_characters() {
         "Expected WideSpacer at (0,2)"
     );
 
-    let glyph_b = get_glyph_from_snapshot(&snapshot, 0, 3).unwrap();
+    let glyph_b = get_glyph_from_snapshot(&snapshot, 0, 3).expect("Glyph should exist at snapshot");
     match glyph_b {
         Glyph::Single(cell) => assert_eq!(cell.c, 'B'),
         _ => panic!("Expected Single 'B' at (0,3)"),
@@ -337,13 +337,13 @@ fn it_should_not_print_second_half_of_wide_char_if_at_edge_and_no_wrap_mode_or_s
     // Screen is "世". Cursor logical (0,2), physical (0,1).
     assert_screen_state(&snapshot, &["世"], Some((0, 1))); // assert_screen_state handles wide char checks
 
-    let glyph_uni_1 = get_glyph_from_snapshot(&snapshot, 0, 0).unwrap();
+    let glyph_uni_1 = get_glyph_from_snapshot(&snapshot, 0, 0).expect("Glyph should exist at snapshot");
     match glyph_uni_1 {
         Glyph::WidePrimary(cell) => assert_eq!(cell.c, '世'),
         _ => panic!("Expected WidePrimary '世' at (0,0)"),
     }
     if snapshot.dimensions.0 > 1 {
-        let glyph_uni_2 = get_glyph_from_snapshot(&snapshot, 0, 1).unwrap();
+        let glyph_uni_2 = get_glyph_from_snapshot(&snapshot, 0, 1).expect("Glyph should exist at snapshot");
         assert!(
             matches!(glyph_uni_2, Glyph::WideSpacer),
             "Expected WideSpacer at (0,1)"
@@ -362,12 +362,12 @@ fn it_should_overwrite_first_half_of_wide_char_with_ascii() {
     let snapshot = term.get_render_snapshot().expect("Snapshot was None");
     assert_screen_state(&snapshot, &["X    "], Some((0, 1))); // assert_screen_state handles this
 
-    let glyph_x = get_glyph_from_snapshot(&snapshot, 0, 0).unwrap();
+    let glyph_x = get_glyph_from_snapshot(&snapshot, 0, 0).expect("Glyph should exist at snapshot");
     match glyph_x {
         Glyph::Single(cell) => assert_eq!(cell.c, 'X'),
         _ => panic!("Expected Single 'X' at (0,0)"),
     }
-    let glyph_after_x = get_glyph_from_snapshot(&snapshot, 0, 1).unwrap();
+    let glyph_after_x = get_glyph_from_snapshot(&snapshot, 0, 1).expect("Glyph should exist at snapshot");
     match glyph_after_x {
         Glyph::Single(cell) => {
             assert_eq!(
@@ -467,10 +467,10 @@ fn it_should_print_ascii_over_wide_char_that_straddles_line_end_after_wrap() {
     let s4 = term.get_render_snapshot().expect("Snapshot was None");
     // Screen: ["世Z", "X "]. Cursor (0,2) (row 0, col 2)
     // Check s4 screen content directly
-    let glyph_s4_0_0 = get_glyph_from_snapshot(&s4, 0, 0).unwrap();
-    let glyph_s4_0_1 = get_glyph_from_snapshot(&s4, 0, 1).unwrap();
-    let glyph_s4_1_0 = get_glyph_from_snapshot(&s4, 1, 0).unwrap();
-    let glyph_s4_1_1 = get_glyph_from_snapshot(&s4, 1, 1).unwrap();
+    let glyph_s4_0_0 = get_glyph_from_snapshot(&s4, 0, 0).expect("Glyph should exist at snapshot");
+    let glyph_s4_0_1 = get_glyph_from_snapshot(&s4, 0, 1).expect("Glyph should exist at snapshot");
+    let glyph_s4_1_0 = get_glyph_from_snapshot(&s4, 1, 0).expect("Glyph should exist at snapshot");
+    let glyph_s4_1_1 = get_glyph_from_snapshot(&s4, 1, 1).expect("Glyph should exist at snapshot");
 
     match glyph_s4_0_0 {
         Glyph::WidePrimary(cell) => assert_eq!(cell.c, '世'),
@@ -496,7 +496,7 @@ fn it_should_print_ascii_over_wide_char_that_straddles_line_end_after_wrap() {
         "s4 cursor position mismatch"
     );
 
-    let glyph_at_0_0 = get_glyph_from_snapshot(&s4, 0, 0).unwrap();
+    let glyph_at_0_0 = get_glyph_from_snapshot(&s4, 0, 0).expect("Glyph should exist at snapshot");
     assert!(
         matches!(glyph_at_0_0, Glyph::WidePrimary(_)),
         "Expected WidePrimary at (0,0)"
@@ -505,7 +505,7 @@ fn it_should_print_ascii_over_wide_char_that_straddles_line_end_after_wrap() {
         assert_eq!(cell.c, '世');
     }
 
-    let glyph_at_0_1 = get_glyph_from_snapshot(&s4, 0, 1).unwrap();
+    let glyph_at_0_1 = get_glyph_from_snapshot(&s4, 0, 1).expect("Glyph should exist at snapshot");
     match glyph_at_0_1 {
         Glyph::Single(cell) => assert_eq!(cell.c, 'Z'),
         _ => panic!("Expected Single at (0,1)"),
@@ -1520,7 +1520,7 @@ fn it_should_scroll_up_entire_screen_by_1_line_on_csi_s_with_param_0_or_1() {
         0,
         0,
     )
-    .unwrap()
+    .expect("Value should be present")
     .display_char();
     assert_eq!(initial_screen_line0_char0, 'A');
 
@@ -1562,7 +1562,7 @@ fn it_should_scroll_up_within_scrolling_region_on_csi_s() {
         .expect("Snapshot was None")
         .cursor_state
         .map(|cs| (cs.y, cs.x))
-        .unwrap();
+        .expect("Value should be present");
     assert_eq!(
         cursor_after_stbm,
         (0, 0),
@@ -1661,7 +1661,7 @@ fn it_should_scroll_down_within_scrolling_region_on_csi_t() {
         .expect("Snapshot was None")
         .cursor_state
         .map(|cs| (cs.y, cs.x))
-        .unwrap();
+        .expect("Value should be present");
     assert_eq!(
         cursor_after_stbm,
         (0, 0),
@@ -1912,7 +1912,7 @@ fn it_should_show_and_hide_cursor_on_dectcem() {
     );
     // Ensure shape is restored (assuming Block is default)
     assert_eq!(
-        snapshot_shown.cursor_state.unwrap().shape,
+        snapshot_shown.cursor_state.expect("Cursor state should be present").shape,
         CursorShape::Block
     );
 }
@@ -2167,8 +2167,8 @@ fn it_should_reset_all_attributes_on_sgr_0() {
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('B'))); // Print after reset
 
     let snapshot = term.get_render_snapshot().expect("Snapshot was None");
-    let glyph_a_wrapper = get_glyph_from_snapshot(&snapshot, 0, 0).unwrap();
-    let glyph_b_wrapper = get_glyph_from_snapshot(&snapshot, 0, 1).unwrap();
+    let glyph_a_wrapper = get_glyph_from_snapshot(&snapshot, 0, 0).expect("Glyph should exist at snapshot");
+    let glyph_b_wrapper = get_glyph_from_snapshot(&snapshot, 0, 1).expect("Glyph should exist at snapshot");
 
     let (attr_a, attr_b) = match (glyph_a_wrapper, glyph_b_wrapper) {
         (Glyph::Single(cell_a), Glyph::Single(cell_b)) => (cell_a.attr, cell_b.attr),
@@ -2208,11 +2208,11 @@ fn it_should_set_bold_on_sgr_1_and_reset_on_sgr_22() {
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('B')));
 
     let snapshot = term.get_render_snapshot().expect("Snapshot was None");
-    let attr_a = match get_glyph_from_snapshot(&snapshot, 0, 0).unwrap() {
+    let attr_a = match get_glyph_from_snapshot(&snapshot, 0, 0).expect("Glyph should exist at snapshot") {
         Glyph::Single(c) => c.attr,
         _ => panic!("Expected Single"),
     };
-    let attr_b = match get_glyph_from_snapshot(&snapshot, 0, 1).unwrap() {
+    let attr_b = match get_glyph_from_snapshot(&snapshot, 0, 1).expect("Glyph should exist at snapshot") {
         Glyph::Single(c) => c.attr,
         _ => panic!("Expected Single"),
     };
@@ -2247,11 +2247,11 @@ fn it_should_set_faint_on_sgr_2_and_reset_on_sgr_22() {
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('B')));
 
     let snapshot = term.get_render_snapshot().expect("Snapshot was None");
-    let attr_a = match get_glyph_from_snapshot(&snapshot, 0, 0).unwrap() {
+    let attr_a = match get_glyph_from_snapshot(&snapshot, 0, 0).expect("Glyph should exist at snapshot") {
         Glyph::Single(c) => c.attr,
         _ => panic!("Expected Single"),
     };
-    let attr_b = match get_glyph_from_snapshot(&snapshot, 0, 1).unwrap() {
+    let attr_b = match get_glyph_from_snapshot(&snapshot, 0, 1).expect("Glyph should exist at snapshot") {
         Glyph::Single(c) => c.attr,
         _ => panic!("Expected Single"),
     };
@@ -2285,11 +2285,11 @@ fn it_should_set_italic_on_sgr_3_and_reset_on_sgr_23() {
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('B')));
 
     let snapshot = term.get_render_snapshot().expect("Snapshot was None");
-    let attr_a = match get_glyph_from_snapshot(&snapshot, 0, 0).unwrap() {
+    let attr_a = match get_glyph_from_snapshot(&snapshot, 0, 0).expect("Glyph should exist at snapshot") {
         Glyph::Single(c) => c.attr,
         _ => panic!("Expected Single"),
     };
-    let attr_b = match get_glyph_from_snapshot(&snapshot, 0, 1).unwrap() {
+    let attr_b = match get_glyph_from_snapshot(&snapshot, 0, 1).expect("Glyph should exist at snapshot") {
         Glyph::Single(c) => c.attr,
         _ => panic!("Expected Single"),
     };
@@ -2319,11 +2319,11 @@ fn it_should_set_underline_on_sgr_4_and_reset_on_sgr_24() {
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('B')));
 
     let snapshot = term.get_render_snapshot().expect("Snapshot was None");
-    let attr_a = match get_glyph_from_snapshot(&snapshot, 0, 0).unwrap() {
+    let attr_a = match get_glyph_from_snapshot(&snapshot, 0, 0).expect("Glyph should exist at snapshot") {
         Glyph::Single(c) => c.attr,
         _ => panic!("Expected Single"),
     };
-    let attr_b = match get_glyph_from_snapshot(&snapshot, 0, 1).unwrap() {
+    let attr_b = match get_glyph_from_snapshot(&snapshot, 0, 1).expect("Glyph should exist at snapshot") {
         Glyph::Single(c) => c.attr,
         _ => panic!("Expected Single"),
     };
@@ -2362,7 +2362,7 @@ fn it_should_set_basic_ansi_foreground_colors_sgr_30_37() {
     }
     let snapshot = term.get_render_snapshot().expect("Snapshot was None");
     for (i, &color_name) in colors.iter().enumerate() {
-        let glyph_wrapper = get_glyph_from_snapshot(&snapshot, 0, i).unwrap();
+        let glyph_wrapper = get_glyph_from_snapshot(&snapshot, 0, i).expect("Glyph should exist at snapshot");
         match glyph_wrapper {
             Glyph::Single(cell) => {
                 assert_eq!(cell.c, ('A' as u8 + i as u8) as char);
@@ -2403,7 +2403,7 @@ fn it_should_set_bright_ansi_foreground_colors_sgr_90_97() {
     }
     let snapshot = term.get_render_snapshot().expect("Snapshot was None");
     for (i, &color_name) in bright_colors.iter().enumerate() {
-        let glyph_wrapper = get_glyph_from_snapshot(&snapshot, 0, i).unwrap();
+        let glyph_wrapper = get_glyph_from_snapshot(&snapshot, 0, i).expect("Glyph should exist at snapshot");
         match glyph_wrapper {
             Glyph::Single(cell) => {
                 assert_eq!(cell.c, ('A' as u8 + i as u8) as char);
@@ -2431,7 +2431,7 @@ fn it_should_set_indexed_foreground_color_sgr_38_5_n() {
         0,
         0,
     )
-    .unwrap()
+    .expect("Value should be present")
     {
         Glyph::Single(c) => c.attr,
         _ => panic!("Expected Single"),
@@ -2451,7 +2451,7 @@ fn it_should_set_rgb_foreground_color_sgr_38_2_r_g_b() {
         0,
         0,
     )
-    .unwrap()
+    .expect("Value should be present")
     {
         Glyph::Single(c) => c.attr,
         _ => panic!("Expected Single"),
@@ -2475,11 +2475,11 @@ fn it_should_reset_foreground_color_on_sgr_39() {
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('B'))); // Default fg 'B'
 
     let snapshot = term.get_render_snapshot().expect("Snapshot was None");
-    let attr_a = match get_glyph_from_snapshot(&snapshot, 0, 0).unwrap() {
+    let attr_a = match get_glyph_from_snapshot(&snapshot, 0, 0).expect("Glyph should exist at snapshot") {
         Glyph::Single(c) => c.attr,
         _ => panic!("Expected Single"),
     };
-    let attr_b = match get_glyph_from_snapshot(&snapshot, 0, 1).unwrap() {
+    let attr_b = match get_glyph_from_snapshot(&snapshot, 0, 1).expect("Glyph should exist at snapshot") {
         Glyph::Single(c) => c.attr,
         _ => panic!("Expected Single"),
     };
@@ -2512,7 +2512,7 @@ fn it_should_set_basic_ansi_background_colors_sgr_40_47() {
     }
     let snapshot = term.get_render_snapshot().expect("Snapshot was None");
     for (i, &color_name) in colors.iter().enumerate() {
-        let glyph_wrapper = get_glyph_from_snapshot(&snapshot, 0, i).unwrap();
+        let glyph_wrapper = get_glyph_from_snapshot(&snapshot, 0, i).expect("Glyph should exist at snapshot");
         match glyph_wrapper {
             Glyph::Single(cell) => {
                 assert_eq!(cell.c, ('A' as u8 + i as u8) as char);
@@ -2553,7 +2553,7 @@ fn it_should_set_bright_ansi_background_colors_sgr_100_107() {
     }
     let snapshot = term.get_render_snapshot().expect("Snapshot was None");
     for (i, &color_name) in bright_colors.iter().enumerate() {
-        let glyph_wrapper = get_glyph_from_snapshot(&snapshot, 0, i).unwrap();
+        let glyph_wrapper = get_glyph_from_snapshot(&snapshot, 0, i).expect("Glyph should exist at snapshot");
         match glyph_wrapper {
             Glyph::Single(cell) => {
                 assert_eq!(cell.c, ('A' as u8 + i as u8) as char);
@@ -2581,7 +2581,7 @@ fn it_should_set_indexed_background_color_sgr_48_5_n() {
         0,
         0,
     )
-    .unwrap()
+    .expect("Value should be present")
     {
         Glyph::Single(c) => c.attr,
         _ => panic!("Expected Single"),
@@ -2601,7 +2601,7 @@ fn it_should_set_rgb_background_color_sgr_48_2_r_g_b() {
         0,
         0,
     )
-    .unwrap()
+    .expect("Value should be present")
     {
         Glyph::Single(c) => c.attr,
         _ => panic!("Expected Single"),
@@ -2625,11 +2625,11 @@ fn it_should_reset_background_color_on_sgr_49() {
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('B'))); // Default bg 'B'
 
     let snapshot = term.get_render_snapshot().expect("Snapshot was None");
-    let attr_a = match get_glyph_from_snapshot(&snapshot, 0, 0).unwrap() {
+    let attr_a = match get_glyph_from_snapshot(&snapshot, 0, 0).expect("Glyph should exist at snapshot") {
         Glyph::Single(c) => c.attr,
         _ => panic!("Expected Single"),
     };
-    let attr_b = match get_glyph_from_snapshot(&snapshot, 0, 1).unwrap() {
+    let attr_b = match get_glyph_from_snapshot(&snapshot, 0, 1).expect("Glyph should exist at snapshot") {
         Glyph::Single(c) => c.attr,
         _ => panic!("Expected Single"),
     };
@@ -2661,11 +2661,11 @@ fn it_should_set_inverse_on_sgr_7_and_reset_on_sgr_27() {
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('B'))); // Not inverse B: fg=Red, bg=Blue
 
     let snapshot = term.get_render_snapshot().expect("Snapshot was None");
-    let attr_a = match get_glyph_from_snapshot(&snapshot, 0, 0).unwrap() {
+    let attr_a = match get_glyph_from_snapshot(&snapshot, 0, 0).expect("Glyph should exist at snapshot") {
         Glyph::Single(c) => c.attr,
         _ => panic!("Expected Single"),
     };
-    let attr_b = match get_glyph_from_snapshot(&snapshot, 0, 1).unwrap() {
+    let attr_b = match get_glyph_from_snapshot(&snapshot, 0, 1).expect("Glyph should exist at snapshot") {
         Glyph::Single(c) => c.attr,
         _ => panic!("Expected Single"),
     };
@@ -2707,7 +2707,7 @@ fn it_should_set_multiple_attributes_in_one_sgr_sequence() {
         0,
         0,
     )
-    .unwrap()
+    .expect("Value should be present")
     {
         Glyph::Single(c) => c.attr,
         _ => panic!("Expected Single"),

--- a/core-term/src/term/tests.rs
+++ b/core-term/src/term/tests.rs
@@ -205,7 +205,7 @@ fn assert_screen_state(
 }
 
 #[test]
-fn test_simple_char_input() {
+fn simple_char_input() {
     let mut term = create_test_emulator(10, 1);
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('A')));
     let snapshot = term.get_render_snapshot().expect("Snapshot was None");
@@ -218,7 +218,7 @@ fn test_simple_char_input() {
 }
 
 #[test]
-fn test_newline_input() {
+fn newline_input() {
     let mut term = create_test_emulator(10, 2);
     // Enable Linefeed/Newline Mode (LNM)
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Csi(CsiCommand::SetMode(
@@ -235,7 +235,7 @@ fn test_newline_input() {
 }
 
 #[test]
-fn test_carriage_return_input() {
+fn carriage_return_input() {
     let mut term = create_test_emulator(10, 1);
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('A')));
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('B')));
@@ -248,7 +248,7 @@ fn test_carriage_return_input() {
 }
 
 #[test]
-fn test_csi_cursor_forward_cuf() {
+fn csi_cursor_forward_cuf() {
     let mut term = create_test_emulator(10, 1); // Cursor at (0,0)
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Csi(
         CsiCommand::CursorForward(1),
@@ -264,7 +264,7 @@ fn test_csi_cursor_forward_cuf() {
 }
 
 #[test]
-fn test_csi_ed_clear_below_csi_j() {
+fn csi_ed_clear_below_csi_j() {
     let mut term = create_test_emulator(3, 2);
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('A')));
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('B')));
@@ -292,7 +292,7 @@ fn test_csi_ed_clear_below_csi_j() {
 }
 
 #[test]
-fn test_csi_sgr_fg_color() {
+fn csi_sgr_fg_color() {
     let mut term = create_test_emulator(5, 1);
     let red_attr = vec![Attribute::Foreground(Color::Named(NamedColor::Red))];
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Csi(
@@ -301,7 +301,7 @@ fn test_csi_sgr_fg_color() {
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('A')));
 
     let snapshot = term.get_render_snapshot().expect("Snapshot was None");
-    let glyph_a_wrapper = get_glyph_from_snapshot(&snapshot, 0, 0).unwrap();
+    let glyph_a_wrapper = get_glyph_from_snapshot(&snapshot, 0, 0).expect("Glyph should exist at snapshot");
 
     match glyph_a_wrapper {
         Glyph::Single(cell) | Glyph::WidePrimary(cell) => {
@@ -325,7 +325,7 @@ fn test_csi_sgr_fg_color() {
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('B')));
     let snapshot_b = term.get_render_snapshot().expect("Snapshot was None");
     assert_screen_state(&snapshot_b, &["AB   "], Some((0, 2))); // A is red, B is default
-    let glyph_b_wrapper = get_glyph_from_snapshot(&snapshot_b, 0, 1).unwrap();
+    let glyph_b_wrapper = get_glyph_from_snapshot(&snapshot_b, 0, 1).expect("Glyph should exist at snapshot");
     match glyph_b_wrapper {
         Glyph::Single(cell) | Glyph::WidePrimary(cell) => {
             assert_eq!(
@@ -370,7 +370,7 @@ fn fill_emulator_screen(emu: &mut TerminalEmulator, text_lines: Vec<String>) {
 
 // --- Basic Selection Flow Tests ---
 #[test]
-fn test_mouse_press_starts_selection() {
+fn mouse_press_starts_selection() {
     let mut emu = create_test_emulator(10, 5);
     let action = send_mouse_input(&mut emu, start_selection_at(1, 1), MouseButton::Left);
 
@@ -402,7 +402,7 @@ fn test_mouse_press_starts_selection() {
 }
 
 #[test]
-fn test_mouse_drag_updates_selection() {
+fn mouse_drag_updates_selection() {
     let mut emu = create_test_emulator(10, 5);
     send_mouse_input(&mut emu, start_selection_at(1, 1), MouseButton::Left);
     let action = send_mouse_input(&mut emu, extend_selection_to(5, 2), MouseButton::Left);
@@ -430,7 +430,7 @@ fn test_mouse_drag_updates_selection() {
 }
 
 #[test]
-fn test_mouse_release_ends_selection_activity() {
+fn mouse_release_ends_selection_activity() {
     let mut emu = create_test_emulator(10, 5);
     send_mouse_input(&mut emu, start_selection_at(1, 1), MouseButton::Left);
     send_mouse_input(&mut emu, extend_selection_to(5, 2), MouseButton::Left);
@@ -470,14 +470,14 @@ fn test_mouse_release_ends_selection_activity() {
 
 // --- Copy Action Tests ---
 #[test]
-fn test_initiate_copy_no_selection() {
+fn initiate_copy_no_selection() {
     let mut emu = create_test_emulator(10, 5);
     let action = emu.interpret_input(EmulatorInput::User(UserInputAction::InitiateCopy));
     assert_eq!(action, None, "Should return None if no selection exists.");
 }
 
 #[test]
-fn test_initiate_copy_with_selection() {
+fn initiate_copy_with_selection() {
     let mut emu = create_test_emulator(10, 2);
     fill_emulator_screen(&mut emu, vec!["Hello".to_string(), "World".to_string()]);
 
@@ -498,7 +498,7 @@ fn test_initiate_copy_with_selection() {
 }
 
 #[test]
-fn test_initiate_copy_block_selection() {
+fn initiate_copy_block_selection() {
     let mut emu = create_test_emulator(3, 3);
     fill_emulator_screen(
         &mut emu,
@@ -525,7 +525,7 @@ fn test_initiate_copy_block_selection() {
 
 // --- Selection Clearing Tests ---
 #[test]
-fn test_new_mouse_press_clears_old_selection() {
+fn new_mouse_press_clears_old_selection() {
     let mut emu = create_test_emulator(10, 5);
 
     send_mouse_input(&mut emu, start_selection_at(0, 0), MouseButton::Left);
@@ -573,7 +573,7 @@ fn test_new_mouse_press_clears_old_selection() {
 
 // --- Selection Interaction with Scrolling Test ---
 #[test]
-fn test_selection_coordinates_adjust_on_scroll() {
+fn selection_coordinates_adjust_on_scroll() {
     let mut emu = create_test_emulator(10, 3);
     fill_emulator_screen(
         &mut emu,
@@ -631,7 +631,7 @@ fn test_selection_coordinates_adjust_on_scroll() {
 
 // --- Selection with Alternate Screen Test ---
 #[test]
-fn test_selection_on_alt_screen_then_exit() {
+fn selection_on_alt_screen_then_exit() {
     let mut emu = create_test_emulator(10, 3);
     fill_emulator_screen(
         &mut emu,
@@ -684,7 +684,7 @@ fn test_selection_on_alt_screen_then_exit() {
 // --- End of Selection with Alternate Screen Test ---
 
 #[test]
-fn test_resize_larger() {
+fn resize_larger() {
     let mut term = create_test_emulator(5, 2);
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('1')));
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('2')));
@@ -709,7 +709,7 @@ fn test_resize_larger() {
 }
 
 #[test]
-fn test_resize_smaller_content_truncation() {
+fn resize_smaller_content_truncation() {
     let mut term = create_test_emulator(5, 2);
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('H')));
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('e')));
@@ -726,7 +726,7 @@ fn test_resize_smaller_content_truncation() {
 }
 
 #[test]
-fn test_osc_set_window_title() {
+fn osc_set_window_title() {
     let mut term = create_test_emulator(10, 1);
 
     let action = term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Osc(
@@ -747,7 +747,7 @@ fn test_osc_set_window_title() {
 }
 
 #[test]
-fn test_key_event_printable_char() {
+fn key_event_printable_char() {
     let mut term = create_test_emulator(5, 1);
     let key_input = UserInputAction::KeyInput {
         symbol: KeySymbol::Char('x'),
@@ -766,7 +766,7 @@ fn test_key_event_printable_char() {
 }
 
 #[test]
-fn test_key_event_arrow_up() {
+fn key_event_arrow_up() {
     let mut term = create_test_emulator(5, 1);
     let key_input = UserInputAction::KeyInput {
         symbol: KeySymbol::Up,
@@ -783,7 +783,7 @@ fn test_key_event_arrow_up() {
 }
 
 #[test]
-fn test_snapshot_with_selection() {
+fn snapshot_with_selection() {
     let num_cols = 10;
     let num_rows = 2;
     let default_glyph = Glyph::Single(ContentCell {
@@ -825,7 +825,7 @@ fn test_snapshot_with_selection() {
     };
 
     assert!(snapshot_with_selection.selection.range.is_some());
-    let sel_range = snapshot_with_selection.selection.range.unwrap();
+    let sel_range = snapshot_with_selection.selection.range.expect("Value should be present");
     assert_eq!(sel_range.start, Point { x: 1, y: 0 });
     assert_eq!(sel_range.end, Point { x: 3, y: 1 });
     assert_eq!(snapshot_with_selection.selection.mode, SelectionMode::Cell);
@@ -842,7 +842,7 @@ fn test_snapshot_with_selection() {
 }
 
 #[test]
-fn test_mode_show_cursor_dectcem() {
+fn mode_show_cursor_dectcem() {
     let mut term = create_test_emulator(5, 1);
 
     let snap_default = term.get_render_snapshot().expect("Snapshot was None");
@@ -850,7 +850,7 @@ fn test_mode_show_cursor_dectcem() {
         snap_default.cursor_state.is_some(),
         "Cursor should be visible by default"
     );
-    let initial_shape = snap_default.cursor_state.as_ref().unwrap().shape;
+    let initial_shape = snap_default.cursor_state.as_ref().expect("Cursor state should be present").shape;
 
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Csi(
         CsiCommand::ResetModePrivate(DecModeConstant::TextCursorEnable as u16),
@@ -870,7 +870,7 @@ fn test_mode_show_cursor_dectcem() {
         "Cursor should be visible again after DECSET ?25h"
     );
     assert_eq!(
-        snap_shown.cursor_state.as_ref().unwrap().shape,
+        snap_shown.cursor_state.as_ref().expect("Cursor state should be present").shape,
         initial_shape,
         "Cursor should revert to its initial non-hidden shape"
     );
@@ -879,7 +879,7 @@ fn test_mode_show_cursor_dectcem() {
 // --- PS1 Multi-line Prompt Tests ---
 
 #[test]
-fn test_ps1_multiline_prompt_at_bottom_causes_scroll() {
+fn ps1_multiline_prompt_at_bottom_causes_scroll() {
     let mut term = create_test_emulator(5, 3);
 
     for _ in 0..5 {
@@ -909,7 +909,7 @@ fn test_ps1_multiline_prompt_at_bottom_causes_scroll() {
 }
 
 #[test]
-fn test_ps1_multiline_prompt_ends_on_last_line_no_scroll_by_prompt() {
+fn ps1_multiline_prompt_ends_on_last_line_no_scroll_by_prompt() {
     let mut term = create_test_emulator(5, 3);
 
     for _ in 0..5 {
@@ -932,7 +932,7 @@ fn test_ps1_multiline_prompt_ends_on_last_line_no_scroll_by_prompt() {
 }
 
 #[test]
-fn test_ps1_multiline_prompt_last_line_fills_screen_then_input() {
+fn ps1_multiline_prompt_last_line_fills_screen_then_input() {
     let mut term = create_test_emulator(3, 2);
 
     for _ in 0..3 {
@@ -962,7 +962,7 @@ fn test_ps1_multiline_prompt_last_line_fills_screen_then_input() {
 }
 
 #[test]
-fn test_ps1_prompt_causes_multiple_scrolls() {
+fn ps1_prompt_causes_multiple_scrolls() {
     let mut term = create_test_emulator(3, 2);
 
     for _ in 0..3 {
@@ -991,7 +991,7 @@ fn test_ps1_prompt_causes_multiple_scrolls() {
 }
 
 #[test]
-fn test_ps1_prompt_with_internal_wrapping_and_scrolling() {
+fn ps1_prompt_with_internal_wrapping_and_scrolling() {
     let mut term = create_test_emulator(3, 2);
     for _ in 0..3 {
         term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('A')));
@@ -1026,7 +1026,7 @@ fn test_ps1_prompt_with_internal_wrapping_and_scrolling() {
 }
 
 #[test]
-fn test_ps1_multiline_exact_fill_then_scroll_on_final_lf() {
+fn ps1_multiline_exact_fill_then_scroll_on_final_lf() {
     let mut term = create_test_emulator(3, 2);
 
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('P')));
@@ -1046,7 +1046,7 @@ fn test_ps1_multiline_exact_fill_then_scroll_on_final_lf() {
 }
 
 #[test]
-fn test_ps1_multiline_with_sgr_at_bottom_scrolls() {
+fn ps1_multiline_with_sgr_at_bottom_scrolls() {
     let mut term = create_test_emulator(5, 2);
 
     for _ in 0..5 {
@@ -1083,11 +1083,11 @@ fn test_ps1_multiline_with_sgr_at_bottom_scrolls() {
     let snapshot = term.get_render_snapshot().expect("Snapshot was None");
     assert_screen_state(&snapshot, &["P1   ", "$    "], Some((1, 2)));
 
-    let glyph_p_wrapper = get_glyph_from_snapshot(&snapshot, 0, 0).unwrap();
-    let glyph_1_wrapper = get_glyph_from_snapshot(&snapshot, 0, 1).unwrap();
-    let glyph_dollar_wrapper = get_glyph_from_snapshot(&snapshot, 1, 0).unwrap();
-    let glyph_space_after_dollar_wrapper = get_glyph_from_snapshot(&snapshot, 1, 1).unwrap();
-    let glyph_final_cursor_cell_wrapper = get_glyph_from_snapshot(&snapshot, 1, 2).unwrap();
+    let glyph_p_wrapper = get_glyph_from_snapshot(&snapshot, 0, 0).expect("Glyph should exist at snapshot");
+    let glyph_1_wrapper = get_glyph_from_snapshot(&snapshot, 0, 1).expect("Glyph should exist at snapshot");
+    let glyph_dollar_wrapper = get_glyph_from_snapshot(&snapshot, 1, 0).expect("Glyph should exist at snapshot");
+    let glyph_space_after_dollar_wrapper = get_glyph_from_snapshot(&snapshot, 1, 1).expect("Glyph should exist at snapshot");
+    let glyph_final_cursor_cell_wrapper = get_glyph_from_snapshot(&snapshot, 1, 2).expect("Glyph should exist at snapshot");
 
     match glyph_p_wrapper {
         Glyph::Single(cell) | Glyph::WidePrimary(cell) => {
@@ -1130,7 +1130,7 @@ fn test_ps1_multiline_with_sgr_at_bottom_scrolls() {
 }
 
 #[test]
-fn test_lf_at_bottom_of_partial_scrolling_region_no_origin_mode() {
+fn lf_at_bottom_of_partial_scrolling_region_no_origin_mode() {
     let cols = 10;
     let rows = 5;
     let mut emu = create_test_emulator(cols, rows);
@@ -1214,7 +1214,7 @@ fn test_lf_at_bottom_of_partial_scrolling_region_no_origin_mode() {
     );
 }
 #[test]
-fn test_primary_device_attributes_response() {
+fn primary_device_attributes_response() {
     let mut term = create_test_emulator(80, 24);
 
     let input_da = EmulatorInput::Ansi(AnsiCommand::Csi(CsiCommand::PrimaryDeviceAttributes));
@@ -1236,7 +1236,7 @@ mod selection_logic_tests {
     use crate::term::snapshot::SelectionRange;
 
     #[test]
-    fn test_start_selection() {
+    fn start_selection() {
         let mut emu = create_test_emulator(10, 5);
         let point = Point { x: 2, y: 1 };
 
@@ -1256,7 +1256,7 @@ mod selection_logic_tests {
     }
 
     #[test]
-    fn test_extend_selection_active_and_inactive() {
+    fn extend_selection_active_and_inactive() {
         let mut emu = create_test_emulator(10, 5);
         let start_point = Point { x: 2, y: 1 };
         let extend_point = Point { x: 5, y: 2 };
@@ -1282,7 +1282,7 @@ mod selection_logic_tests {
     }
 
     #[test]
-    fn test_apply_selection_clear_click_and_drag() {
+    fn apply_selection_clear_click_and_drag() {
         let mut emu = create_test_emulator(10, 5);
         let point1 = Point { x: 2, y: 1 };
         let point2 = Point { x: 5, y: 1 };
@@ -1326,7 +1326,7 @@ mod selection_logic_tests {
     }
 
     #[test]
-    fn test_clear_selection() {
+    fn clear_selection() {
         let mut emu = create_test_emulator(10, 5);
 
         // Create and deactivate a selection
@@ -1351,13 +1351,13 @@ mod get_selected_text_tests {
     use super::*;
 
     #[test]
-    fn test_get_selected_text_no_selection() {
+    fn get_selected_text_no_selection() {
         let emu = create_test_emulator(10, 5);
         assert_eq!(emu.get_selected_text(), None);
     }
 
     #[test]
-    fn test_get_selected_text_single_line() {
+    fn get_selected_text_single_line() {
         let mut emu = create_test_emulator(10, 5);
         fill_emulator_screen(&mut emu, vec!["Hello World".to_string()]);
 
@@ -1374,7 +1374,7 @@ mod get_selected_text_tests {
     }
 
     #[test]
-    fn test_get_selected_text_single_line_trailing_spaces_in_selection() {
+    fn get_selected_text_single_line_trailing_spaces_in_selection() {
         let mut emu = create_test_emulator(10, 1);
         fill_emulator_screen(&mut emu, vec!["Hi   ".to_string()]);
 
@@ -1390,7 +1390,7 @@ mod get_selected_text_tests {
     }
 
     #[test]
-    fn test_get_selected_text_multi_line() {
+    fn get_selected_text_multi_line() {
         let mut emu = create_test_emulator(10, 5);
         fill_emulator_screen(
             &mut emu,
@@ -1413,7 +1413,7 @@ mod get_selected_text_tests {
     }
 
     #[test]
-    fn test_get_selected_text_multi_line_full_lines() {
+    fn get_selected_text_multi_line_full_lines() {
         let mut emu = create_test_emulator(10, 3);
         fill_emulator_screen(
             &mut emu,
@@ -1449,7 +1449,7 @@ mod get_selected_text_tests {
     }
 
     #[test]
-    fn test_get_selected_text_line_boundaries() {
+    fn get_selected_text_line_boundaries() {
         let mut emu = create_test_emulator(10, 2);
         fill_emulator_screen(
             &mut emu,
@@ -1468,7 +1468,7 @@ mod get_selected_text_tests {
     }
 
     #[test]
-    fn test_get_selected_text_empty_cells_within_grid() {
+    fn get_selected_text_empty_cells_within_grid() {
         let mut emu = create_test_emulator(5, 1);
         // Create sparse content: "A   E" by printing A, moving cursor to col 4, then printing E
         emu.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('A')));
@@ -1489,7 +1489,7 @@ mod get_selected_text_tests {
     }
 
     #[test]
-    fn test_get_selected_text_selection_beyond_line_length() {
+    fn get_selected_text_selection_beyond_line_length() {
         let mut emu = create_test_emulator(10, 1);
         fill_emulator_screen(&mut emu, vec!["Test".to_string()]);
 
@@ -1505,7 +1505,7 @@ mod get_selected_text_tests {
     }
 
     #[test]
-    fn test_get_selected_text_reversed_points() {
+    fn get_selected_text_reversed_points() {
         let mut emu = create_test_emulator(10, 5);
         fill_emulator_screen(&mut emu, vec!["Hello World".to_string()]);
 
@@ -1527,7 +1527,7 @@ mod paste_text_tests {
     use super::*;
 
     #[test]
-    fn test_paste_text_bracketed_off_simple() {
+    fn paste_text_bracketed_off_simple() {
         let mut emu = create_test_emulator(20, 1);
         // Bracketed paste mode is off by default - just verify behavior
 
@@ -1544,7 +1544,7 @@ mod paste_text_tests {
     }
 
     #[test]
-    fn test_paste_text_bracketed_off_with_newline() {
+    fn paste_text_bracketed_off_with_newline() {
         let mut emu = create_test_emulator(20, 2);
         // Bracketed paste mode is off by default - just verify behavior
 
@@ -1558,7 +1558,7 @@ mod paste_text_tests {
     }
 
     #[test]
-    fn test_paste_text_bracketed_off_causes_wrap() {
+    fn paste_text_bracketed_off_causes_wrap() {
         let mut emu = create_test_emulator(5, 2);
         // Bracketed paste mode is off by default - just verify wrapping behavior
 
@@ -1574,7 +1574,7 @@ mod paste_text_tests {
     }
 
     #[test]
-    fn test_paste_text_bracketed_on_logs_warning_processes_chars() {
+    fn paste_text_bracketed_on_logs_warning_processes_chars() {
         let mut emu = create_test_emulator(20, 1);
         // Enable bracketed paste mode
         emu.interpret_input(EmulatorInput::Ansi(AnsiCommand::Csi(
@@ -1594,7 +1594,7 @@ mod paste_text_tests {
     }
 
     #[test]
-    fn test_ansi_resize_sets_terminal_dimensions() {
+    fn ansi_resize_sets_terminal_dimensions() {
         let mut emu = create_test_emulator(80, 24);
         assert_eq!(emu.dimensions(), (80, 24));
 
@@ -1613,7 +1613,7 @@ mod paste_text_tests {
     }
 
     #[test]
-    fn test_ansi_resize_updates_snapshot_dimensions() {
+    fn ansi_resize_updates_snapshot_dimensions() {
         let mut emu = create_test_emulator(80, 24);
 
         let resize_command = AnsiCommand::Csi(CsiCommand::WindowManipulation {
@@ -1632,7 +1632,7 @@ mod paste_text_tests {
     }
 
     #[test]
-    fn test_ansi_resize_with_zero_rows_ignored() {
+    fn ansi_resize_with_zero_rows_ignored() {
         let mut emu = create_test_emulator(80, 24);
 
         let resize_command = AnsiCommand::Csi(CsiCommand::WindowManipulation {
@@ -1650,7 +1650,7 @@ mod paste_text_tests {
     }
 
     #[test]
-    fn test_ansi_resize_with_zero_cols_ignored() {
+    fn ansi_resize_with_zero_cols_ignored() {
         let mut emu = create_test_emulator(80, 24);
 
         let resize_command = AnsiCommand::Csi(CsiCommand::WindowManipulation {
@@ -1668,7 +1668,7 @@ mod paste_text_tests {
     }
 
     #[test]
-    fn test_ansi_resize_with_missing_params_ignored() {
+    fn ansi_resize_with_missing_params_ignored() {
         let mut emu = create_test_emulator(80, 24);
 
         let resize_command = AnsiCommand::Csi(CsiCommand::WindowManipulation {
@@ -1699,7 +1699,7 @@ mod paste_text_tests {
     }
 
     #[test]
-    fn test_window_manipulation_report_size() {
+    fn window_manipulation_report_size() {
         let mut emu = create_test_emulator(80, 24);
 
         let report_command = AnsiCommand::Csi(CsiCommand::WindowManipulation {


### PR DESCRIPTION
Refactored `core-term/src/term/tests.rs` and `core-term/src/term/core_tests.rs` to enforce `STYLE.md` conventions:
- Replaced naked `.unwrap()` calls with context-specific `.expect("...")` messages.
- Removed redundant `test_` prefixes from function names annotated with `#[test]`.

---
*PR created automatically by Jules for task [18296759142509807087](https://jules.google.com/task/18296759142509807087) started by @jppittman*