### PR TITLE
⚡ Bolt: Remove redundant sqrt before rsqrt

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,8 @@
 ## 2025-12-28 - Rasterizer Inner Loop Hoisting
 **Learning:** The inner loop of `execute_stripe` was re-evaluating `Field::sequential(start)` on every iteration, which involves multiple SIMD instructions (broadcast/load + add).
 **Action:** Hoisted the initialization of `xs` out of the loop and updated it incrementally using a pre-computed `step` vector. This reduced the inner loop overhead significantly, yielding a ~34% improvement in rasterization throughput.
+## 2024-05-24 - Redundant `.sqrt()` before `.rsqrt()`
+
+**Learning:** When calculating the inverse length of a squared vector (`n_len_sq`), using `.sqrt().rsqrt()` incorrectly applies the root twice (calculating $1/(x^{1/4})$ instead of the required $1/\sqrt{x}$) and involves an entirely redundant and computationally expensive operation. `.rsqrt()` alone is sufficient and mathematically correct for getting the inverse length from a squared length.
+
+**Action:** Always scan for redundant mathematical operations, especially chained roots or inverse roots in hot path graphics/vector math code. Use `.rsqrt()` directly on squared lengths for vector normalization to improve both accuracy and performance.

--- a/pixelflow-graphics/src/scene3d.rs
+++ b/pixelflow-graphics/src/scene3d.rs
@@ -598,7 +598,8 @@ impl<M: ManifoldCompat<Jet3, Output = Field>> Manifold<Jet3_4> for Reflect<M> {
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        // Optimization: removed redundant .sqrt() before .rsqrt()
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         // Normal components - evaluate at Jet3 construction boundary
         let nx = (cross_x * inv_n_len.clone()).constant();
@@ -686,7 +687,8 @@ impl<M: ManifoldCompat<Jet3, Output = Discrete>> Manifold<Jet3_4> for ColorRefle
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        // Optimization: removed redundant .sqrt() before .rsqrt()
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         // Normal components - evaluate at Jet3 construction boundary
         let nx = (cross_x * inv_n_len.clone()).constant();
@@ -793,7 +795,8 @@ where
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        // Optimization: removed redundant .sqrt() before .rsqrt()
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         let nx = (cross_x * inv_n_len.clone()).constant();
         let ny = (cross_y * inv_n_len.clone()).constant();
@@ -906,7 +909,8 @@ where
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        // Optimization: removed redundant .sqrt() before .rsqrt()
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         let nx = (cross_x * inv_n_len.clone()).constant();
         let ny = (cross_y * inv_n_len.clone()).constant();


### PR DESCRIPTION
### 💡 What
Removed redundant `.sqrt()` calls before `.rsqrt()` in the calculation of `inv_n_len` across four identical locations in `scene3d.rs`.

### 🎯 Why
When calculating the inverse length from a squared vector length (`n_len_sq`), chaining `.sqrt().rsqrt()` effectively calculates $1/(x^{1/4})$, which is mathematically incorrect for vector normalization and forces the CPU to perform an entirely redundant and expensive square root operation. `.rsqrt()` alone provides the correct $1/\sqrt{x}$ value.

### 📊 Impact
- **Performance:** Saves a redundant and computationally expensive square root calculation in the hot path of normal vector normalization, which is evaluated frequently during 3D scene construction and evaluation.
- **Correctness:** Fixes a bug where normal vectors were incorrectly normalized.

### 🔬 Measurement
This optimization can be verified by observing correct normal vector interpolation and shading in 3D scenes, and potentially measuring reduced cycle counts in microbenchmarks of the `Reflect` and `ColorReflect` manifold evaluations. The core test suite confirms no regressions in expected behavior.

---
*PR created automatically by Jules for task [149337290995254468](https://jules.google.com/task/149337290995254468) started by @jppittman*