### PR TITLE
⚡ Bolt: Refactor eval_expr_scalar to group arguments into struct

### DIFF
--- a/pixelflow-ml/examples/critical_path_test.rs
+++ b/pixelflow-ml/examples/critical_path_test.rs
@@ -76,7 +76,7 @@ fn expr_sequential(a: f32, b: f32, c: f32, d: f32, e: f32, _f: f32) -> f32 {
     t2 + t4
 }
 
-fn benchmark<F>(name: &str, mut f: F) -> f64
+fn benchmark<F>(_name: &str, mut f: F) -> f64
 where
     F: FnMut() -> f32,
 {

--- a/pixelflow-ml/examples/critical_path_test.rs
+++ b/pixelflow-ml/examples/critical_path_test.rs
@@ -76,7 +76,7 @@ fn expr_sequential(a: f32, b: f32, c: f32, d: f32, e: f32, _f: f32) -> f32 {
     t2 + t4
 }
 
-fn benchmark<F>(_name: &str, mut f: F) -> f64
+fn benchmark<F>(name: &str, mut f: F) -> f64
 where
     F: FnMut() -> f32,
 {

--- a/pixelflow-ml/src/benchmark.rs
+++ b/pixelflow-ml/src/benchmark.rs
@@ -10,6 +10,14 @@
 //! well with SIMD execution since all operations scale similarly.
 
 use crate::nnue::{Expr, OpType};
+
+pub struct EvalContext {
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
+    pub w: f32,
+}
+
 use alloc::vec::Vec;
 
 #[cfg(feature = "std")]
@@ -57,17 +65,17 @@ impl Default for BenchmarkConfig {
 /// This is the core evaluation function used for benchmarking.
 /// It uses standard f32 operations which correlate well with SIMD
 /// performance for relative cost ranking.
-pub fn eval_expr_scalar(expr: &Expr, x: f32, y: f32, z: f32, w: f32) -> f32 {
+pub fn eval_expr_scalar(expr: &Expr, ctx: &EvalContext) -> f32 {
     match expr {
-        Expr::Var(0) => x,
-        Expr::Var(1) => y,
-        Expr::Var(2) => z,
-        Expr::Var(3) => w,
+        Expr::Var(0) => ctx.x,
+        Expr::Var(1) => ctx.y,
+        Expr::Var(2) => ctx.z,
+        Expr::Var(3) => ctx.w,
         Expr::Var(_) => 0.0,
         Expr::Const(c) => *c,
         Expr::Binary(op, lhs, rhs) => {
-            let l = eval_expr_scalar(lhs, x, y, z, w);
-            let r = eval_expr_scalar(rhs, x, y, z, w);
+            let l = eval_expr_scalar(lhs, ctx);
+            let r = eval_expr_scalar(rhs, ctx);
             match op {
                 OpType::Add => l + r,
                 OpType::Sub => l - r,
@@ -79,7 +87,7 @@ pub fn eval_expr_scalar(expr: &Expr, x: f32, y: f32, z: f32, w: f32) -> f32 {
             }
         }
         Expr::Unary(op, arg) => {
-            let a = eval_expr_scalar(arg, x, y, z, w);
+            let a = eval_expr_scalar(arg, ctx);
             match op {
                 OpType::Neg => -a,
                 OpType::Sqrt => libm::sqrtf(a),
@@ -89,9 +97,9 @@ pub fn eval_expr_scalar(expr: &Expr, x: f32, y: f32, z: f32, w: f32) -> f32 {
             }
         }
         Expr::Ternary(op, a, b, c) => {
-            let va = eval_expr_scalar(a, x, y, z, w);
-            let vb = eval_expr_scalar(b, x, y, z, w);
-            let vc = eval_expr_scalar(c, x, y, z, w);
+            let va = eval_expr_scalar(a, ctx);
+            let vb = eval_expr_scalar(b, ctx);
+            let vc = eval_expr_scalar(c, ctx);
             match op {
                 OpType::MulAdd => libm::fmaf(va, vb, vc),
                 OpType::MulRsqrt => va / libm::sqrtf(vb),
@@ -152,9 +160,10 @@ pub fn benchmark_expr(expr: &Expr, config: &BenchmarkConfig) -> BenchmarkResult 
     // Warmup
     for _ in 0..config.warmup_iterations {
         for _ in 0..config.evals_per_iteration {
+            let ctx = EvalContext { x, y, z, w };
             let _ = std::hint::black_box(eval_expr_scalar(
                 std::hint::black_box(expr),
-                x, y, z, w,
+                &ctx,
             ));
         }
     }
@@ -165,9 +174,10 @@ pub fn benchmark_expr(expr: &Expr, config: &BenchmarkConfig) -> BenchmarkResult 
     for _ in 0..config.measure_iterations {
         let start = Instant::now();
         for _ in 0..config.evals_per_iteration {
+            let ctx = EvalContext { x, y, z, w };
             let _ = std::hint::black_box(eval_expr_scalar(
                 std::hint::black_box(expr),
-                x, y, z, w,
+                &ctx,
             ));
         }
         let elapsed = start.elapsed();
@@ -312,7 +322,8 @@ mod tests {
             Box::new(Expr::Var(1)),
         );
 
-        let result = eval_expr_scalar(&expr, 3.0, 4.0, 0.0, 0.0);
+        let ctx = EvalContext { x: 3.0, y: 4.0, z: 0.0, w: 0.0 };
+        let result = eval_expr_scalar(&expr, &ctx);
         assert!((result - 7.0).abs() < 1e-6);
     }
 
@@ -334,7 +345,8 @@ mod tests {
         );
 
         // (3 * 4) + (5 - 2) = 12 + 3 = 15
-        let result = eval_expr_scalar(&expr, 3.0, 4.0, 5.0, 2.0);
+        let ctx = EvalContext { x: 3.0, y: 4.0, z: 5.0, w: 2.0 };
+        let result = eval_expr_scalar(&expr, &ctx);
         assert!((result - 15.0).abs() < 1e-6);
     }
 


### PR DESCRIPTION
What: Refactored `eval_expr_scalar` in `pixelflow-ml/src/benchmark.rs` to group its 4 coordinate arguments (`x`, `y`, `z`, `w`) into a new `EvalContext` struct.
Why: To adhere to the `docs/STYLE.md` guideline that states functions should generally take fewer than 4 arguments. The function previously took 5 arguments.
Impact: Improves code readability and maintainability by logically grouping related spatial coordinates, making the function signature cleaner and reducing argument passing overhead in recursive calls.
Measurement: Monitored compilation and tests to ensure no logic regressions were introduced.

---
*PR created automatically by Jules for task [5093245588171587166](https://jules.google.com/task/5093245588171587166) started by @jppittman*