### PR TITLE
⚡ Bolt: Use Vec::with_capacity for grid layout rows and cells

### DIFF
--- a/core-term/src/terminal_app.rs
+++ b/core-term/src/terminal_app.rs
@@ -288,11 +288,13 @@ impl TerminalApp {
         let default_bg = self.config.colors.background;
 
         // Build 2-level BSP: Vertical (Rows) -> Horizontal (Cells)
-        let mut row_items = Vec::new();
+        // Pre-allocate to avoid heap reallocations during terminal layout building
+        let mut row_items = Vec::with_capacity(rows);
 
         for row in 0..rows {
             let line = &snapshot.lines[row];
-            let mut cell_items = Vec::new();
+            // Pre-allocate to avoid heap reallocations per row
+            let mut cell_items = Vec::with_capacity(cols);
 
             for col in 0..cols {
                 let glyph = &line.cells[col];


### PR DESCRIPTION
What: Replaced Vec::new() with Vec::with_capacity() for row_items and cell_items in terminal_app.rs. Why: cols and rows are already known exactly before building the terminal layout vectors. Pre-allocating the vectors eliminates unnecessary dynamic memory reallocations inside hot loops processing the terminal grid. Impact: Reduces heap reallocations when rendering terminal grids. Measurement: Memory profiling and execution time measurement during rendering large terminal grids.

---
*PR created automatically by Jules for task [6983090541138005807](https://jules.google.com/task/6983090541138005807) started by @jppittman*