### PR TITLE
Enforce test style guide in frame.rs

### DIFF
--- a/pixelflow-runtime/src/frame.rs
+++ b/pixelflow-runtime/src/frame.rs
@@ -147,13 +147,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_channels() {
-        let (_handle, _rx) = create_frame_channel::<TestSurface>();
-        let (_recycle_tx, _recycle_rx) = create_recycle_channel::<TestSurface>();
-    }
-
-    #[test]
-    fn test_submit_and_receive() {
+    fn submit_frame_should_receive_packet_when_submitted() {
         let (handle, rx) = create_frame_channel::<TestSurface>();
         let (recycle_tx, _recycle_rx) = create_recycle_channel::<TestSurface>();
 
@@ -167,7 +161,7 @@ mod tests {
     }
 
     #[test]
-    fn test_recycle_loop() {
+    fn recycle_should_send_packet_when_called() {
         let (handle, rx) = create_frame_channel::<TestSurface>();
         let (recycle_tx, recycle_rx) = create_recycle_channel::<TestSurface>();
 


### PR DESCRIPTION
What: Refactored test names to adhere to the test naming convention and removed test_create_channels which lacked assertions. Why: To comply with the testing directives outlined in docs/STYLE.md. Impact: Improves test readability and ensures all tests contain valid assertions. Measurement: The modified tests pass successfully using cargo test.

---
*PR created automatically by Jules for task [4358628749049584911](https://jules.google.com/task/4358628749049584911) started by @jppittman*