### PR TITLE
Refactor toggle_jit_write to use JitWriteState enum

### DIFF
--- a/pixelflow-ir/src/backend/emit/executable.rs
+++ b/pixelflow-ir/src/backend/emit/executable.rs
@@ -218,7 +218,7 @@ impl CodeBuffer {
         {
             // With MAP_JIT on macOS, the memory starts RW. Toggle to RX.
             unsafe {
-                toggle_jit_write(false);
+                toggle_jit_write(JitWriteState::Executable);
             }
         }
 
@@ -252,7 +252,7 @@ impl CodeBuffer {
             // Toggle to writable.
             #[cfg(target_os = "macos")]
             {
-                toggle_jit_write(true);
+                toggle_jit_write(JitWriteState::Writable);
             }
             #[cfg(not(target_os = "macos"))]
             {
@@ -273,7 +273,7 @@ impl CodeBuffer {
             // Toggle to executable.
             #[cfg(target_os = "macos")]
             {
-                toggle_jit_write(false);
+                toggle_jit_write(JitWriteState::Executable);
                 // Instruction cache coherence on Apple Silicon.
                 // sys_icache_invalidate is needed after writing code on ARM.
                 unsafe extern "C" {
@@ -322,6 +322,13 @@ impl Drop for CodeBuffer {
     }
 }
 
+#[cfg(target_os = "macos")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum JitWriteState {
+    Writable,
+    Executable,
+}
+
 /// Toggle JIT write protection on macOS (Apple Silicon).
 ///
 /// When `writable` is true, the current thread can write to MAP_JIT memory.
@@ -330,7 +337,7 @@ impl Drop for CodeBuffer {
 /// This is much cheaper than mprotect (~0.5µs vs ~5µs) and is per-thread,
 /// so it doesn't affect other threads' ability to execute the code.
 #[cfg(target_os = "macos")]
-unsafe fn toggle_jit_write(writable: bool) {
+unsafe fn toggle_jit_write(state: JitWriteState) {
     // pthread_jit_write_protect_np(true) = write-protect (executable)
     // pthread_jit_write_protect_np(false) = writable (not executable)
     // Note: the semantics are inverted from what you'd expect!
@@ -342,7 +349,10 @@ unsafe fn toggle_jit_write(writable: bool) {
     // SAFETY: pthread_jit_write_protect_np is always safe to call — it only
     // affects the calling thread's JIT write permission.
     unsafe {
-        pthread_jit_write_protect_np(!writable);
+        match state {
+            JitWriteState::Writable => pthread_jit_write_protect_np(false),
+            JitWriteState::Executable => pthread_jit_write_protect_np(true),
+        }
     }
 }
 


### PR DESCRIPTION
What: Replaced the boolean argument in `toggle_jit_write` with an intention-revealing `JitWriteState` enum.
Why: The boolean argument (`writable`) was a boolean trap, obscuring the call site intent. Additionally, the underlying API (`pthread_jit_write_protect_np`) has inverted semantics (true means write-protect), which makes using a boolean even more confusing.
Impact: Improves code readability and safety by explicitly communicating the intended JIT write state at the call site.
Measurement: `cargo check` and `cargo test` run successfully without regressions.

---
*PR created automatically by Jules for task [9585665366304538369](https://jules.google.com/task/9585665366304538369) started by @jppittman*