### PR TITLE
⚡ Bolt: Replace redundant .sqrt().rsqrt() with .rsqrt() in scene3d.rs normal calculations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2025-12-28 - Rasterizer Inner Loop Hoisting
 **Learning:** The inner loop of `execute_stripe` was re-evaluating `Field::sequential(start)` on every iteration, which involves multiple SIMD instructions (broadcast/load + add).
 **Action:** Hoisted the initialization of `xs` out of the loop and updated it incrementally using a pre-computed `step` vector. This reduced the inner loop overhead significantly, yielding a ~34% improvement in rasterization throughput.
+
+## 2025-12-29 - Vector Normalization Redundant Sqrt
+**Learning:** In `scene3d.rs`, vector normalization was erroneously calculating `inv_n_len` using `.sqrt().rsqrt()`. This applies the root twice (calculating $x^{-0.25}$ instead of $x^{-0.5}$) and forces two expensive operations. Replacing it with just `.rsqrt()` fixes the math and removes a heavy instruction from the core rendering path.
+**Action:** When auditing vector math, always check for redundant or conflicting inverse square root operations stacked together.

--- a/pixelflow-graphics/src/scene3d.rs
+++ b/pixelflow-graphics/src/scene3d.rs
@@ -13,9 +13,9 @@
 //!
 //! No iteration. Nesting is occlusion.
 
+use pixelflow_compiler::{kernel, ManifoldExpr};
 use pixelflow_core::jet::Jet3;
 use pixelflow_core::*;
-use pixelflow_compiler::{kernel, ManifoldExpr};
 
 /// The standard 4D Field domain type.
 type Field4 = (Field, Field, Field, Field);
@@ -598,7 +598,7 @@ impl<M: ManifoldCompat<Jet3, Output = Field>> Manifold<Jet3_4> for Reflect<M> {
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt(); // Bolt: Removed redundant .sqrt() before .rsqrt() for performance
 
         // Normal components - evaluate at Jet3 construction boundary
         let nx = (cross_x * inv_n_len.clone()).constant();
@@ -686,7 +686,7 @@ impl<M: ManifoldCompat<Jet3, Output = Discrete>> Manifold<Jet3_4> for ColorRefle
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt(); // Bolt: Removed redundant .sqrt() before .rsqrt() for performance
 
         // Normal components - evaluate at Jet3 construction boundary
         let nx = (cross_x * inv_n_len.clone()).constant();
@@ -793,7 +793,7 @@ where
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt(); // Bolt: Removed redundant .sqrt() before .rsqrt() for performance
 
         let nx = (cross_x * inv_n_len.clone()).constant();
         let ny = (cross_y * inv_n_len.clone()).constant();
@@ -906,7 +906,7 @@ where
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt(); // Bolt: Removed redundant .sqrt() before .rsqrt() for performance
 
         let nx = (cross_x * inv_n_len.clone()).constant();
         let ny = (cross_y * inv_n_len.clone()).constant();
@@ -1136,7 +1136,10 @@ impl<C: ManifoldCompat<Field, Output = Discrete>> Manifold<Jet3_4> for ColorChec
         // Coverage: how much of the pixel is in this cell vs neighbor
         let zero = Field::from(0.0);
         let one = Field::from(1.0);
-        let coverage = (dist_to_edge / pixel_size).min(one.clone()).max(zero).constant();
+        let coverage = (dist_to_edge / pixel_size)
+            .min(one.clone())
+            .max(zero)
+            .constant();
 
         // Select and blend colors
         let r_base = is_even.clone().select(ra.clone(), rb.clone());


### PR DESCRIPTION
What: Removed the redundant .sqrt() call before .rsqrt() when calculating inv_n_len in four places within scene3d.rs.
Why: The expression .sqrt().rsqrt() applies the square root twice (calculating 1/(x^(1/4))) which is mathematically incorrect for vector normalization and computationally expensive.
Impact: Improves performance by eliminating an unnecessary and expensive mathematical operation in the 3D scene rendering pipeline.
Measurement: Review the generated assembly or profile the rendering performance to confirm the reduction in math operations during normal normalization.

---
*PR created automatically by Jules for task [1719100680289222519](https://jules.google.com/task/1719100680289222519) started by @jppittman*