### PR TITLE
⚡ Bolt: Remove redundant sqrt in vector normalization

### DIFF
--- a/pixelflow-graphics/benches/font_rendering.rs
+++ b/pixelflow-graphics/benches/font_rendering.rs
@@ -65,13 +65,17 @@ fn bench_pixelflow_threading(c: &mut Criterion) {
     let colored = Grayscale(glyph);
 
     for threads in [1, 2, 4, 8] {
-        group.bench_with_input(BenchmarkId::from_parameter(threads), &threads, |b, &threads| {
-            let mut frame = Frame::<Rgba8>::new(360, 24);
+        group.bench_with_input(
+            BenchmarkId::from_parameter(threads),
+            &threads,
+            |b, &threads| {
+                let mut frame = Frame::<Rgba8>::new(360, 24);
 
-            b.iter(|| {
-                rasterize(black_box(&colored), black_box(&mut frame), threads);
-            });
-        });
+                b.iter(|| {
+                    rasterize(black_box(&colored), black_box(&mut frame), threads);
+                });
+            },
+        );
     }
 
     group.finish();
@@ -132,7 +136,8 @@ fn bench_freetype_single_char(c: &mut Criterion) {
             face.set_char_size(0, 32 * 64, 96, 96).unwrap();
 
             b.iter(|| {
-                face.load_char(ch as usize, ft::face::LoadFlag::RENDER).unwrap();
+                face.load_char(ch as usize, ft::face::LoadFlag::RENDER)
+                    .unwrap();
                 let glyph = face.glyph();
                 black_box(glyph.bitmap());
             });
@@ -157,7 +162,8 @@ fn bench_freetype_text(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::from_parameter(length), &length, |b, _| {
             b.iter(|| {
                 for ch in text_str.chars() {
-                    face.load_char(ch as usize, ft::face::LoadFlag::RENDER).unwrap();
+                    face.load_char(ch as usize, ft::face::LoadFlag::RENDER)
+                        .unwrap();
                     let glyph = face.glyph();
                     black_box(glyph.bitmap());
                 }

--- a/pixelflow-graphics/benches/kernel_bench.rs
+++ b/pixelflow-graphics/benches/kernel_bench.rs
@@ -3,8 +3,8 @@
 //! Tests the effectiveness of the e-graph optimizer on complex algebraic expressions.
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
-use pixelflow_core::{Field, ManifoldCompat, ManifoldExt, PARALLELISM, X, Y};
 use pixelflow_compiler::kernel;
+use pixelflow_core::{Field, ManifoldCompat, ManifoldExt, PARALLELISM, X, Y};
 
 /// Complex polynomial: f(x, y) = x³ + 2x²y + 3xy² + y³
 /// Manual construction (no automatic fusion anymore)
@@ -17,9 +17,7 @@ pub fn manual_poly(x: Field, y: Field) -> Field {
 /// Same polynomial using kernel! (optimized by e-graph)
 #[inline(never)]
 pub fn kernel_poly(x: Field, y: Field) -> Field {
-    let k = kernel!(|| {
-        X * X * X + X * X * Y * 2.0 + X * Y * Y * 3.0 + Y * Y * Y
-    });
+    let k = kernel!(|| { X * X * X + X * X * Y * 2.0 + X * Y * Y * 3.0 + Y * Y * Y });
     k().eval_raw(x, y, Field::from(0.0), Field::from(0.0))
 }
 

--- a/pixelflow-graphics/examples/chrome_asm.rs
+++ b/pixelflow-graphics/examples/chrome_asm.rs
@@ -2,13 +2,13 @@
 //!
 //! Run: cargo-asm -p pixelflow-graphics --example chrome_asm eval_one_pixel --release
 
+use pixelflow_compiler::ManifoldExpr;
 use pixelflow_core::combinators::At;
 use pixelflow_core::jet::Jet3;
 use pixelflow_core::{Discrete, Field, Manifold, ManifoldCompat};
 use pixelflow_graphics::render::color::RgbaColorCube;
-use pixelflow_compiler::ManifoldExpr;
 use pixelflow_graphics::scene3d::{
-    ColorChecker, ColorReflect, ColorScreenToDir, ColorSky, ColorSurface, plane,
+    plane, ColorChecker, ColorReflect, ColorScreenToDir, ColorSky, ColorSurface,
 };
 
 type Field4 = (Field, Field, Field, Field);
@@ -87,7 +87,9 @@ pub fn eval_one_pixel(x: Field, y: Field) -> Discrete {
             center: (0.0, 0.0, 4.0),
             radius: 1.0,
         },
-        material: ColorReflect { inner: world.clone() },
+        material: ColorReflect {
+            inner: world.clone(),
+        },
         background: world,
     };
 

--- a/pixelflow-graphics/examples/compose_test.rs
+++ b/pixelflow-graphics/examples/compose_test.rs
@@ -1,11 +1,16 @@
 //! Testing kernel composition patterns
-use pixelflow_core::{Field, Manifold};
 use pixelflow_compiler::kernel;
+use pixelflow_core::{Field, Manifold};
 
 type Field4 = (Field, Field, Field, Field);
 
 fn field4(x: f32, y: f32) -> Field4 {
-    (Field::from(x), Field::from(y), Field::from(0.0), Field::from(0.0))
+    (
+        Field::from(x),
+        Field::from(y),
+        Field::from(0.0),
+        Field::from(0.0),
+    )
 }
 
 fn main() {
@@ -33,5 +38,8 @@ fn main() {
 
     let c = circle(1.0, 2.0, 0.5);
     let result2 = c.eval(p);
-    println!("circle(center=(1.0, 2.0), r=0.5) at (1.5, 2.0): {:?}", result2);
+    println!(
+        "circle(center=(1.0, 2.0), r=0.5) at (1.5, 2.0): {:?}",
+        result2
+    );
 }

--- a/pixelflow-graphics/examples/kernel_scale_test.rs
+++ b/pixelflow-graphics/examples/kernel_scale_test.rs
@@ -1,15 +1,20 @@
-use pixelflow_core::{Field, Manifold, ManifoldExt};
 use pixelflow_compiler::kernel;
+use pixelflow_core::{Field, Manifold, ManifoldExt};
 
 type Field4 = (Field, Field, Field, Field);
 
 fn field4(x: f32, y: f32, z: f32, w: f32) -> Field4 {
-    (Field::from(x), Field::from(y), Field::from(z), Field::from(w))
+    (
+        Field::from(x),
+        Field::from(y),
+        Field::from(z),
+        Field::from(w),
+    )
 }
 
 fn main() {
     let p = field4(1.0, 2.0, 3.0, 4.0);
-    
+
     // 20 different 4-param kernels (no division with Var)
     let k1 = kernel!(|a: f32, b: f32, c: f32, d: f32| X + a + Y * b);
     let k2 = kernel!(|a: f32, b: f32, c: f32, d: f32| X - a + Y * b);
@@ -30,28 +35,32 @@ fn main() {
     let k17 = kernel!(|a: f32, b: f32, c: f32, d: f32| X * a * Y * b);
     let k18 = kernel!(|a: f32, b: f32, c: f32, d: f32| (X * X + Y * Y).sqrt() - a);
     let k19 = kernel!(|a: f32, b: f32, c: f32, d: f32| (X * X + Y * Y + Z * Z).sqrt() - a);
-    let k20 = kernel!(|a: f32, b: f32, c: f32, d: f32| { let dx = X - a; let dy = Y - b; (dx * dx + dy * dy).sqrt() });
-    
+    let k20 = kernel!(|a: f32, b: f32, c: f32, d: f32| {
+        let dx = X - a;
+        let dy = Y - b;
+        (dx * dx + dy * dy).sqrt()
+    });
+
     // Use them all to prevent DCE
     let v = 1.0f32;
-    let _ = k1(v,v,v,v).eval(p);
-    let _ = k2(v,v,v,v).eval(p);
-    let _ = k3(v,v,v,v).eval(p);
-    let _ = k4(v,v,v,v).eval(p);
-    let _ = k5(v,v,v,v).eval(p);
-    let _ = k6(v,v,v,v).eval(p);
-    let _ = k7(v,v,v,v).eval(p);
-    let _ = k8(v,v,v,v).eval(p);
-    let _ = k9(v,v,v,v).eval(p);
-    let _ = k10(v,v,v,v).eval(p);
-    let _ = k11(v,v,v,v).eval(p);
-    let _ = k12(v,v,v,v).eval(p);
-    let _ = k13(v,v,v,v).eval(p);
-    let _ = k14(v,v,v,v).eval(p);
-    let _ = k15(v,v,v,v).eval(p);
-    let _ = k16(v,v,v,v).eval(p);
-    let _ = k17(v,v,v,v).eval(p);
-    let _ = k18(v,v,v,v).eval(p);
-    let _ = k19(v,v,v,v).eval(p);
-    let _ = k20(v,v,v,v).eval(p);
+    let _ = k1(v, v, v, v).eval(p);
+    let _ = k2(v, v, v, v).eval(p);
+    let _ = k3(v, v, v, v).eval(p);
+    let _ = k4(v, v, v, v).eval(p);
+    let _ = k5(v, v, v, v).eval(p);
+    let _ = k6(v, v, v, v).eval(p);
+    let _ = k7(v, v, v, v).eval(p);
+    let _ = k8(v, v, v, v).eval(p);
+    let _ = k9(v, v, v, v).eval(p);
+    let _ = k10(v, v, v, v).eval(p);
+    let _ = k11(v, v, v, v).eval(p);
+    let _ = k12(v, v, v, v).eval(p);
+    let _ = k13(v, v, v, v).eval(p);
+    let _ = k14(v, v, v, v).eval(p);
+    let _ = k15(v, v, v, v).eval(p);
+    let _ = k16(v, v, v, v).eval(p);
+    let _ = k17(v, v, v, v).eval(p);
+    let _ = k18(v, v, v, v).eval(p);
+    let _ = k19(v, v, v, v).eval(p);
+    let _ = k20(v, v, v, v).eval(p);
 }

--- a/pixelflow-graphics/src/fonts/ttf.rs
+++ b/pixelflow-graphics/src/fonts/ttf.rs
@@ -6,11 +6,8 @@
 //! All derivatives are precomputed polynomials - no Jets needed!
 
 use crate::shapes::{square, Bounded};
-use pixelflow_core::{
-    At, Field, Manifold, ManifoldCompat, ManifoldExt,
-    W, Z,
-};
 use pixelflow_compiler::kernel;
+use pixelflow_core::{At, Field, Manifold, ManifoldCompat, ManifoldExt, W, Z};
 use std::sync::Arc;
 
 // Import analytical curve kernels
@@ -18,7 +15,6 @@ use super::ttf_curve_analytical::{AnalyticalLine, AnalyticalQuad};
 
 /// The standard 4D Field domain type.
 type Field4 = (Field, Field, Field, Field);
-
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Type Aliases for Concrete Kernel Types
@@ -92,7 +88,6 @@ impl<M: Manifold<Field4, Output = Field>> Manifold<Field4> for Sum<M> {
     }
 }
 
-
 // ═══════════════════════════════════════════════════════════════════════════
 // Geometry
 // ═══════════════════════════════════════════════════════════════════════════
@@ -146,7 +141,6 @@ impl<K: Manifold<Field4, Output = Field>> Manifold<Field4> for Line<K> {
     }
 }
 
-
 impl<K: Manifold<Field4, Output = Field>> Manifold<Field4> for Quad<K> {
     type Output = Field;
 
@@ -156,7 +150,6 @@ impl<K: Manifold<Field4, Output = Field>> Manifold<Field4> for Quad<K> {
         self.kernel.eval_raw(x, y, z, w)
     }
 }
-
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Glyph (Compositional Scene Graph)
@@ -202,7 +195,6 @@ impl<L: Manifold<Field4, Output = Field>, Q: Manifold<Field4, Output = Field>> M
             .eval_raw(fzero, fzero, fzero, fzero)
     }
 }
-
 
 /// A simple glyph: segments in unit space, bounded, then transformed.
 ///
@@ -290,7 +282,6 @@ where
         }
     }
 }
-
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Reader
@@ -554,11 +545,9 @@ impl<'a> Font<'a> {
                         ENCODING_WINDOWS_UNICODE_FULL,
                         FORMAT_SEGMENTED_COVERAGE,
                     )
-                    | (
-                        PLATFORM_UNICODE,
-                        ENCODING_UNICODE_2_0_FULL,
-                        FORMAT_SEGMENTED_COVERAGE,
-                    ) => Some((2, o, f)),
+                    | (PLATFORM_UNICODE, ENCODING_UNICODE_2_0_FULL, FORMAT_SEGMENTED_COVERAGE) => {
+                        Some((2, o, f))
+                    }
 
                     (PLATFORM_WINDOWS, ENCODING_WINDOWS_UNICODE_BMP, FORMAT_SEGMENT_MAPPING)
                     | (PLATFORM_UNICODE, ENCODING_UNICODE_2_0_BMP, FORMAT_SEGMENT_MAPPING) => {
@@ -590,10 +579,7 @@ impl<'a> Font<'a> {
 
     /// Get glyph by pre-looked-up glyph ID (avoids redundant CMAP lookup).
     #[inline]
-    pub fn glyph_by_id(
-        &self,
-        id: u16,
-    ) -> Option<Glyph<Line<LineKernel>, Quad<QuadKernel>>> {
+    pub fn glyph_by_id(&self, id: u16) -> Option<Glyph<Line<LineKernel>, Quad<QuadKernel>>> {
         self.compile(id)
     }
 

--- a/pixelflow-graphics/src/lib.rs
+++ b/pixelflow-graphics/src/lib.rs
@@ -1,4 +1,3 @@
-
 //! # PixelFlow Graphics
 //!
 //! Turns **algebraic manifolds into pixels** through three composable tiers: colors, fonts, and materialization.

--- a/pixelflow-graphics/src/render/color.rs
+++ b/pixelflow-graphics/src/render/color.rs
@@ -206,9 +206,21 @@ const fn generate_palette() -> [u32; 256] {
             let r_comp = (cube_idx / (COLOR_CUBE_SIZE * COLOR_CUBE_SIZE)) % COLOR_CUBE_SIZE;
             let g_comp = (cube_idx / COLOR_CUBE_SIZE) % COLOR_CUBE_SIZE;
             let b_comp = cube_idx % COLOR_CUBE_SIZE;
-            let r_val = if r_comp == 0 { 0 } else { r_comp * CUBE_SCALE_FACTOR + CUBE_BASE_OFFSET };
-            let g_val = if g_comp == 0 { 0 } else { g_comp * CUBE_SCALE_FACTOR + CUBE_BASE_OFFSET };
-            let b_val = if b_comp == 0 { 0 } else { b_comp * CUBE_SCALE_FACTOR + CUBE_BASE_OFFSET };
+            let r_val = if r_comp == 0 {
+                0
+            } else {
+                r_comp * CUBE_SCALE_FACTOR + CUBE_BASE_OFFSET
+            };
+            let g_val = if g_comp == 0 {
+                0
+            } else {
+                g_comp * CUBE_SCALE_FACTOR + CUBE_BASE_OFFSET
+            };
+            let b_val = if b_comp == 0 {
+                0
+            } else {
+                b_comp * CUBE_SCALE_FACTOR + CUBE_BASE_OFFSET
+            };
             (r_val, g_val, b_val)
         } else {
             // Grayscale ramp (indices 232-255)

--- a/pixelflow-graphics/src/render/rasterizer/mod.rs
+++ b/pixelflow-graphics/src/render/rasterizer/mod.rs
@@ -271,7 +271,12 @@ where
         let mut xs = Field::sequential(x as f32 + 0.5);
         let step = Field::from(PARALLELISM as f32);
         // Field ignores the domain arguments, so we pass zeroes. Hoisted to avoid reconstruction.
-        let dummy_domain = (Field::from(0.0), Field::from(0.0), Field::from(0.0), Field::from(0.0));
+        let dummy_domain = (
+            Field::from(0.0),
+            Field::from(0.0),
+            Field::from(0.0),
+            Field::from(0.0),
+        );
 
         // SIMD Hot Path - process PARALLELISM pixels at a time
         while x + PARALLELISM <= stripe.width {

--- a/pixelflow-graphics/src/scene3d.rs
+++ b/pixelflow-graphics/src/scene3d.rs
@@ -13,9 +13,9 @@
 //!
 //! No iteration. Nesting is occlusion.
 
+use pixelflow_compiler::{kernel, ManifoldExpr};
 use pixelflow_core::jet::Jet3;
 use pixelflow_core::*;
-use pixelflow_compiler::{kernel, ManifoldExpr};
 
 /// The standard 4D Field domain type.
 type Field4 = (Field, Field, Field, Field);
@@ -598,7 +598,7 @@ impl<M: ManifoldCompat<Jet3, Output = Field>> Manifold<Jet3_4> for Reflect<M> {
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt(); // ⚡ Bolt: Direct rsqrt is mathematically correct and avoids redundant sqrt
 
         // Normal components - evaluate at Jet3 construction boundary
         let nx = (cross_x * inv_n_len.clone()).constant();
@@ -686,7 +686,7 @@ impl<M: ManifoldCompat<Jet3, Output = Discrete>> Manifold<Jet3_4> for ColorRefle
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt(); // ⚡ Bolt: Direct rsqrt is mathematically correct and avoids redundant sqrt
 
         // Normal components - evaluate at Jet3 construction boundary
         let nx = (cross_x * inv_n_len.clone()).constant();
@@ -793,7 +793,7 @@ where
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt(); // ⚡ Bolt: Direct rsqrt is mathematically correct and avoids redundant sqrt
 
         let nx = (cross_x * inv_n_len.clone()).constant();
         let ny = (cross_y * inv_n_len.clone()).constant();
@@ -906,7 +906,7 @@ where
         let n_len_sq = cross_x.clone() * cross_x.clone()
             + cross_y.clone() * cross_y.clone()
             + cross_z.clone() * cross_z.clone();
-        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).rsqrt(); // ⚡ Bolt: Direct rsqrt is mathematically correct and avoids redundant sqrt
 
         let nx = (cross_x * inv_n_len.clone()).constant();
         let ny = (cross_y * inv_n_len.clone()).constant();
@@ -1136,7 +1136,10 @@ impl<C: ManifoldCompat<Field, Output = Discrete>> Manifold<Jet3_4> for ColorChec
         // Coverage: how much of the pixel is in this cell vs neighbor
         let zero = Field::from(0.0);
         let one = Field::from(1.0);
-        let coverage = (dist_to_edge / pixel_size).min(one.clone()).max(zero).constant();
+        let coverage = (dist_to_edge / pixel_size)
+            .min(one.clone())
+            .max(zero)
+            .constant();
 
         // Select and blend colors
         let r_base = is_even.clone().select(ra.clone(), rb.clone());

--- a/pixelflow-graphics/src/spatial_bsp.rs
+++ b/pixelflow-graphics/src/spatial_bsp.rs
@@ -283,7 +283,12 @@ where
         let right_val = self.eval_child(node.right, x, y, z, w);
 
         // Blend using Select combinator
-        Select { cond: mask, if_true: left_val, if_false: right_val }.eval((x, y, z, w))
+        Select {
+            cond: mask,
+            if_true: left_val,
+            if_false: right_val,
+        }
+        .eval((x, y, z, w))
     }
 
     /// Evaluate a child node (either interior or leaf).

--- a/pixelflow-graphics/src/subdivision.rs
+++ b/pixelflow-graphics/src/subdivision.rs
@@ -20,9 +20,9 @@
 //! - No finite differences, no extra evaluations
 
 use crate::mesh::{Point3, QuadMesh};
+use pixelflow_compiler::ManifoldExpr;
 use pixelflow_core::jet::Jet3;
 use pixelflow_core::{Field, Manifold, ManifoldExt};
-use pixelflow_compiler::ManifoldExpr;
 
 /// The 4D Jet3 domain type for 3D ray tracing autodiff.
 type Jet3_4 = (Jet3, Jet3, Jet3, Jet3);

--- a/pixelflow-graphics/src/transform.rs
+++ b/pixelflow-graphics/src/transform.rs
@@ -3,7 +3,7 @@
 //! Provides composable coordinate warping using the `At` combinator.
 
 use pixelflow_core::ops::{Div, Sub};
-use pixelflow_core::{At, Field, Manifold, X, Y, Z, W};
+use pixelflow_core::{At, Field, Manifold, W, X, Y, Z};
 
 /// The standard 4D Field domain type.
 type Field4 = (Field, Field, Field, Field);

--- a/pixelflow-graphics/tests/e2e_render_to_file.rs
+++ b/pixelflow-graphics/tests/e2e_render_to_file.rs
@@ -3,8 +3,8 @@
 //! This test verifies the full pipeline from manifold composition
 //! through rasterization to file output.
 
-use pixelflow_core::{Discrete, Field, Manifold, ManifoldCompat, ManifoldExt, X, Y};
 use pixelflow_compiler::kernel;
+use pixelflow_core::{Discrete, Field, Manifold, ManifoldCompat, ManifoldExt, X, Y};
 use pixelflow_graphics::render::color::{Grayscale, NamedColor, Rgba8};
 
 type Field4 = (Field, Field, Field, Field);

--- a/pixelflow-graphics/tests/font_orientation_test.rs
+++ b/pixelflow-graphics/tests/font_orientation_test.rs
@@ -12,11 +12,7 @@ const FONT_BYTES: &[u8] = include_bytes!("../assets/NotoSansMono-Regular.ttf");
 
 /// Measure the horizontal extent of rendered pixels at a given Y row.
 /// Returns (leftmost_x, rightmost_x) of pixels above the threshold, or None if row is empty.
-fn measure_row_extent(
-    frame: &Frame<Rgba8>,
-    y: usize,
-    threshold: u8,
-) -> Option<(usize, usize)> {
+fn measure_row_extent(frame: &Frame<Rgba8>, y: usize, threshold: u8) -> Option<(usize, usize)> {
     let width = frame.width;
     let row_start = y * width;
     let row = &frame.data[row_start..row_start + width];

--- a/pixelflow-graphics/tests/kernel_macro.rs
+++ b/pixelflow-graphics/tests/kernel_macro.rs
@@ -23,9 +23,9 @@
 //! values. Instead we test using Field-level comparisons and check that all
 //! lanes satisfy the expected condition.
 
+use pixelflow_compiler::kernel;
 use pixelflow_core::jet::Jet3;
 use pixelflow_core::{Field, Manifold, ManifoldExt};
-use pixelflow_compiler::kernel;
 
 type Field4 = (Field, Field, Field, Field);
 
@@ -629,7 +629,7 @@ fn test_jet3_literals_and_params() {
 // - Normalized3D(m)  → (dx, dy, dz) / √(dx² + dy² + dz²)
 
 use pixelflow_core::jet::Jet2;
-use pixelflow_core::{GradientMag2D, GradientMag3D, Antialias2D, Antialias3D, Normalized2D};
+use pixelflow_core::{Antialias2D, Antialias3D, GradientMag2D, GradientMag3D, Normalized2D};
 
 type Jet2_4 = (Jet2, Jet2, Jet2, Jet2);
 
@@ -658,9 +658,8 @@ fn jet3_4_seeded(x: f32, y: f32, z: f32) -> Jet3_4 {
 fn test_gradient_mag_2d() {
     // For f(x,y) = sqrt(x² + y²), the gradient is (x/r, y/r) where r = sqrt(x²+y²)
     // Gradient magnitude is always 1.0 for distance fields
-    let dist = (pixelflow_core::X * pixelflow_core::X
-        + pixelflow_core::Y * pixelflow_core::Y)
-        .sqrt();
+    let dist =
+        (pixelflow_core::X * pixelflow_core::X + pixelflow_core::Y * pixelflow_core::Y).sqrt();
 
     let grad_mag = GradientMag2D(dist);
 
@@ -696,9 +695,7 @@ fn test_gradient_mag_3d() {
 fn test_antialias_2d() {
     // Circle SDF using kernel! macro (handles literal promotion)
     // At (2, 0): val = 1.0, gradient = (1, 0), so antialias = 1.0 / 1.0 = 1.0
-    let circle_sdf = kernel!(|| -> Jet2 {
-        (X * X + Y * Y).sqrt() - 1.0
-    });
+    let circle_sdf = kernel!(|| -> Jet2 { (X * X + Y * Y).sqrt() - 1.0 });
     let sdf = circle_sdf();
 
     let aa = Antialias2D(sdf);
@@ -715,9 +712,7 @@ fn test_antialias_2d() {
 fn test_antialias_3d() {
     // Sphere SDF using kernel! macro
     // At (2, 0, 0): val = 1.0, gradient = (1, 0, 0), so antialias = 1.0 / 1.0 = 1.0
-    let sphere_sdf = kernel!(|| -> Jet3 {
-        (X * X + Y * Y + Z * Z).sqrt() - 1.0
-    });
+    let sphere_sdf = kernel!(|| -> Jet3 { (X * X + Y * Y + Z * Z).sqrt() - 1.0 });
     let sdf = sphere_sdf();
 
     let aa = Antialias3D(sdf);
@@ -734,9 +729,8 @@ fn test_antialias_3d() {
 fn test_normalized_2d() {
     // Distance field: sqrt(x² + y²)
     // At (3, 4): gradient = (3/5, 4/5) = (0.6, 0.8)
-    let dist = (pixelflow_core::X * pixelflow_core::X
-        + pixelflow_core::Y * pixelflow_core::Y)
-        .sqrt();
+    let dist =
+        (pixelflow_core::X * pixelflow_core::X + pixelflow_core::Y * pixelflow_core::Y).sqrt();
 
     let normal = Normalized2D(dist);
 
@@ -797,15 +791,14 @@ fn test_fused_combinators_with_kernel_composition() {
 // FUSED COMBINATORS (GradientMag2D, Antialias2D, etc.) which evaluate
 // the inner manifold once and compute derived quantities efficiently.
 
-use pixelflow_core::{V, DX, DY, DZ};
+use pixelflow_core::{DX, DY, DZ, V};
 
 /// Test V accessor extracts the value component from Jet2.
 #[test]
 fn test_v_accessor() {
     // Distance from origin: sqrt(x² + y²)
-    let dist = (pixelflow_core::X * pixelflow_core::X
-        + pixelflow_core::Y * pixelflow_core::Y)
-        .sqrt();
+    let dist =
+        (pixelflow_core::X * pixelflow_core::X + pixelflow_core::Y * pixelflow_core::Y).sqrt();
 
     // Extract just the value
     let val_only = V(dist);
@@ -823,9 +816,8 @@ fn test_v_accessor() {
 fn test_dx_accessor() {
     // Distance from origin: sqrt(x² + y²)
     // ∂dist/∂x = x / sqrt(x² + y²) = x / dist
-    let dist = (pixelflow_core::X * pixelflow_core::X
-        + pixelflow_core::Y * pixelflow_core::Y)
-        .sqrt();
+    let dist =
+        (pixelflow_core::X * pixelflow_core::X + pixelflow_core::Y * pixelflow_core::Y).sqrt();
 
     // Extract ∂f/∂x
     let dx_only = DX(dist);
@@ -843,9 +835,8 @@ fn test_dx_accessor() {
 fn test_dy_accessor() {
     // Distance from origin: sqrt(x² + y²)
     // ∂dist/∂y = y / sqrt(x² + y²) = y / dist
-    let dist = (pixelflow_core::X * pixelflow_core::X
-        + pixelflow_core::Y * pixelflow_core::Y)
-        .sqrt();
+    let dist =
+        (pixelflow_core::X * pixelflow_core::X + pixelflow_core::Y * pixelflow_core::Y).sqrt();
 
     // Extract ∂f/∂y
     let dy_only = DY(dist);
@@ -887,9 +878,8 @@ fn test_dz_accessor() {
 #[test]
 fn test_manual_gradient_magnitude() {
     // Distance from origin
-    let dist = (pixelflow_core::X * pixelflow_core::X
-        + pixelflow_core::Y * pixelflow_core::Y)
-        .sqrt();
+    let dist =
+        (pixelflow_core::X * pixelflow_core::X + pixelflow_core::Y * pixelflow_core::Y).sqrt();
 
     // Manual gradient magnitude using DX/DY accessors
     let grad_mag = (DX(dist) * DX(dist) + DY(dist) * DY(dist)).sqrt();

--- a/pixelflow-graphics/tests/optimization_fuzz.rs
+++ b/pixelflow-graphics/tests/optimization_fuzz.rs
@@ -9,8 +9,8 @@
 //! 3. Use proptest to generate random inputs
 //! 4. Assert kernel output matches reference within epsilon
 
-use pixelflow_core::{Field, Manifold};
 use pixelflow_compiler::kernel;
+use pixelflow_core::{Field, Manifold};
 use proptest::prelude::*;
 
 type Field4 = (Field, Field, Field, Field);
@@ -25,7 +25,12 @@ const EPSILON: f32 = 1e-4;
 const ABS_EPSILON: f32 = 1e-6;
 
 fn field4(x: f32, y: f32, z: f32, w: f32) -> Field4 {
-    (Field::from(x), Field::from(y), Field::from(z), Field::from(w))
+    (
+        Field::from(x),
+        Field::from(y),
+        Field::from(z),
+        Field::from(w),
+    )
 }
 
 /// Extract first lane from Field for comparison.
@@ -326,7 +331,9 @@ fn regression_sqrt_with_param() {
 
     assert!(
         approx_eq(result, expected),
-        "sqrt with param: got {} expected {}", result, expected
+        "sqrt with param: got {} expected {}",
+        result,
+        expected
     );
 }
 
@@ -341,7 +348,9 @@ fn regression_mul_then_method() {
 
     assert!(
         approx_eq(result, expected),
-        "mul then abs: got {} expected {}", result, expected
+        "mul then abs: got {} expected {}",
+        result,
+        expected
     );
 }
 
@@ -355,6 +364,8 @@ fn regression_sub_then_method() {
 
     assert!(
         approx_eq(result, expected),
-        "sub then floor: got {} expected {}", result, expected
+        "sub then floor: got {} expected {}",
+        result,
+        expected
     );
 }

--- a/pixelflow-graphics/tests/rasterizer_parallel_test.rs
+++ b/pixelflow-graphics/tests/rasterizer_parallel_test.rs
@@ -4,12 +4,12 @@
 //! to single-threaded execution, and handle edge cases (small height, odd dimensions).
 
 use pixelflow_core::{Field, Manifold};
+use pixelflow_graphics::render::color::Rgba8;
 use pixelflow_graphics::render::frame::Frame;
 use pixelflow_graphics::render::rasterizer::parallel::{
     render_parallel, render_work_stealing, RenderOptions,
 };
 use pixelflow_graphics::render::rasterizer::rasterize;
-use pixelflow_graphics::render::color::Rgba8;
 
 // A simple test manifold: Gradient X + Y
 #[derive(Copy, Clone)]
@@ -23,7 +23,12 @@ impl Manifold<(Field, Field, Field, Field)> for TestGradient {
         // Evaluate AST to get Field values
         // Note: Field ops return AST nodes, so we must call .eval() to get the result.
         // Since operands are concrete Fields, we can pass dummy coordinates.
-        let dummy: (Field, Field, Field, Field) = (Field::default(), Field::default(), Field::default(), Field::default());
+        let dummy: (Field, Field, Field, Field) = (
+            Field::default(),
+            Field::default(),
+            Field::default(),
+            Field::default(),
+        );
 
         // Simple gradient: (x + y) * 0.1
         let val = ((x + y) * Field::from(0.1)).eval(dummy);
@@ -55,7 +60,10 @@ fn render_parallel_matches_single_threaded_output() {
     // Target: render_parallel
     render_parallel(&TestGradient, &mut frame, options);
 
-    assert_eq!(frame.data, reference.data, "render_parallel output mismatch");
+    assert_eq!(
+        frame.data, reference.data,
+        "render_parallel output mismatch"
+    );
 }
 
 #[test]
@@ -69,7 +77,10 @@ fn render_parallel_matches_single_threaded_output_odd_threads() {
 
     render_parallel(&TestGradient, &mut frame, options);
 
-    assert_eq!(frame.data, reference.data, "render_parallel (3 threads) output mismatch");
+    assert_eq!(
+        frame.data, reference.data,
+        "render_parallel (3 threads) output mismatch"
+    );
 }
 
 #[test]
@@ -84,7 +95,10 @@ fn render_parallel_handles_small_height() {
 
     render_parallel(&TestGradient, &mut frame, options);
 
-    assert_eq!(frame.data, reference.data, "render_parallel small height mismatch");
+    assert_eq!(
+        frame.data, reference.data,
+        "render_parallel small height mismatch"
+    );
 }
 
 #[test]
@@ -101,7 +115,10 @@ fn render_parallel_handles_height_one() {
     // but we test the interface contract.
     render_parallel(&TestGradient, &mut frame, options);
 
-    assert_eq!(frame.data, reference.data, "render_parallel height=1 mismatch");
+    assert_eq!(
+        frame.data, reference.data,
+        "render_parallel height=1 mismatch"
+    );
 }
 
 #[test]
@@ -115,7 +132,10 @@ fn render_work_stealing_matches_single_threaded_output() {
 
     render_work_stealing(&TestGradient, &mut frame, options);
 
-    assert_eq!(frame.data, reference.data, "render_work_stealing output mismatch");
+    assert_eq!(
+        frame.data, reference.data,
+        "render_work_stealing output mismatch"
+    );
 }
 
 #[test]
@@ -129,5 +149,8 @@ fn render_work_stealing_handles_height_one() {
 
     render_work_stealing(&TestGradient, &mut frame, options);
 
-    assert_eq!(frame.data, reference.data, "render_work_stealing height=1 mismatch");
+    assert_eq!(
+        frame.data, reference.data,
+        "render_work_stealing height=1 mismatch"
+    );
 }

--- a/pixelflow-graphics/tests/raymarch_sphere.rs
+++ b/pixelflow-graphics/tests/raymarch_sphere.rs
@@ -1,9 +1,9 @@
 //! Test: 3D scene rendering with sphere + floor using the scene3d architecture
 
+use pixelflow_compiler::ManifoldExpr;
 use pixelflow_core::combinators::At;
 use pixelflow_core::jet::Jet3;
 use pixelflow_core::{Discrete, Field, Manifold, ManifoldCompat};
-use pixelflow_compiler::ManifoldExpr;
 
 type Field4 = (Field, Field, Field, Field);
 type Jet3_4 = (Jet3, Jet3, Jet3, Jet3);
@@ -11,7 +11,7 @@ use pixelflow_graphics::render::color::{Rgba8, RgbaColorCube};
 use pixelflow_graphics::render::frame::Frame;
 use pixelflow_graphics::render::rasterizer::rasterize;
 use pixelflow_graphics::scene3d::{
-    ColorChecker, ColorReflect, ColorScreenToDir, ColorSky, ColorSurface, plane,
+    plane, ColorChecker, ColorReflect, ColorScreenToDir, ColorSky, ColorSurface,
 };
 
 /// Sphere at given center with radius (local to this test).
@@ -93,7 +93,9 @@ fn test_sphere_on_floor() {
             center: (0.0, 0.5, 4.0),
             radius: 1.0,
         },
-        material: ColorReflect { inner: world.clone() },
+        material: ColorReflect {
+            inner: world.clone(),
+        },
         background: world,
     };
 
@@ -128,8 +130,6 @@ fn test_sphere_on_floor() {
 /// Test with solid gray material (non-reflective)
 #[test]
 fn test_sphere_on_matte_floor() {
-
-
     const W: usize = 400;
     const H: usize = 300;
 
@@ -210,7 +210,9 @@ fn test_chrome_sphere_on_checkerboard() {
             center: (0.0, 0.5, 4.0),
             radius: 1.0,
         },
-        material: ColorReflect { inner: world.clone() },
+        material: ColorReflect {
+            inner: world.clone(),
+        },
         background: world,
     };
 

--- a/pixelflow-graphics/tests/scene3d_test.rs
+++ b/pixelflow-graphics/tests/scene3d_test.rs
@@ -5,10 +5,10 @@
 //! 2. Surface: Warps `P = ray * t` - creates tangent frame via chain rule
 //! 3. Material: Reconstructs normal from derivatives - Reflect, Checker, Sky
 
+use pixelflow_compiler::ManifoldExpr;
 use pixelflow_core::combinators::At;
 use pixelflow_core::jet::Jet3;
 use pixelflow_core::{Discrete, Field, Manifold, ManifoldCompat, ManifoldExt};
-use pixelflow_compiler::ManifoldExpr;
 
 type Field4 = (Field, Field, Field, Field);
 type Jet3_4 = (Jet3, Jet3, Jet3, Jet3);
@@ -16,8 +16,8 @@ use pixelflow_graphics::render::color::{Rgba8, RgbaColorCube};
 use pixelflow_graphics::render::frame::Frame;
 use pixelflow_graphics::render::rasterizer::rasterize;
 use pixelflow_graphics::scene3d::{
-    Checker, ColorChecker, ColorReflect, ColorScreenToDir, ColorSky, ColorSurface, plane,
-    Reflect, ScreenToDir, sky, Surface,
+    plane, sky, Checker, ColorChecker, ColorReflect, ColorScreenToDir, ColorSky, ColorSurface,
+    Reflect, ScreenToDir, Surface,
 };
 use std::fs::File;
 use std::io::Write;
@@ -120,7 +120,9 @@ fn test_chrome_unit_sphere() {
             center: (0.0, 0.0, 4.0),
             radius: 1.0,
         },
-        material: Reflect { inner: world.clone() },
+        material: Reflect {
+            inner: world.clone(),
+        },
         background: world,
     };
 
@@ -291,7 +293,9 @@ fn test_color_chrome_sphere() {
             center: (0.0, 0.0, 4.0),
             radius: 1.0,
         },
-        material: ColorReflect { inner: world.clone() },
+        material: ColorReflect {
+            inner: world.clone(),
+        },
         background: world,
     };
 
@@ -450,7 +454,9 @@ fn test_mullet_vs_3channel_comparison() {
                         center: (0.0, 0.0, 4.0),
                         radius: 1.0,
                     },
-                    material: Reflect { inner: world.clone() },
+                    material: Reflect {
+                        inner: world.clone(),
+                    },
                     background: world,
                 },
             },
@@ -533,7 +539,9 @@ fn test_mullet_vs_3channel_comparison() {
                     center: (0.0, 0.0, 4.0),
                     radius: 1.0,
                 },
-                material: ColorReflect { inner: world.clone() },
+                material: ColorReflect {
+                    inner: world.clone(),
+                },
                 background: world,
             },
         },
@@ -616,7 +624,9 @@ fn test_work_stealing_benchmark() {
             center: (0.0, 0.0, 4.0),
             radius: 1.0,
         },
-        material: ColorReflect { inner: world.clone() },
+        material: ColorReflect {
+            inner: world.clone(),
+        },
         background: world,
     };
 


### PR DESCRIPTION
What: Replaced `.sqrt().rsqrt()` with `.rsqrt()` when calculating inverse normal length. Why: Mathematically, `.sqrt().rsqrt()` computes x^(-1/4), which is incorrect for inverse length calculation (x^(-1/2)). Additionally, `sqrt()` is an expensive operation (~20-30 cycles) that is unnecessary here. Impact: Corrects the mathematical calculation and removes an expensive operation in the 3D scene evaluation hot path. Measurement: Compare the cycle count of the generated assembly or measure the latency of the hot path to confirm the speedup.

---
*PR created automatically by Jules for task [16743043814093384075](https://jules.google.com/task/16743043814093384075) started by @jppittman*