### PR TITLE
style: rename tests in core-term to match STYLE.md conventions

### DIFF
--- a/core-term/src/io/event_monitor_actor/write_thread/mod.rs
+++ b/core-term/src/io/event_monitor_actor/write_thread/mod.rs
@@ -82,7 +82,7 @@ mod tests {
     use std::sync::mpsc::sync_channel;
 
     #[test]
-    fn test_write_thread_handles_resize_command() {
+    fn write_thread_handles_resize_command_should_succeed_when_invoked() {
         // Create a real PTY for testing
         let config = PtyConfig {
             command_executable: "/bin/cat",
@@ -115,7 +115,7 @@ mod tests {
     }
 
     #[test]
-    fn test_write_thread_handles_write_command() {
+    fn write_thread_handles_write_command_should_succeed_when_invoked() {
         let config = PtyConfig {
             command_executable: "/bin/cat",
             args: &[],

--- a/core-term/src/io/pty_tests.rs
+++ b/core-term/src/io/pty_tests.rs
@@ -118,7 +118,7 @@ fn read_from_pty_with_timeout(pty: &mut NixPty, expected_str: &str) -> Result<St
 }
 
 #[test]
-fn test_pty_spawn_successful() {
+fn pty_spawn_successful_should_succeed_when_invoked() {
     // Use sh -c to be more robust across platforms and ensure output flushing
     let config = PtyConfig {
         command_executable: "/bin/sh",
@@ -156,7 +156,7 @@ fn test_pty_spawn_successful() {
 }
 
 #[test]
-fn test_pty_read_write_interaction() {
+fn pty_read_write_interaction_should_succeed_when_invoked() {
     let shell_command = "read r_line; echo \"input was: $r_line\"";
     let config = PtyConfig {
         command_executable: "/bin/sh",
@@ -197,7 +197,7 @@ fn test_pty_read_write_interaction() {
 }
 
 #[test]
-fn test_pty_resize_successful() {
+fn pty_resize_successful_should_succeed_when_invoked() {
     // Use `sleep` from PATH to be cross-platform (macOS has /bin/sleep, Linux /usr/bin/sleep)
     let config = PtyConfig {
         command_executable: "sleep",
@@ -235,7 +235,7 @@ fn test_pty_resize_successful() {
 }
 
 #[test]
-fn test_pty_child_termination_on_drop() {
+fn pty_child_termination_on_drop_should_succeed_when_invoked() {
     let config = PtyConfig {
         command_executable: "sleep",
         args: &["2"], // Arg for sleep is just the duration
@@ -295,7 +295,7 @@ fn test_pty_child_termination_on_drop() {
 }
 
 #[test]
-fn test_pty_spawn_invalid_command() {
+fn pty_spawn_invalid_command_should_succeed_when_invoked() {
     let non_existent_cmd = "/path/to/absolutely/nonexistent/command_39291az";
     let config = PtyConfig {
         command_executable: non_existent_cmd,

--- a/core-term/src/keys.rs
+++ b/core-term/src/keys.rs
@@ -41,7 +41,7 @@ mod tests {
     }
 
     #[test]
-    fn test_map_key_found() {
+    fn map_key_found_should_succeed_when_invoked() {
         let bindings = vec![
             Keybinding {
                 key: KeySymbol::Char('C'),
@@ -69,7 +69,7 @@ mod tests {
     }
 
     #[test]
-    fn test_map_key_not_found_symbol_mismatch() {
+    fn map_key_not_found_symbol_mismatch_should_succeed_when_invoked() {
         let bindings = vec![Keybinding {
             key: KeySymbol::Char('C'),
             mods: Modifiers::CONTROL | Modifiers::SHIFT,
@@ -86,7 +86,7 @@ mod tests {
     }
 
     #[test]
-    fn test_map_key_not_found_modifier_mismatch() {
+    fn map_key_not_found_modifier_mismatch_should_succeed_when_invoked() {
         let bindings = vec![Keybinding {
             key: KeySymbol::Char('C'),
             mods: Modifiers::CONTROL | Modifiers::SHIFT,
@@ -99,7 +99,7 @@ mod tests {
     }
 
     #[test]
-    fn test_map_key_not_found_empty_bindings() {
+    fn map_key_not_found_empty_bindings_should_succeed_when_invoked() {
         let config = config_with_bindings(vec![]);
         let result = map_key_event_to_action(
             KeySymbol::Char('C'),
@@ -110,7 +110,7 @@ mod tests {
     }
 
     #[test]
-    fn test_map_key_multiple_bindings_first_match() {
+    fn map_key_multiple_bindings_first_match_should_succeed_when_invoked() {
         let bindings = vec![
             Keybinding {
                 key: KeySymbol::Char('A'),

--- a/core-term/src/surface/manifold.rs
+++ b/core-term/src/surface/manifold.rs
@@ -326,7 +326,7 @@ mod tests {
     }
 
     #[test]
-    fn test_grid_construction() {
+    fn grid_construction_should_succeed_when_invoked() {
         use pixelflow_graphics::render::rasterizer::rasterize;
 
         let factory = MockFactory {
@@ -351,7 +351,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cell_channel_blending() {
+    fn cell_channel_blending_should_blend_colors_when_invoked() {
         use pixelflow_graphics::render::rasterizer::rasterize;
 
         let cell = Cell::new(
@@ -384,7 +384,7 @@ mod tests {
     }
 
     #[test]
-    fn test_color_manifold() {
+    fn color_manifold_should_compute_color_when_evaluated() {
         use pixelflow_graphics::render::rasterizer::rasterize;
 
         // Color::Rgb from pixelflow-graphics implements Manifold<Output = Discrete>

--- a/core-term/src/term/emulator/input_handler.rs
+++ b/core-term/src/term/emulator/input_handler.rs
@@ -204,7 +204,7 @@ mod tests {
     }
 
     #[test]
-    fn test_paste_text_action_bracketed_on() {
+    fn paste_text_action_bracketed_on_should_succeed_when_invoked() {
         let mut emu = create_test_emu_for_input();
         // Enable bracketed paste mode via public API (CSI ? 2004 h)
         // This ensures we test the mode setting logic and state representation contract
@@ -224,7 +224,7 @@ mod tests {
     }
 
     #[test]
-    fn test_paste_text_action_bracketed_off() {
+    fn paste_text_action_bracketed_off_should_succeed_when_invoked() {
         let mut emu = create_test_emu_for_input();
         assert!(!emu.dec_modes.bracketed_paste_mode);
 
@@ -293,7 +293,7 @@ mod tests {
     }
 
     #[test]
-    fn test_control_event_resize_returns_resize_pty_action() {
+    fn control_event_resize_returns_resize_pty_action_should_succeed_when_invoked() {
         let mut emu = create_test_emu_for_input();
 
         // Default cell size is 10x16 (from config)
@@ -325,7 +325,7 @@ mod tests {
     }
 
     #[test]
-    fn test_control_event_resize_minimum_dimensions() {
+    fn control_event_resize_minimum_dimensions_should_succeed_when_invoked() {
         let mut emu = create_test_emu_for_input();
 
         // Very small resize (should clamp to MIN_GRID_DIMENSION)
@@ -357,7 +357,7 @@ mod tests {
     }
 
     #[test]
-    fn test_control_event_request_snapshot_returns_none() {
+    fn control_event_request_snapshot_returns_none_should_succeed_when_invoked() {
         let mut emu = create_test_emu_for_input();
 
         let result = process_control_event(&mut emu, ControlEvent::RequestSnapshot);
@@ -366,7 +366,7 @@ mod tests {
     }
 
     #[test]
-    fn test_control_event_pty_data_ready_returns_none() {
+    fn control_event_pty_data_ready_returns_none_should_succeed_when_invoked() {
         let mut emu = create_test_emu_for_input();
 
         let result = process_control_event(&mut emu, ControlEvent::PtyDataReady);

--- a/core-term/src/term/emulator/key_translator.rs
+++ b/core-term/src/term/emulator/key_translator.rs
@@ -162,7 +162,7 @@ mod tests {
     use crate::term::modes::DecPrivateModes;
 
     #[test]
-    fn test_simple_chars() {
+    fn simple_chars_should_succeed_when_invoked() {
         let modes = DecPrivateModes::default();
         assert_eq!(
             translate_key_input(
@@ -180,7 +180,7 @@ mod tests {
     }
 
     #[test]
-    fn test_ctrl_chars() {
+    fn ctrl_chars_should_succeed_when_invoked() {
         let modes = DecPrivateModes::default();
         // Test Ctrl+c
         assert_eq!(
@@ -195,7 +195,7 @@ mod tests {
     }
 
     #[test]
-    fn test_alt_chars() {
+    fn alt_chars_should_succeed_when_invoked() {
         let modes = DecPrivateModes::default();
         assert_eq!(
             translate_key_input(KeySymbol::Char('a'), Modifiers::ALT, None, &modes),
@@ -204,7 +204,7 @@ mod tests {
     }
 
     #[test]
-    fn test_arrow_keys_normal_mode() {
+    fn arrow_keys_normal_mode_should_succeed_when_invoked() {
         let mut modes = DecPrivateModes::default();
         modes.cursor_keys_app_mode = false;
         assert_eq!(
@@ -226,7 +226,7 @@ mod tests {
     }
 
     #[test]
-    fn test_arrow_keys_app_mode() {
+    fn arrow_keys_app_mode_should_succeed_when_invoked() {
         let mut modes = DecPrivateModes::default();
         modes.cursor_keys_app_mode = true;
         assert_eq!(
@@ -248,7 +248,7 @@ mod tests {
     }
 
     #[test]
-    fn test_shift_tab() {
+    fn shift_tab_should_succeed_when_invoked() {
         let modes = DecPrivateModes::default();
         assert_eq!(
             translate_key_input(KeySymbol::Tab, Modifiers::SHIFT, None, &modes),

--- a/core-term/src/term/layout.rs
+++ b/core-term/src/term/layout.rs
@@ -129,7 +129,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_pixels_to_cells_basic() {
+    fn pixels_to_cells_basic_should_compute_cells_when_called() {
         let layout = Layout {
             cols: 80,
             rows: 24,
@@ -154,7 +154,7 @@ mod tests {
     }
 
     #[test]
-    fn test_pixels_to_cells_with_padding() {
+    fn pixels_to_cells_with_padding_should_compute_cells_when_called() {
         let layout = Layout {
             cols: 80,
             rows: 24,
@@ -176,7 +176,7 @@ mod tests {
     }
 
     #[test]
-    fn test_pixels_to_cells_out_of_bounds() {
+    fn pixels_to_cells_out_of_bounds_should_clamp_when_called() {
         let layout = Layout {
             cols: 80,
             rows: 24,
@@ -197,7 +197,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cells_to_pixels() {
+    fn cells_to_pixels_should_compute_pixels_when_called() {
         let layout = Layout {
             cols: 80,
             rows: 24,
@@ -214,7 +214,7 @@ mod tests {
     }
 
     #[test]
-    fn test_pixel_dimensions() {
+    fn pixel_dimensions_should_compute_size_when_called() {
         let layout = Layout {
             cols: 80,
             rows: 24,
@@ -230,7 +230,7 @@ mod tests {
     }
 
     #[test]
-    fn test_resize() {
+    fn resize_should_update_layout_when_called() {
         let mut layout = Layout::new(80, 24);
 
         assert_eq!(layout.cols, 80);

--- a/core-term/src/term/screen.rs
+++ b/core-term/src/term/screen.rs
@@ -1206,13 +1206,13 @@ mod tests {
     }
 
     #[test]
-    fn test_selection_default_state() {
+    fn selection_default_state_should_succeed_when_invoked() {
         let screen = create_test_screen(10, 5);
         assert_eq!(screen.selection, Selection::default());
     }
 
     #[test]
-    fn test_start_selection() {
+    fn start_selection_should_succeed_when_invoked() {
         let mut screen = create_test_screen(10, 5);
         let start_point = Point { x: 1, y: 1 };
         screen.dirty.fill(0);
@@ -1229,7 +1229,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_selection() {
+    fn update_selection_should_succeed_when_invoked() {
         let mut screen = create_test_screen(10, 5);
         let start_point = Point { x: 1, y: 1 };
         let update_point = Point { x: 5, y: 2 };
@@ -1243,7 +1243,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_selection_marks_old_and_new_lines_dirty() {
+    fn update_selection_marks_old_and_new_lines_dirty_should_succeed_when_invoked() {
         let mut screen = create_test_screen(10, 5);
         screen.start_selection(Point { x: 1, y: 1 }, SelectionMode::Cell); // Replaced Normal with Cell
         screen.update_selection(Point { x: 3, y: 1 });
@@ -1254,7 +1254,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_selection_when_not_active() {
+    fn update_selection_when_not_active_should_succeed_when_invoked() {
         let mut screen = create_test_screen(10, 5);
         screen.start_selection(Point { x: 1, y: 1 }, SelectionMode::Cell); // Replaced Normal with Cell
         screen.selection.is_active = false;
@@ -1264,7 +1264,7 @@ mod tests {
     }
 
     #[test]
-    fn test_end_selection() {
+    fn end_selection_should_succeed_when_invoked() {
         let mut screen = create_test_screen(10, 5);
         screen.start_selection(Point { x: 1, y: 1 }, SelectionMode::Cell); // Replaced Normal with Cell
         screen.end_selection();
@@ -1272,7 +1272,7 @@ mod tests {
     }
 
     #[test]
-    fn test_clear_selection() {
+    fn clear_selection_should_succeed_when_invoked() {
         let mut screen = create_test_screen(10, 5);
         screen.start_selection(Point { x: 1, y: 1 }, SelectionMode::Cell); // Replaced Normal with Cell
         screen.update_selection(Point { x: 3, y: 2 });
@@ -1284,13 +1284,13 @@ mod tests {
     }
 
     #[test]
-    fn test_is_selected_normal_no_selection() {
+    fn is_selected_normal_no_selection_should_succeed_when_invoked() {
         let screen = create_test_screen(10, 5);
         assert!(!screen.is_selected(Point { x: 1, y: 1 }));
     }
 
     #[test]
-    fn test_is_selected_normal_single_line() {
+    fn is_selected_normal_single_line_should_succeed_when_invoked() {
         let mut screen = create_test_screen(10, 5);
         screen.start_selection(Point { x: 2, y: 1 }, SelectionMode::Cell); // Replaced Normal with Cell
         screen.update_selection(Point { x: 5, y: 1 });
@@ -1301,7 +1301,7 @@ mod tests {
     }
 
     #[test]
-    fn test_is_selected_normal_multi_line() {
+    fn is_selected_normal_multi_line_should_succeed_when_invoked() {
         let mut screen = create_test_screen(10, 5);
         screen.start_selection(Point { x: 3, y: 1 }, SelectionMode::Cell); // Replaced Normal with Cell
         screen.update_selection(Point { x: 2, y: 3 });
@@ -1313,7 +1313,7 @@ mod tests {
     }
 
     #[test]
-    fn test_is_selected_normal_multi_line_selection_ends_at_width_minus_1() {
+    fn is_selected_normal_multi_line_selection_ends_at_width_minus_1_should_succeed_when_invoked() {
         let mut screen = create_test_screen(10, 5);
         screen.start_selection(Point { x: 8, y: 0 }, SelectionMode::Cell); // Replaced Normal with Cell
         screen.update_selection(Point { x: 2, y: 2 });
@@ -1325,7 +1325,7 @@ mod tests {
     }
 
     #[test]
-    fn test_is_selected_normal_reverse_selection_points() {
+    fn is_selected_normal_reverse_selection_points_should_succeed_when_invoked() {
         let mut screen = create_test_screen(10, 5);
         screen.start_selection(Point { x: 5, y: 2 }, SelectionMode::Cell); // Replaced Normal with Cell
         screen.update_selection(Point { x: 1, y: 1 });
@@ -1338,7 +1338,7 @@ mod tests {
     }
 
     #[test]
-    fn test_is_selected_point_equals_start_or_end() {
+    fn is_selected_point_equals_start_or_end_should_succeed_when_invoked() {
         let mut screen = create_test_screen(10, 5);
         screen.start_selection(Point { x: 2, y: 2 }, SelectionMode::Cell); // Replaced Normal with Cell
         assert!(screen.is_selected(Point { x: 2, y: 2 }));
@@ -1348,7 +1348,7 @@ mod tests {
     }
 
     #[test]
-    fn test_is_selected_out_of_bounds_point() {
+    fn is_selected_out_of_bounds_point_should_succeed_when_invoked() {
         let mut screen = create_test_screen(10, 5);
         screen.start_selection(Point { x: 0, y: 0 }, SelectionMode::Cell); // Replaced Normal with Cell
         screen.update_selection(Point {
@@ -1366,13 +1366,13 @@ mod tests {
     }
 
     #[test]
-    fn test_is_selected_block_no_selection() {
+    fn is_selected_block_no_selection_should_succeed_when_invoked() {
         let screen = create_test_screen(10, 5);
         assert!(!screen.is_selected(Point { x: 1, y: 1 }));
     }
 
     #[test]
-    fn test_is_selected_block_simple() {
+    fn is_selected_block_simple_should_succeed_when_invoked() {
         let mut screen = create_test_screen(10, 5);
         screen.start_selection(Point { x: 1, y: 1 }, SelectionMode::Block);
         screen.update_selection(Point { x: 3, y: 3 });
@@ -1381,7 +1381,7 @@ mod tests {
     }
 
     #[test]
-    fn test_is_selected_block_reverse_points() {
+    fn is_selected_block_reverse_points_should_succeed_when_invoked() {
         let mut screen = create_test_screen(10, 5);
         screen.start_selection(Point { x: 3, y: 3 }, SelectionMode::Block);
         screen.update_selection(Point { x: 1, y: 1 });
@@ -1389,13 +1389,13 @@ mod tests {
     }
 
     #[test]
-    fn test_get_selected_text_normal_no_selection() {
+    fn get_selected_text_normal_no_selection_should_succeed_when_invoked() {
         let screen = create_test_screen(10, 5);
         assert_eq!(screen.get_selected_text(), None);
     }
 
     #[test]
-    fn test_get_selected_text_normal_single_char() {
+    fn get_selected_text_normal_single_char_should_succeed_when_invoked() {
         let mut screen = create_test_screen(5, 3);
         fill_screen_with_pattern(&mut screen);
         screen.start_selection(Point { x: 1, y: 1 }, SelectionMode::Cell); // Replaced Normal with Cell
@@ -1403,7 +1403,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_selected_text_normal_single_line_partial() {
+    fn get_selected_text_normal_single_line_partial_should_succeed_when_invoked() {
         let mut screen = create_test_screen(5, 3);
         fill_screen_with_pattern(&mut screen);
         screen.start_selection(Point { x: 1, y: 0 }, SelectionMode::Cell); // Replaced Normal with Cell
@@ -1412,7 +1412,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_selected_text_normal_single_line_full() {
+    fn get_selected_text_normal_single_line_full_should_succeed_when_invoked() {
         let mut screen = create_test_screen(5, 3);
         fill_screen_with_pattern(&mut screen);
         screen.start_selection(Point { x: 0, y: 0 }, SelectionMode::Cell); // Replaced Normal with Cell
@@ -1424,7 +1424,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_selected_text_normal_multi_line() {
+    fn get_selected_text_normal_multi_line_should_succeed_when_invoked() {
         let mut screen = create_test_screen(3, 3);
         fill_screen_with_pattern(&mut screen);
         screen.start_selection(Point { x: 1, y: 0 }, SelectionMode::Cell); // Replaced Normal with Cell
@@ -1433,7 +1433,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_selected_text_normal_multi_line_reversed_points() {
+    fn get_selected_text_normal_multi_line_reversed_points_should_succeed_when_invoked() {
         let mut screen = create_test_screen(3, 3);
         fill_screen_with_pattern(&mut screen);
         screen.start_selection(Point { x: 1, y: 2 }, SelectionMode::Cell); // Replaced Normal with Cell
@@ -1442,7 +1442,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_selected_text_normal_trailing_spaces_behavior() {
+    fn get_selected_text_normal_trailing_spaces_behavior_should_succeed_when_invoked() {
         let mut screen = create_test_screen(5, 2);
         {
             let row0 = Arc::make_mut(&mut screen.grid[0]);
@@ -1511,14 +1511,14 @@ mod tests {
     }
 
     #[test]
-    fn test_get_selected_text_block_no_selection() {
+    fn get_selected_text_block_no_selection_should_succeed_when_invoked() {
         let mut screen = create_test_screen(10, 5);
         screen.selection.mode = SelectionMode::Block;
         assert_eq!(screen.get_selected_text(), None);
     }
 
     #[test]
-    fn test_get_selected_text_block_simple() {
+    fn get_selected_text_block_simple_should_succeed_when_invoked() {
         let mut screen = create_test_screen(5, 4);
         fill_screen_with_pattern(&mut screen);
         screen.start_selection(Point { x: 1, y: 0 }, SelectionMode::Block);
@@ -1530,7 +1530,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_selected_text_block_reversed_points() {
+    fn get_selected_text_block_reversed_points_should_succeed_when_invoked() {
         let mut screen = create_test_screen(5, 4);
         fill_screen_with_pattern(&mut screen);
         screen.start_selection(Point { x: 3, y: 2 }, SelectionMode::Block);
@@ -1542,7 +1542,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_selected_text_block_one_column() {
+    fn get_selected_text_block_one_column_should_succeed_when_invoked() {
         let mut screen = create_test_screen(5, 4);
         fill_screen_with_pattern(&mut screen);
         screen.start_selection(Point { x: 1, y: 0 }, SelectionMode::Block);
@@ -1551,7 +1551,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_selected_text_block_one_row() {
+    fn get_selected_text_block_one_row_should_succeed_when_invoked() {
         let mut screen = create_test_screen(5, 4);
         fill_screen_with_pattern(&mut screen);
         screen.start_selection(Point { x: 1, y: 1 }, SelectionMode::Block);
@@ -1560,7 +1560,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_selected_text_block_beyond_line_length() {
+    fn get_selected_text_block_beyond_line_length_should_succeed_when_invoked() {
         let mut screen = create_test_screen(3, 2);
         {
             let row0 = Arc::make_mut(&mut screen.grid[0]);
@@ -1607,7 +1607,7 @@ mod tests {
     }
 
     #[test]
-    fn test_selection_cleared_on_resize() {
+    fn selection_cleared_on_resize_should_succeed_when_invoked() {
         let mut screen = create_test_screen(10, 5);
         screen.start_selection(Point { x: 1, y: 1 }, SelectionMode::Cell); // Replaced Normal with Cell
         screen.update_selection(Point { x: 5, y: 2 });
@@ -1617,7 +1617,7 @@ mod tests {
     }
 
     #[test]
-    fn test_scroll_up_populates_scrollback() {
+    fn scroll_up_populates_scrollback_should_succeed_when_invoked() {
         let mut screen = create_test_screen_with_scrollback(10, 5, 10);
         fill_screen_with_pattern(&mut screen);
         // scroll up 1 line. Top line should go to scrollback.
@@ -1660,7 +1660,7 @@ mod tests {
     }
 
     #[test]
-    fn test_block_selection_wide_char_full() {
+    fn block_selection_wide_char_full_should_succeed_when_invoked() {
         let mut screen = create_screen_with_wide_char();
         // Select "b" "你" "c" (columns 1 to 4)
         screen.start_selection(Point { x: 1, y: 0 }, SelectionMode::Block);
@@ -1671,7 +1671,7 @@ mod tests {
     }
 
     #[test]
-    fn test_block_selection_wide_char_partial_left() {
+    fn block_selection_wide_char_partial_left_should_succeed_when_invoked() {
         let mut screen = create_screen_with_wide_char();
         // Select "b" "你" (primary only) (columns 1 to 2)
         screen.start_selection(Point { x: 1, y: 0 }, SelectionMode::Block);
@@ -1683,7 +1683,7 @@ mod tests {
     }
 
     #[test]
-    fn test_block_selection_wide_char_partial_right() {
+    fn block_selection_wide_char_partial_right_should_succeed_when_invoked() {
         let mut screen = create_screen_with_wide_char();
         // Select spacer of "你" and "c" (columns 3 to 4)
         screen.start_selection(Point { x: 3, y: 0 }, SelectionMode::Block);

--- a/core-term/src/term/tests.rs
+++ b/core-term/src/term/tests.rs
@@ -205,7 +205,7 @@ fn assert_screen_state(
 }
 
 #[test]
-fn test_simple_char_input() {
+fn simple_char_input_should_succeed_when_invoked() {
     let mut term = create_test_emulator(10, 1);
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('A')));
     let snapshot = term.get_render_snapshot().expect("Snapshot was None");
@@ -218,7 +218,7 @@ fn test_simple_char_input() {
 }
 
 #[test]
-fn test_newline_input() {
+fn newline_input_should_succeed_when_invoked() {
     let mut term = create_test_emulator(10, 2);
     // Enable Linefeed/Newline Mode (LNM)
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Csi(CsiCommand::SetMode(
@@ -235,7 +235,7 @@ fn test_newline_input() {
 }
 
 #[test]
-fn test_carriage_return_input() {
+fn carriage_return_input_should_succeed_when_invoked() {
     let mut term = create_test_emulator(10, 1);
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('A')));
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('B')));
@@ -248,7 +248,7 @@ fn test_carriage_return_input() {
 }
 
 #[test]
-fn test_csi_cursor_forward_cuf() {
+fn csi_cursor_forward_cuf_should_succeed_when_invoked() {
     let mut term = create_test_emulator(10, 1); // Cursor at (0,0)
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Csi(
         CsiCommand::CursorForward(1),
@@ -264,7 +264,7 @@ fn test_csi_cursor_forward_cuf() {
 }
 
 #[test]
-fn test_csi_ed_clear_below_csi_j() {
+fn csi_ed_clear_below_csi_j_should_succeed_when_invoked() {
     let mut term = create_test_emulator(3, 2);
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('A')));
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('B')));
@@ -292,7 +292,7 @@ fn test_csi_ed_clear_below_csi_j() {
 }
 
 #[test]
-fn test_csi_sgr_fg_color() {
+fn csi_sgr_fg_color_should_succeed_when_invoked() {
     let mut term = create_test_emulator(5, 1);
     let red_attr = vec![Attribute::Foreground(Color::Named(NamedColor::Red))];
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Csi(
@@ -370,7 +370,7 @@ fn fill_emulator_screen(emu: &mut TerminalEmulator, text_lines: Vec<String>) {
 
 // --- Basic Selection Flow Tests ---
 #[test]
-fn test_mouse_press_starts_selection() {
+fn mouse_press_starts_selection_should_succeed_when_invoked() {
     let mut emu = create_test_emulator(10, 5);
     let action = send_mouse_input(&mut emu, start_selection_at(1, 1), MouseButton::Left);
 
@@ -402,7 +402,7 @@ fn test_mouse_press_starts_selection() {
 }
 
 #[test]
-fn test_mouse_drag_updates_selection() {
+fn mouse_drag_updates_selection_should_succeed_when_invoked() {
     let mut emu = create_test_emulator(10, 5);
     send_mouse_input(&mut emu, start_selection_at(1, 1), MouseButton::Left);
     let action = send_mouse_input(&mut emu, extend_selection_to(5, 2), MouseButton::Left);
@@ -430,7 +430,7 @@ fn test_mouse_drag_updates_selection() {
 }
 
 #[test]
-fn test_mouse_release_ends_selection_activity() {
+fn mouse_release_ends_selection_activity_should_succeed_when_invoked() {
     let mut emu = create_test_emulator(10, 5);
     send_mouse_input(&mut emu, start_selection_at(1, 1), MouseButton::Left);
     send_mouse_input(&mut emu, extend_selection_to(5, 2), MouseButton::Left);
@@ -470,14 +470,14 @@ fn test_mouse_release_ends_selection_activity() {
 
 // --- Copy Action Tests ---
 #[test]
-fn test_initiate_copy_no_selection() {
+fn initiate_copy_no_selection_should_succeed_when_invoked() {
     let mut emu = create_test_emulator(10, 5);
     let action = emu.interpret_input(EmulatorInput::User(UserInputAction::InitiateCopy));
     assert_eq!(action, None, "Should return None if no selection exists.");
 }
 
 #[test]
-fn test_initiate_copy_with_selection() {
+fn initiate_copy_with_selection_should_succeed_when_invoked() {
     let mut emu = create_test_emulator(10, 2);
     fill_emulator_screen(&mut emu, vec!["Hello".to_string(), "World".to_string()]);
 
@@ -498,7 +498,7 @@ fn test_initiate_copy_with_selection() {
 }
 
 #[test]
-fn test_initiate_copy_block_selection() {
+fn initiate_copy_block_selection_should_succeed_when_invoked() {
     let mut emu = create_test_emulator(3, 3);
     fill_emulator_screen(
         &mut emu,
@@ -525,7 +525,7 @@ fn test_initiate_copy_block_selection() {
 
 // --- Selection Clearing Tests ---
 #[test]
-fn test_new_mouse_press_clears_old_selection() {
+fn new_mouse_press_clears_old_selection_should_succeed_when_invoked() {
     let mut emu = create_test_emulator(10, 5);
 
     send_mouse_input(&mut emu, start_selection_at(0, 0), MouseButton::Left);
@@ -573,7 +573,7 @@ fn test_new_mouse_press_clears_old_selection() {
 
 // --- Selection Interaction with Scrolling Test ---
 #[test]
-fn test_selection_coordinates_adjust_on_scroll() {
+fn selection_coordinates_adjust_on_scroll_should_succeed_when_invoked() {
     let mut emu = create_test_emulator(10, 3);
     fill_emulator_screen(
         &mut emu,
@@ -631,7 +631,7 @@ fn test_selection_coordinates_adjust_on_scroll() {
 
 // --- Selection with Alternate Screen Test ---
 #[test]
-fn test_selection_on_alt_screen_then_exit() {
+fn selection_on_alt_screen_then_exit_should_succeed_when_invoked() {
     let mut emu = create_test_emulator(10, 3);
     fill_emulator_screen(
         &mut emu,
@@ -684,7 +684,7 @@ fn test_selection_on_alt_screen_then_exit() {
 // --- End of Selection with Alternate Screen Test ---
 
 #[test]
-fn test_resize_larger() {
+fn resize_larger_should_succeed_when_invoked() {
     let mut term = create_test_emulator(5, 2);
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('1')));
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('2')));
@@ -709,7 +709,7 @@ fn test_resize_larger() {
 }
 
 #[test]
-fn test_resize_smaller_content_truncation() {
+fn resize_smaller_content_truncation_should_succeed_when_invoked() {
     let mut term = create_test_emulator(5, 2);
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('H')));
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('e')));
@@ -726,7 +726,7 @@ fn test_resize_smaller_content_truncation() {
 }
 
 #[test]
-fn test_osc_set_window_title() {
+fn osc_set_window_title_should_succeed_when_invoked() {
     let mut term = create_test_emulator(10, 1);
 
     let action = term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Osc(
@@ -747,7 +747,7 @@ fn test_osc_set_window_title() {
 }
 
 #[test]
-fn test_key_event_printable_char() {
+fn key_event_printable_char_should_succeed_when_invoked() {
     let mut term = create_test_emulator(5, 1);
     let key_input = UserInputAction::KeyInput {
         symbol: KeySymbol::Char('x'),
@@ -766,7 +766,7 @@ fn test_key_event_printable_char() {
 }
 
 #[test]
-fn test_key_event_arrow_up() {
+fn key_event_arrow_up_should_succeed_when_invoked() {
     let mut term = create_test_emulator(5, 1);
     let key_input = UserInputAction::KeyInput {
         symbol: KeySymbol::Up,
@@ -783,7 +783,7 @@ fn test_key_event_arrow_up() {
 }
 
 #[test]
-fn test_snapshot_with_selection() {
+fn snapshot_with_selection_should_succeed_when_invoked() {
     let num_cols = 10;
     let num_rows = 2;
     let default_glyph = Glyph::Single(ContentCell {
@@ -842,7 +842,7 @@ fn test_snapshot_with_selection() {
 }
 
 #[test]
-fn test_mode_show_cursor_dectcem() {
+fn mode_show_cursor_dectcem_should_succeed_when_invoked() {
     let mut term = create_test_emulator(5, 1);
 
     let snap_default = term.get_render_snapshot().expect("Snapshot was None");
@@ -879,7 +879,7 @@ fn test_mode_show_cursor_dectcem() {
 // --- PS1 Multi-line Prompt Tests ---
 
 #[test]
-fn test_ps1_multiline_prompt_at_bottom_causes_scroll() {
+fn ps1_multiline_prompt_at_bottom_causes_scroll_should_succeed_when_invoked() {
     let mut term = create_test_emulator(5, 3);
 
     for _ in 0..5 {
@@ -909,7 +909,7 @@ fn test_ps1_multiline_prompt_at_bottom_causes_scroll() {
 }
 
 #[test]
-fn test_ps1_multiline_prompt_ends_on_last_line_no_scroll_by_prompt() {
+fn ps1_multiline_prompt_ends_on_last_line_no_scroll_by_prompt_should_succeed_when_invoked() {
     let mut term = create_test_emulator(5, 3);
 
     for _ in 0..5 {
@@ -932,7 +932,7 @@ fn test_ps1_multiline_prompt_ends_on_last_line_no_scroll_by_prompt() {
 }
 
 #[test]
-fn test_ps1_multiline_prompt_last_line_fills_screen_then_input() {
+fn ps1_multiline_prompt_last_line_fills_screen_then_input_should_succeed_when_invoked() {
     let mut term = create_test_emulator(3, 2);
 
     for _ in 0..3 {
@@ -962,7 +962,7 @@ fn test_ps1_multiline_prompt_last_line_fills_screen_then_input() {
 }
 
 #[test]
-fn test_ps1_prompt_causes_multiple_scrolls() {
+fn ps1_prompt_causes_multiple_scrolls_should_succeed_when_invoked() {
     let mut term = create_test_emulator(3, 2);
 
     for _ in 0..3 {
@@ -991,7 +991,7 @@ fn test_ps1_prompt_causes_multiple_scrolls() {
 }
 
 #[test]
-fn test_ps1_prompt_with_internal_wrapping_and_scrolling() {
+fn ps1_prompt_with_internal_wrapping_and_scrolling_should_succeed_when_invoked() {
     let mut term = create_test_emulator(3, 2);
     for _ in 0..3 {
         term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('A')));
@@ -1026,7 +1026,7 @@ fn test_ps1_prompt_with_internal_wrapping_and_scrolling() {
 }
 
 #[test]
-fn test_ps1_multiline_exact_fill_then_scroll_on_final_lf() {
+fn ps1_multiline_exact_fill_then_scroll_on_final_lf_should_succeed_when_invoked() {
     let mut term = create_test_emulator(3, 2);
 
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('P')));
@@ -1046,7 +1046,7 @@ fn test_ps1_multiline_exact_fill_then_scroll_on_final_lf() {
 }
 
 #[test]
-fn test_ps1_multiline_with_sgr_at_bottom_scrolls() {
+fn ps1_multiline_with_sgr_at_bottom_scrolls_should_succeed_when_invoked() {
     let mut term = create_test_emulator(5, 2);
 
     for _ in 0..5 {
@@ -1130,7 +1130,7 @@ fn test_ps1_multiline_with_sgr_at_bottom_scrolls() {
 }
 
 #[test]
-fn test_lf_at_bottom_of_partial_scrolling_region_no_origin_mode() {
+fn lf_at_bottom_of_partial_scrolling_region_no_origin_mode_should_succeed_when_invoked() {
     let cols = 10;
     let rows = 5;
     let mut emu = create_test_emulator(cols, rows);
@@ -1214,7 +1214,7 @@ fn test_lf_at_bottom_of_partial_scrolling_region_no_origin_mode() {
     );
 }
 #[test]
-fn test_primary_device_attributes_response() {
+fn primary_device_attributes_response_should_succeed_when_invoked() {
     let mut term = create_test_emulator(80, 24);
 
     let input_da = EmulatorInput::Ansi(AnsiCommand::Csi(CsiCommand::PrimaryDeviceAttributes));
@@ -1236,7 +1236,7 @@ mod selection_logic_tests {
     use crate::term::snapshot::SelectionRange;
 
     #[test]
-    fn test_start_selection() {
+    fn start_selection_should_succeed_when_invoked() {
         let mut emu = create_test_emulator(10, 5);
         let point = Point { x: 2, y: 1 };
 
@@ -1256,7 +1256,7 @@ mod selection_logic_tests {
     }
 
     #[test]
-    fn test_extend_selection_active_and_inactive() {
+    fn extend_selection_active_and_inactive_should_succeed_when_invoked() {
         let mut emu = create_test_emulator(10, 5);
         let start_point = Point { x: 2, y: 1 };
         let extend_point = Point { x: 5, y: 2 };
@@ -1282,7 +1282,7 @@ mod selection_logic_tests {
     }
 
     #[test]
-    fn test_apply_selection_clear_click_and_drag() {
+    fn apply_selection_clear_click_and_drag_should_succeed_when_invoked() {
         let mut emu = create_test_emulator(10, 5);
         let point1 = Point { x: 2, y: 1 };
         let point2 = Point { x: 5, y: 1 };
@@ -1326,7 +1326,7 @@ mod selection_logic_tests {
     }
 
     #[test]
-    fn test_clear_selection() {
+    fn clear_selection_should_succeed_when_invoked() {
         let mut emu = create_test_emulator(10, 5);
 
         // Create and deactivate a selection
@@ -1351,13 +1351,13 @@ mod get_selected_text_tests {
     use super::*;
 
     #[test]
-    fn test_get_selected_text_no_selection() {
+    fn get_selected_text_no_selection_should_succeed_when_invoked() {
         let emu = create_test_emulator(10, 5);
         assert_eq!(emu.get_selected_text(), None);
     }
 
     #[test]
-    fn test_get_selected_text_single_line() {
+    fn get_selected_text_single_line_should_succeed_when_invoked() {
         let mut emu = create_test_emulator(10, 5);
         fill_emulator_screen(&mut emu, vec!["Hello World".to_string()]);
 
@@ -1374,7 +1374,7 @@ mod get_selected_text_tests {
     }
 
     #[test]
-    fn test_get_selected_text_single_line_trailing_spaces_in_selection() {
+    fn get_selected_text_single_line_trailing_spaces_in_selection_should_succeed_when_invoked() {
         let mut emu = create_test_emulator(10, 1);
         fill_emulator_screen(&mut emu, vec!["Hi   ".to_string()]);
 
@@ -1390,7 +1390,7 @@ mod get_selected_text_tests {
     }
 
     #[test]
-    fn test_get_selected_text_multi_line() {
+    fn get_selected_text_multi_line_should_succeed_when_invoked() {
         let mut emu = create_test_emulator(10, 5);
         fill_emulator_screen(
             &mut emu,
@@ -1413,7 +1413,7 @@ mod get_selected_text_tests {
     }
 
     #[test]
-    fn test_get_selected_text_multi_line_full_lines() {
+    fn get_selected_text_multi_line_full_lines_should_succeed_when_invoked() {
         let mut emu = create_test_emulator(10, 3);
         fill_emulator_screen(
             &mut emu,
@@ -1449,7 +1449,7 @@ mod get_selected_text_tests {
     }
 
     #[test]
-    fn test_get_selected_text_line_boundaries() {
+    fn get_selected_text_line_boundaries_should_succeed_when_invoked() {
         let mut emu = create_test_emulator(10, 2);
         fill_emulator_screen(
             &mut emu,
@@ -1468,7 +1468,7 @@ mod get_selected_text_tests {
     }
 
     #[test]
-    fn test_get_selected_text_empty_cells_within_grid() {
+    fn get_selected_text_empty_cells_within_grid_should_succeed_when_invoked() {
         let mut emu = create_test_emulator(5, 1);
         // Create sparse content: "A   E" by printing A, moving cursor to col 4, then printing E
         emu.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('A')));
@@ -1489,7 +1489,7 @@ mod get_selected_text_tests {
     }
 
     #[test]
-    fn test_get_selected_text_selection_beyond_line_length() {
+    fn get_selected_text_selection_beyond_line_length_should_succeed_when_invoked() {
         let mut emu = create_test_emulator(10, 1);
         fill_emulator_screen(&mut emu, vec!["Test".to_string()]);
 
@@ -1505,7 +1505,7 @@ mod get_selected_text_tests {
     }
 
     #[test]
-    fn test_get_selected_text_reversed_points() {
+    fn get_selected_text_reversed_points_should_succeed_when_invoked() {
         let mut emu = create_test_emulator(10, 5);
         fill_emulator_screen(&mut emu, vec!["Hello World".to_string()]);
 
@@ -1527,7 +1527,7 @@ mod paste_text_tests {
     use super::*;
 
     #[test]
-    fn test_paste_text_bracketed_off_simple() {
+    fn paste_text_bracketed_off_simple_should_succeed_when_invoked() {
         let mut emu = create_test_emulator(20, 1);
         // Bracketed paste mode is off by default - just verify behavior
 
@@ -1544,7 +1544,7 @@ mod paste_text_tests {
     }
 
     #[test]
-    fn test_paste_text_bracketed_off_with_newline() {
+    fn paste_text_bracketed_off_with_newline_should_succeed_when_invoked() {
         let mut emu = create_test_emulator(20, 2);
         // Bracketed paste mode is off by default - just verify behavior
 
@@ -1558,7 +1558,7 @@ mod paste_text_tests {
     }
 
     #[test]
-    fn test_paste_text_bracketed_off_causes_wrap() {
+    fn paste_text_bracketed_off_causes_wrap_should_succeed_when_invoked() {
         let mut emu = create_test_emulator(5, 2);
         // Bracketed paste mode is off by default - just verify wrapping behavior
 
@@ -1574,7 +1574,7 @@ mod paste_text_tests {
     }
 
     #[test]
-    fn test_paste_text_bracketed_on_logs_warning_processes_chars() {
+    fn paste_text_bracketed_on_logs_warning_processes_chars_should_succeed_when_invoked() {
         let mut emu = create_test_emulator(20, 1);
         // Enable bracketed paste mode
         emu.interpret_input(EmulatorInput::Ansi(AnsiCommand::Csi(
@@ -1594,7 +1594,7 @@ mod paste_text_tests {
     }
 
     #[test]
-    fn test_ansi_resize_sets_terminal_dimensions() {
+    fn ansi_resize_sets_terminal_dimensions_should_succeed_when_invoked() {
         let mut emu = create_test_emulator(80, 24);
         assert_eq!(emu.dimensions(), (80, 24));
 
@@ -1613,7 +1613,7 @@ mod paste_text_tests {
     }
 
     #[test]
-    fn test_ansi_resize_updates_snapshot_dimensions() {
+    fn ansi_resize_updates_snapshot_dimensions_should_succeed_when_invoked() {
         let mut emu = create_test_emulator(80, 24);
 
         let resize_command = AnsiCommand::Csi(CsiCommand::WindowManipulation {
@@ -1632,7 +1632,7 @@ mod paste_text_tests {
     }
 
     #[test]
-    fn test_ansi_resize_with_zero_rows_ignored() {
+    fn ansi_resize_with_zero_rows_ignored_should_succeed_when_invoked() {
         let mut emu = create_test_emulator(80, 24);
 
         let resize_command = AnsiCommand::Csi(CsiCommand::WindowManipulation {
@@ -1650,7 +1650,7 @@ mod paste_text_tests {
     }
 
     #[test]
-    fn test_ansi_resize_with_zero_cols_ignored() {
+    fn ansi_resize_with_zero_cols_ignored_should_succeed_when_invoked() {
         let mut emu = create_test_emulator(80, 24);
 
         let resize_command = AnsiCommand::Csi(CsiCommand::WindowManipulation {
@@ -1668,7 +1668,7 @@ mod paste_text_tests {
     }
 
     #[test]
-    fn test_ansi_resize_with_missing_params_ignored() {
+    fn ansi_resize_with_missing_params_ignored_should_succeed_when_invoked() {
         let mut emu = create_test_emulator(80, 24);
 
         let resize_command = AnsiCommand::Csi(CsiCommand::WindowManipulation {
@@ -1699,7 +1699,7 @@ mod paste_text_tests {
     }
 
     #[test]
-    fn test_window_manipulation_report_size() {
+    fn window_manipulation_report_size_should_succeed_when_invoked() {
         let mut emu = create_test_emulator(80, 24);
 
         let report_command = AnsiCommand::Csi(CsiCommand::WindowManipulation {

--- a/core-term/src/term/unicode.rs
+++ b/core-term/src/term/unicode.rs
@@ -77,14 +77,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_ascii_char_width() {
+    fn ascii_char_width_should_succeed_when_invoked() {
         assert_eq!(get_char_display_width('A'), 1, "Width of 'A' should be 1");
         assert_eq!(get_char_display_width(' '), 1, "Width of space should be 1");
         assert_eq!(get_char_display_width('~'), 1, "Width of '~' should be 1");
     }
 
     #[test]
-    fn test_box_drawing_char_widths() {
+    fn box_drawing_char_widths_should_succeed_when_invoked() {
         assert_eq!(
             get_char_display_width('─'),
             1,
@@ -144,7 +144,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cjk_wide_char_widths() {
+    fn cjk_wide_char_widths_should_succeed_when_invoked() {
         assert_eq!(
             get_char_display_width('世'),
             2,
@@ -168,7 +168,7 @@ mod tests {
     }
 
     #[test]
-    fn test_control_char_widths() {
+    fn control_char_widths_should_succeed_when_invoked() {
         assert_eq!(
             get_char_display_width('\u{0000}'),
             0,
@@ -194,7 +194,7 @@ mod tests {
     }
 
     #[test]
-    fn test_zero_width_chars() {
+    fn zero_width_chars_should_succeed_when_invoked() {
         assert_eq!(
             get_char_display_width('\u{200D}'),
             0,
@@ -208,7 +208,7 @@ mod tests {
     }
 
     #[test]
-    fn test_locale_initializer_called() {
+    fn locale_initializer_called_should_succeed_when_invoked() {
         // Ensure OnceLock mechanism is engaged
         let _ = get_char_display_width(' ');
         assert!(

--- a/core-term/src/terminal_app.rs
+++ b/core-term/src/terminal_app.rs
@@ -872,7 +872,7 @@ mod tests {
     }
 
     #[test]
-    fn test_handle_control_resize() {
+    fn handle_control_resize_should_update_dimensions_when_called() {
         let (mut app, pty_rx, _, _scheduler) = match create_test_app() {
             Some(v) => v,
             None => return,
@@ -913,7 +913,7 @@ mod tests {
     }
 
     #[test]
-    fn test_handle_management_keydown() {
+    fn handle_management_keydown_should_process_key_when_called() {
         let (mut app, pty_rx, _, _scheduler) = match create_test_app() {
             Some(v) => v,
             None => return,

--- a/pixelflow-graphics/src/patch.rs
+++ b/pixelflow-graphics/src/patch.rs
@@ -118,7 +118,7 @@ mod tests {
     use pixelflow_core::ManifoldCompat;
 
     #[test]
-    fn test_flat_patch() {
+    fn flat_patch_should_evaluate_to_zero_when_sampled() {
         let patch = BezierPatch::flat(1.0);
         let z = Field::from(0.0);
         let result = patch.eval_raw(Field::from(0.5), Field::from(0.5), z, z);
@@ -126,7 +126,7 @@ mod tests {
     }
 
     #[test]
-    fn test_derivatives() {
+    fn derivatives_should_be_near_zero_when_sampled_at_center() {
         let patch = BezierPatch::paraboloid(2.0, 1.0);
         let u = Jet2H::x(Field::from(0.5));
         let v = Jet2H::y(Field::from(0.5));

--- a/pixelflow-graphics/src/render/rasterizer/actor.rs
+++ b/pixelflow-graphics/src/render/rasterizer/actor.rs
@@ -233,7 +233,7 @@ mod tests {
     use std::sync::{mpsc, Arc};
 
     #[test]
-    fn test_rasterizer_actor_basic() {
+    fn rasterizer_actor_basic_should_initialize_when_created() {
         // Step 1: Spawn with setup handle
         let (setup_handle, actor_thread) = RasterizerActor::<Rgba8>::spawn_with_setup(1);
 
@@ -274,7 +274,7 @@ mod tests {
     }
 
     #[test]
-    fn test_rasterizer_actor_thread_count_update() {
+    fn rasterizer_actor_thread_count_should_update_when_set() {
         // Spawn with setup
         let (setup_handle, actor_thread) = RasterizerActor::<Rgba8>::spawn_with_setup(2);
 
@@ -311,7 +311,7 @@ mod tests {
     }
 
     #[test]
-    fn test_rasterizer_actor_pause_resume() {
+    fn rasterizer_actor_should_pause_and_resume_when_commanded() {
         // Spawn with setup
         let (setup_handle, actor_thread) = RasterizerActor::<Rgba8>::spawn_with_setup(1);
 


### PR DESCRIPTION
Renamed `test_` prefixed tests in `core-term` to follow the `[method]_should_[outcome]_when_[condition]` format according to STYLE.md.

---
*PR created automatically by Jules for task [13299557675504774716](https://jules.google.com/task/13299557675504774716) started by @jppittman*