### PR TITLE
⚡ Bolt: Pre-allocate render layout vectors in core-term

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2025-12-28 - Rasterizer Inner Loop Hoisting
 **Learning:** The inner loop of `execute_stripe` was re-evaluating `Field::sequential(start)` on every iteration, which involves multiple SIMD instructions (broadcast/load + add).
 **Action:** Hoisted the initialization of `xs` out of the loop and updated it incrementally using a pre-computed `step` vector. This reduced the inner loop overhead significantly, yielding a ~34% improvement in rasterization throughput.
+
+## 2025-12-28 - Vec Initialization Optimization
+**Learning:** In hot paths (like building rendering layout trees in `core-term`), vectors were dynamically growing by using `Vec::new()`, causing expensive heap reallocations.
+**Action:** Use `Vec::with_capacity(size)` instead of `Vec::new()` to initialize vectors with their known target sizes.

--- a/core-term/src/terminal_app.rs
+++ b/core-term/src/terminal_app.rs
@@ -288,11 +288,12 @@ impl TerminalApp {
         let default_bg = self.config.colors.background;
 
         // Build 2-level BSP: Vertical (Rows) -> Horizontal (Cells)
-        let mut row_items = Vec::new();
+        // Optimization: Pre-allocate vectors with known dimensions to prevent heap reallocations
+        let mut row_items = Vec::with_capacity(rows);
 
         for row in 0..rows {
             let line = &snapshot.lines[row];
-            let mut cell_items = Vec::new();
+            let mut cell_items = Vec::with_capacity(cols);
 
             for col in 0..cols {
                 let glyph = &line.cells[col];


### PR DESCRIPTION
* 💡 What: Replaced `Vec::new()` with `Vec::with_capacity(...)` for `row_items` and `cell_items` in `build_manifold` inside `core-term/src/terminal_app.rs`.
* 🎯 Why: Vectors were being populated inside loops with known bounds (`rows` and `cols`), causing expensive heap reallocations.
* 📊 Impact: Reduces memory reallocations during terminal rendering, improving rasterization latency.
* 🔬 Measurement: Observe reduction in memory allocations during rendering in flamegraphs/profiling.

---
*PR created automatically by Jules for task [11803975824299957554](https://jules.google.com/task/11803975824299957554) started by @jppittman*