### PR TITLE
StyleEnforcer: Remove obvious 'What' comment in hce_extractor.rs

### DIFF
--- a/pixelflow-ml/src/hce_extractor.rs
+++ b/pixelflow-ml/src/hce_extractor.rs
@@ -635,7 +635,6 @@ pub fn correlation_loss(weights: &[i32], samples: &[(Expr, u64)]) -> f64 {
     let n_f = n as f64;
     let rho = 1.0 - (6.0 * sum_d2) / (n_f * (n_f * n_f - 1.0));
 
-    // Return 1 - correlation (so lower is better)
     1.0 - rho
 }
 


### PR DESCRIPTION
Removed an unnecessary comment explaining that the code returns 1 - correlation, which was already obvious from the return statement `1.0 - rho`. This addresses a violation of the StyleEnforcer guidelines (`docs/STYLE.md`).

---
*PR created automatically by Jules for task [1023064661833020911](https://jules.google.com/task/1023064661833020911) started by @jppittman*