### PR TITLE
⚡ Bolt: Refactor set_visible boolean arguments to explicit methods

### DIFF
--- a/core-term/src/term/cursor.rs
+++ b/core-term/src/term/cursor.rs
@@ -238,13 +238,16 @@ impl CursorController {
         self.cursor.attributes
     }
 
-    /// Sets the visibility of the cursor.
-    pub fn set_visible(&mut self, visibility: CursorVisibility) {
-        trace!("Cursor visibility set to: {:?}", visibility);
-        self.cursor.visible = match visibility {
-            CursorVisibility::Visible => true,
-            CursorVisibility::Hidden => false,
-        };
+    /// Shows the cursor.
+    pub fn show(&mut self) {
+        trace!("Cursor visibility set to: Visible");
+        self.cursor.visible = true;
+    }
+
+    /// Hides the cursor.
+    pub fn hide(&mut self) {
+        trace!("Cursor visibility set to: Hidden");
+        self.cursor.visible = false;
     }
 
     /// Returns `true` if the cursor is currently set to be visible.
@@ -398,7 +401,7 @@ impl CursorController {
     }
     pub fn reset(&mut self) {
         self.set_attributes(Attributes::default());
-        self.set_visible(CursorVisibility::Visible);
+        self.show();
         self.cursor = Cursor::default();
     }
 }

--- a/core-term/src/term/emulator/mode_handler.rs
+++ b/core-term/src/term/emulator/mode_handler.rs
@@ -104,7 +104,11 @@ impl TerminalEmulator {
                     Some(DecModeConstant::TextCursorEnable) => {
                         self.dec_modes.text_cursor_enable_mode = enable;
                         let visibility = CursorVisibility::from(enable);
-                        self.cursor_controller.set_visible(visibility);
+                        if enable {
+                            self.cursor_controller.show();
+                        } else {
+                            self.cursor_controller.hide();
+                        }
                         action_to_return = Some(EmulatorAction::SetCursorVisibility(visibility));
                     }
                     Some(DecModeConstant::AltScreenBufferClear)

--- a/pixelflow-runtime/examples/animated_sphere.rs
+++ b/pixelflow-runtime/examples/animated_sphere.rs
@@ -14,13 +14,13 @@
 //! - Scene is rebuilt with new dimensions on next frame
 
 use actor_scheduler::Message;
+use pixelflow_compiler::ManifoldExpr;
 use pixelflow_core::combinators::At;
 use pixelflow_core::jet::Jet3;
 use pixelflow_core::{Discrete, Field, Manifold, ManifoldCompat};
 use pixelflow_graphics::scene3d::{
     plane, ColorChecker, ColorReflect, ColorScreenToDir, ColorSky, ColorSurface,
 };
-use pixelflow_compiler::ManifoldExpr;
 use pixelflow_runtime::api::private::EngineData;
 use pixelflow_runtime::api::public::{AppData, EngineEvent, EngineEventControl, EngineEventData};
 use pixelflow_runtime::platform::ColorCube;

--- a/pixelflow-runtime/examples/chrome_sphere.rs
+++ b/pixelflow-runtime/examples/chrome_sphere.rs
@@ -3,10 +3,10 @@
 //! Compares single-threaded vs parallel rasterization of the 3D chrome sphere scene.
 //! Uses the mullet architecture: geometry once, colors as packed Discrete.
 
+use pixelflow_compiler::ManifoldExpr;
 use pixelflow_core::combinators::At;
 use pixelflow_core::jet::Jet3;
 use pixelflow_core::{Discrete, Field, Manifold, ManifoldCompat};
-use pixelflow_compiler::ManifoldExpr;
 
 type Field4 = (Field, Field, Field, Field);
 type Jet3_4 = (Jet3, Jet3, Jet3, Jet3);

--- a/pixelflow-runtime/examples/image_viewer.rs
+++ b/pixelflow-runtime/examples/image_viewer.rs
@@ -6,10 +6,10 @@
 //! 3. Send a manifold to render
 //! 4. Run the event loop
 
+use pixelflow_compiler::ManifoldExpr;
 use pixelflow_core::combinators::At;
 use pixelflow_core::jet::Jet3;
 use pixelflow_core::{Discrete, Field, Manifold, ManifoldCompat};
-use pixelflow_compiler::ManifoldExpr;
 use pixelflow_runtime::{api::public::AppData, EngineConfig, EngineTroupe, WindowConfig};
 use std::sync::Arc;
 

--- a/pixelflow-runtime/examples/psychedelic_shader.rs
+++ b/pixelflow-runtime/examples/psychedelic_shader.rs
@@ -16,8 +16,8 @@
 //! enabling CSE (common subexpression elimination) across the entire expression.
 
 use actor_scheduler::Message;
-use pixelflow_core::{Discrete, Field, Manifold};
 use pixelflow_compiler::kernel;
+use pixelflow_core::{Discrete, Field, Manifold};
 use pixelflow_runtime::api::private::EngineData;
 use pixelflow_runtime::api::public::{AppData, EngineEvent, EngineEventControl, EngineEventData};
 use pixelflow_runtime::platform::ColorCube;

--- a/pixelflow-runtime/src/display/messages.rs
+++ b/pixelflow-runtime/src/display/messages.rs
@@ -156,19 +156,31 @@ pub enum DisplayControl {
     /// - `cursor`: Cursor icon (arrow, text, etc.)
     SetCursor { id: WindowId, cursor: CursorIcon },
 
-    /// Show or hide the window.
+    /// Show the window.
     ///
     /// # Contract
     ///
-    /// **Sender**: Specifies visibility state.
+    /// **Sender**: Requests the window to be shown.
     ///
-    /// **Receiver**: Shows or hides the window. Window remains in the taskbar/app switcher.
+    /// **Receiver**: Shows the window.
     ///
     /// # Arguments
     ///
     /// - `id`: Window identifier
-    /// - `visible`: `true` to show, `false` to hide
-    SetVisible { id: WindowId, visible: bool },
+    ShowWindow { id: WindowId },
+
+    /// Hide the window.
+    ///
+    /// # Contract
+    ///
+    /// **Sender**: Requests the window to be hidden.
+    ///
+    /// **Receiver**: Hides the window. Window remains in the taskbar/app switcher.
+    ///
+    /// # Arguments
+    ///
+    /// - `id`: Window identifier
+    HideWindow { id: WindowId },
 
     /// Request an immediate redraw.
     ///

--- a/pixelflow-runtime/src/platform/linux/platform.rs
+++ b/pixelflow-runtime/src/platform/linux/platform.rs
@@ -103,7 +103,9 @@ impl PlatformOps for LinuxOps {
                 DisplayControl::Bell => {
                     window.bell();
                 }
-                DisplayControl::SetVisible { .. } | DisplayControl::RequestRedraw { .. } => {
+                DisplayControl::ShowWindow { .. }
+                | DisplayControl::HideWindow { .. }
+                | DisplayControl::RequestRedraw { .. } => {
                     // Not implemented for Linux yet
                 }
             }

--- a/pixelflow-runtime/src/platform/macos/platform.rs
+++ b/pixelflow-runtime/src/platform/macos/platform.rs
@@ -100,9 +100,14 @@ impl PlatformOps for MetalOps {
                     win.set_cursor(cursor);
                 }
             }
-            DisplayControl::SetVisible { id, visible } => {
+            DisplayControl::ShowWindow { id } => {
                 if let Some(win) = self.windows.get_mut(&id) {
-                    win.set_visible(visible);
+                    win.show();
+                }
+            }
+            DisplayControl::HideWindow { id } => {
+                if let Some(win) = self.windows.get_mut(&id) {
+                    win.hide();
                 }
             }
             DisplayControl::RequestRedraw { id } => {
@@ -164,7 +169,7 @@ impl PlatformOps for MetalOps {
             }
             DisplayMgmt::Destroy { id } => {
                 if let Some(mut win) = self.windows.remove(&id) {
-                    win.set_visible(false);
+                    win.hide();
                     // Drop closes it implicitly or we call close
                     // win.window.close(); // If we expose it
                     self.window_map.remove(&(win.window.0 as usize));

--- a/pixelflow-runtime/src/platform/macos/window.rs
+++ b/pixelflow-runtime/src/platform/macos/window.rs
@@ -122,13 +122,13 @@ impl MacWindow {
         }
     }
 
-    pub fn set_visible(&mut self, visible: bool) {
-        if visible {
-            self.window.make_key_and_order_front();
-        } else {
-            unsafe {
-                sys::send::<()>(self.window.0, sys::sel(b"orderOut:\0"));
-            }
+    pub fn show(&mut self) {
+        self.window.make_key_and_order_front();
+    }
+
+    pub fn hide(&mut self) {
+        unsafe {
+            sys::send::<()>(self.window.0, sys::sel(b"orderOut:\0"));
         }
     }
 


### PR DESCRIPTION
What: Refactored `DisplayControl::SetVisible` into `ShowWindow` and `HideWindow`, and `window.set_visible(bool)` into `window.show()` and `window.hide()`. Why: To adhere to `docs/STYLE.md` guidelines against boolean arguments, which obscure intent at the call site. Impact: Improves code readability and maintainability by making intent explicit. Measurement: Code successfully compiles and passes linter checks.

---
*PR created automatically by Jules for task [6796861176127492539](https://jules.google.com/task/6796861176127492539) started by @jppittman*