### PR TITLE
Fix boolean trap violation in `toggle_jit_write`

### DIFF
--- a/pixelflow-ir/src/backend/emit/executable.rs
+++ b/pixelflow-ir/src/backend/emit/executable.rs
@@ -26,7 +26,7 @@ impl ExecutableCode {
     /// for the current architecture.
     #[cfg(unix)]
     pub unsafe fn from_code(code: &[u8]) -> Result<Self, &'static str> {
-        use libc::{MAP_ANON, MAP_PRIVATE, PROT_EXEC, PROT_READ, PROT_WRITE, mmap, mprotect};
+        use libc::{mmap, mprotect, MAP_ANON, MAP_PRIVATE, PROT_EXEC, PROT_READ, PROT_WRITE};
 
         if code.is_empty() {
             return Err("empty code buffer");
@@ -166,7 +166,7 @@ impl CodeBuffer {
     /// Returns an error if mmap fails.
     #[cfg(unix)]
     pub fn new(capacity: usize) -> Result<Self, &'static str> {
-        use libc::{MAP_ANON, MAP_PRIVATE, PROT_READ, PROT_WRITE, mmap};
+        use libc::{mmap, MAP_ANON, MAP_PRIVATE, PROT_READ, PROT_WRITE};
 
         if capacity == 0 {
             return Err("CodeBuffer capacity must be > 0");
@@ -218,7 +218,7 @@ impl CodeBuffer {
         {
             // With MAP_JIT on macOS, the memory starts RW. Toggle to RX.
             unsafe {
-                toggle_jit_write(false);
+                toggle_jit_write(JitWriteState::Executable);
             }
         }
 
@@ -252,7 +252,7 @@ impl CodeBuffer {
             // Toggle to writable.
             #[cfg(target_os = "macos")]
             {
-                toggle_jit_write(true);
+                toggle_jit_write(JitWriteState::Writable);
             }
             #[cfg(not(target_os = "macos"))]
             {
@@ -273,7 +273,7 @@ impl CodeBuffer {
             // Toggle to executable.
             #[cfg(target_os = "macos")]
             {
-                toggle_jit_write(false);
+                toggle_jit_write(JitWriteState::Executable);
                 // Instruction cache coherence on Apple Silicon.
                 // sys_icache_invalidate is needed after writing code on ARM.
                 unsafe extern "C" {
@@ -322,27 +322,40 @@ impl Drop for CodeBuffer {
     }
 }
 
+/// Represents the desired JIT write protection state.
+#[cfg(target_os = "macos")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JitWriteState {
+    /// JIT memory can be written to (W^X: writable, not executable).
+    Writable,
+    /// JIT memory can be executed (W^X: executable, not writable).
+    Executable,
+}
+
 /// Toggle JIT write protection on macOS (Apple Silicon).
 ///
-/// When `writable` is true, the current thread can write to MAP_JIT memory.
-/// When false, the memory is executable but not writable (W^X).
+/// When `state` is `JitWriteState::Writable`, the current thread can write to MAP_JIT memory.
+/// When `state` is `JitWriteState::Executable`, the memory is executable but not writable (W^X).
 ///
 /// This is much cheaper than mprotect (~0.5µs vs ~5µs) and is per-thread,
 /// so it doesn't affect other threads' ability to execute the code.
 #[cfg(target_os = "macos")]
-unsafe fn toggle_jit_write(writable: bool) {
+unsafe fn toggle_jit_write(state: JitWriteState) {
     // pthread_jit_write_protect_np(true) = write-protect (executable)
     // pthread_jit_write_protect_np(false) = writable (not executable)
     // Note: the semantics are inverted from what you'd expect!
     unsafe extern "C" {
         fn pthread_jit_write_protect_np(enabled: bool);
     }
-    // writable=true → we want to write → disable write protection
-    // writable=false → we want to execute → enable write protection
+    // Writable -> we want to write -> disable write protection
+    // Executable -> we want to execute -> enable write protection
     // SAFETY: pthread_jit_write_protect_np is always safe to call — it only
     // affects the calling thread's JIT write permission.
     unsafe {
-        pthread_jit_write_protect_np(!writable);
+        match state {
+            JitWriteState::Writable => pthread_jit_write_protect_np(false),
+            JitWriteState::Executable => pthread_jit_write_protect_np(true),
+        }
     }
 }
 


### PR DESCRIPTION
Refactors `toggle_jit_write` to use a new `JitWriteState` enum rather than a boolean, making the intent at call sites clearer and adhering to the style guidelines.

### What
Replaced the boolean flag in `toggle_jit_write` with the `JitWriteState` enum.
Updated all call sites to use `JitWriteState::Executable` and `JitWriteState::Writable`.

### Why
To adhere to the `STYLE.md` guideline against boolean trap arguments, improving readability and maintainability.

### Impact
Call sites are now self-documenting regarding the desired memory protection state.

### Measurement
Verified via `cargo check` and `cargo test` on the `pixelflow-ir` crate.

---
*PR created automatically by Jules for task [11424054937828305581](https://jules.google.com/task/11424054937828305581) started by @jppittman*