### PR TITLE
Refactor DisplayControl::SetVisible to use ShowWindow enum

### DIFF
--- a/pixelflow-runtime/examples/animated_sphere.rs
+++ b/pixelflow-runtime/examples/animated_sphere.rs
@@ -14,13 +14,13 @@
 //! - Scene is rebuilt with new dimensions on next frame
 
 use actor_scheduler::Message;
+use pixelflow_compiler::ManifoldExpr;
 use pixelflow_core::combinators::At;
 use pixelflow_core::jet::Jet3;
 use pixelflow_core::{Discrete, Field, Manifold, ManifoldCompat};
 use pixelflow_graphics::scene3d::{
     plane, ColorChecker, ColorReflect, ColorScreenToDir, ColorSky, ColorSurface,
 };
-use pixelflow_compiler::ManifoldExpr;
 use pixelflow_runtime::api::private::EngineData;
 use pixelflow_runtime::api::public::{AppData, EngineEvent, EngineEventControl, EngineEventData};
 use pixelflow_runtime::platform::ColorCube;

--- a/pixelflow-runtime/examples/chrome_sphere.rs
+++ b/pixelflow-runtime/examples/chrome_sphere.rs
@@ -3,10 +3,10 @@
 //! Compares single-threaded vs parallel rasterization of the 3D chrome sphere scene.
 //! Uses the mullet architecture: geometry once, colors as packed Discrete.
 
+use pixelflow_compiler::ManifoldExpr;
 use pixelflow_core::combinators::At;
 use pixelflow_core::jet::Jet3;
 use pixelflow_core::{Discrete, Field, Manifold, ManifoldCompat};
-use pixelflow_compiler::ManifoldExpr;
 
 type Field4 = (Field, Field, Field, Field);
 type Jet3_4 = (Jet3, Jet3, Jet3, Jet3);

--- a/pixelflow-runtime/examples/image_viewer.rs
+++ b/pixelflow-runtime/examples/image_viewer.rs
@@ -6,10 +6,10 @@
 //! 3. Send a manifold to render
 //! 4. Run the event loop
 
+use pixelflow_compiler::ManifoldExpr;
 use pixelflow_core::combinators::At;
 use pixelflow_core::jet::Jet3;
 use pixelflow_core::{Discrete, Field, Manifold, ManifoldCompat};
-use pixelflow_compiler::ManifoldExpr;
 use pixelflow_runtime::{api::public::AppData, EngineConfig, EngineTroupe, WindowConfig};
 use std::sync::Arc;
 

--- a/pixelflow-runtime/examples/psychedelic_shader.rs
+++ b/pixelflow-runtime/examples/psychedelic_shader.rs
@@ -16,8 +16,8 @@
 //! enabling CSE (common subexpression elimination) across the entire expression.
 
 use actor_scheduler::Message;
-use pixelflow_core::{Discrete, Field, Manifold};
 use pixelflow_compiler::kernel;
+use pixelflow_core::{Discrete, Field, Manifold};
 use pixelflow_runtime::api::private::EngineData;
 use pixelflow_runtime::api::public::{AppData, EngineEvent, EngineEventControl, EngineEventData};
 use pixelflow_runtime::platform::ColorCube;

--- a/pixelflow-runtime/src/display/messages.rs
+++ b/pixelflow-runtime/src/display/messages.rs
@@ -67,6 +67,12 @@ pub enum DisplayData {
     Present { window: Window },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShowWindow {
+    Show,
+    Hide,
+}
+
 /// Control messages for the display driver (configuration and lifecycle).
 ///
 /// Control messages are for state changes and non-rendering operations.
@@ -167,8 +173,8 @@ pub enum DisplayControl {
     /// # Arguments
     ///
     /// - `id`: Window identifier
-    /// - `visible`: `true` to show, `false` to hide
-    SetVisible { id: WindowId, visible: bool },
+    /// - `state`: `ShowWindow::Show` to show, `ShowWindow::Hide` to hide
+    SetVisible { id: WindowId, state: ShowWindow },
 
     /// Request an immediate redraw.
     ///

--- a/pixelflow-runtime/src/platform/macos/platform.rs
+++ b/pixelflow-runtime/src/platform/macos/platform.rs
@@ -100,9 +100,9 @@ impl PlatformOps for MetalOps {
                     win.set_cursor(cursor);
                 }
             }
-            DisplayControl::SetVisible { id, visible } => {
+            DisplayControl::SetVisible { id, state } => {
                 if let Some(win) = self.windows.get_mut(&id) {
-                    win.set_visible(visible);
+                    win.set_visible(state);
                 }
             }
             DisplayControl::RequestRedraw { id } => {
@@ -164,7 +164,7 @@ impl PlatformOps for MetalOps {
             }
             DisplayMgmt::Destroy { id } => {
                 if let Some(mut win) = self.windows.remove(&id) {
-                    win.set_visible(false);
+                    win.set_visible(crate::display::messages::ShowWindow::Hide);
                     // Drop closes it implicitly or we call close
                     // win.window.close(); // If we expose it
                     self.window_map.remove(&(win.window.0 as usize));

--- a/pixelflow-runtime/src/platform/macos/window.rs
+++ b/pixelflow-runtime/src/platform/macos/window.rs
@@ -122,13 +122,14 @@ impl MacWindow {
         }
     }
 
-    pub fn set_visible(&mut self, visible: bool) {
-        if visible {
-            self.window.make_key_and_order_front();
-        } else {
-            unsafe {
-                sys::send::<()>(self.window.0, sys::sel(b"orderOut:\0"));
+    pub fn set_visible(&mut self, state: crate::display::messages::ShowWindow) {
+        match state {
+            crate::display::messages::ShowWindow::Show => {
+                self.window.make_key_and_order_front();
             }
+            crate::display::messages::ShowWindow::Hide => unsafe {
+                sys::send::<()>(self.window.0, sys::sel(b"orderOut:\0"));
+            },
         }
     }
 


### PR DESCRIPTION
What: Refactored `DisplayControl::SetVisible` to use a `ShowWindow` enum instead of a boolean argument.
Why: To conform to `STYLE.md` guidelines avoiding boolean arguments and improving code clarity.
Impact: Improves code readability by avoiding the boolean trap.
Measurement: All tests pass.

---
*PR created automatically by Jules for task [7941304451990059666](https://jules.google.com/task/7941304451990059666) started by @jppittman*