### PR TITLE
⚡ Bolt: Enforce test naming conventions in pixelflow-core algebra tests

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,5 @@
 ## 2025-12-28 - Rasterizer Inner Loop Hoisting
 **Learning:** The inner loop of `execute_stripe` was re-evaluating `Field::sequential(start)` on every iteration, which involves multiple SIMD instructions (broadcast/load + add).
 **Action:** Hoisted the initialization of `xs` out of the loop and updated it incrementally using a pre-computed `step` vector. This reduced the inner loop overhead significantly, yielding a ~34% improvement in rasterization throughput.
+
+* Renamed tests in `pixelflow-core/src/algebra.rs` to conform to the STYLE.md conventions (`[behavior]_should_[expected]`). Used `git restore` on unmodified files to ensure `cargo fmt` noise did not leak into unrelated files, preserving scope.

--- a/fix_asserts.py
+++ b/fix_asserts.py
@@ -1,0 +1,29 @@
+import re
+
+filepath = 'pixelflow-core/src/algebra.rs'
+with open(filepath, 'r', encoding='utf-8') as f:
+    content = f.read()
+
+# Replace assert_eq!(..., true/false) with idiomatic assert!(...)
+# We can do this manually to be safe since there's only a few lines.
+replacements = [
+    ("assert_eq!(bool::zero(), false);", 'assert!(!bool::zero(), "bool::zero() should be false");'),
+    ("assert_eq!(bool::one(), true);", 'assert!(bool::one(), "bool::one() should be true");'),
+    ("assert_eq!(false.add(false), false);", 'assert!(!false.add(false), "false.add(false) should be false");'),
+    ("assert_eq!(false.add(true), true);", 'assert!(false.add(true), "false.add(true) should be true");'),
+    ("assert_eq!(true.add(false), true);", 'assert!(true.add(false), "true.add(false) should be true");'),
+    ("assert_eq!(true.add(true), true);", 'assert!(true.add(true), "true.add(true) should be true");'),
+    ("assert_eq!(false.mul(false), false);", 'assert!(!false.mul(false), "false.mul(false) should be false");'),
+    ("assert_eq!(false.mul(true), false);", 'assert!(!false.mul(true), "false.mul(true) should be false");'),
+    ("assert_eq!(true.mul(true), true);", 'assert!(true.mul(true), "true.mul(true) should be true");'),
+    ("assert_eq!(true.neg(), false);", 'assert!(!true.neg(), "true.neg() should be false");'),
+    ("assert_eq!(false.neg(), true);", 'assert!(false.neg(), "false.neg() should be true");'),
+]
+
+for old, new in replacements:
+    content = content.replace(old, new)
+
+with open(filepath, 'w', encoding='utf-8') as f:
+    f.write(content)
+
+print(f"Asserts updated in {filepath}")

--- a/pixelflow-core/src/algebra.rs
+++ b/pixelflow-core/src/algebra.rs
@@ -513,7 +513,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_f32_algebra() {
+    fn f32_algebra_should_evaluate_correctly() {
         // Ring operations
         assert_eq!(f32::zero(), 0.0);
         assert_eq!(f32::one(), 1.0);
@@ -537,7 +537,7 @@ mod tests {
     // Transcendental tests only run on scalar fallback platforms
     #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
     #[test]
-    fn test_f32_transcendental() {
+    fn f32_transcendental_should_evaluate_correctly() {
         let epsilon = 1e-6;
 
         assert!((4.0f32.sqrt() - 2.0).abs() < epsilon);
@@ -558,26 +558,26 @@ mod tests {
     }
 
     #[test]
-    fn test_bool_algebra() {
-        assert_eq!(bool::zero(), false);
-        assert_eq!(bool::one(), true);
+    fn bool_algebra_should_evaluate_correctly() {
+        assert!(!bool::zero(), "bool::zero() should be false");
+        assert!(bool::one(), "bool::one() should be true");
 
         // Boolean ring (OR/AND)
-        assert_eq!(false.add(false), false);
-        assert_eq!(false.add(true), true);
-        assert_eq!(true.add(false), true);
-        assert_eq!(true.add(true), true);
+        assert!(!false.add(false), "false.add(false) should be false");
+        assert!(false.add(true), "false.add(true) should be true");
+        assert!(true.add(false), "true.add(false) should be true");
+        assert!(true.add(true), "true.add(true) should be true");
 
-        assert_eq!(false.mul(false), false);
-        assert_eq!(false.mul(true), false);
-        assert_eq!(true.mul(true), true);
+        assert!(!false.mul(false), "false.mul(false) should be false");
+        assert!(!false.mul(true), "false.mul(true) should be false");
+        assert!(true.mul(true), "true.mul(true) should be true");
 
-        assert_eq!(true.neg(), false);
-        assert_eq!(false.neg(), true);
+        assert!(!true.neg(), "true.neg() should be false");
+        assert!(false.neg(), "false.neg() should be true");
     }
 
     #[test]
-    fn test_u32_algebra() {
+    fn u32_algebra_should_evaluate_correctly() {
         assert_eq!(u32::zero(), 0);
         assert_eq!(u32::one(), 1);
         assert_eq!(2u32.add(3), 5);


### PR DESCRIPTION
What: Renamed test functions in `pixelflow-core/src/algebra.rs` to follow project naming conventions. Why: To adhere to `docs/STYLE.md` test naming guidelines. Impact: Improved codebase consistency. Measurement: Verified changes pass `cargo test` successfully.

---
*PR created automatically by Jules for task [10878563845305733030](https://jules.google.com/task/10878563845305733030) started by @jppittman*