### PR TITLE
⚡ Bolt: Use Vec::with_capacity in terminal_app.rs

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,6 @@
 ## 2025-12-28 - Rasterizer Inner Loop Hoisting
 **Learning:** The inner loop of `execute_stripe` was re-evaluating `Field::sequential(start)` on every iteration, which involves multiple SIMD instructions (broadcast/load + add).
 **Action:** Hoisted the initialization of `xs` out of the loop and updated it incrementally using a pre-computed `step` vector. This reduced the inner loop overhead significantly, yielding a ~34% improvement in rasterization throughput.
+## 2024-05-18 - Vec Capacity Pre-Allocation Optimization
+**Learning:** Found a hot path in `core-term/src/terminal_app.rs` (`build_manifold`) where dynamic vector allocation for `row_items` and `cell_items` caused expensive heap reallocations. This pattern of growing dynamically without known targets is heavily penalizing during render tree construction.
+**Action:** Always inspect vector creation in tight, hot loops (like grid parsing and rendering routines). Identify when target collection sizes (`rows`, `cols`) are known upfront, and use `Vec::with_capacity(size)` instead of `Vec::new()` to save memory overhead and prevent costly runtime allocations.

--- a/core-term/src/terminal_app.rs
+++ b/core-term/src/terminal_app.rs
@@ -288,11 +288,13 @@ impl TerminalApp {
         let default_bg = self.config.colors.background;
 
         // Build 2-level BSP: Vertical (Rows) -> Horizontal (Cells)
-        let mut row_items = Vec::new();
+        // Optimization: Pre-allocate row items vector to known number of rows to prevent heap reallocations.
+        let mut row_items = Vec::with_capacity(rows);
 
         for row in 0..rows {
             let line = &snapshot.lines[row];
-            let mut cell_items = Vec::new();
+            // Optimization: Pre-allocate cell items vector to known number of cols to prevent heap reallocations.
+            let mut cell_items = Vec::with_capacity(cols);
 
             for col in 0..cols {
                 let glyph = &line.cells[col];


### PR DESCRIPTION
What: Optimized `row_items` and `cell_items` vector creation in `core-term/src/terminal_app.rs` to use `Vec::with_capacity` instead of `Vec::new`.
Why: To prevent expensive, dynamic heap reallocations when building the render manifold since the target sizes (rows and cols) are already known.
Impact: Reduces the number of allocations required to render each frame, increasing performance.
Measurement: Check execution time of rendering frames.

---
*PR created automatically by Jules for task [17535051409518465955](https://jules.google.com/task/17535051409518465955) started by @jppittman*