### PR TITLE
⚡ Bolt: Pre-allocate BSP layout vectors in terminal render loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2025-12-28 - Rasterizer Inner Loop Hoisting
 **Learning:** The inner loop of `execute_stripe` was re-evaluating `Field::sequential(start)` on every iteration, which involves multiple SIMD instructions (broadcast/load + add).
 **Action:** Hoisted the initialization of `xs` out of the loop and updated it incrementally using a pre-computed `step` vector. This reduced the inner loop overhead significantly, yielding a ~34% improvement in rasterization throughput.
+
+## 2025-12-28 - Terminal BSP Layout Vector Pre-allocation
+**Learning:** The terminal application's hot path for building the spatial BSP layout tree was creating dynamically growing vectors without initializing capacity. This caused O(log N) unnecessary heap reallocations per frame for every row and cell processing iteration.
+**Action:** When building vectors inside rendering loops where the dimension or item count is predetermined (like terminal grid rows and cols), always initialize them using `Vec::with_capacity(size)` instead of `Vec::new()` to save memory allocation overhead.

--- a/core-term/src/terminal_app.rs
+++ b/core-term/src/terminal_app.rs
@@ -288,11 +288,13 @@ impl TerminalApp {
         let default_bg = self.config.colors.background;
 
         // Build 2-level BSP: Vertical (Rows) -> Horizontal (Cells)
-        let mut row_items = Vec::new();
+        // Pre-allocate vector to prevent reallocation in hot path
+        let mut row_items = Vec::with_capacity(rows);
 
         for row in 0..rows {
             let line = &snapshot.lines[row];
-            let mut cell_items = Vec::new();
+            // Pre-allocate vector to prevent reallocation in hot path
+            let mut cell_items = Vec::with_capacity(cols);
 
             for col in 0..cols {
                 let glyph = &line.cells[col];


### PR DESCRIPTION
**What:** Replaced `Vec::new()` with `Vec::with_capacity(rows)` for `row_items` and `Vec::with_capacity(cols)` for `cell_items` in the terminal render loop inside `core-term/src/terminal_app.rs`. Added explanatory comments to document the optimization.
**Why:** During the hot path of building the rendering layout tree, these dynamically growing vectors were being initialized without a known size, leading to expensive and unnecessary heap reallocations.
**Impact:** Eliminates up to O(log N) heap allocations per frame per row by initializing vectors to their exact known required sizes based on the terminal grid dimensions.
**Measurement:** Measure the execution time of the terminal render layout loop (`build_bsp` / rendering) in a CPU profiler to verify reduced memory allocation overhead.

---
*PR created automatically by Jules for task [8478040177780580794](https://jules.google.com/task/8478040177780580794) started by @jppittman*