### PR TITLE
⚡ Bolt: Optimize vector allocations in terminal layout generation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2025-12-28 - Rasterizer Inner Loop Hoisting
 **Learning:** The inner loop of `execute_stripe` was re-evaluating `Field::sequential(start)` on every iteration, which involves multiple SIMD instructions (broadcast/load + add).
 **Action:** Hoisted the initialization of `xs` out of the loop and updated it incrementally using a pre-computed `step` vector. This reduced the inner loop overhead significantly, yielding a ~34% improvement in rasterization throughput.
+
+## 2024-05-30 - Optimize vector allocation in terminal hot loop
+**Learning:** The terminal rendering hot loop builds 2-level BSP layout trees every frame. Pre-allocating `Vec::with_capacity` using known dimensions (`rows` and `cols`) prevents expensive heap reallocations during this frequent operation.
+**Action:** Always pre-calculate and allocate capacity for collections built during frame-by-frame rendering loops.

--- a/core-term/src/terminal_app.rs
+++ b/core-term/src/terminal_app.rs
@@ -288,11 +288,11 @@ impl TerminalApp {
         let default_bg = self.config.colors.background;
 
         // Build 2-level BSP: Vertical (Rows) -> Horizontal (Cells)
-        let mut row_items = Vec::new();
+        let mut row_items = Vec::with_capacity(rows);
 
         for row in 0..rows {
             let line = &snapshot.lines[row];
-            let mut cell_items = Vec::new();
+            let mut cell_items = Vec::with_capacity(cols);
 
             for col in 0..cols {
                 let glyph = &line.cells[col];


### PR DESCRIPTION
💡 What: Replaced Vec::new() with Vec::with_capacity() for row_items and cell_items in the terminal's 2-level BSP layout tree generation.
🎯 Why: To prevent expensive heap reallocations during the frequent rendering loop where the exact target sizes (rows and columns) are already known.
📊 Impact: Reduces heap reallocations to zero when building the layout tree per frame, lowering per-frame render latency.
🔬 Measurement: Run a flamegraph profiling session to observe fewer allocation calls during the render loop.

---
*PR created automatically by Jules for task [18334964195424785633](https://jules.google.com/task/18334964195424785633) started by @jppittman*