### PR TITLE
⚡ Bolt: Enforce test style guidelines in graphics and core

### DIFF
--- a/pixelflow-core/src/algebra.rs
+++ b/pixelflow-core/src/algebra.rs
@@ -513,7 +513,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_f32_algebra() {
+    fn f32_algebra_should_evaluate_correctly() {
         // Ring operations
         assert_eq!(f32::zero(), 0.0);
         assert_eq!(f32::one(), 1.0);
@@ -537,7 +537,7 @@ mod tests {
     // Transcendental tests only run on scalar fallback platforms
     #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
     #[test]
-    fn test_f32_transcendental() {
+    fn f32_transcendental_should_evaluate_correctly() {
         let epsilon = 1e-6;
 
         assert!((4.0f32.sqrt() - 2.0).abs() < epsilon);
@@ -558,26 +558,26 @@ mod tests {
     }
 
     #[test]
-    fn test_bool_algebra() {
-        assert_eq!(bool::zero(), false);
-        assert_eq!(bool::one(), true);
+    fn bool_algebra_should_evaluate_correctly() {
+        assert!(!bool::zero(), "bool::zero() must be false");
+        assert!(bool::one(), "bool::one() must be true");
 
         // Boolean ring (OR/AND)
-        assert_eq!(false.add(false), false);
-        assert_eq!(false.add(true), true);
-        assert_eq!(true.add(false), true);
-        assert_eq!(true.add(true), true);
+        assert!(!false.add(false), "false.add(false) must be false");
+        assert!(false.add(true), "false.add(true) must be true");
+        assert!(true.add(false), "true.add(false) must be true");
+        assert!(true.add(true), "true.add(true) must be true");
 
-        assert_eq!(false.mul(false), false);
-        assert_eq!(false.mul(true), false);
-        assert_eq!(true.mul(true), true);
+        assert!(!false.mul(false), "false.mul(false) must be false");
+        assert!(!false.mul(true), "false.mul(true) must be false");
+        assert!(true.mul(true), "true.mul(true) must be true");
 
-        assert_eq!(true.neg(), false);
-        assert_eq!(false.neg(), true);
+        assert!(!true.neg(), "true.neg() must be false");
+        assert!(false.neg(), "false.neg() must be true");
     }
 
     #[test]
-    fn test_u32_algebra() {
+    fn u32_algebra_should_evaluate_correctly() {
         assert_eq!(u32::zero(), 0);
         assert_eq!(u32::one(), 1);
         assert_eq!(2u32.add(3), 5);

--- a/pixelflow-core/src/ext.rs
+++ b/pixelflow-core/src/ext.rs
@@ -61,7 +61,7 @@ use crate::Manifold;
 use crate::combinators::{At, ClosureMap, Map, Select};
 use crate::ops::{
     Abs, Acos, Add, Asin, Atan, Atan2, Ceil, Clamp, Cos, Div, Eq, Exp, Exp2, Floor, Fract, Ge, Gt,
-    Hypot, Le, Ln, Log10, Log2, Lt, Max, Min, Mul, MulAdd, MulRsqrt, Ne, Neg, Pow, Recip, Round,
+    Hypot, Le, Ln, Log2, Log10, Lt, Max, Min, Mul, MulAdd, MulRsqrt, Ne, Neg, Pow, Recip, Round,
     Rsqrt, Sin, Sqrt, Sub, Tan,
 };
 

--- a/pixelflow-core/src/jet/jet2.rs
+++ b/pixelflow-core/src/jet/jet2.rs
@@ -753,8 +753,12 @@ impl Numeric for Jet2 {
         let db_coeff = result.raw_mul(half_inv_b);
         Self::new(
             result,
-            self.dx.raw_mul(da_coeff).raw_sub(other.dx.raw_mul(db_coeff)),
-            self.dy.raw_mul(da_coeff).raw_sub(other.dy.raw_mul(db_coeff)),
+            self.dx
+                .raw_mul(da_coeff)
+                .raw_sub(other.dx.raw_mul(db_coeff)),
+            self.dy
+                .raw_mul(da_coeff)
+                .raw_sub(other.dy.raw_mul(db_coeff)),
         )
     }
 
@@ -776,7 +780,11 @@ impl Numeric for Jet2 {
             lo.dy,
             Field::select_raw(mask_high, hi.dy, self.dy),
         );
-        Self { val: clamped, dx, dy }
+        Self {
+            val: clamped,
+            dx,
+            dy,
+        }
     }
 
     #[inline(always)]

--- a/pixelflow-core/src/jet/jet2h.rs
+++ b/pixelflow-core/src/jet/jet2h.rs
@@ -1025,7 +1025,14 @@ impl Numeric for Jet2H {
 
     #[inline(always)]
     fn fract(self) -> Self {
-        Self::new(self.val.fract(), self.dx, self.dy, self.dxx, self.dxy, self.dyy)
+        Self::new(
+            self.val.fract(),
+            self.dx,
+            self.dy,
+            self.dxx,
+            self.dxy,
+            self.dyy,
+        )
     }
 
     #[inline(always)]
@@ -1058,11 +1065,31 @@ impl Numeric for Jet2H {
         let clamped = self.val.clamp(lo.val, hi.val);
         Self {
             val: clamped,
-            dx: Field::select_raw(mask_low, lo.dx, Field::select_raw(mask_high, hi.dx, self.dx)),
-            dy: Field::select_raw(mask_low, lo.dy, Field::select_raw(mask_high, hi.dy, self.dy)),
-            dxx: Field::select_raw(mask_low, lo.dxx, Field::select_raw(mask_high, hi.dxx, self.dxx)),
-            dxy: Field::select_raw(mask_low, lo.dxy, Field::select_raw(mask_high, hi.dxy, self.dxy)),
-            dyy: Field::select_raw(mask_low, lo.dyy, Field::select_raw(mask_high, hi.dyy, self.dyy)),
+            dx: Field::select_raw(
+                mask_low,
+                lo.dx,
+                Field::select_raw(mask_high, hi.dx, self.dx),
+            ),
+            dy: Field::select_raw(
+                mask_low,
+                lo.dy,
+                Field::select_raw(mask_high, hi.dy, self.dy),
+            ),
+            dxx: Field::select_raw(
+                mask_low,
+                lo.dxx,
+                Field::select_raw(mask_high, hi.dxx, self.dxx),
+            ),
+            dxy: Field::select_raw(
+                mask_low,
+                lo.dxy,
+                Field::select_raw(mask_high, hi.dxy, self.dxy),
+            ),
+            dyy: Field::select_raw(
+                mask_low,
+                lo.dyy,
+                Field::select_raw(mask_high, hi.dyy, self.dyy),
+            ),
         }
     }
 
@@ -1110,7 +1137,9 @@ impl Numeric for Jet2H {
 
     #[inline(always)]
     fn raw_neg(self) -> Self {
-        Self::new(-self.val, -self.dx, -self.dy, -self.dxx, -self.dxy, -self.dyy)
+        Self::new(
+            -self.val, -self.dx, -self.dy, -self.dxx, -self.dxy, -self.dyy,
+        )
     }
 }
 

--- a/pixelflow-core/src/jet/jet3.rs
+++ b/pixelflow-core/src/jet/jet3.rs
@@ -403,12 +403,7 @@ impl Jet3 {
     /// via operator overloads, not call raw SIMD operations directly.
     #[inline(always)]
     pub(crate) fn scale(self, s: Field) -> Jet3 {
-        Jet3::new(
-            self.val * s,
-            self.dx * s,
-            self.dy * s,
-            self.dz * s,
-        )
+        Jet3::new(self.val * s, self.dx * s, self.dy * s, self.dz * s)
     }
 }
 
@@ -865,9 +860,15 @@ impl Numeric for Jet3 {
         let db_coeff = result.raw_mul(half_inv_b);
         Self::new(
             result,
-            self.dx.raw_mul(da_coeff).raw_sub(other.dx.raw_mul(db_coeff)),
-            self.dy.raw_mul(da_coeff).raw_sub(other.dy.raw_mul(db_coeff)),
-            self.dz.raw_mul(da_coeff).raw_sub(other.dz.raw_mul(db_coeff)),
+            self.dx
+                .raw_mul(da_coeff)
+                .raw_sub(other.dx.raw_mul(db_coeff)),
+            self.dy
+                .raw_mul(da_coeff)
+                .raw_sub(other.dy.raw_mul(db_coeff)),
+            self.dz
+                .raw_mul(da_coeff)
+                .raw_sub(other.dz.raw_mul(db_coeff)),
         )
     }
 
@@ -891,7 +892,12 @@ impl Numeric for Jet3 {
             lo.dz,
             Field::select_raw(mask_high, hi.dz, self.dz),
         );
-        Self { val: clamped, dx, dy, dz }
+        Self {
+            val: clamped,
+            dx,
+            dy,
+            dz,
+        }
     }
 
     #[inline(always)]

--- a/pixelflow-core/src/ops/base.rs
+++ b/pixelflow-core/src/ops/base.rs
@@ -30,8 +30,9 @@
 //! This uses fast rsqrt (~3 cycles) instead of sqrt (~12) + div (~12).
 
 use super::{
-    Abs, Acos, Add, AddMasked, Asin, Atan, Ceil, Cos, Div, Exp, Exp2, Floor, Fract, Ln, Log10,
-    Log2, Max, Min, Mul, MulAdd, MulRecip, MulRsqrt, Neg, Recip, Round, Rsqrt, Sin, Sqrt, Sub, Tan,
+    Abs, Acos, Add, AddMasked, Asin, Atan, Ceil, Cos, Div, Exp, Exp2, Floor, Fract, Ln, Log2,
+    Log10, Max, Min, Mul, MulAdd, MulRecip, MulRsqrt, Neg, Recip, Round, Rsqrt, Sin, Sqrt, Sub,
+    Tan,
 };
 use crate::Field;
 use crate::combinators::Select;

--- a/pixelflow-core/src/ops/binary.rs
+++ b/pixelflow-core/src/ops/binary.rs
@@ -17,9 +17,9 @@
 //! let auto = x / Sqrt(y);            // Becomes Mul<X, Rsqrt<Y>> at compile time!
 //! ```
 
+use crate::Field;
 use crate::Manifold;
 use crate::jet::Jet3;
-use crate::Field;
 use pixelflow_compiler::Element;
 
 /// Addition: L + R

--- a/pixelflow-core/src/ops/derivative.rs
+++ b/pixelflow-core/src/ops/derivative.rs
@@ -24,10 +24,10 @@
 //! let aa = Antialias2D(sdf);  // Evaluates sdf ONCE, divides by gradient mag
 //! ```
 
-use crate::combinators::binding::{Let, Var, N0, N1, N2};
-use crate::ext::ManifoldExt;
 use crate::Field;
 use crate::Manifold;
+use crate::combinators::binding::{Let, N0, N1, N2, Var};
+use crate::ext::ManifoldExt;
 use pixelflow_compiler::Element;
 
 // ============================================================================
@@ -375,7 +375,11 @@ where
         let expr = v0 / (v1 * v1 + v2 * v2 + v3 * v3).sqrt();
 
         // Bind and eval
-        Let::new(dz_val, Let::new(dy_val, Let::new(dx_val, Let::new(val, expr)))).eval(p)
+        Let::new(
+            dz_val,
+            Let::new(dy_val, Let::new(dx_val, Let::new(val, expr))),
+        )
+        .eval(p)
     }
 }
 
@@ -484,11 +488,11 @@ where
         let expr = numerator / denominator;
 
         // Bind all values (outermost = deepest Var index)
-        Let::new(fyy,
-            Let::new(fxy,
-                Let::new(fxx,
-                    Let::new(fy,
-                        Let::new(fx, expr))))).eval(p)
+        Let::new(
+            fyy,
+            Let::new(fxy, Let::new(fxx, Let::new(fy, Let::new(fx, expr)))),
+        )
+        .eval(p)
     }
 }
 
@@ -528,7 +532,6 @@ where
         self.0.eval(p).val()
     }
 }
-
 
 // ============================================================================
 // DxOf: Extract .dx() from any domain where output has derivatives

--- a/pixelflow-core/tests/test_kernel_5params.rs
+++ b/pixelflow-core/tests/test_kernel_5params.rs
@@ -2,8 +2,8 @@
 //!
 //! This is the key test - the old nested Let approach failed with >4 params.
 
-use pixelflow_core::{Field, Manifold};
 use pixelflow_compiler::kernel;
+use pixelflow_core::{Field, Manifold};
 
 type Field4 = (Field, Field, Field, Field);
 
@@ -12,9 +12,7 @@ fn test_kernel_5_params_compiles() {
     // THE KEY TEST: This should now compile with 5 params!
     // The old nested Let approach caused trait solver explosion at this point.
 
-    let k = kernel!(|a: f32, b: f32, c: f32, d: f32, e: f32| {
-        a + b + c + d + e
-    });
+    let k = kernel!(|a: f32, b: f32, c: f32, d: f32, e: f32| { a + b + c + d + e });
 
     // Construct the kernel - if this compiles, we've proven WithContext works!
     let _kernel_instance = k(1.0, 2.0, 3.0, 4.0, 5.0);
@@ -25,9 +23,7 @@ fn test_kernel_5_params_compiles() {
 #[test]
 fn test_kernel_6_params_compiles() {
     // Test 6 parameters
-    let k = kernel!(|a: f32, b: f32, c: f32, d: f32, e: f32, f: f32| {
-        a + b + c + d + e + f
-    });
+    let k = kernel!(|a: f32, b: f32, c: f32, d: f32, e: f32, f: f32| { a + b + c + d + e + f });
 
     let _kernel_instance = k(1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
 }
@@ -47,9 +43,11 @@ fn test_kernel_8_params_compiles() {
     // Even more ambitious - 8 parameters!
     // This would definitely fail with nested Let.
 
-    let k = kernel!(|a: f32, b: f32, c: f32, d: f32, e: f32, f: f32, g: f32, h: f32| {
-        a + b + c + d + e + f + g + h
-    });
+    let k = kernel!(
+        |a: f32, b: f32, c: f32, d: f32, e: f32, f: f32, g: f32, h: f32| {
+            a + b + c + d + e + f + g + h
+        }
+    );
 
     let _kernel_instance = k(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
 
@@ -59,21 +57,21 @@ fn test_kernel_8_params_compiles() {
 #[test]
 fn test_jet_kernel_with_param() {
     use pixelflow_compiler::kernel;
-    use pixelflow_core::{Manifold, Y, jet::Jet3, Field};
-    
+    use pixelflow_core::{Field, Manifold, Y, jet::Jet3};
+
     type Jet3_4 = (Jet3, Jet3, Jet3, Jet3);
-    
+
     // Test that 1-parameter Jet kernel compiles and evaluates
     let k = kernel!(|h: f32| -> Jet3 { h / Y });
     let f = k(5.0);
-    
+
     let p: Jet3_4 = (
         Jet3::from(Field::from(1.0)),
         Jet3::from(Field::from(2.0)),
         Jet3::from(Field::from(3.0)),
         Jet3::from(Field::from(4.0)),
     );
-    
+
     let _result = f.eval(p);
     // If it compiles and evaluates, the test passes
 }

--- a/pixelflow-core/tests/test_sphere_debug.rs
+++ b/pixelflow-core/tests/test_sphere_debug.rs
@@ -1,7 +1,7 @@
 //! Debug: test if sphere_at returns valid t values
+use pixelflow_compiler::kernel;
 use pixelflow_core::jet::Jet3;
 use pixelflow_core::{Field, Manifold, ManifoldExt};
-use pixelflow_compiler::kernel;
 
 type Jet3_4 = (Jet3, Jet3, Jet3, Jet3);
 
@@ -19,16 +19,12 @@ fn sphere_at(cx: f32, cy: f32, cz: f32, r: f32) -> impl Manifold<Jet3_4, Output 
 
 // Simple test: just return a parameter
 fn simple_return_param(val: f32) -> impl Manifold<Jet3_4, Output = Jet3> + Clone {
-    kernel!(|val: f32| -> Jet3 {
-        val
-    })(val)
+    kernel!(|val: f32| -> Jet3 { val })(val)
 }
 
 // Test: X + param
 fn x_plus_param(val: f32) -> impl Manifold<Jet3_4, Output = Jet3> + Clone {
-    kernel!(|val: f32| -> Jet3 {
-        X + val
-    })(val)
+    kernel!(|val: f32| -> Jet3 { X + val })(val)
 }
 
 #[test]
@@ -45,7 +41,10 @@ fn test_simple_param() {
     let low = Field::from(41.9);
     let high = Field::from(42.1);
     let in_range = result.val.gt(low) & result.val.lt(high);
-    assert!(in_range.all(), "simple_return_param(42.0) should return ~42.0");
+    assert!(
+        in_range.all(),
+        "simple_return_param(42.0) should return ~42.0"
+    );
 }
 
 #[test]
@@ -63,36 +62,38 @@ fn test_x_plus_param() {
     let low = Field::from(14.9);
     let high = Field::from(15.1);
     let in_range = result.val.gt(low) & result.val.lt(high);
-    assert!(in_range.all(), "x_plus_param(10) with X=5 should return ~15.0");
+    assert!(
+        in_range.all(),
+        "x_plus_param(10) with X=5 should return ~15.0"
+    );
 }
 
 // Test d_dot_c = X * cx + Y * cy + Z * cz
 // For ray (0, 0, 1) and center (0, 0, 4): d_dot_c = 0*0 + 0*0 + 1*4 = 4
 fn test_d_dot_c(cx: f32, cy: f32, cz: f32) -> impl Manifold<Jet3_4, Output = Jet3> + Clone {
-    kernel!(|cx: f32, cy: f32, cz: f32| -> Jet3 {
-        X * cx + Y * cy + Z * cz
-    })(cx, cy, cz)
+    kernel!(|cx: f32, cy: f32, cz: f32| -> Jet3 { X * cx + Y * cy + Z * cz })(cx, cy, cz)
 }
 
 // Test c_sq = cx*cx + cy*cy + cz*cz (should be 16 for center at (0,0,4))
 // Returns Field since this only computes with scalar params
 fn test_c_sq(cx: f32, cy: f32, cz: f32) -> impl Manifold<Jet3_4, Output = Field> + Clone {
-    kernel!(|cx: f32, cy: f32, cz: f32| -> Field {
-        cx * cx + cy * cy + cz * cz
-    })(cx, cy, cz)
+    kernel!(|cx: f32, cy: f32, cz: f32| -> Field { cx * cx + cy * cy + cz * cz })(cx, cy, cz)
 }
 
 // Test: just r*r (should be 1 for r=1)
 // Returns Field since this only computes with scalar params
 fn test_r_sq(r: f32) -> impl Manifold<Jet3_4, Output = Field> + Clone {
-    kernel!(|r: f32| -> Field {
-        r * r
-    })(r)
+    kernel!(|r: f32| -> Field { r * r })(r)
 }
 
 // Test: c_sq - r_sq (should be 15 for c_sq=16, r_sq=1)
 // Returns Field since this only computes with scalar params
-fn test_c_sq_minus_r_sq(cx: f32, cy: f32, cz: f32, r: f32) -> impl Manifold<Jet3_4, Output = Field> + Clone {
+fn test_c_sq_minus_r_sq(
+    cx: f32,
+    cy: f32,
+    cz: f32,
+    r: f32,
+) -> impl Manifold<Jet3_4, Output = Field> + Clone {
     kernel!(|cx: f32, cy: f32, cz: f32, r: f32| -> Field {
         let c_sq = cx * cx + cy * cy + cz * cz;
         let r_sq = r * r;
@@ -110,7 +111,12 @@ fn test_d_dot_c_sq(cx: f32, cy: f32, cz: f32) -> impl Manifold<Jet3_4, Output = 
 
 // Test discriminant = d_dot_c² - (c_sq - r_sq)
 // = 4*4 - (16 - 1) = 16 - 15 = 1
-fn test_discriminant(cx: f32, cy: f32, cz: f32, r: f32) -> impl Manifold<Jet3_4, Output = Jet3> + Clone {
+fn test_discriminant(
+    cx: f32,
+    cy: f32,
+    cz: f32,
+    r: f32,
+) -> impl Manifold<Jet3_4, Output = Jet3> + Clone {
     kernel!(|cx: f32, cy: f32, cz: f32, r: f32| -> Jet3 {
         let d_dot_c = X * cx + Y * cy + Z * cz;
         let c_sq = cx * cx + cy * cy + cz * cz;
@@ -252,5 +258,8 @@ fn test_sphere_hit() {
 
     // t > 2 and t < 4 (should be ~3.0)
     let in_range = t.val.gt(two) & t.val.lt(four);
-    assert!(in_range.all(), "t should be between 2 and 4 (expected ~3.0)");
+    assert!(
+        in_range.all(),
+        "t should be between 2 and 4 (expected ~3.0)"
+    );
 }

--- a/pixelflow-graphics/benches/font_rendering.rs
+++ b/pixelflow-graphics/benches/font_rendering.rs
@@ -65,13 +65,17 @@ fn bench_pixelflow_threading(c: &mut Criterion) {
     let colored = Grayscale(glyph);
 
     for threads in [1, 2, 4, 8] {
-        group.bench_with_input(BenchmarkId::from_parameter(threads), &threads, |b, &threads| {
-            let mut frame = Frame::<Rgba8>::new(360, 24);
+        group.bench_with_input(
+            BenchmarkId::from_parameter(threads),
+            &threads,
+            |b, &threads| {
+                let mut frame = Frame::<Rgba8>::new(360, 24);
 
-            b.iter(|| {
-                rasterize(black_box(&colored), black_box(&mut frame), threads);
-            });
-        });
+                b.iter(|| {
+                    rasterize(black_box(&colored), black_box(&mut frame), threads);
+                });
+            },
+        );
     }
 
     group.finish();
@@ -132,7 +136,8 @@ fn bench_freetype_single_char(c: &mut Criterion) {
             face.set_char_size(0, 32 * 64, 96, 96).unwrap();
 
             b.iter(|| {
-                face.load_char(ch as usize, ft::face::LoadFlag::RENDER).unwrap();
+                face.load_char(ch as usize, ft::face::LoadFlag::RENDER)
+                    .unwrap();
                 let glyph = face.glyph();
                 black_box(glyph.bitmap());
             });
@@ -157,7 +162,8 @@ fn bench_freetype_text(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::from_parameter(length), &length, |b, _| {
             b.iter(|| {
                 for ch in text_str.chars() {
-                    face.load_char(ch as usize, ft::face::LoadFlag::RENDER).unwrap();
+                    face.load_char(ch as usize, ft::face::LoadFlag::RENDER)
+                        .unwrap();
                     let glyph = face.glyph();
                     black_box(glyph.bitmap());
                 }

--- a/pixelflow-graphics/benches/kernel_bench.rs
+++ b/pixelflow-graphics/benches/kernel_bench.rs
@@ -3,8 +3,8 @@
 //! Tests the effectiveness of the e-graph optimizer on complex algebraic expressions.
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
-use pixelflow_core::{Field, ManifoldCompat, ManifoldExt, PARALLELISM, X, Y};
 use pixelflow_compiler::kernel;
+use pixelflow_core::{Field, ManifoldCompat, ManifoldExt, PARALLELISM, X, Y};
 
 /// Complex polynomial: f(x, y) = x³ + 2x²y + 3xy² + y³
 /// Manual construction (no automatic fusion anymore)
@@ -17,9 +17,7 @@ pub fn manual_poly(x: Field, y: Field) -> Field {
 /// Same polynomial using kernel! (optimized by e-graph)
 #[inline(never)]
 pub fn kernel_poly(x: Field, y: Field) -> Field {
-    let k = kernel!(|| {
-        X * X * X + X * X * Y * 2.0 + X * Y * Y * 3.0 + Y * Y * Y
-    });
+    let k = kernel!(|| { X * X * X + X * X * Y * 2.0 + X * Y * Y * 3.0 + Y * Y * Y });
     k().eval_raw(x, y, Field::from(0.0), Field::from(0.0))
 }
 

--- a/pixelflow-graphics/examples/chrome_asm.rs
+++ b/pixelflow-graphics/examples/chrome_asm.rs
@@ -2,13 +2,13 @@
 //!
 //! Run: cargo-asm -p pixelflow-graphics --example chrome_asm eval_one_pixel --release
 
+use pixelflow_compiler::ManifoldExpr;
 use pixelflow_core::combinators::At;
 use pixelflow_core::jet::Jet3;
 use pixelflow_core::{Discrete, Field, Manifold, ManifoldCompat};
 use pixelflow_graphics::render::color::RgbaColorCube;
-use pixelflow_compiler::ManifoldExpr;
 use pixelflow_graphics::scene3d::{
-    ColorChecker, ColorReflect, ColorScreenToDir, ColorSky, ColorSurface, plane,
+    plane, ColorChecker, ColorReflect, ColorScreenToDir, ColorSky, ColorSurface,
 };
 
 type Field4 = (Field, Field, Field, Field);
@@ -87,7 +87,9 @@ pub fn eval_one_pixel(x: Field, y: Field) -> Discrete {
             center: (0.0, 0.0, 4.0),
             radius: 1.0,
         },
-        material: ColorReflect { inner: world.clone() },
+        material: ColorReflect {
+            inner: world.clone(),
+        },
         background: world,
     };
 

--- a/pixelflow-graphics/examples/compose_test.rs
+++ b/pixelflow-graphics/examples/compose_test.rs
@@ -1,11 +1,16 @@
 //! Testing kernel composition patterns
-use pixelflow_core::{Field, Manifold};
 use pixelflow_compiler::kernel;
+use pixelflow_core::{Field, Manifold};
 
 type Field4 = (Field, Field, Field, Field);
 
 fn field4(x: f32, y: f32) -> Field4 {
-    (Field::from(x), Field::from(y), Field::from(0.0), Field::from(0.0))
+    (
+        Field::from(x),
+        Field::from(y),
+        Field::from(0.0),
+        Field::from(0.0),
+    )
 }
 
 fn main() {
@@ -33,5 +38,8 @@ fn main() {
 
     let c = circle(1.0, 2.0, 0.5);
     let result2 = c.eval(p);
-    println!("circle(center=(1.0, 2.0), r=0.5) at (1.5, 2.0): {:?}", result2);
+    println!(
+        "circle(center=(1.0, 2.0), r=0.5) at (1.5, 2.0): {:?}",
+        result2
+    );
 }

--- a/pixelflow-graphics/examples/kernel_scale_test.rs
+++ b/pixelflow-graphics/examples/kernel_scale_test.rs
@@ -1,15 +1,20 @@
-use pixelflow_core::{Field, Manifold, ManifoldExt};
 use pixelflow_compiler::kernel;
+use pixelflow_core::{Field, Manifold, ManifoldExt};
 
 type Field4 = (Field, Field, Field, Field);
 
 fn field4(x: f32, y: f32, z: f32, w: f32) -> Field4 {
-    (Field::from(x), Field::from(y), Field::from(z), Field::from(w))
+    (
+        Field::from(x),
+        Field::from(y),
+        Field::from(z),
+        Field::from(w),
+    )
 }
 
 fn main() {
     let p = field4(1.0, 2.0, 3.0, 4.0);
-    
+
     // 20 different 4-param kernels (no division with Var)
     let k1 = kernel!(|a: f32, b: f32, c: f32, d: f32| X + a + Y * b);
     let k2 = kernel!(|a: f32, b: f32, c: f32, d: f32| X - a + Y * b);
@@ -30,28 +35,32 @@ fn main() {
     let k17 = kernel!(|a: f32, b: f32, c: f32, d: f32| X * a * Y * b);
     let k18 = kernel!(|a: f32, b: f32, c: f32, d: f32| (X * X + Y * Y).sqrt() - a);
     let k19 = kernel!(|a: f32, b: f32, c: f32, d: f32| (X * X + Y * Y + Z * Z).sqrt() - a);
-    let k20 = kernel!(|a: f32, b: f32, c: f32, d: f32| { let dx = X - a; let dy = Y - b; (dx * dx + dy * dy).sqrt() });
-    
+    let k20 = kernel!(|a: f32, b: f32, c: f32, d: f32| {
+        let dx = X - a;
+        let dy = Y - b;
+        (dx * dx + dy * dy).sqrt()
+    });
+
     // Use them all to prevent DCE
     let v = 1.0f32;
-    let _ = k1(v,v,v,v).eval(p);
-    let _ = k2(v,v,v,v).eval(p);
-    let _ = k3(v,v,v,v).eval(p);
-    let _ = k4(v,v,v,v).eval(p);
-    let _ = k5(v,v,v,v).eval(p);
-    let _ = k6(v,v,v,v).eval(p);
-    let _ = k7(v,v,v,v).eval(p);
-    let _ = k8(v,v,v,v).eval(p);
-    let _ = k9(v,v,v,v).eval(p);
-    let _ = k10(v,v,v,v).eval(p);
-    let _ = k11(v,v,v,v).eval(p);
-    let _ = k12(v,v,v,v).eval(p);
-    let _ = k13(v,v,v,v).eval(p);
-    let _ = k14(v,v,v,v).eval(p);
-    let _ = k15(v,v,v,v).eval(p);
-    let _ = k16(v,v,v,v).eval(p);
-    let _ = k17(v,v,v,v).eval(p);
-    let _ = k18(v,v,v,v).eval(p);
-    let _ = k19(v,v,v,v).eval(p);
-    let _ = k20(v,v,v,v).eval(p);
+    let _ = k1(v, v, v, v).eval(p);
+    let _ = k2(v, v, v, v).eval(p);
+    let _ = k3(v, v, v, v).eval(p);
+    let _ = k4(v, v, v, v).eval(p);
+    let _ = k5(v, v, v, v).eval(p);
+    let _ = k6(v, v, v, v).eval(p);
+    let _ = k7(v, v, v, v).eval(p);
+    let _ = k8(v, v, v, v).eval(p);
+    let _ = k9(v, v, v, v).eval(p);
+    let _ = k10(v, v, v, v).eval(p);
+    let _ = k11(v, v, v, v).eval(p);
+    let _ = k12(v, v, v, v).eval(p);
+    let _ = k13(v, v, v, v).eval(p);
+    let _ = k14(v, v, v, v).eval(p);
+    let _ = k15(v, v, v, v).eval(p);
+    let _ = k16(v, v, v, v).eval(p);
+    let _ = k17(v, v, v, v).eval(p);
+    let _ = k18(v, v, v, v).eval(p);
+    let _ = k19(v, v, v, v).eval(p);
+    let _ = k20(v, v, v, v).eval(p);
 }

--- a/pixelflow-graphics/src/fonts/ttf.rs
+++ b/pixelflow-graphics/src/fonts/ttf.rs
@@ -6,11 +6,8 @@
 //! All derivatives are precomputed polynomials - no Jets needed!
 
 use crate::shapes::{square, Bounded};
-use pixelflow_core::{
-    At, Field, Manifold, ManifoldCompat, ManifoldExt,
-    W, Z,
-};
 use pixelflow_compiler::kernel;
+use pixelflow_core::{At, Field, Manifold, ManifoldCompat, ManifoldExt, W, Z};
 use std::sync::Arc;
 
 // Import analytical curve kernels
@@ -18,7 +15,6 @@ use super::ttf_curve_analytical::{AnalyticalLine, AnalyticalQuad};
 
 /// The standard 4D Field domain type.
 type Field4 = (Field, Field, Field, Field);
-
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Type Aliases for Concrete Kernel Types
@@ -92,7 +88,6 @@ impl<M: Manifold<Field4, Output = Field>> Manifold<Field4> for Sum<M> {
     }
 }
 
-
 // ═══════════════════════════════════════════════════════════════════════════
 // Geometry
 // ═══════════════════════════════════════════════════════════════════════════
@@ -146,7 +141,6 @@ impl<K: Manifold<Field4, Output = Field>> Manifold<Field4> for Line<K> {
     }
 }
 
-
 impl<K: Manifold<Field4, Output = Field>> Manifold<Field4> for Quad<K> {
     type Output = Field;
 
@@ -156,7 +150,6 @@ impl<K: Manifold<Field4, Output = Field>> Manifold<Field4> for Quad<K> {
         self.kernel.eval_raw(x, y, z, w)
     }
 }
-
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Glyph (Compositional Scene Graph)
@@ -202,7 +195,6 @@ impl<L: Manifold<Field4, Output = Field>, Q: Manifold<Field4, Output = Field>> M
             .eval_raw(fzero, fzero, fzero, fzero)
     }
 }
-
 
 /// A simple glyph: segments in unit space, bounded, then transformed.
 ///
@@ -290,7 +282,6 @@ where
         }
     }
 }
-
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Reader
@@ -554,11 +545,9 @@ impl<'a> Font<'a> {
                         ENCODING_WINDOWS_UNICODE_FULL,
                         FORMAT_SEGMENTED_COVERAGE,
                     )
-                    | (
-                        PLATFORM_UNICODE,
-                        ENCODING_UNICODE_2_0_FULL,
-                        FORMAT_SEGMENTED_COVERAGE,
-                    ) => Some((2, o, f)),
+                    | (PLATFORM_UNICODE, ENCODING_UNICODE_2_0_FULL, FORMAT_SEGMENTED_COVERAGE) => {
+                        Some((2, o, f))
+                    }
 
                     (PLATFORM_WINDOWS, ENCODING_WINDOWS_UNICODE_BMP, FORMAT_SEGMENT_MAPPING)
                     | (PLATFORM_UNICODE, ENCODING_UNICODE_2_0_BMP, FORMAT_SEGMENT_MAPPING) => {
@@ -590,10 +579,7 @@ impl<'a> Font<'a> {
 
     /// Get glyph by pre-looked-up glyph ID (avoids redundant CMAP lookup).
     #[inline]
-    pub fn glyph_by_id(
-        &self,
-        id: u16,
-    ) -> Option<Glyph<Line<LineKernel>, Quad<QuadKernel>>> {
+    pub fn glyph_by_id(&self, id: u16) -> Option<Glyph<Line<LineKernel>, Quad<QuadKernel>>> {
         self.compile(id)
     }
 

--- a/pixelflow-graphics/src/fonts/ttf_curve_analytical.rs
+++ b/pixelflow-graphics/src/fonts/ttf_curve_analytical.rs
@@ -10,8 +10,8 @@
 //! hard step (0 or 1), not a smooth ramp. Geometry::eval applies
 //! abs().min(1.0) to convert winding to inside/outside coverage.
 
-use pixelflow_core::{Field, Manifold, ManifoldExt, W, X, Y, Z};
 use pixelflow_compiler::kernel;
+use pixelflow_core::{Field, Manifold, ManifoldExt, W, X, Y, Z};
 
 type Field4 = (Field, Field, Field, Field);
 
@@ -150,8 +150,15 @@ impl Manifold<Field4> for AnalyticalQuad {
 
         // True quadratic: solve ay*t^2 + by*t + (cy - Y) = 0
         // discriminant = by^2 - 4*ay*(cy - Y) = disc_const + disc_slope*Y
-        let k = kernel!(|ax: f32, bx: f32, cx: f32, ay: f32, by: f32,
-                         inv_2a: f32, neg_b_2a: f32, disc_const: f32, disc_slope: f32| {
+        let k = kernel!(|ax: f32,
+                         bx: f32,
+                         cx: f32,
+                         ay: f32,
+                         by: f32,
+                         inv_2a: f32,
+                         neg_b_2a: f32,
+                         disc_const: f32,
+                         disc_slope: f32| {
             let disc = Y * disc_slope + disc_const;
             let sqrt_disc = disc.max(0.0).sqrt();
 
@@ -160,7 +167,9 @@ impl Manifold<Field4> for AnalyticalQuad {
             let t_minus = sqrt_disc * -inv_2a + neg_b_2a;
 
             // X-coordinates at intersection points
-            let x_plus = t_plus.clone() * t_plus.clone() * ax.clone() + t_plus.clone() * bx.clone() + cx.clone();
+            let x_plus = t_plus.clone() * t_plus.clone() * ax.clone()
+                + t_plus.clone() * bx.clone()
+                + cx.clone();
             let x_minus = t_minus.clone() * t_minus.clone() * ax + t_minus.clone() * bx + cx;
 
             // Tangent dy/dt at each root for winding direction
@@ -185,7 +194,17 @@ impl Manifold<Field4> for AnalyticalQuad {
             disc.ge(0.0).select(contrib_plus + contrib_minus, 0.0)
         });
 
-        k(self.ax, self.bx, self.cx, self.ay, self.by,
-          self.inv_2ay, self.neg_b_2a, self.disc_const, self.disc_slope).eval(p)
+        k(
+            self.ax,
+            self.bx,
+            self.cx,
+            self.ay,
+            self.by,
+            self.inv_2ay,
+            self.neg_b_2a,
+            self.disc_const,
+            self.disc_slope,
+        )
+        .eval(p)
     }
 }

--- a/pixelflow-graphics/src/lib.rs
+++ b/pixelflow-graphics/src/lib.rs
@@ -1,4 +1,3 @@
-
 //! # PixelFlow Graphics
 //!
 //! Turns **algebraic manifolds into pixels** through three composable tiers: colors, fonts, and materialization.

--- a/pixelflow-graphics/src/render/color.rs
+++ b/pixelflow-graphics/src/render/color.rs
@@ -206,9 +206,21 @@ const fn generate_palette() -> [u32; 256] {
             let r_comp = (cube_idx / (COLOR_CUBE_SIZE * COLOR_CUBE_SIZE)) % COLOR_CUBE_SIZE;
             let g_comp = (cube_idx / COLOR_CUBE_SIZE) % COLOR_CUBE_SIZE;
             let b_comp = cube_idx % COLOR_CUBE_SIZE;
-            let r_val = if r_comp == 0 { 0 } else { r_comp * CUBE_SCALE_FACTOR + CUBE_BASE_OFFSET };
-            let g_val = if g_comp == 0 { 0 } else { g_comp * CUBE_SCALE_FACTOR + CUBE_BASE_OFFSET };
-            let b_val = if b_comp == 0 { 0 } else { b_comp * CUBE_SCALE_FACTOR + CUBE_BASE_OFFSET };
+            let r_val = if r_comp == 0 {
+                0
+            } else {
+                r_comp * CUBE_SCALE_FACTOR + CUBE_BASE_OFFSET
+            };
+            let g_val = if g_comp == 0 {
+                0
+            } else {
+                g_comp * CUBE_SCALE_FACTOR + CUBE_BASE_OFFSET
+            };
+            let b_val = if b_comp == 0 {
+                0
+            } else {
+                b_comp * CUBE_SCALE_FACTOR + CUBE_BASE_OFFSET
+            };
             (r_val, g_val, b_val)
         } else {
             // Grayscale ramp (indices 232-255)

--- a/pixelflow-graphics/src/render/rasterizer/mod.rs
+++ b/pixelflow-graphics/src/render/rasterizer/mod.rs
@@ -271,7 +271,12 @@ where
         let mut xs = Field::sequential(x as f32 + 0.5);
         let step = Field::from(PARALLELISM as f32);
         // Field ignores the domain arguments, so we pass zeroes. Hoisted to avoid reconstruction.
-        let dummy_domain = (Field::from(0.0), Field::from(0.0), Field::from(0.0), Field::from(0.0));
+        let dummy_domain = (
+            Field::from(0.0),
+            Field::from(0.0),
+            Field::from(0.0),
+            Field::from(0.0),
+        );
 
         // SIMD Hot Path - process PARALLELISM pixels at a time
         while x + PARALLELISM <= stripe.width {

--- a/pixelflow-graphics/src/scene3d.rs
+++ b/pixelflow-graphics/src/scene3d.rs
@@ -13,9 +13,9 @@
 //!
 //! No iteration. Nesting is occlusion.
 
+use pixelflow_compiler::{kernel, ManifoldExpr};
 use pixelflow_core::jet::Jet3;
 use pixelflow_core::*;
-use pixelflow_compiler::{kernel, ManifoldExpr};
 
 /// The standard 4D Field domain type.
 type Field4 = (Field, Field, Field, Field);
@@ -1136,7 +1136,10 @@ impl<C: ManifoldCompat<Field, Output = Discrete>> Manifold<Jet3_4> for ColorChec
         // Coverage: how much of the pixel is in this cell vs neighbor
         let zero = Field::from(0.0);
         let one = Field::from(1.0);
-        let coverage = (dist_to_edge / pixel_size).min(one.clone()).max(zero).constant();
+        let coverage = (dist_to_edge / pixel_size)
+            .min(one.clone())
+            .max(zero)
+            .constant();
 
         // Select and blend colors
         let r_base = is_even.clone().select(ra.clone(), rb.clone());

--- a/pixelflow-graphics/src/spatial_bsp.rs
+++ b/pixelflow-graphics/src/spatial_bsp.rs
@@ -283,7 +283,12 @@ where
         let right_val = self.eval_child(node.right, x, y, z, w);
 
         // Blend using Select combinator
-        Select { cond: mask, if_true: left_val, if_false: right_val }.eval((x, y, z, w))
+        Select {
+            cond: mask,
+            if_true: left_val,
+            if_false: right_val,
+        }
+        .eval((x, y, z, w))
     }
 
     /// Evaluate a child node (either interior or leaf).

--- a/pixelflow-graphics/src/subdivision.rs
+++ b/pixelflow-graphics/src/subdivision.rs
@@ -20,9 +20,9 @@
 //! - No finite differences, no extra evaluations
 
 use crate::mesh::{Point3, QuadMesh};
+use pixelflow_compiler::ManifoldExpr;
 use pixelflow_core::jet::Jet3;
 use pixelflow_core::{Field, Manifold, ManifoldExt};
-use pixelflow_compiler::ManifoldExpr;
 
 /// The 4D Jet3 domain type for 3D ray tracing autodiff.
 type Jet3_4 = (Jet3, Jet3, Jet3, Jet3);
@@ -465,7 +465,7 @@ mod tests {
     use std::io::Cursor;
 
     #[test]
-    fn test_regular_patch() {
+    fn patch_should_be_extraordinary_when_valences_are_one() {
         let obj = "
 v 0.0 0.0 0.0
 v 1.0 0.0 0.0
@@ -473,16 +473,25 @@ v 1.0 1.0 0.0
 v 0.0 1.0 0.0
 f 1 2 3 4
 ";
-        let mesh = QuadMesh::from_obj(BufReader::new(Cursor::new(obj))).unwrap();
-        let patch = SubdivisionPatch::from_mesh(&mesh, 0).unwrap();
+        let mesh = QuadMesh::from_obj(BufReader::new(Cursor::new(obj)))
+            .expect("Failed to parse QuadMesh from obj string");
+        let patch = SubdivisionPatch::from_mesh(&mesh, 0)
+            .expect("Failed to create SubdivisionPatch from mesh");
 
         // All corners have valence 1 (only one face)
-        assert_eq!(patch.corner_valences, [1, 1, 1, 1]);
-        assert!(patch.is_extraordinary()); // Valence 1 is extraordinary
+        assert_eq!(
+            patch.corner_valences,
+            [1, 1, 1, 1],
+            "Corner valences must be all 1s"
+        );
+        assert!(
+            patch.is_extraordinary(),
+            "Valence 1 must be considered extraordinary"
+        ); // Valence 1 is extraordinary
     }
 
     #[test]
-    fn test_limit_eval() {
+    fn limit_eval_should_fallback_when_extraordinary() {
         let obj = "
 v 0.0 0.0 0.0
 v 1.0 0.0 0.0
@@ -490,8 +499,10 @@ v 1.0 1.0 0.0
 v 0.0 1.0 0.0
 f 1 2 3 4
 ";
-        let mesh = QuadMesh::from_obj(BufReader::new(Cursor::new(obj))).unwrap();
-        let patch = SubdivisionPatch::from_mesh(&mesh, 0).unwrap();
+        let mesh = QuadMesh::from_obj(BufReader::new(Cursor::new(obj)))
+            .expect("Failed to parse QuadMesh from obj string");
+        let patch = SubdivisionPatch::from_mesh(&mesh, 0)
+            .expect("Failed to create SubdivisionPatch from mesh");
 
         // Evaluate at center (0.5, 0.5) using Jet3
         let u = Jet3::constant(Field::from(0.5));
@@ -505,11 +516,14 @@ f 1 2 3 4
 
         // For bilinear fallback, center should be roughly (0.5, 0.5, 0.0)
         // We can't easily check SIMD Field values in tests, so this is a smoke test
-        assert_eq!(patch.is_extraordinary(), true);
+        assert!(
+            patch.is_extraordinary(),
+            "Bilinear fallback patch must be extraordinary"
+        );
     }
 
     #[test]
-    fn test_surface_stats() {
+    fn stats_should_count_patches_when_surface_created() {
         let obj = "
 v 0.0 0.0 0.0
 v 1.0 0.0 0.0
@@ -520,10 +534,15 @@ v 2.0 1.0 0.0
 f 1 2 3 4
 f 2 5 6 3
 ";
-        let mesh = QuadMesh::from_obj(BufReader::new(Cursor::new(obj))).unwrap();
-        let surface = SubdivisionSurface::from_mesh(mesh).unwrap();
+        let mesh = QuadMesh::from_obj(BufReader::new(Cursor::new(obj)))
+            .expect("Failed to parse QuadMesh from obj string");
+        let surface = SubdivisionSurface::from_mesh(mesh)
+            .expect("Failed to create SubdivisionSurface from mesh");
         let stats = surface.stats();
 
-        assert_eq!(stats.total_patches, 2);
+        assert_eq!(
+            stats.total_patches, 2,
+            "Surface must contain exactly 2 patches"
+        );
     }
 }

--- a/pixelflow-graphics/src/transform.rs
+++ b/pixelflow-graphics/src/transform.rs
@@ -3,7 +3,7 @@
 //! Provides composable coordinate warping using the `At` combinator.
 
 use pixelflow_core::ops::{Div, Sub};
-use pixelflow_core::{At, Field, Manifold, X, Y, Z, W};
+use pixelflow_core::{At, Field, Manifold, W, X, Y, Z};
 
 /// The standard 4D Field domain type.
 type Field4 = (Field, Field, Field, Field);

--- a/pixelflow-graphics/tests/e2e_render_to_file.rs
+++ b/pixelflow-graphics/tests/e2e_render_to_file.rs
@@ -3,8 +3,8 @@
 //! This test verifies the full pipeline from manifold composition
 //! through rasterization to file output.
 
-use pixelflow_core::{Discrete, Field, Manifold, ManifoldCompat, ManifoldExt, X, Y};
 use pixelflow_compiler::kernel;
+use pixelflow_core::{Discrete, Field, Manifold, ManifoldCompat, ManifoldExt, X, Y};
 use pixelflow_graphics::render::color::{Grayscale, NamedColor, Rgba8};
 
 type Field4 = (Field, Field, Field, Field);

--- a/pixelflow-graphics/tests/font_orientation_test.rs
+++ b/pixelflow-graphics/tests/font_orientation_test.rs
@@ -12,11 +12,7 @@ const FONT_BYTES: &[u8] = include_bytes!("../assets/NotoSansMono-Regular.ttf");
 
 /// Measure the horizontal extent of rendered pixels at a given Y row.
 /// Returns (leftmost_x, rightmost_x) of pixels above the threshold, or None if row is empty.
-fn measure_row_extent(
-    frame: &Frame<Rgba8>,
-    y: usize,
-    threshold: u8,
-) -> Option<(usize, usize)> {
+fn measure_row_extent(frame: &Frame<Rgba8>, y: usize, threshold: u8) -> Option<(usize, usize)> {
     let width = frame.width;
     let row_start = y * width;
     let row = &frame.data[row_start..row_start + width];

--- a/pixelflow-graphics/tests/kernel_macro.rs
+++ b/pixelflow-graphics/tests/kernel_macro.rs
@@ -23,9 +23,9 @@
 //! values. Instead we test using Field-level comparisons and check that all
 //! lanes satisfy the expected condition.
 
+use pixelflow_compiler::kernel;
 use pixelflow_core::jet::Jet3;
 use pixelflow_core::{Field, Manifold, ManifoldExt};
-use pixelflow_compiler::kernel;
 
 type Field4 = (Field, Field, Field, Field);
 
@@ -629,7 +629,7 @@ fn test_jet3_literals_and_params() {
 // - Normalized3D(m)  → (dx, dy, dz) / √(dx² + dy² + dz²)
 
 use pixelflow_core::jet::Jet2;
-use pixelflow_core::{GradientMag2D, GradientMag3D, Antialias2D, Antialias3D, Normalized2D};
+use pixelflow_core::{Antialias2D, Antialias3D, GradientMag2D, GradientMag3D, Normalized2D};
 
 type Jet2_4 = (Jet2, Jet2, Jet2, Jet2);
 
@@ -658,9 +658,8 @@ fn jet3_4_seeded(x: f32, y: f32, z: f32) -> Jet3_4 {
 fn test_gradient_mag_2d() {
     // For f(x,y) = sqrt(x² + y²), the gradient is (x/r, y/r) where r = sqrt(x²+y²)
     // Gradient magnitude is always 1.0 for distance fields
-    let dist = (pixelflow_core::X * pixelflow_core::X
-        + pixelflow_core::Y * pixelflow_core::Y)
-        .sqrt();
+    let dist =
+        (pixelflow_core::X * pixelflow_core::X + pixelflow_core::Y * pixelflow_core::Y).sqrt();
 
     let grad_mag = GradientMag2D(dist);
 
@@ -696,9 +695,7 @@ fn test_gradient_mag_3d() {
 fn test_antialias_2d() {
     // Circle SDF using kernel! macro (handles literal promotion)
     // At (2, 0): val = 1.0, gradient = (1, 0), so antialias = 1.0 / 1.0 = 1.0
-    let circle_sdf = kernel!(|| -> Jet2 {
-        (X * X + Y * Y).sqrt() - 1.0
-    });
+    let circle_sdf = kernel!(|| -> Jet2 { (X * X + Y * Y).sqrt() - 1.0 });
     let sdf = circle_sdf();
 
     let aa = Antialias2D(sdf);
@@ -715,9 +712,7 @@ fn test_antialias_2d() {
 fn test_antialias_3d() {
     // Sphere SDF using kernel! macro
     // At (2, 0, 0): val = 1.0, gradient = (1, 0, 0), so antialias = 1.0 / 1.0 = 1.0
-    let sphere_sdf = kernel!(|| -> Jet3 {
-        (X * X + Y * Y + Z * Z).sqrt() - 1.0
-    });
+    let sphere_sdf = kernel!(|| -> Jet3 { (X * X + Y * Y + Z * Z).sqrt() - 1.0 });
     let sdf = sphere_sdf();
 
     let aa = Antialias3D(sdf);
@@ -734,9 +729,8 @@ fn test_antialias_3d() {
 fn test_normalized_2d() {
     // Distance field: sqrt(x² + y²)
     // At (3, 4): gradient = (3/5, 4/5) = (0.6, 0.8)
-    let dist = (pixelflow_core::X * pixelflow_core::X
-        + pixelflow_core::Y * pixelflow_core::Y)
-        .sqrt();
+    let dist =
+        (pixelflow_core::X * pixelflow_core::X + pixelflow_core::Y * pixelflow_core::Y).sqrt();
 
     let normal = Normalized2D(dist);
 
@@ -797,15 +791,14 @@ fn test_fused_combinators_with_kernel_composition() {
 // FUSED COMBINATORS (GradientMag2D, Antialias2D, etc.) which evaluate
 // the inner manifold once and compute derived quantities efficiently.
 
-use pixelflow_core::{V, DX, DY, DZ};
+use pixelflow_core::{DX, DY, DZ, V};
 
 /// Test V accessor extracts the value component from Jet2.
 #[test]
 fn test_v_accessor() {
     // Distance from origin: sqrt(x² + y²)
-    let dist = (pixelflow_core::X * pixelflow_core::X
-        + pixelflow_core::Y * pixelflow_core::Y)
-        .sqrt();
+    let dist =
+        (pixelflow_core::X * pixelflow_core::X + pixelflow_core::Y * pixelflow_core::Y).sqrt();
 
     // Extract just the value
     let val_only = V(dist);
@@ -823,9 +816,8 @@ fn test_v_accessor() {
 fn test_dx_accessor() {
     // Distance from origin: sqrt(x² + y²)
     // ∂dist/∂x = x / sqrt(x² + y²) = x / dist
-    let dist = (pixelflow_core::X * pixelflow_core::X
-        + pixelflow_core::Y * pixelflow_core::Y)
-        .sqrt();
+    let dist =
+        (pixelflow_core::X * pixelflow_core::X + pixelflow_core::Y * pixelflow_core::Y).sqrt();
 
     // Extract ∂f/∂x
     let dx_only = DX(dist);
@@ -843,9 +835,8 @@ fn test_dx_accessor() {
 fn test_dy_accessor() {
     // Distance from origin: sqrt(x² + y²)
     // ∂dist/∂y = y / sqrt(x² + y²) = y / dist
-    let dist = (pixelflow_core::X * pixelflow_core::X
-        + pixelflow_core::Y * pixelflow_core::Y)
-        .sqrt();
+    let dist =
+        (pixelflow_core::X * pixelflow_core::X + pixelflow_core::Y * pixelflow_core::Y).sqrt();
 
     // Extract ∂f/∂y
     let dy_only = DY(dist);
@@ -887,9 +878,8 @@ fn test_dz_accessor() {
 #[test]
 fn test_manual_gradient_magnitude() {
     // Distance from origin
-    let dist = (pixelflow_core::X * pixelflow_core::X
-        + pixelflow_core::Y * pixelflow_core::Y)
-        .sqrt();
+    let dist =
+        (pixelflow_core::X * pixelflow_core::X + pixelflow_core::Y * pixelflow_core::Y).sqrt();
 
     // Manual gradient magnitude using DX/DY accessors
     let grad_mag = (DX(dist) * DX(dist) + DY(dist) * DY(dist)).sqrt();

--- a/pixelflow-graphics/tests/optimization_fuzz.rs
+++ b/pixelflow-graphics/tests/optimization_fuzz.rs
@@ -9,8 +9,8 @@
 //! 3. Use proptest to generate random inputs
 //! 4. Assert kernel output matches reference within epsilon
 
-use pixelflow_core::{Field, Manifold};
 use pixelflow_compiler::kernel;
+use pixelflow_core::{Field, Manifold};
 use proptest::prelude::*;
 
 type Field4 = (Field, Field, Field, Field);
@@ -25,7 +25,12 @@ const EPSILON: f32 = 1e-4;
 const ABS_EPSILON: f32 = 1e-6;
 
 fn field4(x: f32, y: f32, z: f32, w: f32) -> Field4 {
-    (Field::from(x), Field::from(y), Field::from(z), Field::from(w))
+    (
+        Field::from(x),
+        Field::from(y),
+        Field::from(z),
+        Field::from(w),
+    )
 }
 
 /// Extract first lane from Field for comparison.
@@ -326,7 +331,9 @@ fn regression_sqrt_with_param() {
 
     assert!(
         approx_eq(result, expected),
-        "sqrt with param: got {} expected {}", result, expected
+        "sqrt with param: got {} expected {}",
+        result,
+        expected
     );
 }
 
@@ -341,7 +348,9 @@ fn regression_mul_then_method() {
 
     assert!(
         approx_eq(result, expected),
-        "mul then abs: got {} expected {}", result, expected
+        "mul then abs: got {} expected {}",
+        result,
+        expected
     );
 }
 
@@ -355,6 +364,8 @@ fn regression_sub_then_method() {
 
     assert!(
         approx_eq(result, expected),
-        "sub then floor: got {} expected {}", result, expected
+        "sub then floor: got {} expected {}",
+        result,
+        expected
     );
 }

--- a/pixelflow-graphics/tests/rasterizer_parallel_test.rs
+++ b/pixelflow-graphics/tests/rasterizer_parallel_test.rs
@@ -4,12 +4,12 @@
 //! to single-threaded execution, and handle edge cases (small height, odd dimensions).
 
 use pixelflow_core::{Field, Manifold};
+use pixelflow_graphics::render::color::Rgba8;
 use pixelflow_graphics::render::frame::Frame;
 use pixelflow_graphics::render::rasterizer::parallel::{
     render_parallel, render_work_stealing, RenderOptions,
 };
 use pixelflow_graphics::render::rasterizer::rasterize;
-use pixelflow_graphics::render::color::Rgba8;
 
 // A simple test manifold: Gradient X + Y
 #[derive(Copy, Clone)]
@@ -23,7 +23,12 @@ impl Manifold<(Field, Field, Field, Field)> for TestGradient {
         // Evaluate AST to get Field values
         // Note: Field ops return AST nodes, so we must call .eval() to get the result.
         // Since operands are concrete Fields, we can pass dummy coordinates.
-        let dummy: (Field, Field, Field, Field) = (Field::default(), Field::default(), Field::default(), Field::default());
+        let dummy: (Field, Field, Field, Field) = (
+            Field::default(),
+            Field::default(),
+            Field::default(),
+            Field::default(),
+        );
 
         // Simple gradient: (x + y) * 0.1
         let val = ((x + y) * Field::from(0.1)).eval(dummy);
@@ -55,7 +60,10 @@ fn render_parallel_matches_single_threaded_output() {
     // Target: render_parallel
     render_parallel(&TestGradient, &mut frame, options);
 
-    assert_eq!(frame.data, reference.data, "render_parallel output mismatch");
+    assert_eq!(
+        frame.data, reference.data,
+        "render_parallel output mismatch"
+    );
 }
 
 #[test]
@@ -69,7 +77,10 @@ fn render_parallel_matches_single_threaded_output_odd_threads() {
 
     render_parallel(&TestGradient, &mut frame, options);
 
-    assert_eq!(frame.data, reference.data, "render_parallel (3 threads) output mismatch");
+    assert_eq!(
+        frame.data, reference.data,
+        "render_parallel (3 threads) output mismatch"
+    );
 }
 
 #[test]
@@ -84,7 +95,10 @@ fn render_parallel_handles_small_height() {
 
     render_parallel(&TestGradient, &mut frame, options);
 
-    assert_eq!(frame.data, reference.data, "render_parallel small height mismatch");
+    assert_eq!(
+        frame.data, reference.data,
+        "render_parallel small height mismatch"
+    );
 }
 
 #[test]
@@ -101,7 +115,10 @@ fn render_parallel_handles_height_one() {
     // but we test the interface contract.
     render_parallel(&TestGradient, &mut frame, options);
 
-    assert_eq!(frame.data, reference.data, "render_parallel height=1 mismatch");
+    assert_eq!(
+        frame.data, reference.data,
+        "render_parallel height=1 mismatch"
+    );
 }
 
 #[test]
@@ -115,7 +132,10 @@ fn render_work_stealing_matches_single_threaded_output() {
 
     render_work_stealing(&TestGradient, &mut frame, options);
 
-    assert_eq!(frame.data, reference.data, "render_work_stealing output mismatch");
+    assert_eq!(
+        frame.data, reference.data,
+        "render_work_stealing output mismatch"
+    );
 }
 
 #[test]
@@ -129,5 +149,8 @@ fn render_work_stealing_handles_height_one() {
 
     render_work_stealing(&TestGradient, &mut frame, options);
 
-    assert_eq!(frame.data, reference.data, "render_work_stealing height=1 mismatch");
+    assert_eq!(
+        frame.data, reference.data,
+        "render_work_stealing height=1 mismatch"
+    );
 }

--- a/pixelflow-graphics/tests/raymarch_sphere.rs
+++ b/pixelflow-graphics/tests/raymarch_sphere.rs
@@ -1,9 +1,9 @@
 //! Test: 3D scene rendering with sphere + floor using the scene3d architecture
 
+use pixelflow_compiler::ManifoldExpr;
 use pixelflow_core::combinators::At;
 use pixelflow_core::jet::Jet3;
 use pixelflow_core::{Discrete, Field, Manifold, ManifoldCompat};
-use pixelflow_compiler::ManifoldExpr;
 
 type Field4 = (Field, Field, Field, Field);
 type Jet3_4 = (Jet3, Jet3, Jet3, Jet3);
@@ -11,7 +11,7 @@ use pixelflow_graphics::render::color::{Rgba8, RgbaColorCube};
 use pixelflow_graphics::render::frame::Frame;
 use pixelflow_graphics::render::rasterizer::rasterize;
 use pixelflow_graphics::scene3d::{
-    ColorChecker, ColorReflect, ColorScreenToDir, ColorSky, ColorSurface, plane,
+    plane, ColorChecker, ColorReflect, ColorScreenToDir, ColorSky, ColorSurface,
 };
 
 /// Sphere at given center with radius (local to this test).
@@ -93,7 +93,9 @@ fn test_sphere_on_floor() {
             center: (0.0, 0.5, 4.0),
             radius: 1.0,
         },
-        material: ColorReflect { inner: world.clone() },
+        material: ColorReflect {
+            inner: world.clone(),
+        },
         background: world,
     };
 
@@ -128,8 +130,6 @@ fn test_sphere_on_floor() {
 /// Test with solid gray material (non-reflective)
 #[test]
 fn test_sphere_on_matte_floor() {
-
-
     const W: usize = 400;
     const H: usize = 300;
 
@@ -210,7 +210,9 @@ fn test_chrome_sphere_on_checkerboard() {
             center: (0.0, 0.5, 4.0),
             radius: 1.0,
         },
-        material: ColorReflect { inner: world.clone() },
+        material: ColorReflect {
+            inner: world.clone(),
+        },
         background: world,
     };
 

--- a/pixelflow-graphics/tests/scene3d_test.rs
+++ b/pixelflow-graphics/tests/scene3d_test.rs
@@ -5,10 +5,10 @@
 //! 2. Surface: Warps `P = ray * t` - creates tangent frame via chain rule
 //! 3. Material: Reconstructs normal from derivatives - Reflect, Checker, Sky
 
+use pixelflow_compiler::ManifoldExpr;
 use pixelflow_core::combinators::At;
 use pixelflow_core::jet::Jet3;
 use pixelflow_core::{Discrete, Field, Manifold, ManifoldCompat, ManifoldExt};
-use pixelflow_compiler::ManifoldExpr;
 
 type Field4 = (Field, Field, Field, Field);
 type Jet3_4 = (Jet3, Jet3, Jet3, Jet3);
@@ -16,8 +16,8 @@ use pixelflow_graphics::render::color::{Rgba8, RgbaColorCube};
 use pixelflow_graphics::render::frame::Frame;
 use pixelflow_graphics::render::rasterizer::rasterize;
 use pixelflow_graphics::scene3d::{
-    Checker, ColorChecker, ColorReflect, ColorScreenToDir, ColorSky, ColorSurface, plane,
-    Reflect, ScreenToDir, sky, Surface,
+    plane, sky, Checker, ColorChecker, ColorReflect, ColorScreenToDir, ColorSky, ColorSurface,
+    Reflect, ScreenToDir, Surface,
 };
 use std::fs::File;
 use std::io::Write;
@@ -120,7 +120,9 @@ fn test_chrome_unit_sphere() {
             center: (0.0, 0.0, 4.0),
             radius: 1.0,
         },
-        material: Reflect { inner: world.clone() },
+        material: Reflect {
+            inner: world.clone(),
+        },
         background: world,
     };
 
@@ -291,7 +293,9 @@ fn test_color_chrome_sphere() {
             center: (0.0, 0.0, 4.0),
             radius: 1.0,
         },
-        material: ColorReflect { inner: world.clone() },
+        material: ColorReflect {
+            inner: world.clone(),
+        },
         background: world,
     };
 
@@ -450,7 +454,9 @@ fn test_mullet_vs_3channel_comparison() {
                         center: (0.0, 0.0, 4.0),
                         radius: 1.0,
                     },
-                    material: Reflect { inner: world.clone() },
+                    material: Reflect {
+                        inner: world.clone(),
+                    },
                     background: world,
                 },
             },
@@ -533,7 +539,9 @@ fn test_mullet_vs_3channel_comparison() {
                     center: (0.0, 0.0, 4.0),
                     radius: 1.0,
                 },
-                material: ColorReflect { inner: world.clone() },
+                material: ColorReflect {
+                    inner: world.clone(),
+                },
                 background: world,
             },
         },
@@ -616,7 +624,9 @@ fn test_work_stealing_benchmark() {
             center: (0.0, 0.0, 4.0),
             radius: 1.0,
         },
-        material: ColorReflect { inner: world.clone() },
+        material: ColorReflect {
+            inner: world.clone(),
+        },
         background: world,
     };
 


### PR DESCRIPTION
**Scope**
Enforce `STYLE.md` testing guidelines across `pixelflow-graphics` and `pixelflow-core` crates.

**Fixes**
- Renamed test functions to use descriptive behavior-driven names (e.g., `test_regular_patch` -> `patch_should_be_extraordinary_when_valences_are_one`).
- Replaced uninformative `.unwrap()` calls with `.expect("detailed reason")`.
- Replaced naked `assert!(...)` and `assert_eq!(..., true/false)` calls with `assert!(..., "descriptive message")` across `subdivision.rs` and `algebra.rs`.

**Unresolved Issues**
- Baseline compilation errors and test failures remain in `pixelflow-graphics` and workspace tests (e.g. `test_log2.rs`), which are unrelated to these changes.

**Verification**
- Formatted with `cargo fmt`.
- `cargo check -p pixelflow-graphics -p pixelflow-core` shows only pre-existing failures.
- Changes were manually reviewed for correctness based on `STYLE.md`.

---
*PR created automatically by Jules for task [11113979267040445755](https://jules.google.com/task/11113979267040445755) started by @jppittman*