### PR TITLE
⚡ Bolt: Optimize inverse length calculation by replacing .sqrt().rsqrt() with .rsqrt()

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,6 @@
 ## 2025-12-28 - Rasterizer Inner Loop Hoisting
 **Learning:** The inner loop of `execute_stripe` was re-evaluating `Field::sequential(start)` on every iteration, which involves multiple SIMD instructions (broadcast/load + add).
 **Action:** Hoisted the initialization of `xs` out of the loop and updated it incrementally using a pre-computed `step` vector. This reduced the inner loop overhead significantly, yielding a ~34% improvement in rasterization throughput.
+## 2025-12-28 - Inverse Length Calculation and `.rsqrt()`
+**Learning:** Found redundant operations in normal vector calculations where `.sqrt().rsqrt()` was used. Not only does this unnecessarily perform the square root calculation twice (as `.rsqrt()` is inherently optimized to compute `1/sqrt(x)` directly), but mathematically it incorrectly calculates `1/(x^(1/4))` instead of the inverse length.
+**Action:** When calculating inverse length or normalizing vectors, ensure `.rsqrt()` is applied directly to the squared length to avoid duplicate computation and mathematical errors.

--- a/pixelflow-graphics/src/scene3d.rs
+++ b/pixelflow-graphics/src/scene3d.rs
@@ -598,7 +598,8 @@ impl<M: ManifoldCompat<Jet3, Output = Field>> Manifold<Jet3_4> for Reflect<M> {
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        // Performance: Use .rsqrt() directly instead of .sqrt().rsqrt() to avoid double root calculation and redundant operations
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         // Normal components - evaluate at Jet3 construction boundary
         let nx = (cross_x * inv_n_len.clone()).constant();
@@ -686,7 +687,8 @@ impl<M: ManifoldCompat<Jet3, Output = Discrete>> Manifold<Jet3_4> for ColorRefle
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        // Performance: Use .rsqrt() directly instead of .sqrt().rsqrt() to avoid double root calculation and redundant operations
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         // Normal components - evaluate at Jet3 construction boundary
         let nx = (cross_x * inv_n_len.clone()).constant();
@@ -793,7 +795,8 @@ where
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        // Performance: Use .rsqrt() directly instead of .sqrt().rsqrt() to avoid double root calculation and redundant operations
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         let nx = (cross_x * inv_n_len.clone()).constant();
         let ny = (cross_y * inv_n_len.clone()).constant();
@@ -906,7 +909,8 @@ where
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        // Performance: Use .rsqrt() directly instead of .sqrt().rsqrt() to avoid double root calculation and redundant operations
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt();
 
         let nx = (cross_x * inv_n_len.clone()).constant();
         let ny = (cross_y * inv_n_len.clone()).constant();


### PR DESCRIPTION
What: Replaced `.sqrt().rsqrt()` with `.rsqrt()` in `pixelflow-graphics/src/scene3d.rs`. Why: The `.sqrt().rsqrt()` chain calculates `1/(x^(1/4))` applying the root twice, which is mathematically incorrect for inverse length and introduces a computationally expensive redundant operation. Impact: Removes redundant square root operations in hot path normalizations, improving mathematical correctness and rendering throughput. Measurement: Profile rasterization throughput before and after the change; verify rendering output correctness for 3D normals.

---
*PR created automatically by Jules for task [1046129700537913714](https://jules.google.com/task/1046129700537913714) started by @jppittman*