### PR TITLE
⚡ Bolt: Optimize vector allocation in terminal snapshot rendering

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2025-12-28 - Rasterizer Inner Loop Hoisting
 **Learning:** The inner loop of `execute_stripe` was re-evaluating `Field::sequential(start)` on every iteration, which involves multiple SIMD instructions (broadcast/load + add).
 **Action:** Hoisted the initialization of `xs` out of the loop and updated it incrementally using a pre-computed `step` vector. This reduced the inner loop overhead significantly, yielding a ~34% improvement in rasterization throughput.
+
+## 2025-12-28 - Optimizing Terminal Rendering Vector Allocations
+**Learning:** In `TerminalApp`'s rendering hot path, building the layout BSP tree dynamically allocated `Vec`s (`row_items` and `cell_items`) using `Vec::new()`. Since the exact terminal dimensions (`rows` and `cols`) are known beforehand from the snapshot, this caused unnecessary and expensive heap reallocations on every frame update.
+**Action:** Always use `Vec::with_capacity(size)` instead of `Vec::new()` in hot loops when the target collection size is known in advance to eliminate continuous memory reallocation overhead.

--- a/core-term/src/terminal_app.rs
+++ b/core-term/src/terminal_app.rs
@@ -288,11 +288,13 @@ impl TerminalApp {
         let default_bg = self.config.colors.background;
 
         // Build 2-level BSP: Vertical (Rows) -> Horizontal (Cells)
-        let mut row_items = Vec::new();
+        // OPTIMIZATION: Pre-allocate row_items with known size to prevent expensive heap reallocations
+        let mut row_items = Vec::with_capacity(rows);
 
         for row in 0..rows {
             let line = &snapshot.lines[row];
-            let mut cell_items = Vec::new();
+            // OPTIMIZATION: Pre-allocate cell_items with known size to prevent expensive heap reallocations
+            let mut cell_items = Vec::with_capacity(cols);
 
             for col in 0..cols {
                 let glyph = &line.cells[col];


### PR DESCRIPTION
- **What:** Replaced `Vec::new()` with `Vec::with_capacity(size)` when building the render tree in `TerminalApp`.
- **Why:** In the hot path of building rendering layouts, vectors were dynamically growing which led to expensive and unnecessary heap reallocations on every frame update.
- **Impact:** Reduces memory allocation overhead and improves throughput during terminal grid rendering by eliminating heap reallocations.
- **Measurement:** Review layout render latency and heap allocations per frame via profiling.

---
*PR created automatically by Jules for task [10315808109687061776](https://jules.google.com/task/10315808109687061776) started by @jppittman*