### PR TITLE
⚡ Bolt: Refactor boolean arguments to enums in macOS platform bindings

### DIFF
--- a/pixelflow-runtime/src/platform/macos/cocoa.rs
+++ b/pixelflow-runtime/src/platform/macos/cocoa.rs
@@ -117,6 +117,18 @@ impl NSRect {
 
 // --- Wrappers ---
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActivationPolicy {
+    IgnoreOtherApps,
+    RespectOtherApps,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EventDequeuePolicy {
+    Dequeue,
+    Peek,
+}
+
 /// Wrapper for NSApplication
 #[derive(Copy, Clone)]
 pub struct NSApplication(pub Id);
@@ -136,9 +148,12 @@ impl NSApplication {
         }
     }
 
-    pub fn activate_ignoring_other_apps(&self, ignore: bool) {
+    pub fn activate_ignoring_other_apps(&self, policy: ActivationPolicy) {
         unsafe {
-            let val = if ignore { YES } else { NO };
+            let val = match policy {
+                ActivationPolicy::IgnoreOtherApps => YES,
+                ActivationPolicy::RespectOtherApps => NO,
+            };
             sys::send_1::<(), BOOL>(self.0, sys::sel(b"activateIgnoringOtherApps:\0"), val);
         }
     }
@@ -156,9 +171,18 @@ impl NSApplication {
     }
 
     // nextEventMatchingMask:untilDate:inMode:dequeue:
-    pub fn next_event(&self, mask: u64, date: Id, mode: Id, dequeue: bool) -> NSEvent {
+    pub fn next_event(
+        &self,
+        mask: u64,
+        date: Id,
+        mode: Id,
+        dequeue: EventDequeuePolicy,
+    ) -> NSEvent {
         unsafe {
-            let d = if dequeue { YES } else { NO };
+            let d = match dequeue {
+                EventDequeuePolicy::Dequeue => YES,
+                EventDequeuePolicy::Peek => NO,
+            };
             let ptr: Id = sys::send_4(
                 self.0,
                 sys::sel(b"nextEventMatchingMask:untilDate:inMode:dequeue:\0"),
@@ -247,6 +271,12 @@ impl NSWindow {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LayerVisibility {
+    WantsLayer,
+    NoLayer,
+}
+
 /// Wrapper for NSView
 #[derive(Copy, Clone)]
 pub struct NSView(pub Id);
@@ -266,9 +296,12 @@ impl NSView {
         }
     }
 
-    pub fn set_wants_layer(&self, wants: bool) {
+    pub fn set_wants_layer(&self, wants: LayerVisibility) {
         unsafe {
-            let val = if wants { YES } else { NO };
+            let val = match wants {
+                LayerVisibility::WantsLayer => YES,
+                LayerVisibility::NoLayer => NO,
+            };
             sys::send_1::<(), BOOL>(self.0, sys::sel(b"setWantsLayer:\0"), val);
         }
     }

--- a/pixelflow-runtime/src/platform/macos/platform.rs
+++ b/pixelflow-runtime/src/platform/macos/platform.rs
@@ -45,7 +45,9 @@ impl MetalOps {
             app.set_activation_policy(NS_APPLICATION_ACTIVATION_POLICY_REGULAR);
 
             app.finish_launching();
-            app.activate_ignoring_other_apps(true);
+            app.activate_ignoring_other_apps(
+                crate::platform::macos::cocoa::ActivationPolicy::IgnoreOtherApps,
+            );
 
             app
         };
@@ -102,7 +104,11 @@ impl PlatformOps for MetalOps {
             }
             DisplayControl::SetVisible { id, visible } => {
                 if let Some(win) = self.windows.get_mut(&id) {
-                    win.set_visible(visible);
+                    win.set_visible(if visible {
+                        crate::platform::macos::window::WindowVisibility::Visible
+                    } else {
+                        crate::platform::macos::window::WindowVisibility::Hidden
+                    });
                 }
             }
             DisplayControl::RequestRedraw { id } => {
@@ -164,7 +170,7 @@ impl PlatformOps for MetalOps {
             }
             DisplayMgmt::Destroy { id } => {
                 if let Some(mut win) = self.windows.remove(&id) {
-                    win.set_visible(false);
+                    win.set_visible(crate::platform::macos::window::WindowVisibility::Hidden);
                     // Drop closes it implicitly or we call close
                     // win.window.close(); // If we expose it
                     self.window_map.remove(&(win.window.0 as usize));
@@ -217,7 +223,7 @@ impl PlatformOps for MetalOps {
                 u64::MAX,
                 until_date,
                 mode,
-                true, // dequeue
+                crate::platform::macos::cocoa::EventDequeuePolicy::Dequeue, // dequeue
             );
 
             // Release mode string

--- a/pixelflow-runtime/src/platform/macos/window.rs
+++ b/pixelflow-runtime/src/platform/macos/window.rs
@@ -12,6 +12,12 @@ pub struct MacWindow {
     pub(crate) current_height: u32,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WindowVisibility {
+    Visible,
+    Hidden,
+}
+
 impl MacWindow {
     pub fn new(desc: WindowDescriptor) -> Result<Self, RuntimeError> {
         let rect = NSRect::new(
@@ -60,7 +66,7 @@ impl MacWindow {
             sys::send_1::<(), Id>(view.0, sys::sel(b"setLayer:\0"), layer);
 
             // [view setWantsLayer: YES]
-            view.set_wants_layer(true);
+            view.set_wants_layer(crate::platform::macos::cocoa::LayerVisibility::WantsLayer);
         }
 
         window.set_content_view(view);
@@ -122,13 +128,14 @@ impl MacWindow {
         }
     }
 
-    pub fn set_visible(&mut self, visible: bool) {
-        if visible {
-            self.window.make_key_and_order_front();
-        } else {
-            unsafe {
-                sys::send::<()>(self.window.0, sys::sel(b"orderOut:\0"));
+    pub fn set_visible(&mut self, visibility: WindowVisibility) {
+        match visibility {
+            WindowVisibility::Visible => {
+                self.window.make_key_and_order_front();
             }
+            WindowVisibility::Hidden => unsafe {
+                sys::send::<()>(self.window.0, sys::sel(b"orderOut:\0"));
+            },
         }
     }
 


### PR DESCRIPTION
What: Refactored boolean arguments in macOS platform bindings (`cocoa.rs`, `window.rs`, `platform.rs`) to use strongly-typed enums. Why: To adhere to STYLE.md guidelines which recommend avoiding boolean arguments to make call sites clearer and more intention-revealing. Impact: Improves code readability and maintainability without altering runtime behavior. Measurement: `cargo check` and `cargo test` pass successfully on the modified crates.

---
*PR created automatically by Jules for task [12536636151261173277](https://jules.google.com/task/12536636151261173277) started by @jppittman*