### PR TITLE
Refactor toggle_jit_write to use JitWriteState enum

### DIFF
--- a/pixelflow-ir/src/backend/emit/executable.rs
+++ b/pixelflow-ir/src/backend/emit/executable.rs
@@ -218,7 +218,7 @@ impl CodeBuffer {
         {
             // With MAP_JIT on macOS, the memory starts RW. Toggle to RX.
             unsafe {
-                toggle_jit_write(false);
+                toggle_jit_write(JitWriteState::Executable);
             }
         }
 
@@ -252,7 +252,7 @@ impl CodeBuffer {
             // Toggle to writable.
             #[cfg(target_os = "macos")]
             {
-                toggle_jit_write(true);
+                toggle_jit_write(JitWriteState::Writable);
             }
             #[cfg(not(target_os = "macos"))]
             {
@@ -273,7 +273,7 @@ impl CodeBuffer {
             // Toggle to executable.
             #[cfg(target_os = "macos")]
             {
-                toggle_jit_write(false);
+                toggle_jit_write(JitWriteState::Executable);
                 // Instruction cache coherence on Apple Silicon.
                 // sys_icache_invalidate is needed after writing code on ARM.
                 unsafe extern "C" {
@@ -325,24 +325,37 @@ impl Drop for CodeBuffer {
 /// Toggle JIT write protection on macOS (Apple Silicon).
 ///
 /// When `writable` is true, the current thread can write to MAP_JIT memory.
-/// When false, the memory is executable but not writable (W^X).
+#[cfg(target_os = "macos")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum JitWriteState {
+    Writable,
+    Executable,
+}
+
+/// Toggles JIT memory protection on Apple Silicon.
+///
+/// When `Writable`, the memory can be written to but not executed.
+/// When `Executable`, the memory can be executed but not written (W^X).
 ///
 /// This is much cheaper than mprotect (~0.5µs vs ~5µs) and is per-thread,
 /// so it doesn't affect other threads' ability to execute the code.
 #[cfg(target_os = "macos")]
-unsafe fn toggle_jit_write(writable: bool) {
+unsafe fn toggle_jit_write(state: JitWriteState) {
     // pthread_jit_write_protect_np(true) = write-protect (executable)
     // pthread_jit_write_protect_np(false) = writable (not executable)
     // Note: the semantics are inverted from what you'd expect!
     unsafe extern "C" {
         fn pthread_jit_write_protect_np(enabled: bool);
     }
-    // writable=true → we want to write → disable write protection
-    // writable=false → we want to execute → enable write protection
+    // Writable → we want to write → disable write protection (false)
+    // Executable → we want to execute → enable write protection (true)
     // SAFETY: pthread_jit_write_protect_np is always safe to call — it only
     // affects the calling thread's JIT write permission.
     unsafe {
-        pthread_jit_write_protect_np(!writable);
+        match state {
+            JitWriteState::Writable => pthread_jit_write_protect_np(false),
+            JitWriteState::Executable => pthread_jit_write_protect_np(true),
+        }
     }
 }
 


### PR DESCRIPTION
Refactor `toggle_jit_write` in `pixelflow-ir/src/backend/emit/executable.rs` to use `JitWriteState` instead of a boolean argument to avoid the boolean trap. Used python script to replace code exactlly. The old `fix_jit.py` was removed.

---
*PR created automatically by Jules for task [2788690960334956322](https://jules.google.com/task/2788690960334956322) started by @jppittman*