### PR TITLE
⚡ Bolt: Pre-allocate vectors in rendering hot path

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2025-12-28 - Rasterizer Inner Loop Hoisting
 **Learning:** The inner loop of `execute_stripe` was re-evaluating `Field::sequential(start)` on every iteration, which involves multiple SIMD instructions (broadcast/load + add).
 **Action:** Hoisted the initialization of `xs` out of the loop and updated it incrementally using a pre-computed `step` vector. This reduced the inner loop overhead significantly, yielding a ~34% improvement in rasterization throughput.
+
+## 2024-06-05 - Pre-allocating Vectors in Rendering Hot Paths
+**Learning:** In the `core-term` rendering pipeline (`terminal_app.rs`), dynamically growing vectors like `row_items` and `cell_items` were initialized with `Vec::new()`, leading to multiple expensive heap reallocations per frame when building the render tree.
+**Action:** When initializing vectors in hot paths with known target sizes (e.g., based on grid dimensions like `rows` and `cols`), always use `Vec::with_capacity(size)` to prevent unnecessary allocations.

--- a/core-term/src/terminal_app.rs
+++ b/core-term/src/terminal_app.rs
@@ -288,11 +288,13 @@ impl TerminalApp {
         let default_bg = self.config.colors.background;
 
         // Build 2-level BSP: Vertical (Rows) -> Horizontal (Cells)
-        let mut row_items = Vec::new();
+        // PERF: Pre-allocate row items based on known grid dimensions
+        let mut row_items = Vec::with_capacity(rows);
 
         for row in 0..rows {
             let line = &snapshot.lines[row];
-            let mut cell_items = Vec::new();
+            // PERF: Pre-allocate cell items based on known grid dimensions
+            let mut cell_items = Vec::with_capacity(cols);
 
             for col in 0..cols {
                 let glyph = &line.cells[col];


### PR DESCRIPTION
💡 What: Replaced `Vec::new()` with `Vec::with_capacity(size)` for `row_items` and `cell_items` in the `core-term` terminal app rendering loop. Added a journal entry detailing this learning.
🎯 Why: `row_items` and `cell_items` are dynamically growing vectors initialized with `Vec::new()` in a very hot path (the rendering loop). Since their target sizes are known in advance (`rows` and `cols`), pre-allocating them avoids multiple expensive heap reallocations per frame when building the render tree.
📊 Impact: Reduces memory allocation overhead during frame rendering, leading to more stable and faster frame times.
🔬 Measurement: Verify by running `cargo test -p core-term` and observing stable performance when rendering large grid updates.

---
*PR created automatically by Jules for task [185910280614798224](https://jules.google.com/task/185910280614798224) started by @jppittman*