### PR TITLE
Refactor: Replace boolean parameters with intention-revealing enums

### DIFF
--- a/pixelflow-ir/src/backend/emit/executable.rs
+++ b/pixelflow-ir/src/backend/emit/executable.rs
@@ -218,7 +218,7 @@ impl CodeBuffer {
         {
             // With MAP_JIT on macOS, the memory starts RW. Toggle to RX.
             unsafe {
-                toggle_jit_write(false);
+                toggle_jit_write(JitWriteState::Executable);
             }
         }
 
@@ -252,7 +252,7 @@ impl CodeBuffer {
             // Toggle to writable.
             #[cfg(target_os = "macos")]
             {
-                toggle_jit_write(true);
+                toggle_jit_write(JitWriteState::Writable);
             }
             #[cfg(not(target_os = "macos"))]
             {
@@ -273,7 +273,7 @@ impl CodeBuffer {
             // Toggle to executable.
             #[cfg(target_os = "macos")]
             {
-                toggle_jit_write(false);
+                toggle_jit_write(JitWriteState::Executable);
                 // Instruction cache coherence on Apple Silicon.
                 // sys_icache_invalidate is needed after writing code on ARM.
                 unsafe extern "C" {
@@ -329,20 +329,33 @@ impl Drop for CodeBuffer {
 ///
 /// This is much cheaper than mprotect (~0.5µs vs ~5µs) and is per-thread,
 /// so it doesn't affect other threads' ability to execute the code.
+/// Enum representing the requested JIT memory permission.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JitWriteState {
+    /// JIT memory is writable (write-protect disabled).
+    Writable,
+    /// JIT memory is executable (write-protect enabled).
+    Executable,
+}
+
 #[cfg(target_os = "macos")]
-unsafe fn toggle_jit_write(writable: bool) {
+unsafe fn toggle_jit_write(state: JitWriteState) {
     // pthread_jit_write_protect_np(true) = write-protect (executable)
     // pthread_jit_write_protect_np(false) = writable (not executable)
     // Note: the semantics are inverted from what you'd expect!
     unsafe extern "C" {
         fn pthread_jit_write_protect_np(enabled: bool);
     }
-    // writable=true → we want to write → disable write protection
-    // writable=false → we want to execute → enable write protection
+    // JitWriteState::Writable → we want to write → disable write protection
+    // JitWriteState::Executable → we want to execute → enable write protection
     // SAFETY: pthread_jit_write_protect_np is always safe to call — it only
     // affects the calling thread's JIT write permission.
+    let enable_write_protect = match state {
+        JitWriteState::Writable => false,
+        JitWriteState::Executable => true,
+    };
     unsafe {
-        pthread_jit_write_protect_np(!writable);
+        pthread_jit_write_protect_np(enable_write_protect);
     }
 }
 

--- a/pixelflow-ir/src/backend/emit/mod.rs
+++ b/pixelflow-ir/src/backend/emit/mod.rs
@@ -418,9 +418,7 @@ fn emit_arena(arena: &ExprArena, id: ExprId, depth: u8) -> Result<(Vec<u8>, Reg)
     // Reserve xmm12..15 for scratch: any node that allocates a value register
     // (everything except a bare Var, which reuses an input register) must fit
     // below the scratch floor.
-    if !matches!(arena.node(id), ExprNode::Var(_))
-        && SCRATCH_BASE + depth > X86_MAX_VALUE_REG
-    {
+    if !matches!(arena.node(id), ExprNode::Var(_)) && SCRATCH_BASE + depth > X86_MAX_VALUE_REG {
         return Err("x86 JIT: expression too deep for SSE register budget");
     }
 
@@ -4051,25 +4049,100 @@ mod tests {
         // accuracy over a sensible input range; exact ops use tight bounds.
         // `rel_err = |jit - scalar| / (1 + |scalar|)`.
         let unary: &[(OpKind, fn(f32) -> f32, &[f32], f32)] = &[
-            (OpKind::Sqrt, |x| x.sqrt(), &[0.25, 1.0, 2.0, 9.0, 100.0], 1e-5),
+            (
+                OpKind::Sqrt,
+                |x| x.sqrt(),
+                &[0.25, 1.0, 2.0, 9.0, 100.0],
+                1e-5,
+            ),
             (OpKind::Abs, |x| x.abs(), &[-3.0, -0.5, 0.0, 2.5], 1e-6),
             (OpKind::Neg, |x| -x, &[-3.0, 0.5, 2.5], 1e-6),
-            (OpKind::Floor, |x| x.floor(), &[-2.3, -0.1, 0.9, 1.5, 3.99], 1e-6),
-            (OpKind::Ceil, |x| x.ceil(), &[-2.3, -0.1, 0.9, 1.5, 3.01], 1e-6),
-            (OpKind::Round, |x| x.round_ties_even(), &[-2.4, -0.4, 0.4, 1.5, 2.6], 1e-6),
-            (OpKind::Fract, |x| x - x.floor(), &[-2.3, 0.1, 0.9, 3.75], 1e-5),
+            (
+                OpKind::Floor,
+                |x| x.floor(),
+                &[-2.3, -0.1, 0.9, 1.5, 3.99],
+                1e-6,
+            ),
+            (
+                OpKind::Ceil,
+                |x| x.ceil(),
+                &[-2.3, -0.1, 0.9, 1.5, 3.01],
+                1e-6,
+            ),
+            (
+                OpKind::Round,
+                |x| x.round_ties_even(),
+                &[-2.4, -0.4, 0.4, 1.5, 2.6],
+                1e-6,
+            ),
+            (
+                OpKind::Fract,
+                |x| x - x.floor(),
+                &[-2.3, 0.1, 0.9, 3.75],
+                1e-5,
+            ),
             // sin/cos: 4-term Chebyshev — accurate well inside [-π, π].
-            (OpKind::Sin, |x| x.sin(), &[-2.0, -1.0, -0.3, 0.0, 0.5, 1.5, 2.0], 6e-3),
-            (OpKind::Cos, |x| x.cos(), &[-1.0, -0.3, 0.0, 0.5, 1.0], 1.5e-2),
-            (OpKind::Tan, |x| x.tan(), &[-1.0, -0.3, 0.0, 0.3, 1.0], 2.5e-2),
-            (OpKind::Exp, |x| x.exp(), &[-2.0, -0.5, 0.0, 1.0, 2.0, 3.0], 5e-3),
-            (OpKind::Exp2, |x| x.exp2(), &[-3.0, -0.5, 0.0, 1.0, 4.0], 5e-3),
+            (
+                OpKind::Sin,
+                |x| x.sin(),
+                &[-2.0, -1.0, -0.3, 0.0, 0.5, 1.5, 2.0],
+                6e-3,
+            ),
+            (
+                OpKind::Cos,
+                |x| x.cos(),
+                &[-1.0, -0.3, 0.0, 0.5, 1.0],
+                1.5e-2,
+            ),
+            (
+                OpKind::Tan,
+                |x| x.tan(),
+                &[-1.0, -0.3, 0.0, 0.3, 1.0],
+                2.5e-2,
+            ),
+            (
+                OpKind::Exp,
+                |x| x.exp(),
+                &[-2.0, -0.5, 0.0, 1.0, 2.0, 3.0],
+                5e-3,
+            ),
+            (
+                OpKind::Exp2,
+                |x| x.exp2(),
+                &[-3.0, -0.5, 0.0, 1.0, 4.0],
+                5e-3,
+            ),
             (OpKind::Ln, |x| x.ln(), &[0.25, 0.5, 1.0, 2.0, 10.0], 5e-3),
-            (OpKind::Log2, |x| x.log2(), &[0.25, 0.5, 1.0, 2.0, 8.0], 5e-3),
-            (OpKind::Log10, |x| x.log10(), &[0.1, 0.5, 1.0, 10.0, 100.0], 5e-3),
-            (OpKind::Atan, |x| x.atan(), &[-5.0, -0.5, -0.2, 0.0, 0.2, 0.5, 5.0], 8e-3),
-            (OpKind::Asin, |x| x.asin(), &[-0.8, -0.5, 0.0, 0.5, 0.8], 1e-2),
-            (OpKind::Acos, |x| x.acos(), &[-0.8, -0.5, 0.0, 0.5, 0.8], 1e-2),
+            (
+                OpKind::Log2,
+                |x| x.log2(),
+                &[0.25, 0.5, 1.0, 2.0, 8.0],
+                5e-3,
+            ),
+            (
+                OpKind::Log10,
+                |x| x.log10(),
+                &[0.1, 0.5, 1.0, 10.0, 100.0],
+                5e-3,
+            ),
+            (
+                OpKind::Atan,
+                |x| x.atan(),
+                &[-5.0, -0.5, -0.2, 0.0, 0.2, 0.5, 5.0],
+                8e-3,
+            ),
+            (
+                OpKind::Asin,
+                |x| x.asin(),
+                &[-0.8, -0.5, 0.0, 0.5, 0.8],
+                1e-2,
+            ),
+            (
+                OpKind::Acos,
+                |x| x.acos(),
+                &[-0.8, -0.5, 0.0, 0.5, 0.8],
+                1e-2,
+            ),
         ];
         for &(op, scalar, inputs, tol) in unary {
             let mut arena = ExprArena::new();
@@ -4101,7 +4174,14 @@ mod tests {
         }
 
         // atan2(y, x): arena Binary(Atan2, Y, X)  (op order: src1=y, src2=x)
-        let pts = [(0.5, 2.0), (2.0, 0.5), (-0.5, 2.0), (0.5, -2.0), (-2.0, -0.5), (3.0, -0.5)];
+        let pts = [
+            (0.5, 2.0),
+            (2.0, 0.5),
+            (-0.5, 2.0),
+            (0.5, -2.0),
+            (-2.0, -0.5),
+            (3.0, -0.5),
+        ];
         {
             let mut a = ExprArena::new();
             let y = a.push_var(1);
@@ -4110,7 +4190,10 @@ mod tests {
             for &(yv, xv) in &pts {
                 let got = unsafe { run2(&a, root, xv, yv) };
                 let want = yv.atan2(xv);
-                assert!((got - want).abs() <= 1.5e-2, "atan2({yv},{xv}): {got} vs {want}");
+                assert!(
+                    (got - want).abs() <= 1.5e-2,
+                    "atan2({yv},{xv}): {got} vs {want}"
+                );
             }
         }
         // pow(X, Y)
@@ -4135,7 +4218,10 @@ mod tests {
             for &(xv, yv) in &[(3.0f32, 4.0f32), (1.0, 1.0), (0.0, 2.0)] {
                 let got = unsafe { run2(&a, root, xv, yv) };
                 let want = xv.hypot(yv);
-                assert!((got - want).abs() <= 1e-4, "hypot({xv},{yv}): {got} vs {want}");
+                assert!(
+                    (got - want).abs() <= 1e-4,
+                    "hypot({xv},{yv}): {got} vs {want}"
+                );
             }
         }
         // Min / Max
@@ -4161,7 +4247,10 @@ mod tests {
             let root = a.push_ternary(OpKind::Clamp, x, lo, hi);
             for &xv in &[-0.5f32, 0.25, 0.9, 1.7] {
                 let got = run1(&a, root, xv);
-                assert!((got - xv.clamp(0.0, 1.0)).abs() <= 1e-6, "clamp({xv})={got}");
+                assert!(
+                    (got - xv.clamp(0.0, 1.0)).abs() <= 1e-6,
+                    "clamp({xv})={got}"
+                );
             }
         }
         // Select(X >= 0, 1.0, -1.0) == signum-ish

--- a/pixelflow-ir/src/backend/emit/x86_64.rs
+++ b/pixelflow-ir/src/backend/emit/x86_64.rs
@@ -314,7 +314,16 @@ pub fn emit_const(code: &mut Vec<u8>, dst: Reg, val: f32, _scratch: [Reg; 4]) {
 /// `reg` is the ModRM.reg operand (a register, or a `/digit` opcode extension
 /// passed as `Reg(digit)`); `vvvv` is the inverted extra source (pass `Reg(0)`
 /// when unused — that encodes the required `1111`); `rm` is the ModRM.rm reg.
-fn emit_vex(code: &mut Vec<u8>, pp: u8, mmmmm: u8, w: u8, reg: Reg, vvvv: Reg, rm: Reg, opcode: u8) {
+fn emit_vex(
+    code: &mut Vec<u8>,
+    pp: u8,
+    mmmmm: u8,
+    w: u8,
+    reg: Reg,
+    vvvv: Reg,
+    rm: Reg,
+    opcode: u8,
+) {
     let rbit = if reg.0 >= 8 { 0x00 } else { 0x80 };
     let xbit = 0x40;
     let bbit = if rm.0 >= 8 { 0x00 } else { 0x20 };

--- a/pixelflow-runtime/src/platform/macos/cocoa.rs
+++ b/pixelflow-runtime/src/platform/macos/cocoa.rs
@@ -117,6 +117,34 @@ impl NSRect {
 
 // --- Wrappers ---
 
+/// Indicates whether to ignore other applications when activating.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActivateIgnore {
+    IgnoreOtherApps,
+    Normal,
+}
+
+/// Indicates whether an event should be dequeued or just peeked.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DequeueStatus {
+    Dequeue,
+    Peek,
+}
+
+/// Indicates whether window creation should be deferred until it's shown.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WindowDefer {
+    Defer,
+    Immediate,
+}
+
+/// Indicates whether a layer is requested for a view.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LayerRequest {
+    WantsLayer,
+    NoLayer,
+}
+
 /// Wrapper for NSApplication
 #[derive(Copy, Clone)]
 pub struct NSApplication(pub Id);
@@ -136,9 +164,12 @@ impl NSApplication {
         }
     }
 
-    pub fn activate_ignoring_other_apps(&self, ignore: bool) {
+    pub fn activate_ignoring_other_apps(&self, ignore: ActivateIgnore) {
         unsafe {
-            let val = if ignore { YES } else { NO };
+            let val = match ignore {
+                ActivateIgnore::IgnoreOtherApps => YES,
+                ActivateIgnore::Normal => NO,
+            };
             sys::send_1::<(), BOOL>(self.0, sys::sel(b"activateIgnoringOtherApps:\0"), val);
         }
     }
@@ -156,9 +187,12 @@ impl NSApplication {
     }
 
     // nextEventMatchingMask:untilDate:inMode:dequeue:
-    pub fn next_event(&self, mask: u64, date: Id, mode: Id, dequeue: bool) -> NSEvent {
+    pub fn next_event(&self, mask: u64, date: Id, mode: Id, dequeue: DequeueStatus) -> NSEvent {
         unsafe {
-            let d = if dequeue { YES } else { NO };
+            let d = match dequeue {
+                DequeueStatus::Dequeue => YES,
+                DequeueStatus::Peek => NO,
+            };
             let ptr: Id = sys::send_4(
                 self.0,
                 sys::sel(b"nextEventMatchingMask:untilDate:inMode:dequeue:\0"),
@@ -190,10 +224,13 @@ impl NSWindow {
         rect: NSRect,
         style_mask: u64,
         backing: u64,
-        defer: bool,
+        defer: WindowDefer,
     ) -> Self {
         unsafe {
-            let d = if defer { YES } else { NO };
+            let d = match defer {
+                WindowDefer::Defer => YES,
+                WindowDefer::Immediate => NO,
+            };
             let ptr: Id = sys::send_4(
                 self.0,
                 sys::sel(b"initWithContentRect:styleMask:backing:defer:\0"),
@@ -266,9 +303,12 @@ impl NSView {
         }
     }
 
-    pub fn set_wants_layer(&self, wants: bool) {
+    pub fn set_wants_layer(&self, wants: LayerRequest) {
         unsafe {
-            let val = if wants { YES } else { NO };
+            let val = match wants {
+                LayerRequest::WantsLayer => YES,
+                LayerRequest::NoLayer => NO,
+            };
             sys::send_1::<(), BOOL>(self.0, sys::sel(b"setWantsLayer:\0"), val);
         }
     }

--- a/pixelflow-runtime/src/platform/macos/platform.rs
+++ b/pixelflow-runtime/src/platform/macos/platform.rs
@@ -45,7 +45,7 @@ impl MetalOps {
             app.set_activation_policy(NS_APPLICATION_ACTIVATION_POLICY_REGULAR);
 
             app.finish_launching();
-            app.activate_ignoring_other_apps(true);
+            app.activate_ignoring_other_apps(cocoa::ActivateIgnore::IgnoreOtherApps);
 
             app
         };
@@ -217,7 +217,7 @@ impl PlatformOps for MetalOps {
                 u64::MAX,
                 until_date,
                 mode,
-                true, // dequeue
+                cocoa::DequeueStatus::Dequeue, // dequeue
             );
 
             // Release mode string

--- a/pixelflow-runtime/src/platform/macos/window.rs
+++ b/pixelflow-runtime/src/platform/macos/window.rs
@@ -24,7 +24,12 @@ impl MacWindow {
         // NSBackingStoreBuffered = 2
         let backing = 2;
 
-        let window = NSWindow::alloc().init_with_content_rect(rect, style_mask, backing, false);
+        let window = NSWindow::alloc().init_with_content_rect(
+            rect,
+            style_mask,
+            backing,
+            super::cocoa::WindowDefer::Immediate,
+        );
         window.set_title(&desc.title);
 
         let view = NSView::alloc().init_with_frame(rect);
@@ -60,7 +65,7 @@ impl MacWindow {
             sys::send_1::<(), Id>(view.0, sys::sel(b"setLayer:\0"), layer);
 
             // [view setWantsLayer: YES]
-            view.set_wants_layer(true);
+            view.set_wants_layer(super::cocoa::LayerRequest::WantsLayer);
         }
 
         window.set_content_view(view);


### PR DESCRIPTION
What: Replaced boolean parameters with intention-revealing enums in `toggle_jit_write`, `activate_ignoring_other_apps`, `next_event`, `init_with_content_rect`, and `set_wants_layer`.
Why: To follow STYLE.md guidelines to avoid the boolean trap and make call sites clearer.
Impact: Improved code readability and reduced the chance of passing incorrect arguments.
Measurement: `cargo test` passes.

---
*PR created automatically by Jules for task [15856074046414012719](https://jules.google.com/task/15856074046414012719) started by @jppittman*