### PR TITLE
⚡ Bolt: Use Vec::with_capacity in terminal layout for performance

### DIFF
--- a/core-term/src/terminal_app.rs
+++ b/core-term/src/terminal_app.rs
@@ -288,11 +288,11 @@ impl TerminalApp {
         let default_bg = self.config.colors.background;
 
         // Build 2-level BSP: Vertical (Rows) -> Horizontal (Cells)
-        let mut row_items = Vec::new();
+        let mut row_items = Vec::with_capacity(rows);
 
         for row in 0..rows {
             let line = &snapshot.lines[row];
-            let mut cell_items = Vec::new();
+            let mut cell_items = Vec::with_capacity(cols);
 
             for col in 0..cols {
                 let glyph = &line.cells[col];


### PR DESCRIPTION
💡 What: Replaced `Vec::new()` with `Vec::with_capacity()` for `row_items` and `cell_items` in `core-term/src/terminal_app.rs`.
🎯 Why: In the nested loops generating the terminal rendering layout tree, pre-allocating the vector capacity to the known exact sizes (`rows` and `cols`) prevents expensive dynamic heap re-allocations that happen automatically as items are pushed, thereby decreasing CPU overhead.
📊 Impact: This optimization is critical on the rendering hot-path where terminal grids can consist of thousands of individual cells created every single frame, resulting in lower memory fragmentation and faster UI execution speeds.
🔬 Measurement: Verify changes in the hot-path execution via `cargo check` and checking trace layouts.

---
*PR created automatically by Jules for task [8353031314325260396](https://jules.google.com/task/8353031314325260396) started by @jppittman*