### PR TITLE
⚡ Bolt: Use Vec::with_capacity in terminal layout

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2025-12-28 - Rasterizer Inner Loop Hoisting
 **Learning:** The inner loop of `execute_stripe` was re-evaluating `Field::sequential(start)` on every iteration, which involves multiple SIMD instructions (broadcast/load + add).
 **Action:** Hoisted the initialization of `xs` out of the loop and updated it incrementally using a pre-computed `step` vector. This reduced the inner loop overhead significantly, yielding a ~34% improvement in rasterization throughput.
+
+## 2024-06-25 - Prevent reallocation overhead in terminal layout
+**Learning:** Found a performance bottleneck where terminal grid parsing allocates `Vec::new()` inside an outer hot loop over `rows` (`core-term/src/terminal_app.rs`), leading to heavy allocations during VSync redraws. The dimensions are pre-known (`rows`, `cols`).
+**Action:** When building grids or rendering structures with known sizes derived from `snapshot`, prefer `Vec::with_capacity(size)` over `Vec::new()` to avoid dynamic reallocation scaling penalties on the rendering thread.

--- a/core-term/src/terminal_app.rs
+++ b/core-term/src/terminal_app.rs
@@ -288,11 +288,11 @@ impl TerminalApp {
         let default_bg = self.config.colors.background;
 
         // Build 2-level BSP: Vertical (Rows) -> Horizontal (Cells)
-        let mut row_items = Vec::new();
+        let mut row_items = Vec::with_capacity(rows);
 
         for row in 0..rows {
             let line = &snapshot.lines[row];
-            let mut cell_items = Vec::new();
+            let mut cell_items = Vec::with_capacity(cols);
 
             for col in 0..cols {
                 let glyph = &line.cells[col];


### PR DESCRIPTION
What: Replaced Vec::new() with Vec::with_capacity() in terminal_app.rs layout tree building.
Why: Avoids dynamic heap reallocations during terminal layout parsing which occurs every VSync redraw.
Impact: Reduces allocations in hot render loop.
Measurement: Profiling vector reallocations to observe dropped overhead.

---
*PR created automatically by Jules for task [14571294861493090155](https://jules.google.com/task/14571294861493090155) started by @jppittman*