### PR TITLE
Refactor boolean arguments to enums in macOS platform layer

### DIFF
--- a/pixelflow-runtime/examples/animated_sphere.rs
+++ b/pixelflow-runtime/examples/animated_sphere.rs
@@ -14,13 +14,13 @@
 //! - Scene is rebuilt with new dimensions on next frame
 
 use actor_scheduler::Message;
+use pixelflow_compiler::ManifoldExpr;
 use pixelflow_core::combinators::At;
 use pixelflow_core::jet::Jet3;
 use pixelflow_core::{Discrete, Field, Manifold, ManifoldCompat};
 use pixelflow_graphics::scene3d::{
     plane, ColorChecker, ColorReflect, ColorScreenToDir, ColorSky, ColorSurface,
 };
-use pixelflow_compiler::ManifoldExpr;
 use pixelflow_runtime::api::private::EngineData;
 use pixelflow_runtime::api::public::{AppData, EngineEvent, EngineEventControl, EngineEventData};
 use pixelflow_runtime::platform::ColorCube;

--- a/pixelflow-runtime/examples/chrome_sphere.rs
+++ b/pixelflow-runtime/examples/chrome_sphere.rs
@@ -3,10 +3,10 @@
 //! Compares single-threaded vs parallel rasterization of the 3D chrome sphere scene.
 //! Uses the mullet architecture: geometry once, colors as packed Discrete.
 
+use pixelflow_compiler::ManifoldExpr;
 use pixelflow_core::combinators::At;
 use pixelflow_core::jet::Jet3;
 use pixelflow_core::{Discrete, Field, Manifold, ManifoldCompat};
-use pixelflow_compiler::ManifoldExpr;
 
 type Field4 = (Field, Field, Field, Field);
 type Jet3_4 = (Jet3, Jet3, Jet3, Jet3);

--- a/pixelflow-runtime/examples/image_viewer.rs
+++ b/pixelflow-runtime/examples/image_viewer.rs
@@ -6,10 +6,10 @@
 //! 3. Send a manifold to render
 //! 4. Run the event loop
 
+use pixelflow_compiler::ManifoldExpr;
 use pixelflow_core::combinators::At;
 use pixelflow_core::jet::Jet3;
 use pixelflow_core::{Discrete, Field, Manifold, ManifoldCompat};
-use pixelflow_compiler::ManifoldExpr;
 use pixelflow_runtime::{api::public::AppData, EngineConfig, EngineTroupe, WindowConfig};
 use std::sync::Arc;
 

--- a/pixelflow-runtime/examples/psychedelic_shader.rs
+++ b/pixelflow-runtime/examples/psychedelic_shader.rs
@@ -16,8 +16,8 @@
 //! enabling CSE (common subexpression elimination) across the entire expression.
 
 use actor_scheduler::Message;
-use pixelflow_core::{Discrete, Field, Manifold};
 use pixelflow_compiler::kernel;
+use pixelflow_core::{Discrete, Field, Manifold};
 use pixelflow_runtime::api::private::EngineData;
 use pixelflow_runtime::api::public::{AppData, EngineEvent, EngineEventControl, EngineEventData};
 use pixelflow_runtime::platform::ColorCube;

--- a/pixelflow-runtime/src/platform/macos/cocoa.rs
+++ b/pixelflow-runtime/src/platform/macos/cocoa.rs
@@ -36,6 +36,18 @@ pub fn nsstring_to_string(ns_str: Id) -> String {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActivationPolicy {
+    RespectOtherApps,
+    IgnoreOtherApps,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LayerSupport {
+    WantsLayer,
+    DoesNotWantLayer,
+}
+
 // --- Structs ---
 
 /// Wrapper for NSPasteboard
@@ -136,9 +148,12 @@ impl NSApplication {
         }
     }
 
-    pub fn activate_ignoring_other_apps(&self, ignore: bool) {
+    pub fn activate_ignoring_other_apps(&self, policy: ActivationPolicy) {
         unsafe {
-            let val = if ignore { YES } else { NO };
+            let val = match policy {
+                ActivationPolicy::IgnoreOtherApps => YES,
+                ActivationPolicy::RespectOtherApps => NO,
+            };
             sys::send_1::<(), BOOL>(self.0, sys::sel(b"activateIgnoringOtherApps:\0"), val);
         }
     }
@@ -266,9 +281,12 @@ impl NSView {
         }
     }
 
-    pub fn set_wants_layer(&self, wants: bool) {
+    pub fn set_wants_layer(&self, support: LayerSupport) {
         unsafe {
-            let val = if wants { YES } else { NO };
+            let val = match support {
+                LayerSupport::WantsLayer => YES,
+                LayerSupport::DoesNotWantLayer => NO,
+            };
             sys::send_1::<(), BOOL>(self.0, sys::sel(b"setWantsLayer:\0"), val);
         }
     }

--- a/pixelflow-runtime/src/platform/macos/platform.rs
+++ b/pixelflow-runtime/src/platform/macos/platform.rs
@@ -45,7 +45,9 @@ impl MetalOps {
             app.set_activation_policy(NS_APPLICATION_ACTIVATION_POLICY_REGULAR);
 
             app.finish_launching();
-            app.activate_ignoring_other_apps(true);
+            app.activate_ignoring_other_apps(
+                crate::platform::macos::cocoa::ActivationPolicy::IgnoreOtherApps,
+            );
 
             app
         };
@@ -102,7 +104,11 @@ impl PlatformOps for MetalOps {
             }
             DisplayControl::SetVisible { id, visible } => {
                 if let Some(win) = self.windows.get_mut(&id) {
-                    win.set_visible(visible);
+                    win.set_visible(if visible {
+                        crate::platform::macos::window::WindowVisibility::Visible
+                    } else {
+                        crate::platform::macos::window::WindowVisibility::Hidden
+                    });
                 }
             }
             DisplayControl::RequestRedraw { id } => {
@@ -164,7 +170,7 @@ impl PlatformOps for MetalOps {
             }
             DisplayMgmt::Destroy { id } => {
                 if let Some(mut win) = self.windows.remove(&id) {
-                    win.set_visible(false);
+                    win.set_visible(crate::platform::macos::window::WindowVisibility::Hidden);
                     // Drop closes it implicitly or we call close
                     // win.window.close(); // If we expose it
                     self.window_map.remove(&(win.window.0 as usize));

--- a/pixelflow-runtime/src/platform/macos/window.rs
+++ b/pixelflow-runtime/src/platform/macos/window.rs
@@ -4,6 +4,12 @@ use crate::platform::macos::cocoa::{NSPoint, NSRect, NSSize, NSView, NSWindow};
 use crate::platform::macos::sys::{self, Id, BOOL, YES};
 use std::ffi::c_void;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WindowVisibility {
+    Hidden,
+    Visible,
+}
+
 pub struct MacWindow {
     pub(crate) window: NSWindow,
     pub(crate) view: NSView,
@@ -60,7 +66,7 @@ impl MacWindow {
             sys::send_1::<(), Id>(view.0, sys::sel(b"setLayer:\0"), layer);
 
             // [view setWantsLayer: YES]
-            view.set_wants_layer(true);
+            view.set_wants_layer(crate::platform::macos::cocoa::LayerSupport::WantsLayer);
         }
 
         window.set_content_view(view);
@@ -122,13 +128,14 @@ impl MacWindow {
         }
     }
 
-    pub fn set_visible(&mut self, visible: bool) {
-        if visible {
-            self.window.make_key_and_order_front();
-        } else {
-            unsafe {
-                sys::send::<()>(self.window.0, sys::sel(b"orderOut:\0"));
+    pub fn set_visible(&mut self, visibility: WindowVisibility) {
+        match visibility {
+            WindowVisibility::Visible => {
+                self.window.make_key_and_order_front();
             }
+            WindowVisibility::Hidden => unsafe {
+                sys::send::<()>(self.window.0, sys::sel(b"orderOut:\0"));
+            },
         }
     }
 


### PR DESCRIPTION
What: Replaced boolean arguments with intention-revealing enums in `NSApplication::activate_ignoring_other_apps`, `NSView::set_wants_layer`, and `MacWindow::set_visible`.
Why: To enforce `STYLE.md` rules against boolean arguments in public APIs and improve call site clarity.
Impact: Safer and more self-documenting macOS window and application management code.
Measurement: `cargo check` and `cargo test` run successfully on `pixelflow-runtime`.

---
*PR created automatically by Jules for task [631256747749955528](https://jules.google.com/task/631256747749955528) started by @jppittman*