### PR TITLE
⚡ Bolt: Remove redundant sqrt before rsqrt in scene3d.rs

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,11 @@
 ## 2025-12-28 - Rasterizer Inner Loop Hoisting
 **Learning:** The inner loop of `execute_stripe` was re-evaluating `Field::sequential(start)` on every iteration, which involves multiple SIMD instructions (broadcast/load + add).
 **Action:** Hoisted the initialization of `xs` out of the loop and updated it incrementally using a pre-computed `step` vector. This reduced the inner loop overhead significantly, yielding a ~34% improvement in rasterization throughput.
+
+## 2025-12-28 - Redundant Math Operations in Normalization
+**Learning:** In mathematical expressions calculating inverse lengths (like vector normalization),  was being used, which incorrectly applies the root twice (calculating 1/(x^(1/4))) and adds a computationally expensive, redundant operation.
+**Action:** Replaced  with . Always ensure standard math identities are correctly implemented to avoid compounded operation costs.
+
+## 2025-12-28 - Redundant Math Operations in Normalization
+**Learning:** In mathematical expressions calculating inverse lengths (like vector normalization), `.sqrt().rsqrt()` was being used, which incorrectly applies the root twice (calculating 1/(x^(1/4))) and adds a computationally expensive, redundant operation.
+**Action:** Replaced `.sqrt().rsqrt()` with `.rsqrt()`. Always ensure standard math identities are correctly implemented to avoid compounded operation costs.

--- a/pixelflow-graphics/src/scene3d.rs
+++ b/pixelflow-graphics/src/scene3d.rs
@@ -13,9 +13,9 @@
 //!
 //! No iteration. Nesting is occlusion.
 
+use pixelflow_compiler::{kernel, ManifoldExpr};
 use pixelflow_core::jet::Jet3;
 use pixelflow_core::*;
-use pixelflow_compiler::{kernel, ManifoldExpr};
 
 /// The standard 4D Field domain type.
 type Field4 = (Field, Field, Field, Field);
@@ -598,7 +598,7 @@ impl<M: ManifoldCompat<Jet3, Output = Field>> Manifold<Jet3_4> for Reflect<M> {
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         // Normal components - evaluate at Jet3 construction boundary
         let nx = (cross_x * inv_n_len.clone()).constant();
@@ -686,7 +686,7 @@ impl<M: ManifoldCompat<Jet3, Output = Discrete>> Manifold<Jet3_4> for ColorRefle
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         // Normal components - evaluate at Jet3 construction boundary
         let nx = (cross_x * inv_n_len.clone()).constant();
@@ -793,7 +793,7 @@ where
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         let nx = (cross_x * inv_n_len.clone()).constant();
         let ny = (cross_y * inv_n_len.clone()).constant();
@@ -906,7 +906,7 @@ where
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         let nx = (cross_x * inv_n_len.clone()).constant();
         let ny = (cross_y * inv_n_len.clone()).constant();
@@ -1136,7 +1136,10 @@ impl<C: ManifoldCompat<Field, Output = Discrete>> Manifold<Jet3_4> for ColorChec
         // Coverage: how much of the pixel is in this cell vs neighbor
         let zero = Field::from(0.0);
         let one = Field::from(1.0);
-        let coverage = (dist_to_edge / pixel_size).min(one.clone()).max(zero).constant();
+        let coverage = (dist_to_edge / pixel_size)
+            .min(one.clone())
+            .max(zero)
+            .constant();
 
         // Select and blend colors
         let r_base = is_even.clone().select(ra.clone(), rb.clone());


### PR DESCRIPTION
**💡 What:** 
Replaced `.sqrt().rsqrt()` with `.rsqrt()` in four locations in `scene3d.rs`.

**🎯 Why:** 
The former applied the root twice (calculating $1/(x^{1/4})$) and performed an entirely redundant and computationally expensive operation during normal vector calculation.

**📊 Impact:** 
Improves normal vector calculation speed and ensures mathematical correctness in 3D scene processing.

**🔬 Measurement:** 
Monitor execution time of 3D scene rendering specifically when normalizing vectors during material and background evaluations.

---
*PR created automatically by Jules for task [4981450402900638084](https://jules.google.com/task/4981450402900638084) started by @jppittman*