### PR TITLE
⚡ Bolt: Preallocate vector capacities for BSP tree in core-term

### DIFF
--- a/core-term/src/terminal_app.rs
+++ b/core-term/src/terminal_app.rs
@@ -288,11 +288,11 @@ impl TerminalApp {
         let default_bg = self.config.colors.background;
 
         // Build 2-level BSP: Vertical (Rows) -> Horizontal (Cells)
-        let mut row_items = Vec::new();
+        let mut row_items = Vec::with_capacity(rows);
 
         for row in 0..rows {
             let line = &snapshot.lines[row];
-            let mut cell_items = Vec::new();
+            let mut cell_items = Vec::with_capacity(cols);
 
             for col in 0..cols {
                 let glyph = &line.cells[col];


### PR DESCRIPTION
💡 **What**: Changed `Vec::new()` to `Vec::with_capacity(rows)` and `Vec::with_capacity(cols)` for `row_items` and `cell_items` respectively in `core-term/src/terminal_app.rs`.

🎯 **Why**: In the terminal rendering hot path, building the 2-level BSP tree previously required dynamic vector growth. Since the target grid dimensions (`rows` and `cols`) are statically known at the start of this loop, preallocating the exact required capacity prevents expensive and unnecessary intermediate heap reallocations and memory copies.

📊 **Impact**: Reduces latency and CPU overhead in the terminal rendering hot path by avoiding dynamic growth of vectors.

🔬 **Measurement**: Verify correctness by ensuring `cargo test -p core-term` still passes (ignoring known upstream crate failures). Ensure memory allocations are reduced during terminal layout passes.

---
*PR created automatically by Jules for task [11142166632075945574](https://jules.google.com/task/11142166632075945574) started by @jppittman*