### PR TITLE
Refactor macos cocoa wrappers to remove boolean arguments

### DIFF
--- a/clean_cocoa.py
+++ b/clean_cocoa.py
@@ -1,0 +1,75 @@
+import re
+
+file_path = "pixelflow-runtime/src/platform/macos/cocoa.rs"
+with open(file_path, "r", encoding="utf-8") as f:
+    content = f.read()
+
+# 1. Add enums at the top
+enums = """
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum EventDequeue {
+    Dequeue,
+    Peek,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum WindowDeferral {
+    Defer,
+    Immediate,
+}
+"""
+content = content.replace("use std::ffi::c_void;\n", "use std::ffi::c_void;\n" + enums)
+
+# 2. Split activate_ignoring_other_apps
+activate_old = r'pub fn activate_ignoring_other_apps\(&self, ignore: bool\) \{[\s\S]*?\}'
+
+activate_new = """pub fn activate_ignoring_other_apps(&self) {
+        unsafe {
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"activateIgnoringOtherApps:\\0"), YES);
+        }
+    }
+
+    pub fn activate_observing_other_apps(&self) {
+        unsafe {
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"activateIgnoringOtherApps:\\0"), NO);
+        }
+    }"""
+content = re.sub(activate_old, activate_new, content, count=1)
+
+# 3. Modify next_event
+next_old = r'pub fn next_event\(&self, mask: u64, date: Id, mode: Id, dequeue: bool\) -> NSEvent \{[\s\S]*?let d = if dequeue \{ YES \} else \{ NO \};'
+next_new = """pub fn next_event(&self, mask: u64, date: Id, mode: Id, dequeue: EventDequeue) -> NSEvent {
+        unsafe {
+            let d = if dequeue == EventDequeue::Dequeue { YES } else { NO };"""
+content = re.sub(next_old, next_new, content, count=1)
+
+# 4. Modify init_with_content_rect
+init_old = r'pub fn init_with_content_rect\([\s\S]*?defer: bool,[\s\S]*?\) -> Self \{[\s\S]*?let d = if defer \{ YES \} else \{ NO \};'
+init_new = """pub fn init_with_content_rect(
+        &self,
+        rect: NSRect,
+        style_mask: u64,
+        backing: u64,
+        defer: WindowDeferral,
+    ) -> Self {
+        unsafe {
+            let d = if defer == WindowDeferral::Defer { YES } else { NO };"""
+content = re.sub(init_old, init_new, content, count=1)
+
+# 5. Split set_wants_layer
+wants_layer_old = r'pub fn set_wants_layer\(&self, wants: bool\) \{[\s\S]*?\}'
+wants_layer_new = """pub fn enable_layer(&self) {
+        unsafe {
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"setWantsLayer:\\0"), YES);
+        }
+    }
+
+    pub fn disable_layer(&self) {
+        unsafe {
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"setWantsLayer:\\0"), NO);
+        }
+    }"""
+content = re.sub(wants_layer_old, wants_layer_new, content, count=1)
+
+with open(file_path, "w", encoding="utf-8") as f:
+    f.write(content)

--- a/clean_cocoa_safe.py
+++ b/clean_cocoa_safe.py
@@ -1,0 +1,89 @@
+import os
+
+file_path = "pixelflow-runtime/src/platform/macos/cocoa.rs"
+with open(file_path, "r", encoding="utf-8") as f:
+    content = f.read()
+
+enums = """
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum EventDequeue {
+    Dequeue,
+    Peek,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum WindowDeferral {
+    Defer,
+    Immediate,
+}
+"""
+content = content.replace("use std::ffi::c_void;\n", "use std::ffi::c_void;\n" + enums)
+
+old_activate = """    pub fn activate_ignoring_other_apps(&self, ignore: bool) {
+        unsafe {
+            let val = if ignore { YES } else { NO };
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"activateIgnoringOtherApps:\\0"), val);
+        }
+    }"""
+new_activate = """    pub fn activate_ignoring_other_apps(&self) {
+        unsafe {
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"activateIgnoringOtherApps:\\0"), YES);
+        }
+    }
+
+    pub fn activate_observing_other_apps(&self) {
+        unsafe {
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"activateIgnoringOtherApps:\\0"), NO);
+        }
+    }"""
+content = content.replace(old_activate, new_activate)
+
+old_next = """    pub fn next_event(&self, mask: u64, date: Id, mode: Id, dequeue: bool) -> NSEvent {
+        unsafe {
+            let d = if dequeue { YES } else { NO };"""
+new_next = """    pub fn next_event(&self, mask: u64, date: Id, mode: Id, dequeue: EventDequeue) -> NSEvent {
+        unsafe {
+            let d = if dequeue == EventDequeue::Dequeue { YES } else { NO };"""
+content = content.replace(old_next, new_next)
+
+old_init = """    pub fn init_with_content_rect(
+        &self,
+        rect: NSRect,
+        style_mask: u64,
+        backing: u64,
+        defer: bool,
+    ) -> Self {
+        unsafe {
+            let d = if defer { YES } else { NO };"""
+new_init = """    pub fn init_with_content_rect(
+        &self,
+        rect: NSRect,
+        style_mask: u64,
+        backing: u64,
+        defer: WindowDeferral,
+    ) -> Self {
+        unsafe {
+            let d = if defer == WindowDeferral::Defer { YES } else { NO };"""
+content = content.replace(old_init, new_init)
+
+old_layer = """    pub fn set_wants_layer(&self, wants: bool) {
+        unsafe {
+            let val = if wants { YES } else { NO };
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"setWantsLayer:\\0"), val);
+        }
+    }"""
+new_layer = """    pub fn enable_layer(&self) {
+        unsafe {
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"setWantsLayer:\\0"), YES);
+        }
+    }
+
+    pub fn disable_layer(&self) {
+        unsafe {
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"setWantsLayer:\\0"), NO);
+        }
+    }"""
+content = content.replace(old_layer, new_layer)
+
+with open(file_path, "w", encoding="utf-8") as f:
+    f.write(content)

--- a/fix_binary.py
+++ b/fix_binary.py
@@ -1,0 +1,15 @@
+import codecs
+
+file_path = "pixelflow-runtime/src/platform/macos/cocoa.rs"
+with open(file_path, "rb") as f:
+    data = f.read()
+
+# Try to decode and fix literal null bytes that were meant to be string escapes
+try:
+    text = data.decode('utf-8')
+    text = text.replace('\x00', '\\0')
+    with open(file_path, "w", encoding='utf-8') as f:
+        f.write(text)
+    print("Fixed!")
+except Exception as e:
+    print("Failed", e)

--- a/fix_binary_again.py
+++ b/fix_binary_again.py
@@ -1,0 +1,10 @@
+import codecs
+
+file_path = "pixelflow-runtime/src/platform/macos/cocoa.rs"
+with open(file_path, "rb") as f:
+    data = f.read()
+
+text = data.decode('utf-8').replace('\x00', '\\0')
+
+with open(file_path, "w", encoding='utf-8') as f:
+    f.write(text)

--- a/fix_cocoa3.py
+++ b/fix_cocoa3.py
@@ -1,0 +1,89 @@
+import re
+
+file_path = "pixelflow-runtime/src/platform/macos/cocoa.rs"
+with open(file_path, "r", encoding="utf-8") as f:
+    content = f.read()
+
+enums = """
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum EventDequeue {
+    Dequeue,
+    Peek,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum WindowDeferral {
+    Defer,
+    Immediate,
+}
+"""
+content = content.replace("use std::ffi::c_void;\n", "use std::ffi::c_void;\n" + enums)
+
+old_activate = """    pub fn activate_ignoring_other_apps(&self, ignore: bool) {
+        unsafe {
+            let val = if ignore { YES } else { NO };
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"activateIgnoringOtherApps:\\0"), val);
+        }
+    }"""
+new_activate = """    pub fn activate_ignoring_other_apps(&self) {
+        unsafe {
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"activateIgnoringOtherApps:\\0"), YES);
+        }
+    }
+
+    pub fn activate_observing_other_apps(&self) {
+        unsafe {
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"activateIgnoringOtherApps:\\0"), NO);
+        }
+    }"""
+content = content.replace(old_activate, new_activate)
+
+old_next = """    pub fn next_event(&self, mask: u64, date: Id, mode: Id, dequeue: bool) -> NSEvent {
+        unsafe {
+            let d = if dequeue { YES } else { NO };"""
+new_next = """    pub fn next_event(&self, mask: u64, date: Id, mode: Id, dequeue: EventDequeue) -> NSEvent {
+        unsafe {
+            let d = if dequeue == EventDequeue::Dequeue { YES } else { NO };"""
+content = content.replace(old_next, new_next)
+
+old_init = """    pub fn init_with_content_rect(
+        &self,
+        rect: NSRect,
+        style_mask: u64,
+        backing: u64,
+        defer: bool,
+    ) -> Self {
+        unsafe {
+            let d = if defer { YES } else { NO };"""
+new_init = """    pub fn init_with_content_rect(
+        &self,
+        rect: NSRect,
+        style_mask: u64,
+        backing: u64,
+        defer: WindowDeferral,
+    ) -> Self {
+        unsafe {
+            let d = if defer == WindowDeferral::Defer { YES } else { NO };"""
+content = content.replace(old_init, new_init)
+
+old_layer = """    pub fn set_wants_layer(&self, wants: bool) {
+        unsafe {
+            let val = if wants { YES } else { NO };
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"setWantsLayer:\\0"), val);
+        }
+    }"""
+new_layer = """    pub fn enable_layer(&self) {
+        unsafe {
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"setWantsLayer:\\0"), YES);
+        }
+    }
+
+    pub fn disable_layer(&self) {
+        unsafe {
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"setWantsLayer:\\0"), NO);
+        }
+    }"""
+content = content.replace(old_layer, new_layer)
+
+with open(file_path, "w", encoding="utf-8") as f:
+    f.write(content)

--- a/pixelflow-runtime/src/platform/macos/cocoa.rs
+++ b/pixelflow-runtime/src/platform/macos/cocoa.rs
@@ -6,6 +6,18 @@
 use super::sys::{self, Id, BOOL, NO, YES};
 use std::ffi::c_void;
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum EventDequeue {
+    Dequeue,
+    Peek,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum WindowDeferral {
+    Defer,
+    Immediate,
+}
+
 // --- Helpers ---
 
 /// Convert Rust string to NSString id.
@@ -136,10 +148,15 @@ impl NSApplication {
         }
     }
 
-    pub fn activate_ignoring_other_apps(&self, ignore: bool) {
+    pub fn activate_ignoring_other_apps(&self) {
         unsafe {
-            let val = if ignore { YES } else { NO };
-            sys::send_1::<(), BOOL>(self.0, sys::sel(b"activateIgnoringOtherApps:\0"), val);
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"activateIgnoringOtherApps:\0"), YES);
+        }
+    }
+
+    pub fn activate_observing_other_apps(&self) {
+        unsafe {
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"activateIgnoringOtherApps:\0"), NO);
         }
     }
 
@@ -156,9 +173,9 @@ impl NSApplication {
     }
 
     // nextEventMatchingMask:untilDate:inMode:dequeue:
-    pub fn next_event(&self, mask: u64, date: Id, mode: Id, dequeue: bool) -> NSEvent {
+    pub fn next_event(&self, mask: u64, date: Id, mode: Id, dequeue: EventDequeue) -> NSEvent {
         unsafe {
-            let d = if dequeue { YES } else { NO };
+            let d = if dequeue == EventDequeue::Dequeue { YES } else { NO };
             let ptr: Id = sys::send_4(
                 self.0,
                 sys::sel(b"nextEventMatchingMask:untilDate:inMode:dequeue:\0"),
@@ -190,10 +207,10 @@ impl NSWindow {
         rect: NSRect,
         style_mask: u64,
         backing: u64,
-        defer: bool,
+        defer: WindowDeferral,
     ) -> Self {
         unsafe {
-            let d = if defer { YES } else { NO };
+            let d = if defer == WindowDeferral::Defer { YES } else { NO };
             let ptr: Id = sys::send_4(
                 self.0,
                 sys::sel(b"initWithContentRect:styleMask:backing:defer:\0"),
@@ -266,10 +283,15 @@ impl NSView {
         }
     }
 
-    pub fn set_wants_layer(&self, wants: bool) {
+    pub fn enable_layer(&self) {
         unsafe {
-            let val = if wants { YES } else { NO };
-            sys::send_1::<(), BOOL>(self.0, sys::sel(b"setWantsLayer:\0"), val);
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"setWantsLayer:\0"), YES);
+        }
+    }
+
+    pub fn disable_layer(&self) {
+        unsafe {
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"setWantsLayer:\0"), NO);
         }
     }
 

--- a/pixelflow-runtime/src/platform/macos/platform.rs
+++ b/pixelflow-runtime/src/platform/macos/platform.rs
@@ -2,7 +2,7 @@ use crate::api::private::{EngineActorHandle, EngineData, WindowId};
 use crate::display::messages::{DisplayControl, DisplayData, DisplayEvent, DisplayMgmt, Window};
 use crate::display::ops::PlatformOps;
 use crate::error::RuntimeError;
-use crate::platform::macos::cocoa::{self, event_type, NSApplication, NSPasteboard};
+use crate::platform::macos::cocoa::{self, event_type, EventDequeue, NSApplication, NSPasteboard};
 use crate::platform::macos::events;
 use crate::platform::macos::sys;
 use crate::platform::macos::window::MacWindow;
@@ -45,7 +45,7 @@ impl MetalOps {
             app.set_activation_policy(NS_APPLICATION_ACTIVATION_POLICY_REGULAR);
 
             app.finish_launching();
-            app.activate_ignoring_other_apps(true);
+            app.activate_ignoring_other_apps();
 
             app
         };
@@ -102,7 +102,7 @@ impl PlatformOps for MetalOps {
             }
             DisplayControl::SetVisible { id, visible } => {
                 if let Some(win) = self.windows.get_mut(&id) {
-                    win.set_visible(visible);
+                    if visible { win.show(); } else { win.hide(); }
                 }
             }
             DisplayControl::RequestRedraw { id } => {
@@ -164,7 +164,7 @@ impl PlatformOps for MetalOps {
             }
             DisplayMgmt::Destroy { id } => {
                 if let Some(mut win) = self.windows.remove(&id) {
-                    win.set_visible(false);
+                    win.hide();
                     // Drop closes it implicitly or we call close
                     // win.window.close(); // If we expose it
                     self.window_map.remove(&(win.window.0 as usize));
@@ -217,7 +217,7 @@ impl PlatformOps for MetalOps {
                 u64::MAX,
                 until_date,
                 mode,
-                true, // dequeue
+                EventDequeue::Dequeue, // dequeue
             );
 
             // Release mode string

--- a/pixelflow-runtime/src/platform/macos/window.rs
+++ b/pixelflow-runtime/src/platform/macos/window.rs
@@ -1,6 +1,6 @@
 use crate::api::public::WindowDescriptor;
 use crate::error::RuntimeError;
-use crate::platform::macos::cocoa::{NSPoint, NSRect, NSSize, NSView, NSWindow};
+use crate::platform::macos::cocoa::{NSPoint, NSRect, NSSize, NSView, NSWindow, WindowDeferral};
 use crate::platform::macos::sys::{self, Id, BOOL, YES};
 use std::ffi::c_void;
 
@@ -24,7 +24,7 @@ impl MacWindow {
         // NSBackingStoreBuffered = 2
         let backing = 2;
 
-        let window = NSWindow::alloc().init_with_content_rect(rect, style_mask, backing, false);
+        let window = NSWindow::alloc().init_with_content_rect(rect, style_mask, backing, WindowDeferral::Immediate);
         window.set_title(&desc.title);
 
         let view = NSView::alloc().init_with_frame(rect);
@@ -60,7 +60,7 @@ impl MacWindow {
             sys::send_1::<(), Id>(view.0, sys::sel(b"setLayer:\0"), layer);
 
             // [view setWantsLayer: YES]
-            view.set_wants_layer(true);
+            view.enable_layer();
         }
 
         window.set_content_view(view);
@@ -122,13 +122,13 @@ impl MacWindow {
         }
     }
 
-    pub fn set_visible(&mut self, visible: bool) {
-        if visible {
-            self.window.make_key_and_order_front();
-        } else {
-            unsafe {
-                sys::send::<()>(self.window.0, sys::sel(b"orderOut:\0"));
-            }
+    pub fn show(&mut self) {
+        self.window.make_key_and_order_front();
+    }
+
+    pub fn hide(&mut self) {
+        unsafe {
+            sys::send::<()>(self.window.0, sys::sel(b"orderOut:\0"));
         }
     }
 

--- a/run_fix.py
+++ b/run_fix.py
@@ -1,0 +1,91 @@
+import re
+
+file_path = "pixelflow-runtime/src/platform/macos/cocoa.rs"
+with open(file_path, "r", encoding="utf-8") as f:
+    content = f.read()
+
+# Make sure we don't duplicate enums!
+if "EventDequeue" not in content:
+    enums = """
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum EventDequeue {
+    Dequeue,
+    Peek,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum WindowDeferral {
+    Defer,
+    Immediate,
+}
+"""
+    content = content.replace("use std::ffi::c_void;\n", "use std::ffi::c_void;\n" + enums)
+
+old_activate = """    pub fn activate_ignoring_other_apps(&self, ignore: bool) {
+        unsafe {
+            let val = if ignore { YES } else { NO };
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"activateIgnoringOtherApps:\\0"), val);
+        }
+    }"""
+new_activate = """    pub fn activate_ignoring_other_apps(&self) {
+        unsafe {
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"activateIgnoringOtherApps:\\0"), YES);
+        }
+    }
+
+    pub fn activate_observing_other_apps(&self) {
+        unsafe {
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"activateIgnoringOtherApps:\\0"), NO);
+        }
+    }"""
+content = content.replace(old_activate, new_activate)
+
+old_next = """    pub fn next_event(&self, mask: u64, date: Id, mode: Id, dequeue: bool) -> NSEvent {
+        unsafe {
+            let d = if dequeue { YES } else { NO };"""
+new_next = """    pub fn next_event(&self, mask: u64, date: Id, mode: Id, dequeue: EventDequeue) -> NSEvent {
+        unsafe {
+            let d = if dequeue == EventDequeue::Dequeue { YES } else { NO };"""
+content = content.replace(old_next, new_next)
+
+old_init = """    pub fn init_with_content_rect(
+        &self,
+        rect: NSRect,
+        style_mask: u64,
+        backing: u64,
+        defer: bool,
+    ) -> Self {
+        unsafe {
+            let d = if defer { YES } else { NO };"""
+new_init = """    pub fn init_with_content_rect(
+        &self,
+        rect: NSRect,
+        style_mask: u64,
+        backing: u64,
+        defer: WindowDeferral,
+    ) -> Self {
+        unsafe {
+            let d = if defer == WindowDeferral::Defer { YES } else { NO };"""
+content = content.replace(old_init, new_init)
+
+old_layer = """    pub fn set_wants_layer(&self, wants: bool) {
+        unsafe {
+            let val = if wants { YES } else { NO };
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"setWantsLayer:\\0"), val);
+        }
+    }"""
+new_layer = """    pub fn enable_layer(&self) {
+        unsafe {
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"setWantsLayer:\\0"), YES);
+        }
+    }
+
+    pub fn disable_layer(&self) {
+        unsafe {
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"setWantsLayer:\\0"), NO);
+        }
+    }"""
+content = content.replace(old_layer, new_layer)
+
+with open(file_path, "w", encoding="utf-8") as f:
+    f.write(content)

--- a/test.py
+++ b/test.py
@@ -1,0 +1,7 @@
+import re
+
+file_path = "pixelflow-runtime/src/platform/macos/cocoa.rs"
+with open(file_path, "r", encoding="utf-8") as f:
+    content = f.read()
+
+print("Contains activate?", "activate_ignoring_other_apps" in content)


### PR DESCRIPTION
Refactor macos cocoa wrappers to remove boolean arguments

This removes boolean arguments from `activate_ignoring_other_apps`, `next_event`, `init_with_content_rect`, and `set_wants_layer` in `pixelflow-runtime/src/platform/macos/cocoa.rs`, replacing them with enums (`EventDequeue`, `WindowDeferral`) or explicit methods (`activate_ignoring_other_apps`/`activate_observing_other_apps`, `enable_layer`/`disable_layer`) to adhere to `STYLE.md`. Calling sites in `window.rs` and `platform.rs` have also been updated.

---
*PR created automatically by Jules for task [5639521198866416396](https://jules.google.com/task/5639521198866416396) started by @jppittman*