### PR TITLE
⚡ Bolt: Refactor boolean arguments to enums in macOS platform code

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,8 @@
 ## 2025-12-28 - Rasterizer Inner Loop Hoisting
 **Learning:** The inner loop of `execute_stripe` was re-evaluating `Field::sequential(start)` on every iteration, which involves multiple SIMD instructions (broadcast/load + add).
 **Action:** Hoisted the initialization of `xs` out of the loop and updated it incrementally using a pre-computed `step` vector. This reduced the inner loop overhead significantly, yielding a ~34% improvement in rasterization throughput.
+
+### Refactoring boolean arguments to enums
+When refactoring boolean arguments to enums to enforce style rules, always add standard derivations (e.g., `#[derive(Debug, Clone, Copy, PartialEq, Eq)]`) to the new enum. This ensures the enum mimics the fundamental usability of a boolean and prevents downstream compilation errors in structs or comparisons that originally relied on boolean trait implementations.
+
+Also, be sure to clean up any temporary scripts created during exploration or fixing.

--- a/pixelflow-runtime/examples/animated_sphere.rs
+++ b/pixelflow-runtime/examples/animated_sphere.rs
@@ -14,13 +14,13 @@
 //! - Scene is rebuilt with new dimensions on next frame
 
 use actor_scheduler::Message;
+use pixelflow_compiler::ManifoldExpr;
 use pixelflow_core::combinators::At;
 use pixelflow_core::jet::Jet3;
 use pixelflow_core::{Discrete, Field, Manifold, ManifoldCompat};
 use pixelflow_graphics::scene3d::{
     plane, ColorChecker, ColorReflect, ColorScreenToDir, ColorSky, ColorSurface,
 };
-use pixelflow_compiler::ManifoldExpr;
 use pixelflow_runtime::api::private::EngineData;
 use pixelflow_runtime::api::public::{AppData, EngineEvent, EngineEventControl, EngineEventData};
 use pixelflow_runtime::platform::ColorCube;

--- a/pixelflow-runtime/examples/chrome_sphere.rs
+++ b/pixelflow-runtime/examples/chrome_sphere.rs
@@ -3,10 +3,10 @@
 //! Compares single-threaded vs parallel rasterization of the 3D chrome sphere scene.
 //! Uses the mullet architecture: geometry once, colors as packed Discrete.
 
+use pixelflow_compiler::ManifoldExpr;
 use pixelflow_core::combinators::At;
 use pixelflow_core::jet::Jet3;
 use pixelflow_core::{Discrete, Field, Manifold, ManifoldCompat};
-use pixelflow_compiler::ManifoldExpr;
 
 type Field4 = (Field, Field, Field, Field);
 type Jet3_4 = (Jet3, Jet3, Jet3, Jet3);

--- a/pixelflow-runtime/examples/image_viewer.rs
+++ b/pixelflow-runtime/examples/image_viewer.rs
@@ -6,10 +6,10 @@
 //! 3. Send a manifold to render
 //! 4. Run the event loop
 
+use pixelflow_compiler::ManifoldExpr;
 use pixelflow_core::combinators::At;
 use pixelflow_core::jet::Jet3;
 use pixelflow_core::{Discrete, Field, Manifold, ManifoldCompat};
-use pixelflow_compiler::ManifoldExpr;
 use pixelflow_runtime::{api::public::AppData, EngineConfig, EngineTroupe, WindowConfig};
 use std::sync::Arc;
 

--- a/pixelflow-runtime/examples/psychedelic_shader.rs
+++ b/pixelflow-runtime/examples/psychedelic_shader.rs
@@ -16,8 +16,8 @@
 //! enabling CSE (common subexpression elimination) across the entire expression.
 
 use actor_scheduler::Message;
-use pixelflow_core::{Discrete, Field, Manifold};
 use pixelflow_compiler::kernel;
+use pixelflow_core::{Discrete, Field, Manifold};
 use pixelflow_runtime::api::private::EngineData;
 use pixelflow_runtime::api::public::{AppData, EngineEvent, EngineEventControl, EngineEventData};
 use pixelflow_runtime::platform::ColorCube;

--- a/pixelflow-runtime/src/platform/macos/cocoa.rs
+++ b/pixelflow-runtime/src/platform/macos/cocoa.rs
@@ -117,6 +117,12 @@ impl NSRect {
 
 // --- Wrappers ---
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IgnoreOtherApps {
+    Yes,
+    No,
+}
+
 /// Wrapper for NSApplication
 #[derive(Copy, Clone)]
 pub struct NSApplication(pub Id);
@@ -136,9 +142,12 @@ impl NSApplication {
         }
     }
 
-    pub fn activate_ignoring_other_apps(&self, ignore: bool) {
+    pub fn activate_ignoring_other_apps(&self, ignore: IgnoreOtherApps) {
         unsafe {
-            let val = if ignore { YES } else { NO };
+            let val = match ignore {
+                IgnoreOtherApps::Yes => YES,
+                IgnoreOtherApps::No => NO,
+            };
             sys::send_1::<(), BOOL>(self.0, sys::sel(b"activateIgnoringOtherApps:\0"), val);
         }
     }
@@ -247,6 +256,12 @@ impl NSWindow {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LayerRequirement {
+    WantsLayer,
+    NoLayer,
+}
+
 /// Wrapper for NSView
 #[derive(Copy, Clone)]
 pub struct NSView(pub Id);
@@ -266,9 +281,12 @@ impl NSView {
         }
     }
 
-    pub fn set_wants_layer(&self, wants: bool) {
+    pub fn set_wants_layer(&self, wants: LayerRequirement) {
         unsafe {
-            let val = if wants { YES } else { NO };
+            let val = match wants {
+                LayerRequirement::WantsLayer => YES,
+                LayerRequirement::NoLayer => NO,
+            };
             sys::send_1::<(), BOOL>(self.0, sys::sel(b"setWantsLayer:\0"), val);
         }
     }

--- a/pixelflow-runtime/src/platform/macos/platform.rs
+++ b/pixelflow-runtime/src/platform/macos/platform.rs
@@ -45,7 +45,7 @@ impl MetalOps {
             app.set_activation_policy(NS_APPLICATION_ACTIVATION_POLICY_REGULAR);
 
             app.finish_launching();
-            app.activate_ignoring_other_apps(true);
+            app.activate_ignoring_other_apps(IgnoreOtherApps::Yes);
 
             app
         };
@@ -102,7 +102,11 @@ impl PlatformOps for MetalOps {
             }
             DisplayControl::SetVisible { id, visible } => {
                 if let Some(win) = self.windows.get_mut(&id) {
-                    win.set_visible(visible);
+                    win.set_visible(if visible {
+                        WindowVisibility::Visible
+                    } else {
+                        WindowVisibility::Hidden
+                    });
                 }
             }
             DisplayControl::RequestRedraw { id } => {
@@ -164,7 +168,7 @@ impl PlatformOps for MetalOps {
             }
             DisplayMgmt::Destroy { id } => {
                 if let Some(mut win) = self.windows.remove(&id) {
-                    win.set_visible(false);
+                    win.set_visible(WindowVisibility::Hidden);
                     // Drop closes it implicitly or we call close
                     // win.window.close(); // If we expose it
                     self.window_map.remove(&(win.window.0 as usize));

--- a/pixelflow-runtime/src/platform/macos/window.rs
+++ b/pixelflow-runtime/src/platform/macos/window.rs
@@ -1,8 +1,14 @@
 use crate::api::public::WindowDescriptor;
 use crate::error::RuntimeError;
-use crate::platform::macos::cocoa::{NSPoint, NSRect, NSSize, NSView, NSWindow};
+use crate::platform::macos::cocoa::{NSPoint, NSRect, NSSize, NSView, NSWindow, LayerRequirement};
 use crate::platform::macos::sys::{self, Id, BOOL, YES};
 use std::ffi::c_void;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WindowVisibility {
+    Visible,
+    Hidden,
+}
 
 pub struct MacWindow {
     pub(crate) window: NSWindow,
@@ -60,7 +66,7 @@ impl MacWindow {
             sys::send_1::<(), Id>(view.0, sys::sel(b"setLayer:\0"), layer);
 
             // [view setWantsLayer: YES]
-            view.set_wants_layer(true);
+            view.set_wants_layer(LayerRequirement::WantsLayer);
         }
 
         window.set_content_view(view);
@@ -122,13 +128,14 @@ impl MacWindow {
         }
     }
 
-    pub fn set_visible(&mut self, visible: bool) {
-        if visible {
-            self.window.make_key_and_order_front();
-        } else {
-            unsafe {
-                sys::send::<()>(self.window.0, sys::sel(b"orderOut:\0"));
+    pub fn set_visible(&mut self, visibility: WindowVisibility) {
+        match visibility {
+            WindowVisibility::Visible => {
+                self.window.make_key_and_order_front();
             }
+            WindowVisibility::Hidden => unsafe {
+                sys::send::<()>(self.window.0, sys::sel(b"orderOut:\0"));
+            },
         }
     }
 


### PR DESCRIPTION
What: Refactored boolean arguments in macOS platform wrappers (`set_wants_layer`, `activate_ignoring_other_apps`, `set_visible`) to use intention-revealing enums (`LayerRequirement`, `IgnoreOtherApps`, `WindowVisibility`).
Why: To adhere to the project's STYLE.md guidelines which recommend avoiding boolean arguments in functions to make the call sites clearer and safer.
Impact: Improves code readability and maintainability without altering runtime behavior.
Measurement: Ensured compilation and tests pass for `pixelflow-runtime` crate.

---
*PR created automatically by Jules for task [1450132913809279356](https://jules.google.com/task/1450132913809279356) started by @jppittman*