### PR TITLE
Refactor `else if` chain to `match` in `osc_handler.rs`

### DIFF
--- a/core-term/src/term/emulator/osc_handler.rs
+++ b/core-term/src/term/emulator/osc_handler.rs
@@ -12,28 +12,32 @@ impl TerminalEmulator {
         let ps_str: &str;
         let content_str: &str;
 
-        if parts.len() == 1 {
-            // No semicolon found, treat the whole string as Ps, content is empty
-            ps_str = parts[0];
-            content_str = "";
-            // Log a debug message for this case, as it might be an implicit expectation
-            debug!(
-                "OSC sequence without semicolon: '{}'. Interpreting Ps='{}', Pt='{}'",
-                osc_str, ps_str, content_str
-            );
-        } else if parts.len() == 2 {
-            // Semicolon found, standard case
-            ps_str = parts[0];
-            content_str = parts[1];
-        } else {
-            // This case should ideally not be reached with splitn(2, ';')
-            // but handle defensively.
-            warn!(
-                "Malformed OSC sequence (unexpected parts count for {}): {}",
-                parts.len(),
-                osc_str
-            );
-            return None;
+        match parts.len() {
+            1 => {
+                // No semicolon found, treat the whole string as Ps, content is empty
+                ps_str = parts[0];
+                content_str = "";
+                // Log a debug message for this case, as it might be an implicit expectation
+                debug!(
+                    "OSC sequence without semicolon: '{}'. Interpreting Ps='{}', Pt='{}'",
+                    osc_str, ps_str, content_str
+                );
+            }
+            2 => {
+                // Semicolon found, standard case
+                ps_str = parts[0];
+                content_str = parts[1];
+            }
+            _ => {
+                // This case should ideally not be reached with splitn(2, ';')
+                // but handle defensively.
+                warn!(
+                    "Malformed OSC sequence (unexpected parts count for {}): {}",
+                    parts.len(),
+                    osc_str
+                );
+                return None;
+            }
         }
 
         // Attempt to parse Ps, default to 0 if parsing fails (e.g., "Implicit Title")


### PR DESCRIPTION
As per the instruction to enforce the `STYLE.md` guidelines, I found an occurrence of an `if-else if-else` chain in `core-term/src/term/emulator/osc_handler.rs` and refactored it into a `match` statement.

The original code:
```rust
if parts.len() == 1 {
    // ...
} else if parts.len() == 2 {
    // ...
} else {
    // ...
}
```

Has been refactored to:
```rust
match parts.len() {
    1 => {
        // ...
    }
    2 => {
        // ...
    }
    _ => {
        // ...
    }
}
```

This ensures architectural consistency according to the repo's style guidelines. Tested locally to ensure no logic was broken.

---
*PR created automatically by Jules for task [17362492787968907904](https://jules.google.com/task/17362492787968907904) started by @jppittman*