### PR TITLE
Fix compilation errors and enforce formatting/lints in core-term

### DIFF
--- a/core-term/src/ansi/tests.rs
+++ b/core-term/src/ansi/tests.rs
@@ -1659,74 +1659,50 @@ mod mutation_tests {
     #[test]
     fn csi_cursor_up_no_param_defaults_to_1() {
         let cmds = process_bytes(b"\x1b[A");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::CursorUp(1))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::CursorUp(1))]);
     }
 
     #[test]
     fn csi_cursor_up_param_zero_is_coerced_to_1() {
         // param_or_1 applies max(1), so 0 -> 1
         let cmds = process_bytes(b"\x1b[0A");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::CursorUp(1))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::CursorUp(1))]);
     }
 
     #[test]
     fn csi_cursor_up_explicit_5() {
         let cmds = process_bytes(b"\x1b[5A");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::CursorUp(5))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::CursorUp(5))]);
     }
 
     #[test]
     fn csi_cursor_down_defaults_to_1() {
         let cmds = process_bytes(b"\x1b[B");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::CursorDown(1))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::CursorDown(1))]);
     }
 
     #[test]
     fn csi_cursor_forward_defaults_to_1() {
         let cmds = process_bytes(b"\x1b[C");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::CursorForward(1))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::CursorForward(1))]);
     }
 
     #[test]
     fn csi_cursor_backward_defaults_to_1() {
         let cmds = process_bytes(b"\x1b[D");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::CursorBackward(1))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::CursorBackward(1))]);
     }
 
     #[test]
     fn csi_cursor_next_line_defaults_to_1() {
         let cmds = process_bytes(b"\x1b[E");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::CursorNextLine(1))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::CursorNextLine(1))]);
     }
 
     #[test]
     fn csi_cursor_prev_line_defaults_to_1() {
         let cmds = process_bytes(b"\x1b[F");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::CursorPrevLine(1))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::CursorPrevLine(1))]);
     }
 
     #[test]
@@ -1778,37 +1754,25 @@ mod mutation_tests {
     #[test]
     fn csi_erase_in_display_no_param_defaults_to_0() {
         let cmds = process_bytes(b"\x1b[J");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::EraseInDisplay(0))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::EraseInDisplay(0))]);
     }
 
     #[test]
     fn csi_erase_in_display_explicit_2() {
         let cmds = process_bytes(b"\x1b[2J");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::EraseInDisplay(2))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::EraseInDisplay(2))]);
     }
 
     #[test]
     fn csi_erase_in_line_no_param_defaults_to_0() {
         let cmds = process_bytes(b"\x1b[K");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::EraseInLine(0))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::EraseInLine(0))]);
     }
 
     #[test]
     fn csi_erase_in_line_explicit_1() {
         let cmds = process_bytes(b"\x1b[1K");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::EraseInLine(1))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::EraseInLine(1))]);
     }
 
     // -----------------------------------------------------------------------
@@ -1887,7 +1851,11 @@ mod mutation_tests {
         if let Some(AnsiCommand::Csi(CsiCommand::SetGraphicsRendition(attrs))) = cmds.first() {
             // Checking len kills mutations that reduce MAX_PARAMS below 16.
             assert_eq!(attrs.len(), 16, "all 16 params must be retained");
-            assert_eq!(attrs[0], Attribute::Bold, "first of 16 params should be Bold");
+            assert_eq!(
+                attrs[0],
+                Attribute::Bold,
+                "first of 16 params should be Bold"
+            );
             assert_eq!(
                 attrs[1],
                 Attribute::Faint,
@@ -1903,8 +1871,7 @@ mod mutation_tests {
         // 16 zeros then ;7 (Reverse). The 17th param (7) must be ignored.
         // We send: ESC [ 0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;7m
         //          that's 16 zeros + 1 extra -> the 7 (Reverse) is the 17th and dropped.
-        let cmds =
-            process_bytes(b"\x1b[0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;7m");
+        let cmds = process_bytes(b"\x1b[0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;7m");
         if let Some(AnsiCommand::Csi(CsiCommand::SetGraphicsRendition(attrs))) = cmds.first() {
             // Every kept attribute should be Reset (0); Reverse (7) must NOT appear.
             assert!(
@@ -2080,28 +2047,19 @@ mod mutation_tests {
     #[test]
     fn csi_ctc_0_is_set_tab_stop() {
         let cmds = process_bytes(b"\x1b[0W");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::SetTabStop)]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::SetTabStop)]);
     }
 
     #[test]
     fn csi_ctc_2_clears_current_tab_stop() {
         let cmds = process_bytes(b"\x1b[2W");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::ClearTabStops(0))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::ClearTabStops(0))]);
     }
 
     #[test]
     fn csi_ctc_5_clears_all_tab_stops() {
         let cmds = process_bytes(b"\x1b[5W");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::ClearTabStops(3))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::ClearTabStops(3))]);
     }
 
     // -----------------------------------------------------------------------
@@ -2112,19 +2070,13 @@ mod mutation_tests {
     #[test]
     fn csi_s_uppercase_is_scroll_up() {
         let cmds = process_bytes(b"\x1b[3S");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::ScrollUp(3))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::ScrollUp(3))]);
     }
 
     #[test]
     fn csi_t_uppercase_is_scroll_down() {
         let cmds = process_bytes(b"\x1b[3T");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::ScrollDown(3))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::ScrollDown(3))]);
     }
 
     // -----------------------------------------------------------------------
@@ -2135,28 +2087,19 @@ mod mutation_tests {
     #[test]
     fn csi_at_is_insert_character() {
         let cmds = process_bytes(b"\x1b[2@");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::InsertCharacter(2))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::InsertCharacter(2))]);
     }
 
     #[test]
     fn csi_p_uppercase_is_delete_character() {
         let cmds = process_bytes(b"\x1b[2P");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::DeleteCharacter(2))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::DeleteCharacter(2))]);
     }
 
     #[test]
     fn csi_x_uppercase_is_erase_character() {
         let cmds = process_bytes(b"\x1b[2X");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::EraseCharacter(2))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::EraseCharacter(2))]);
     }
 
     // -----------------------------------------------------------------------
@@ -2166,19 +2109,13 @@ mod mutation_tests {
     #[test]
     fn csi_l_uppercase_is_insert_line() {
         let cmds = process_bytes(b"\x1b[4L");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::InsertLine(4))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::InsertLine(4))]);
     }
 
     #[test]
     fn csi_m_uppercase_is_delete_line() {
         let cmds = process_bytes(b"\x1b[4M");
-        assert_eq!(
-            cmds,
-            vec![AnsiCommand::Csi(CsiCommand::DeleteLine(4))]
-        );
+        assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::DeleteLine(4))]);
     }
 
     // -----------------------------------------------------------------------

--- a/core-term/src/term/action.rs
+++ b/core-term/src/term/action.rs
@@ -78,7 +78,7 @@ pub enum UserInputAction {
     KeyInput {
         symbol: KeySymbol,
         modifiers: Modifiers,
-        text: Option<std::borrow::Cow<'static, str>>>,
+        text: Option<std::borrow::Cow<'static, str>>,
     },
 
     /// Initiate copy of selected text.

--- a/core-term/src/term/emulator/mod.rs
+++ b/core-term/src/term/emulator/mod.rs
@@ -374,10 +374,7 @@ impl TerminalEmulator {
     ///
     /// Coordinates `col` and `row` are 0-based cell positions.
     #[must_use]
-    pub fn encode_mouse_event(
-        &self,
-        params: mouse::MouseEncodingParams,
-    ) -> Option<Vec<u8>> {
+    pub fn encode_mouse_event(&self, params: mouse::MouseEncodingParams) -> Option<Vec<u8>> {
         mouse::encode_mouse_event(&self.dec_modes, params)
     }
 

--- a/core-term/src/term/emulator/mouse.rs
+++ b/core-term/src/term/emulator/mouse.rs
@@ -63,9 +63,7 @@ fn should_report(modes: &DecPrivateModes, kind: MouseEventKind) -> bool {
         }
         MouseEventKind::Release => {
             // X10 mode does not report releases
-            modes.mouse_vt200_mode
-                || modes.mouse_button_event_mode
-                || modes.mouse_any_event_mode
+            modes.mouse_vt200_mode || modes.mouse_button_event_mode || modes.mouse_any_event_mode
         }
         MouseEventKind::Motion => {
             // Button-event mode reports motion only while a button is held,
@@ -88,7 +86,11 @@ fn button_base_code(button: MouseButton) -> u8 {
         MouseButton::ScrollDown => 65,
         MouseButton::Other(n) => {
             // Buttons 4+ map to codes 128+
-            if n >= 4 { 128 + n - 4 } else { n }
+            if n >= 4 {
+                128 + n - 4
+            } else {
+                n
+            }
         }
     }
 }
@@ -124,7 +126,11 @@ fn legacy_button_code(button: MouseButton, kind: MouseEventKind) -> u8 {
 /// Format: `ESC [ < Cb ; Cx ; Cy M` for press/motion, `ESC [ < Cb ; Cx ; Cy m` for release.
 /// Coordinates are 1-based.
 fn encode_sgr(button_code: u8, col: usize, row: usize, kind: MouseEventKind) -> Vec<u8> {
-    let suffix = if kind == MouseEventKind::Release { b'm' } else { b'M' };
+    let suffix = if kind == MouseEventKind::Release {
+        b'm'
+    } else {
+        b'M'
+    };
     // SGR uses 1-based coordinates
     let cx = col + 1;
     let cy = row + 1;
@@ -191,15 +197,31 @@ mod tests {
     #[test]
     fn no_mode_returns_none() {
         let modes = DecPrivateModes::default();
-        let result = encode_mouse_event(&modes, MouseEncodingParams { button: MouseButton::Left, col: 5, row: 10, kind: MouseEventKind::Press });
+        let result = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Left,
+                col: 5,
+                row: 10,
+                kind: MouseEventKind::Press,
+            },
+        );
         assert_eq!(result, None);
     }
 
     #[test]
     fn sgr_left_press() {
         let modes = modes_with_sgr();
-        let result =
-            encode_mouse_event(&modes, MouseEncodingParams { button: MouseButton::Left, col: 5, row: 10, kind: MouseEventKind::Press }).unwrap();
+        let result = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Left,
+                col: 5,
+                row: 10,
+                kind: MouseEventKind::Press,
+            },
+        )
+        .unwrap();
         // SGR: ESC[<0;6;11M (1-based coords)
         assert_eq!(result, b"\x1b[<0;6;11M");
     }
@@ -207,8 +229,16 @@ mod tests {
     #[test]
     fn sgr_left_release() {
         let modes = modes_with_sgr();
-        let result =
-            encode_mouse_event(&modes, MouseEncodingParams { button: MouseButton::Left, col: 5, row: 10, kind: MouseEventKind::Release }).unwrap();
+        let result = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Left,
+                col: 5,
+                row: 10,
+                kind: MouseEventKind::Release,
+            },
+        )
+        .unwrap();
         // SGR release uses lowercase 'm', button code preserved
         assert_eq!(result, b"\x1b[<0;6;11m");
     }
@@ -216,16 +246,32 @@ mod tests {
     #[test]
     fn sgr_right_press() {
         let modes = modes_with_sgr();
-        let result =
-            encode_mouse_event(&modes, MouseEncodingParams { button: MouseButton::Right, col: 0, row: 0, kind: MouseEventKind::Press }).unwrap();
+        let result = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Right,
+                col: 0,
+                row: 0,
+                kind: MouseEventKind::Press,
+            },
+        )
+        .unwrap();
         assert_eq!(result, b"\x1b[<2;1;1M");
     }
 
     #[test]
     fn sgr_right_release() {
         let modes = modes_with_sgr();
-        let result =
-            encode_mouse_event(&modes, MouseEncodingParams { button: MouseButton::Right, col: 3, row: 7, kind: MouseEventKind::Release }).unwrap();
+        let result = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Right,
+                col: 3,
+                row: 7,
+                kind: MouseEventKind::Release,
+            },
+        )
+        .unwrap();
         // SGR preserves button identity on release
         assert_eq!(result, b"\x1b[<2;4;8m");
     }
@@ -233,17 +279,32 @@ mod tests {
     #[test]
     fn sgr_middle_press() {
         let modes = modes_with_sgr();
-        let result =
-            encode_mouse_event(&modes, MouseEncodingParams { button: MouseButton::Middle, col: 79, row: 23, kind: MouseEventKind::Press })
-                .unwrap();
+        let result = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Middle,
+                col: 79,
+                row: 23,
+                kind: MouseEventKind::Press,
+            },
+        )
+        .unwrap();
         assert_eq!(result, b"\x1b[<1;80;24M");
     }
 
     #[test]
     fn sgr_motion_left() {
         let modes = modes_with_any_event_sgr();
-        let result =
-            encode_mouse_event(&modes, MouseEncodingParams { button: MouseButton::Left, col: 10, row: 5, kind: MouseEventKind::Motion }).unwrap();
+        let result = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Left,
+                col: 10,
+                row: 5,
+                kind: MouseEventKind::Motion,
+            },
+        )
+        .unwrap();
         // Motion adds 32 to button code: 0 + 32 = 32
         assert_eq!(result, b"\x1b[<32;11;6M");
     }
@@ -251,8 +312,16 @@ mod tests {
     #[test]
     fn sgr_motion_right() {
         let modes = modes_with_button_event_sgr();
-        let result =
-            encode_mouse_event(&modes, MouseEncodingParams { button: MouseButton::Right, col: 10, row: 5, kind: MouseEventKind::Motion }).unwrap();
+        let result = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Right,
+                col: 10,
+                row: 5,
+                kind: MouseEventKind::Motion,
+            },
+        )
+        .unwrap();
         // Motion adds 32 to button code: 2 + 32 = 34
         assert_eq!(result, b"\x1b[<34;11;6M");
     }
@@ -260,26 +329,48 @@ mod tests {
     #[test]
     fn sgr_scroll_up() {
         let modes = modes_with_sgr();
-        let result =
-            encode_mouse_event(&modes, MouseEncodingParams { button: MouseButton::ScrollUp, col: 10, row: 5, kind: MouseEventKind::Press })
-                .unwrap();
+        let result = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::ScrollUp,
+                col: 10,
+                row: 5,
+                kind: MouseEventKind::Press,
+            },
+        )
+        .unwrap();
         assert_eq!(result, b"\x1b[<64;11;6M");
     }
 
     #[test]
     fn sgr_scroll_down() {
         let modes = modes_with_sgr();
-        let result =
-            encode_mouse_event(&modes, MouseEncodingParams { button: MouseButton::ScrollDown, col: 10, row: 5, kind: MouseEventKind::Press })
-                .unwrap();
+        let result = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::ScrollDown,
+                col: 10,
+                row: 5,
+                kind: MouseEventKind::Press,
+            },
+        )
+        .unwrap();
         assert_eq!(result, b"\x1b[<65;11;6M");
     }
 
     #[test]
     fn legacy_left_press() {
         let modes = modes_with_vt200();
-        let result =
-            encode_mouse_event(&modes, MouseEncodingParams { button: MouseButton::Left, col: 5, row: 10, kind: MouseEventKind::Press }).unwrap();
+        let result = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Left,
+                col: 5,
+                row: 10,
+                kind: MouseEventKind::Press,
+            },
+        )
+        .unwrap();
         // Legacy: ESC[M + (0+32) + (5+33) + (10+33)
         assert_eq!(result, vec![0x1b, b'[', b'M', 32, 38, 43]);
     }
@@ -287,8 +378,16 @@ mod tests {
     #[test]
     fn legacy_left_release_uses_code_3() {
         let modes = modes_with_vt200();
-        let result =
-            encode_mouse_event(&modes, MouseEncodingParams { button: MouseButton::Left, col: 5, row: 10, kind: MouseEventKind::Release }).unwrap();
+        let result = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Left,
+                col: 5,
+                row: 10,
+                kind: MouseEventKind::Release,
+            },
+        )
+        .unwrap();
         // Legacy release: button code = 3, so Cb = 3 + 32 = 35
         assert_eq!(result, vec![0x1b, b'[', b'M', 35, 38, 43]);
     }
@@ -296,9 +395,16 @@ mod tests {
     #[test]
     fn legacy_right_release_uses_code_3() {
         let modes = modes_with_vt200();
-        let result =
-            encode_mouse_event(&modes, MouseEncodingParams { button: MouseButton::Right, col: 5, row: 10, kind: MouseEventKind::Release })
-                .unwrap();
+        let result = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Right,
+                col: 5,
+                row: 10,
+                kind: MouseEventKind::Release,
+            },
+        )
+        .unwrap();
         // Legacy release always uses code 3 regardless of which button was released
         assert_eq!(result, vec![0x1b, b'[', b'M', 35, 38, 43]);
     }
@@ -306,32 +412,85 @@ mod tests {
     #[test]
     fn legacy_coords_overflow_returns_none() {
         let modes = modes_with_vt200();
-        let result =
-            encode_mouse_event(&modes, MouseEncodingParams { button: MouseButton::Left, col: 300, row: 10, kind: MouseEventKind::Press });
+        let result = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Left,
+                col: 300,
+                row: 10,
+                kind: MouseEventKind::Press,
+            },
+        );
         assert_eq!(result, None);
     }
 
     #[test]
     fn x10_reports_press_only() {
         let modes = modes_with_x10();
-        let press = encode_mouse_event(&modes, MouseEncodingParams { button: MouseButton::Left, col: 0, row: 0, kind: MouseEventKind::Press });
+        let press = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Left,
+                col: 0,
+                row: 0,
+                kind: MouseEventKind::Press,
+            },
+        );
         assert!(press.is_some());
-        let release =
-            encode_mouse_event(&modes, MouseEncodingParams { button: MouseButton::Left, col: 0, row: 0, kind: MouseEventKind::Release });
+        let release = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Left,
+                col: 0,
+                row: 0,
+                kind: MouseEventKind::Release,
+            },
+        );
         assert_eq!(release, None);
-        let motion = encode_mouse_event(&modes, MouseEncodingParams { button: MouseButton::Left, col: 0, row: 0, kind: MouseEventKind::Motion });
+        let motion = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Left,
+                col: 0,
+                row: 0,
+                kind: MouseEventKind::Motion,
+            },
+        );
         assert_eq!(motion, None);
     }
 
     #[test]
     fn vt200_reports_press_and_release() {
         let modes = modes_with_vt200();
-        let press = encode_mouse_event(&modes, MouseEncodingParams { button: MouseButton::Left, col: 0, row: 0, kind: MouseEventKind::Press });
+        let press = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Left,
+                col: 0,
+                row: 0,
+                kind: MouseEventKind::Press,
+            },
+        );
         assert!(press.is_some());
-        let release =
-            encode_mouse_event(&modes, MouseEncodingParams { button: MouseButton::Left, col: 0, row: 0, kind: MouseEventKind::Release });
+        let release = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Left,
+                col: 0,
+                row: 0,
+                kind: MouseEventKind::Release,
+            },
+        );
         assert!(release.is_some());
-        let motion = encode_mouse_event(&modes, MouseEncodingParams { button: MouseButton::Left, col: 0, row: 0, kind: MouseEventKind::Motion });
+        let motion = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Left,
+                col: 0,
+                row: 0,
+                kind: MouseEventKind::Motion,
+            },
+        );
         assert_eq!(motion, None);
     }
 
@@ -339,9 +498,16 @@ mod tests {
     fn sgr_large_coordinates() {
         let modes = modes_with_sgr();
         // SGR has no coordinate limit
-        let result =
-            encode_mouse_event(&modes, MouseEncodingParams { button: MouseButton::Left, col: 500, row: 300, kind: MouseEventKind::Press })
-                .unwrap();
+        let result = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Left,
+                col: 500,
+                row: 300,
+                kind: MouseEventKind::Press,
+            },
+        )
+        .unwrap();
         assert_eq!(result, b"\x1b[<0;501;301M");
     }
 }

--- a/core-term/src/term/mod.rs
+++ b/core-term/src/term/mod.rs
@@ -19,7 +19,7 @@ pub mod snapshot; // Add this line to declare the module
 // Re-export items for easier use by other modules and within this module
 pub use action::{ControlEvent, EmulatorAction, UserInputAction};
 pub use charset::{map_to_dec_line_drawing, CharacterSet};
-pub use emulator::mouse::{MouseEventKind, MouseEncodingParams};
+pub use emulator::mouse::{MouseEncodingParams, MouseEventKind};
 pub use emulator::TerminalEmulator;
 pub use layout::Layout;
 pub use snapshot::{

--- a/core-term/src/terminal_app.rs
+++ b/core-term/src/terminal_app.rs
@@ -561,7 +561,6 @@ impl Actor<TerminalData, EngineEventControl, EngineEventManagement> for Terminal
                 }
             }
             EngineEventManagement::MouseClick { button, x, y } => {
-
                 let col = (x / self.config.appearance.cell_width_px as u32) as usize;
                 let row = (y / self.config.appearance.cell_height_px as u32) as usize;
                 log::trace!(
@@ -573,7 +572,12 @@ impl Actor<TerminalData, EngineEventControl, EngineEventManagement> for Terminal
                 self.pressed_mouse_button = Some(button);
                 if let Some(bytes) =
                     self.emulator
-                        .encode_mouse_event(crate::term::MouseEncodingParams { button, col, row, kind: crate::term::MouseEventKind::Press })
+                        .encode_mouse_event(crate::term::MouseEncodingParams {
+                            button,
+                            col,
+                            row,
+                            kind: crate::term::MouseEventKind::Press,
+                        })
                 {
                     if let Err(e) = self.pty_tx.send(PtyCommand::Write(bytes)) {
                         log::warn!("Failed to send mouse press to PTY: {}", e);
@@ -581,7 +585,6 @@ impl Actor<TerminalData, EngineEventControl, EngineEventManagement> for Terminal
                 }
             }
             EngineEventManagement::MouseRelease { button, x, y } => {
-
                 let col = (x / self.config.appearance.cell_width_px as u32) as usize;
                 let row = (y / self.config.appearance.cell_height_px as u32) as usize;
                 log::trace!(
@@ -593,7 +596,12 @@ impl Actor<TerminalData, EngineEventControl, EngineEventManagement> for Terminal
                 self.pressed_mouse_button = None;
                 if let Some(bytes) =
                     self.emulator
-                        .encode_mouse_event(crate::term::MouseEncodingParams { button, col, row, kind: crate::term::MouseEventKind::Release })
+                        .encode_mouse_event(crate::term::MouseEncodingParams {
+                            button,
+                            col,
+                            row,
+                            kind: crate::term::MouseEventKind::Release,
+                        })
                 {
                     if let Err(e) = self.pty_tx.send(PtyCommand::Write(bytes)) {
                         log::warn!("Failed to send mouse release to PTY: {}", e);
@@ -601,7 +609,6 @@ impl Actor<TerminalData, EngineEventControl, EngineEventManagement> for Terminal
                 }
             }
             EngineEventManagement::MouseMove { x, y, mods: _ } => {
-
                 let col = (x / self.config.appearance.cell_width_px as u32) as usize;
                 let row = (y / self.config.appearance.cell_height_px as u32) as usize;
                 log::trace!("Mouse move: cell ({}, {})", col, row);
@@ -613,7 +620,12 @@ impl Actor<TerminalData, EngineEventControl, EngineEventManagement> for Terminal
                         .unwrap_or(pixelflow_runtime::input::MouseButton::Left);
                     if let Some(bytes) =
                         self.emulator
-                            .encode_mouse_event(crate::term::MouseEncodingParams { button, col, row, kind: crate::term::MouseEventKind::Motion })
+                            .encode_mouse_event(crate::term::MouseEncodingParams {
+                                button,
+                                col,
+                                row,
+                                kind: crate::term::MouseEventKind::Motion,
+                            })
                     {
                         if let Err(e) = self.pty_tx.send(PtyCommand::Write(bytes)) {
                             log::warn!("Failed to send mouse motion to PTY: {}", e);
@@ -622,9 +634,15 @@ impl Actor<TerminalData, EngineEventControl, EngineEventManagement> for Terminal
                 } else if self.emulator.reports_button_motion() {
                     // button-event mode: only report when a button is held
                     if let Some(button) = self.pressed_mouse_button {
-                        if let Some(bytes) = self.emulator.encode_mouse_event(
-                            crate::term::MouseEncodingParams { button, col, row, kind: crate::term::MouseEventKind::Motion }
-                        ) {
+                        if let Some(bytes) =
+                            self.emulator
+                                .encode_mouse_event(crate::term::MouseEncodingParams {
+                                    button,
+                                    col,
+                                    row,
+                                    kind: crate::term::MouseEventKind::Motion,
+                                })
+                        {
                             if let Err(e) = self.pty_tx.send(PtyCommand::Write(bytes)) {
                                 log::warn!("Failed to send mouse motion to PTY: {}", e);
                             }
@@ -642,7 +660,6 @@ impl Actor<TerminalData, EngineEventControl, EngineEventManagement> for Terminal
                 log::trace!("Mouse scroll: delta dy={}", dy);
                 // When mouse tracking is active, report scroll as button press events
                 if self.emulator.is_mouse_tracking_active() && dy != 0.0 {
-
                     use pixelflow_runtime::input::MouseButton;
                     let col = (x / self.config.appearance.cell_width_px as u32) as usize;
                     let row = (y / self.config.appearance.cell_height_px as u32) as usize;
@@ -653,7 +670,12 @@ impl Actor<TerminalData, EngineEventControl, EngineEventManagement> for Terminal
                     };
                     if let Some(bytes) =
                         self.emulator
-                            .encode_mouse_event(crate::term::MouseEncodingParams { button, col, row, kind: crate::term::MouseEventKind::Press })
+                            .encode_mouse_event(crate::term::MouseEncodingParams {
+                                button,
+                                col,
+                                row,
+                                kind: crate::term::MouseEventKind::Press,
+                            })
                     {
                         if let Err(e) = self.pty_tx.send(PtyCommand::Write(bytes)) {
                             log::warn!("Failed to send mouse scroll to PTY: {}", e);


### PR DESCRIPTION
Fix compilation errors and enforce formatting/lints in core-term

Scope: `core-term` crate.

Fixes:
- Fixed syntax error in `src/term/action.rs` (extra `>` character) causing compile failures.
- Formatted all files in `core-term` using `cargo fmt`.

Unresolved Issues:
- The workspace as a whole has pre-existing compilation errors in `pixelflow-graphics` and `pixelflow-compiler` which are out-of-scope for the `core-term` maintenance task.

Verification:
- `cargo fmt --check -p core-term` passes.
- `cargo clippy -p core-term --all-targets --all-features -- -D warnings` passes without warnings.
- `cargo check -p core-term` and `cargo test -p core-term` execute on the `core-term` targets correctly, despite upstream workspace-level errors.

---
*PR created automatically by Jules for task [10653406131303748027](https://jules.google.com/task/10653406131303748027) started by @jppittman*