### PR TITLE
⚡ Bolt: Refactor DisplayControl::SetVisible to ShowWindow and HideWindow

### DIFF
--- a/pixelflow-runtime/src/display/messages.rs
+++ b/pixelflow-runtime/src/display/messages.rs
@@ -156,19 +156,31 @@ pub enum DisplayControl {
     /// - `cursor`: Cursor icon (arrow, text, etc.)
     SetCursor { id: WindowId, cursor: CursorIcon },
 
-    /// Show or hide the window.
+    /// Show the window.
     ///
     /// # Contract
     ///
-    /// **Sender**: Specifies visibility state.
+    /// **Sender**: Requests to show the window.
     ///
-    /// **Receiver**: Shows or hides the window. Window remains in the taskbar/app switcher.
+    /// **Receiver**: Shows the window. Window remains in the taskbar/app switcher.
     ///
     /// # Arguments
     ///
     /// - `id`: Window identifier
-    /// - `visible`: `true` to show, `false` to hide
-    SetVisible { id: WindowId, visible: bool },
+    ShowWindow { id: WindowId },
+
+    /// Hide the window.
+    ///
+    /// # Contract
+    ///
+    /// **Sender**: Requests to hide the window.
+    ///
+    /// **Receiver**: Hides the window. Window remains in the taskbar/app switcher.
+    ///
+    /// # Arguments
+    ///
+    /// - `id`: Window identifier
+    HideWindow { id: WindowId },
 
     /// Request an immediate redraw.
     ///

--- a/pixelflow-runtime/src/platform/linux/platform.rs
+++ b/pixelflow-runtime/src/platform/linux/platform.rs
@@ -103,7 +103,9 @@ impl PlatformOps for LinuxOps {
                 DisplayControl::Bell => {
                     window.bell();
                 }
-                DisplayControl::SetVisible { .. } | DisplayControl::RequestRedraw { .. } => {
+                DisplayControl::ShowWindow { .. }
+                | DisplayControl::HideWindow { .. }
+                | DisplayControl::RequestRedraw { .. } => {
                     // Not implemented for Linux yet
                 }
             }

--- a/pixelflow-runtime/src/platform/macos/platform.rs
+++ b/pixelflow-runtime/src/platform/macos/platform.rs
@@ -100,9 +100,14 @@ impl PlatformOps for MetalOps {
                     win.set_cursor(cursor);
                 }
             }
-            DisplayControl::SetVisible { id, visible } => {
+            DisplayControl::ShowWindow { id } => {
                 if let Some(win) = self.windows.get_mut(&id) {
-                    win.set_visible(visible);
+                    win.show();
+                }
+            }
+            DisplayControl::HideWindow { id } => {
+                if let Some(win) = self.windows.get_mut(&id) {
+                    win.hide();
                 }
             }
             DisplayControl::RequestRedraw { id } => {
@@ -164,7 +169,7 @@ impl PlatformOps for MetalOps {
             }
             DisplayMgmt::Destroy { id } => {
                 if let Some(mut win) = self.windows.remove(&id) {
-                    win.set_visible(false);
+                    win.hide();
                     // Drop closes it implicitly or we call close
                     // win.window.close(); // If we expose it
                     self.window_map.remove(&(win.window.0 as usize));

--- a/pixelflow-runtime/src/platform/macos/window.rs
+++ b/pixelflow-runtime/src/platform/macos/window.rs
@@ -122,13 +122,13 @@ impl MacWindow {
         }
     }
 
-    pub fn set_visible(&mut self, visible: bool) {
-        if visible {
-            self.window.make_key_and_order_front();
-        } else {
-            unsafe {
-                sys::send::<()>(self.window.0, sys::sel(b"orderOut:\0"));
-            }
+    pub fn show(&mut self) {
+        self.window.make_key_and_order_front();
+    }
+
+    pub fn hide(&mut self) {
+        unsafe {
+            sys::send::<()>(self.window.0, sys::sel(b"orderOut:\0"));
         }
     }
 


### PR DESCRIPTION
What: Refactored `DisplayControl::SetVisible(bool)` to `ShowWindow` and `HideWindow`, updating caller `platform.rs` and method `set_visible` in `window.rs` to `show`/`hide`.
Why: Adheres to `docs/STYLE.md` by eliminating a boolean argument that obscures call-site intent.
Impact: Improves clarity and reduces boolean trap risks.
Measurement: `cargo check` and `cargo test` run successfully for the `pixelflow-runtime` crate.

---
*PR created automatically by Jules for task [13779553899219974163](https://jules.google.com/task/13779553899219974163) started by @jppittman*