### PR TITLE
style: replace boolean arguments with semantic enums in cocoa bindings

### DIFF
--- a/pixelflow-runtime/src/platform/macos/cocoa.rs
+++ b/pixelflow-runtime/src/platform/macos/cocoa.rs
@@ -36,6 +36,19 @@ pub fn nsstring_to_string(ns_str: Id) -> String {
     }
 }
 
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum EventDequeue {
+    Dequeue,
+    Peek,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum WindowDeferral {
+    Defer,
+    Immediate,
+}
+
 // --- Structs ---
 
 /// Wrapper for NSPasteboard
@@ -136,10 +149,15 @@ impl NSApplication {
         }
     }
 
-    pub fn activate_ignoring_other_apps(&self, ignore: bool) {
+    pub fn activate_ignoring_other_apps(&self) {
         unsafe {
-            let val = if ignore { YES } else { NO };
-            sys::send_1::<(), BOOL>(self.0, sys::sel(b"activateIgnoringOtherApps:\0"), val);
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"activateIgnoringOtherApps:\0"), YES);
+        }
+    }
+
+    pub fn activate_respecting_other_apps(&self) {
+        unsafe {
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"activateIgnoringOtherApps:\0"), NO);
         }
     }
 
@@ -156,9 +174,12 @@ impl NSApplication {
     }
 
     // nextEventMatchingMask:untilDate:inMode:dequeue:
-    pub fn next_event(&self, mask: u64, date: Id, mode: Id, dequeue: bool) -> NSEvent {
+    pub fn next_event(&self, mask: u64, date: Id, mode: Id, dequeue: EventDequeue) -> NSEvent {
         unsafe {
-            let d = if dequeue { YES } else { NO };
+            let d = match dequeue {
+                EventDequeue::Dequeue => YES,
+                EventDequeue::Peek => NO,
+            };
             let ptr: Id = sys::send_4(
                 self.0,
                 sys::sel(b"nextEventMatchingMask:untilDate:inMode:dequeue:\0"),
@@ -190,10 +211,13 @@ impl NSWindow {
         rect: NSRect,
         style_mask: u64,
         backing: u64,
-        defer: bool,
+        defer: WindowDeferral,
     ) -> Self {
         unsafe {
-            let d = if defer { YES } else { NO };
+            let d = match defer {
+                WindowDeferral::Defer => YES,
+                WindowDeferral::Immediate => NO,
+            };
             let ptr: Id = sys::send_4(
                 self.0,
                 sys::sel(b"initWithContentRect:styleMask:backing:defer:\0"),
@@ -266,10 +290,15 @@ impl NSView {
         }
     }
 
-    pub fn set_wants_layer(&self, wants: bool) {
+    pub fn enable_layer(&self) {
         unsafe {
-            let val = if wants { YES } else { NO };
-            sys::send_1::<(), BOOL>(self.0, sys::sel(b"setWantsLayer:\0"), val);
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"setWantsLayer:\0"), YES);
+        }
+    }
+
+    pub fn disable_layer(&self) {
+        unsafe {
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"setWantsLayer:\0"), NO);
         }
     }
 

--- a/pixelflow-runtime/src/platform/macos/platform.rs
+++ b/pixelflow-runtime/src/platform/macos/platform.rs
@@ -2,7 +2,7 @@ use crate::api::private::{EngineActorHandle, EngineData, WindowId};
 use crate::display::messages::{DisplayControl, DisplayData, DisplayEvent, DisplayMgmt, Window};
 use crate::display::ops::PlatformOps;
 use crate::error::RuntimeError;
-use crate::platform::macos::cocoa::{self, event_type, NSApplication, NSPasteboard};
+use crate::platform::macos::cocoa::{self, event_type, NSApplication, NSPasteboard, EventDequeue};
 use crate::platform::macos::events;
 use crate::platform::macos::sys;
 use crate::platform::macos::window::MacWindow;
@@ -45,7 +45,7 @@ impl MetalOps {
             app.set_activation_policy(NS_APPLICATION_ACTIVATION_POLICY_REGULAR);
 
             app.finish_launching();
-            app.activate_ignoring_other_apps(true);
+            app.activate_ignoring_other_apps();
 
             app
         };
@@ -217,7 +217,7 @@ impl PlatformOps for MetalOps {
                 u64::MAX,
                 until_date,
                 mode,
-                true, // dequeue
+                EventDequeue::Dequeue, // dequeue
             );
 
             // Release mode string

--- a/pixelflow-runtime/src/platform/macos/window.rs
+++ b/pixelflow-runtime/src/platform/macos/window.rs
@@ -1,6 +1,6 @@
 use crate::api::public::WindowDescriptor;
 use crate::error::RuntimeError;
-use crate::platform::macos::cocoa::{NSPoint, NSRect, NSSize, NSView, NSWindow};
+use crate::platform::macos::cocoa::{NSPoint, NSRect, NSSize, NSView, NSWindow, WindowDeferral};
 use crate::platform::macos::sys::{self, Id, BOOL, YES};
 use std::ffi::c_void;
 
@@ -24,7 +24,7 @@ impl MacWindow {
         // NSBackingStoreBuffered = 2
         let backing = 2;
 
-        let window = NSWindow::alloc().init_with_content_rect(rect, style_mask, backing, false);
+        let window = NSWindow::alloc().init_with_content_rect(rect, style_mask, backing, WindowDeferral::Immediate);
         window.set_title(&desc.title);
 
         let view = NSView::alloc().init_with_frame(rect);
@@ -60,7 +60,7 @@ impl MacWindow {
             sys::send_1::<(), Id>(view.0, sys::sel(b"setLayer:\0"), layer);
 
             // [view setWantsLayer: YES]
-            view.set_wants_layer(true);
+            view.enable_layer();
         }
 
         window.set_content_view(view);


### PR DESCRIPTION
This PR addresses an egregious violation of `STYLE.md`'s rule against "boolean blindness" discovered in `pixelflow-runtime/src/platform/macos/cocoa.rs`.

**Fixes:**
- Replaced the boolean argument in `activate_ignoring_other_apps` with explicit `activate_ignoring_other_apps` and `activate_respecting_other_apps` methods.
- Replaced the boolean `dequeue` argument in `next_event` with the `EventDequeue` enum (`Dequeue`, `Peek`).
- Replaced the boolean `defer` argument in `init_with_content_rect` with the `WindowDeferral` enum (`Defer`, `Immediate`).
- Replaced the boolean `wants` argument in `set_wants_layer` with explicit `enable_layer` and `disable_layer` methods.
- Updated callsites in `window.rs` and `platform.rs` accordingly.

**Verification:**
- Ran `git diff` to ensure edits were applied as intended.
- Ran `cargo check -p pixelflow-runtime` and `cargo test -p pixelflow-runtime` to ensure that no specific compilation regressions were introduced in the crate. (Note: standard pre-existing `pixelflow-graphics` workspace compilation failures were observed, consistent with baseline).

**Scope:**
Limited to `pixelflow-runtime/src/platform/macos`.

---
*PR created automatically by Jules for task [3377526166768102406](https://jules.google.com/task/3377526166768102406) started by @jppittman*