### PR TITLE
Refactor boolean arguments in macOS platform API

### DIFF
--- a/pixelflow-runtime/src/platform/macos/cocoa.rs
+++ b/pixelflow-runtime/src/platform/macos/cocoa.rs
@@ -117,6 +117,12 @@ impl NSRect {
 
 // --- Wrappers ---
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum EventDequeue {
+    Dequeue,
+    Peek,
+}
+
 /// Wrapper for NSApplication
 #[derive(Copy, Clone)]
 pub struct NSApplication(pub Id);
@@ -136,10 +142,15 @@ impl NSApplication {
         }
     }
 
-    pub fn activate_ignoring_other_apps(&self, ignore: bool) {
+    pub fn activate_ignoring_other_apps(&self) {
         unsafe {
-            let val = if ignore { YES } else { NO };
-            sys::send_1::<(), BOOL>(self.0, sys::sel(b"activateIgnoringOtherApps:\0"), val);
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"activateIgnoringOtherApps:\0"), YES);
+        }
+    }
+
+    pub fn activate_normally(&self) {
+        unsafe {
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"activateIgnoringOtherApps:\0"), NO);
         }
     }
 
@@ -156,9 +167,13 @@ impl NSApplication {
     }
 
     // nextEventMatchingMask:untilDate:inMode:dequeue:
-    pub fn next_event(&self, mask: u64, date: Id, mode: Id, dequeue: bool) -> NSEvent {
+
+    pub fn next_event(&self, mask: u64, date: Id, mode: Id, dequeue: EventDequeue) -> NSEvent {
         unsafe {
-            let d = if dequeue { YES } else { NO };
+            let d = match dequeue {
+                EventDequeue::Dequeue => YES,
+                EventDequeue::Peek => NO,
+            };
             let ptr: Id = sys::send_4(
                 self.0,
                 sys::sel(b"nextEventMatchingMask:untilDate:inMode:dequeue:\0"),
@@ -170,6 +185,12 @@ impl NSApplication {
             NSEvent(ptr)
         }
     }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum WindowDeferral {
+    Defer,
+    Immediate,
 }
 
 /// Wrapper for NSWindow
@@ -185,15 +206,20 @@ impl NSWindow {
         }
     }
 
+
+
     pub fn init_with_content_rect(
         &self,
         rect: NSRect,
         style_mask: u64,
         backing: u64,
-        defer: bool,
+        defer: WindowDeferral,
     ) -> Self {
         unsafe {
-            let d = if defer { YES } else { NO };
+            let d = match defer {
+                WindowDeferral::Defer => YES,
+                WindowDeferral::Immediate => NO,
+            };
             let ptr: Id = sys::send_4(
                 self.0,
                 sys::sel(b"initWithContentRect:styleMask:backing:defer:\0"),
@@ -266,10 +292,15 @@ impl NSView {
         }
     }
 
-    pub fn set_wants_layer(&self, wants: bool) {
+    pub fn enable_layer(&self) {
         unsafe {
-            let val = if wants { YES } else { NO };
-            sys::send_1::<(), BOOL>(self.0, sys::sel(b"setWantsLayer:\0"), val);
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"setWantsLayer:\0"), YES);
+        }
+    }
+
+    pub fn disable_layer(&self) {
+        unsafe {
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"setWantsLayer:\0"), NO);
         }
     }
 

--- a/pixelflow-runtime/src/platform/macos/cocoa.rs
+++ b/pixelflow-runtime/src/platform/macos/cocoa.rs
@@ -167,7 +167,6 @@ impl NSApplication {
     }
 
     // nextEventMatchingMask:untilDate:inMode:dequeue:
-
     pub fn next_event(&self, mask: u64, date: Id, mode: Id, dequeue: EventDequeue) -> NSEvent {
         unsafe {
             let d = match dequeue {
@@ -205,8 +204,6 @@ impl NSWindow {
             Self(ptr)
         }
     }
-
-
 
     pub fn init_with_content_rect(
         &self,

--- a/pixelflow-runtime/src/platform/macos/platform.rs
+++ b/pixelflow-runtime/src/platform/macos/platform.rs
@@ -45,7 +45,7 @@ impl MetalOps {
             app.set_activation_policy(NS_APPLICATION_ACTIVATION_POLICY_REGULAR);
 
             app.finish_launching();
-            app.activate_ignoring_other_apps(true);
+            app.activate_ignoring_other_apps();
 
             app
         };
@@ -102,7 +102,11 @@ impl PlatformOps for MetalOps {
             }
             DisplayControl::SetVisible { id, visible } => {
                 if let Some(win) = self.windows.get_mut(&id) {
-                    win.set_visible(visible);
+                    if visible {
+                        win.show();
+                    } else {
+                        win.hide();
+                    }
                 }
             }
             DisplayControl::RequestRedraw { id } => {
@@ -164,7 +168,7 @@ impl PlatformOps for MetalOps {
             }
             DisplayMgmt::Destroy { id } => {
                 if let Some(mut win) = self.windows.remove(&id) {
-                    win.set_visible(false);
+                    win.hide();
                     // Drop closes it implicitly or we call close
                     // win.window.close(); // If we expose it
                     self.window_map.remove(&(win.window.0 as usize));
@@ -217,7 +221,7 @@ impl PlatformOps for MetalOps {
                 u64::MAX,
                 until_date,
                 mode,
-                true, // dequeue
+                crate::platform::macos::cocoa::EventDequeue::Dequeue, // dequeue
             );
 
             // Release mode string

--- a/pixelflow-runtime/src/platform/macos/window.rs
+++ b/pixelflow-runtime/src/platform/macos/window.rs
@@ -24,7 +24,7 @@ impl MacWindow {
         // NSBackingStoreBuffered = 2
         let backing = 2;
 
-        let window = NSWindow::alloc().init_with_content_rect(rect, style_mask, backing, false);
+        let window = NSWindow::alloc().init_with_content_rect(rect, style_mask, backing, crate::platform::macos::cocoa::WindowDeferral::Immediate);
         window.set_title(&desc.title);
 
         let view = NSView::alloc().init_with_frame(rect);
@@ -60,7 +60,7 @@ impl MacWindow {
             sys::send_1::<(), Id>(view.0, sys::sel(b"setLayer:\0"), layer);
 
             // [view setWantsLayer: YES]
-            view.set_wants_layer(true);
+            view.enable_layer();
         }
 
         window.set_content_view(view);
@@ -122,13 +122,13 @@ impl MacWindow {
         }
     }
 
-    pub fn set_visible(&mut self, visible: bool) {
-        if visible {
-            self.window.make_key_and_order_front();
-        } else {
-            unsafe {
-                sys::send::<()>(self.window.0, sys::sel(b"orderOut:\0"));
-            }
+    pub fn show(&mut self) {
+        self.window.make_key_and_order_front();
+    }
+
+    pub fn hide(&mut self) {
+        unsafe {
+            sys::send::<()>(self.window.0, sys::sel(b"orderOut:\0"));
         }
     }
 


### PR DESCRIPTION
Refactored boolean arguments in the macOS platform layer to enforce strict typing and idiomatic API design, aligning with `STYLE.md` rules against boolean arguments.

---
*PR created automatically by Jules for task [15401833817801872605](https://jules.google.com/task/15401833817801872605) started by @jppittman*