### PR TITLE
StyleEnforcer: Enforce idiomatic assert! usage in tests

### DIFF
--- a/pixelflow-core/src/algebra.rs
+++ b/pixelflow-core/src/algebra.rs
@@ -559,21 +559,21 @@ mod tests {
 
     #[test]
     fn test_bool_algebra() {
-        assert_eq!(bool::zero(), false);
-        assert_eq!(bool::one(), true);
+        assert!(!bool::zero(), "Expected bool::zero() to be false");
+        assert!(bool::one(), "Expected bool::one() to be true");
 
         // Boolean ring (OR/AND)
-        assert_eq!(false.add(false), false);
-        assert_eq!(false.add(true), true);
-        assert_eq!(true.add(false), true);
-        assert_eq!(true.add(true), true);
+        assert!(!false.add(false), "Expected false.add(false) to be false");
+        assert!(false.add(true), "Expected false.add(true) to be true");
+        assert!(true.add(false), "Expected true.add(false) to be true");
+        assert!(true.add(true), "Expected true.add(true) to be true");
 
-        assert_eq!(false.mul(false), false);
-        assert_eq!(false.mul(true), false);
-        assert_eq!(true.mul(true), true);
+        assert!(!false.mul(false), "Expected false.mul(false) to be false");
+        assert!(!false.mul(true), "Expected false.mul(true) to be false");
+        assert!(true.mul(true), "Expected true.mul(true) to be true");
 
-        assert_eq!(true.neg(), false);
-        assert_eq!(false.neg(), true);
+        assert!(!true.neg(), "Expected true.neg() to be false");
+        assert!(false.neg(), "Expected false.neg() to be true");
     }
 
     #[test]

--- a/pixelflow-graphics/src/subdivision.rs
+++ b/pixelflow-graphics/src/subdivision.rs
@@ -505,7 +505,7 @@ f 1 2 3 4
 
         // For bilinear fallback, center should be roughly (0.5, 0.5, 0.0)
         // We can't easily check SIMD Field values in tests, so this is a smoke test
-        assert_eq!(patch.is_extraordinary(), true);
+        assert!(patch.is_extraordinary(), "Expected patch.is_extraordinary() to be true");
     }
 
     #[test]


### PR DESCRIPTION
- **Scope:** Refactored tests in `pixelflow-core/src/algebra.rs` and `pixelflow-graphics/src/subdivision.rs`.
- **Fixes:** Enforced idiomatic Rust test assertions (`assert!` over `assert_eq!(..., true)`) per `STYLE.md`. Added explicit failure messages for improved debugging context.
- **Unresolved Issues:** Some workspace crates have pre-existing test/compilation failures, which are explicitly out of scope for this task and left untouched.
- **Verification:** Ran `cargo test -p pixelflow-core` confirming modified unit tests compile and pass successfully. Cargo check on `pixelflow-graphics` failed due to pre-existing errors from baseline.

---
*PR created automatically by Jules for task [16922477896513752665](https://jules.google.com/task/16922477896513752665) started by @jppittman*