### PR TITLE
⚡ Bolt: Replace Vec::new() with Vec::with_capacity() in terminal_app.rs

### DIFF
--- a/core-term/src/terminal_app.rs
+++ b/core-term/src/terminal_app.rs
@@ -288,11 +288,11 @@ impl TerminalApp {
         let default_bg = self.config.colors.background;
 
         // Build 2-level BSP: Vertical (Rows) -> Horizontal (Cells)
-        let mut row_items = Vec::new();
+        let mut row_items = Vec::with_capacity(rows);
 
         for row in 0..rows {
             let line = &snapshot.lines[row];
-            let mut cell_items = Vec::new();
+            let mut cell_items = Vec::with_capacity(cols);
 
             for col in 0..cols {
                 let glyph = &line.cells[col];

--- a/pixelflow-core/src/ops/logic.rs
+++ b/pixelflow-core/src/ops/logic.rs
@@ -3,8 +3,6 @@
 //! AST nodes for bitwise logic: And, Or, Not.
 
 use crate::Manifold;
-use crate::numeric::Numeric;
-use core::ops::{BitAnd, BitOr, Not};
 use pixelflow_compiler::Element;
 
 /// Bitwise AND.

--- a/pixelflow-core/src/ops/unary.rs
+++ b/pixelflow-core/src/ops/unary.rs
@@ -1,7 +1,7 @@
 //! Unary operations: sqrt, abs, floor, ceil, round, sin, cos, exp, log2, recip.
 
 use crate::Manifold;
-use crate::numeric::{Computational, Numeric};
+use crate::numeric::Numeric;
 use pixelflow_compiler::Element;
 
 /// Square root.


### PR DESCRIPTION
What: Replace Vec::new() with Vec::with_capacity() for known sizes when building render trees. Why: Avoids unnecessary reallocations when the exact number of elements (rows and columns) is already known. Impact: Reduces dynamic array resizing and memory overhead during frame rendering. Measurement: Check the benchmark or profiler for allocation events during active terminal updates.

---
*PR created automatically by Jules for task [11142537458078592133](https://jules.google.com/task/11142537458078592133) started by @jppittman*