### PR TITLE
⚡ Bolt: Refactor DisplayControl::SetVisible to ShowWindow and HideWindow

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2025-12-28 - Rasterizer Inner Loop Hoisting
 **Learning:** The inner loop of `execute_stripe` was re-evaluating `Field::sequential(start)` on every iteration, which involves multiple SIMD instructions (broadcast/load + add).
 **Action:** Hoisted the initialization of `xs` out of the loop and updated it incrementally using a pre-computed `step` vector. This reduced the inner loop overhead significantly, yielding a ~34% improvement in rasterization throughput.
+
+## 2024-05-18 - StyleEnforcer: Eliminating Boolean Blindness in DisplayControl
+**Learning:** Found that `docs/STYLE.md` forbids the use of boolean arguments to control state because they obscure intent at the call site (the "boolean trap"). The `DisplayControl::SetVisible` variant took a `bool`, which propagated down to `MacWindow::set_visible`.
+**Action:** Refactored `SetVisible { visible: bool }` into explicitly named enum variants `ShowWindow` and `HideWindow`. Also split the underlying implementation method into `show()` and `hide()`. This improves readability and maintains equivalent functionality without side-effects.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,7 +13,3 @@
 ## 2025-12-28 - Rasterizer Inner Loop Hoisting
 **Learning:** The inner loop of `execute_stripe` was re-evaluating `Field::sequential(start)` on every iteration, which involves multiple SIMD instructions (broadcast/load + add).
 **Action:** Hoisted the initialization of `xs` out of the loop and updated it incrementally using a pre-computed `step` vector. This reduced the inner loop overhead significantly, yielding a ~34% improvement in rasterization throughput.
-
-## 2024-05-18 - StyleEnforcer: Eliminating Boolean Blindness in DisplayControl
-**Learning:** Found that `docs/STYLE.md` forbids the use of boolean arguments to control state because they obscure intent at the call site (the "boolean trap"). The `DisplayControl::SetVisible` variant took a `bool`, which propagated down to `MacWindow::set_visible`.
-**Action:** Refactored `SetVisible { visible: bool }` into explicitly named enum variants `ShowWindow` and `HideWindow`. Also split the underlying implementation method into `show()` and `hide()`. This improves readability and maintains equivalent functionality without side-effects.

--- a/pixelflow-runtime/src/display/messages.rs
+++ b/pixelflow-runtime/src/display/messages.rs
@@ -156,19 +156,31 @@ pub enum DisplayControl {
     /// - `cursor`: Cursor icon (arrow, text, etc.)
     SetCursor { id: WindowId, cursor: CursorIcon },
 
-    /// Show or hide the window.
+    /// Show the window.
     ///
     /// # Contract
     ///
     /// **Sender**: Specifies visibility state.
     ///
-    /// **Receiver**: Shows or hides the window. Window remains in the taskbar/app switcher.
+    /// **Receiver**: Shows the window. Window remains in the taskbar/app switcher.
     ///
     /// # Arguments
     ///
     /// - `id`: Window identifier
-    /// - `visible`: `true` to show, `false` to hide
-    SetVisible { id: WindowId, visible: bool },
+    ShowWindow { id: WindowId },
+
+    /// Hide the window.
+    ///
+    /// # Contract
+    ///
+    /// **Sender**: Specifies visibility state.
+    ///
+    /// **Receiver**: Hides the window. Window remains in the taskbar/app switcher.
+    ///
+    /// # Arguments
+    ///
+    /// - `id`: Window identifier
+    HideWindow { id: WindowId },
 
     /// Request an immediate redraw.
     ///

--- a/pixelflow-runtime/src/platform/linux/platform.rs
+++ b/pixelflow-runtime/src/platform/linux/platform.rs
@@ -103,7 +103,7 @@ impl PlatformOps for LinuxOps {
                 DisplayControl::Bell => {
                     window.bell();
                 }
-                DisplayControl::SetVisible { .. } | DisplayControl::RequestRedraw { .. } => {
+                DisplayControl::ShowWindow { .. } | DisplayControl::HideWindow { .. } | DisplayControl::RequestRedraw { .. } => {
                     // Not implemented for Linux yet
                 }
             }

--- a/pixelflow-runtime/src/platform/macos/platform.rs
+++ b/pixelflow-runtime/src/platform/macos/platform.rs
@@ -100,9 +100,14 @@ impl PlatformOps for MetalOps {
                     win.set_cursor(cursor);
                 }
             }
-            DisplayControl::SetVisible { id, visible } => {
+            DisplayControl::ShowWindow { id } => {
                 if let Some(win) = self.windows.get_mut(&id) {
-                    win.set_visible(visible);
+                    win.show();
+                }
+            }
+            DisplayControl::HideWindow { id } => {
+                if let Some(win) = self.windows.get_mut(&id) {
+                    win.hide();
                 }
             }
             DisplayControl::RequestRedraw { id } => {
@@ -164,7 +169,7 @@ impl PlatformOps for MetalOps {
             }
             DisplayMgmt::Destroy { id } => {
                 if let Some(mut win) = self.windows.remove(&id) {
-                    win.set_visible(false);
+                    win.hide();
                     // Drop closes it implicitly or we call close
                     // win.window.close(); // If we expose it
                     self.window_map.remove(&(win.window.0 as usize));

--- a/pixelflow-runtime/src/platform/macos/window.rs
+++ b/pixelflow-runtime/src/platform/macos/window.rs
@@ -122,13 +122,13 @@ impl MacWindow {
         }
     }
 
-    pub fn set_visible(&mut self, visible: bool) {
-        if visible {
-            self.window.make_key_and_order_front();
-        } else {
-            unsafe {
-                sys::send::<()>(self.window.0, sys::sel(b"orderOut:\0"));
-            }
+    pub fn show(&mut self) {
+        self.window.make_key_and_order_front();
+    }
+
+    pub fn hide(&mut self) {
+        unsafe {
+            sys::send::<()>(self.window.0, sys::sel(b"orderOut:\0"));
         }
     }
 


### PR DESCRIPTION
- What: Refactored `DisplayControl::SetVisible` boolean argument into two distinct enum variants: `ShowWindow` and `HideWindow`. Similarly split `MacWindow::set_visible(bool)` into `show()` and `hide()`.
- Why: To adhere to `docs/STYLE.md` guideline #3 which recommends avoiding boolean arguments that obscure intent at the call site (the "boolean trap") in favor of enums or splitting into separate semantically clear functions.
- Impact: Improved readability and intent at the call sites within `pixelflow-runtime` without altering functionality.
- Measurement: Monitored compilation using `cargo check` and passing functionality with `cargo test` (noting pre-existing unrelated compilation issues in `pixelflow-graphics`).

---
*PR created automatically by Jules for task [8670136638354825429](https://jules.google.com/task/8670136638354825429) started by @jppittman*