### PR TITLE
⚡ Bolt: Refactor `dequeue` boolean argument to enum in `cocoa.rs`

### DIFF
--- a/pixelflow-runtime/src/platform/macos/cocoa.rs
+++ b/pixelflow-runtime/src/platform/macos/cocoa.rs
@@ -117,6 +117,12 @@ impl NSRect {
 
 // --- Wrappers ---
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DequeueEvent {
+    Yes,
+    No,
+}
+
 /// Wrapper for NSApplication
 #[derive(Copy, Clone)]
 pub struct NSApplication(pub Id);
@@ -156,9 +162,12 @@ impl NSApplication {
     }
 
     // nextEventMatchingMask:untilDate:inMode:dequeue:
-    pub fn next_event(&self, mask: u64, date: Id, mode: Id, dequeue: bool) -> NSEvent {
+    pub fn next_event(&self, mask: u64, date: Id, mode: Id, dequeue: DequeueEvent) -> NSEvent {
         unsafe {
-            let d = if dequeue { YES } else { NO };
+            let d = match dequeue {
+                DequeueEvent::Yes => YES,
+                DequeueEvent::No => NO,
+            };
             let ptr: Id = sys::send_4(
                 self.0,
                 sys::sel(b"nextEventMatchingMask:untilDate:inMode:dequeue:\0"),

--- a/pixelflow-runtime/src/platform/macos/platform.rs
+++ b/pixelflow-runtime/src/platform/macos/platform.rs
@@ -2,7 +2,7 @@ use crate::api::private::{EngineActorHandle, EngineData, WindowId};
 use crate::display::messages::{DisplayControl, DisplayData, DisplayEvent, DisplayMgmt, Window};
 use crate::display::ops::PlatformOps;
 use crate::error::RuntimeError;
-use crate::platform::macos::cocoa::{self, event_type, NSApplication, NSPasteboard};
+use crate::platform::macos::cocoa::{self, event_type, DequeueEvent, NSApplication, NSPasteboard};
 use crate::platform::macos::events;
 use crate::platform::macos::sys;
 use crate::platform::macos::window::MacWindow;
@@ -217,7 +217,7 @@ impl PlatformOps for MetalOps {
                 u64::MAX,
                 until_date,
                 mode,
-                true, // dequeue
+                DequeueEvent::Yes, // dequeue
             );
 
             // Release mode string


### PR DESCRIPTION
What: Replaced the `dequeue` boolean flag with a clearly named enum `DequeueEvent` in `pixelflow-runtime/src/platform/macos/cocoa.rs`.
Why: To adhere to the `STYLE.md` guideline of avoiding boolean arguments, enhancing the readability and clarity of the call site.
Impact: Improves code maintainability without changing runtime behavior.
Measurement: `cargo test -p pixelflow-runtime` passes and manual inspection of the updated files.

---
*PR created automatically by Jules for task [18108999745772371542](https://jules.google.com/task/18108999745772371542) started by @jppittman*