### PR TITLE
Fix style violation in vsync actor test

### DIFF
--- a/pixelflow-runtime/src/vsync_actor_test.rs
+++ b/pixelflow-runtime/src/vsync_actor_test.rs
@@ -31,7 +31,7 @@ mod tests {
     // we will rely on 'cargo check' which we already ran.
 
     #[test]
-    fn test_vsync_command_debug() {
+    fn vsync_command_debug_should_succeed() {
         let (tx, _rx) = mpsc::channel();
         let cmd = VsyncCommand::RequestCurrentFPS(tx);
         let debug_str = format!("{:?}", cmd);


### PR DESCRIPTION
Fix style violation in vsync actor test by renaming test_ prefix

The `docs/STYLE.md` and repository guidelines mandate avoiding the `test_` prefix in test functions since the `#[test]` attribute already indicates it. This commit renames the test function `test_vsync_command_debug` to `vsync_command_debug_should_succeed` in `pixelflow-runtime/src/vsync_actor_test.rs` to conform to the style guidelines.

---
*PR created automatically by Jules for task [18380887541780724172](https://jules.google.com/task/18380887541780724172) started by @jppittman*