### PR TITLE
Fix test styling violations in frame.rs

### DIFF
--- a/pixelflow-runtime/src/frame.rs
+++ b/pixelflow-runtime/src/frame.rs
@@ -147,44 +147,45 @@ mod tests {
     }
 
     #[test]
-    fn test_create_channels() {
-        let (_handle, _rx) = create_frame_channel::<TestSurface>();
-        let (_recycle_tx, _recycle_rx) = create_recycle_channel::<TestSurface>();
-    }
-
-    #[test]
-    fn test_submit_and_receive() {
+    fn handle_should_transmit_packet_when_submitted() {
         let (handle, rx) = create_frame_channel::<TestSurface>();
         let (recycle_tx, _recycle_rx) = create_recycle_channel::<TestSurface>();
 
         let surface = TestSurface { color: 1.0 };
         let packet = FramePacket::new(surface, recycle_tx);
 
-        handle.submit_frame(packet).unwrap();
+        handle
+            .submit_frame(packet)
+            .expect("Failed to submit frame packet");
 
-        let received = rx.recv().unwrap();
-        assert_eq!(received.surface.color, 1.0);
+        let received = rx.recv().expect("Failed to receive frame packet");
+        assert_eq!(received.surface.color, 1.0, "Expected color to be 1.0");
     }
 
     #[test]
-    fn test_recycle_loop() {
+    fn packet_should_return_to_logic_thread_when_recycled() {
         let (handle, rx) = create_frame_channel::<TestSurface>();
         let (recycle_tx, recycle_rx) = create_recycle_channel::<TestSurface>();
 
         // Create and submit a packet
         let surface = TestSurface { color: 1.0 };
         let packet = FramePacket::new(surface, Arc::clone(&recycle_tx));
-        handle.submit_frame(packet).unwrap();
+        handle.submit_frame(packet).expect("Failed to submit frame");
 
         // Receive and "render" it
-        let received = rx.recv().unwrap();
-        assert_eq!(received.surface.color, 1.0);
+        let received = rx.recv().expect("Failed to receive frame");
+        assert_eq!(received.surface.color, 1.0, "Expected color to be 1.0");
 
         // Recycle using the method (clean API)
         received.recycle();
 
         // Logic thread receives the recycled packet
-        let recycled = recycle_rx.recv().unwrap();
-        assert_eq!(recycled.surface.color, 1.0);
+        let recycled = recycle_rx
+            .recv()
+            .expect("Failed to receive recycled packet");
+        assert_eq!(
+            recycled.surface.color, 1.0,
+            "Expected recycled color to be 1.0"
+        );
     }
 }


### PR DESCRIPTION
### What
Fixed test naming, removed empty tests, and replaced `.unwrap()` with `.expect()` in `pixelflow-runtime/src/frame.rs`.

### Why
To comply with the testing directives outlined in `docs/STYLE.md`. Tests must have meaningful assertions, use descriptive names (`[method]_should_[outcome]_when_[condition]`), and avoid using `unwrap()`.

### Impact
Improved testing guidelines compliance and test reliability.

### Measurement
`cargo test -p pixelflow-runtime` passes with the updated tests.

---
*PR created automatically by Jules for task [14139904143675763232](https://jules.google.com/task/14139904143675763232) started by @jppittman*