### PR TITLE
⚡ Bolt: Preallocate terminal app vectors

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,6 @@
 ## 2025-12-28 - Rasterizer Inner Loop Hoisting
 **Learning:** The inner loop of `execute_stripe` was re-evaluating `Field::sequential(start)` on every iteration, which involves multiple SIMD instructions (broadcast/load + add).
 **Action:** Hoisted the initialization of `xs` out of the loop and updated it incrementally using a pre-computed `step` vector. This reduced the inner loop overhead significantly, yielding a ~34% improvement in rasterization throughput.
+## 2024-06-06 - Preallocate terminal app vectors
+**Learning:** Found a hot path in `core-term/src/terminal_app.rs` (`build_manifold`, called every frame) that used `Vec::new()` to initialize dynamically growing vectors (`row_items`, `cell_items`). This is an anti-pattern as it triggers expensive heap reallocations when pushing elements.
+**Action:** Replaced `Vec::new()` with `Vec::with_capacity()` when the exact size is known upfront (from `rows` and `cols`), as this avoids multiple dynamic heap allocations and memory copying operations.

--- a/core-term/src/terminal_app.rs
+++ b/core-term/src/terminal_app.rs
@@ -288,11 +288,13 @@ impl TerminalApp {
         let default_bg = self.config.colors.background;
 
         // Build 2-level BSP: Vertical (Rows) -> Horizontal (Cells)
-        let mut row_items = Vec::new();
+        // PERF: Preallocate row_items with known capacity to avoid reallocation
+        let mut row_items = Vec::with_capacity(rows);
 
         for row in 0..rows {
             let line = &snapshot.lines[row];
-            let mut cell_items = Vec::new();
+            // PERF: Preallocate cell_items with known capacity to avoid reallocation
+            let mut cell_items = Vec::with_capacity(cols);
 
             for col in 0..cols {
                 let glyph = &line.cells[col];


### PR DESCRIPTION
💡 What: Replaced `Vec::new()` with `Vec::with_capacity()` for `row_items` and `cell_items` in `core-term/src/terminal_app.rs`.
🎯 Why: Initializing dynamically growing vectors with `Vec::new()` without known sizes triggers expensive heap reallocations. Preallocating using `Vec::with_capacity()` optimizes this hot path by reserving the memory up-front.
📊 Impact: Reduces heap reallocations during terminal screen renders, potentially saving noticeable milliseconds over many frames.
🔬 Measurement: Performance profiling in terminal rendering or comparing flame graphs of execution before and after.

---
*PR created automatically by Jules for task [4609504603194914029](https://jules.google.com/task/4609504603194914029) started by @jppittman*