### PR TITLE
Refactor toggle_jit_write to use enum instead of bool

### DIFF
--- a/pixelflow-ir/src/backend/emit/executable.rs
+++ b/pixelflow-ir/src/backend/emit/executable.rs
@@ -26,7 +26,7 @@ impl ExecutableCode {
     /// for the current architecture.
     #[cfg(unix)]
     pub unsafe fn from_code(code: &[u8]) -> Result<Self, &'static str> {
-        use libc::{MAP_ANON, MAP_PRIVATE, PROT_EXEC, PROT_READ, PROT_WRITE, mmap, mprotect};
+        use libc::{mmap, mprotect, MAP_ANON, MAP_PRIVATE, PROT_EXEC, PROT_READ, PROT_WRITE};
 
         if code.is_empty() {
             return Err("empty code buffer");
@@ -166,7 +166,7 @@ impl CodeBuffer {
     /// Returns an error if mmap fails.
     #[cfg(unix)]
     pub fn new(capacity: usize) -> Result<Self, &'static str> {
-        use libc::{MAP_ANON, MAP_PRIVATE, PROT_READ, PROT_WRITE, mmap};
+        use libc::{mmap, MAP_ANON, MAP_PRIVATE, PROT_READ, PROT_WRITE};
 
         if capacity == 0 {
             return Err("CodeBuffer capacity must be > 0");
@@ -218,7 +218,7 @@ impl CodeBuffer {
         {
             // With MAP_JIT on macOS, the memory starts RW. Toggle to RX.
             unsafe {
-                toggle_jit_write(false);
+                toggle_jit_write(JitWriteState::Executable);
             }
         }
 
@@ -252,7 +252,7 @@ impl CodeBuffer {
             // Toggle to writable.
             #[cfg(target_os = "macos")]
             {
-                toggle_jit_write(true);
+                toggle_jit_write(JitWriteState::Writable);
             }
             #[cfg(not(target_os = "macos"))]
             {
@@ -273,7 +273,7 @@ impl CodeBuffer {
             // Toggle to executable.
             #[cfg(target_os = "macos")]
             {
-                toggle_jit_write(false);
+                toggle_jit_write(JitWriteState::Executable);
                 // Instruction cache coherence on Apple Silicon.
                 // sys_icache_invalidate is needed after writing code on ARM.
                 unsafe extern "C" {
@@ -322,27 +322,38 @@ impl Drop for CodeBuffer {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg(target_os = "macos")]
+pub enum JitWriteState {
+    Writable,
+    Executable,
+}
+
 /// Toggle JIT write protection on macOS (Apple Silicon).
 ///
-/// When `writable` is true, the current thread can write to MAP_JIT memory.
-/// When false, the memory is executable but not writable (W^X).
+/// When `state` is `JitWriteState::Writable`, the current thread can write to MAP_JIT memory.
+/// When `JitWriteState::Executable`, the memory is executable but not writable (W^X).
 ///
 /// This is much cheaper than mprotect (~0.5µs vs ~5µs) and is per-thread,
 /// so it doesn't affect other threads' ability to execute the code.
 #[cfg(target_os = "macos")]
-unsafe fn toggle_jit_write(writable: bool) {
+unsafe fn toggle_jit_write(state: JitWriteState) {
     // pthread_jit_write_protect_np(true) = write-protect (executable)
     // pthread_jit_write_protect_np(false) = writable (not executable)
     // Note: the semantics are inverted from what you'd expect!
     unsafe extern "C" {
-        fn pthread_jit_write_protect_np(enabled: bool);
+        fn pthread_jit_write_protect_np(enabled: core::ffi::c_int);
     }
-    // writable=true → we want to write → disable write protection
-    // writable=false → we want to execute → enable write protection
+    // Writable → we want to write → disable write protection
+    // Executable → we want to execute → enable write protection
     // SAFETY: pthread_jit_write_protect_np is always safe to call — it only
     // affects the calling thread's JIT write permission.
+    let enabled = match state {
+        JitWriteState::Executable => 1,
+        JitWriteState::Writable => 0,
+    };
     unsafe {
-        pthread_jit_write_protect_np(!writable);
+        pthread_jit_write_protect_np(enabled);
     }
 }
 


### PR DESCRIPTION
## What
Replaced the boolean argument in `toggle_jit_write` with a `JitWriteState` enum (`Writable` and `Executable`).

## Why
The previous implementation used a boolean (`writable: bool`), which can create a "boolean trap" at the call site where the meaning of `true` or `false` is not immediately clear. Additionally, the underlying `pthread_jit_write_protect_np` has inverted semantics (where `true` means write-protect/executable). Using an explicit enum improves readability and reduces the risk of incorrect usage.

## Impact
- Improved readability and maintainability for code interacting with macOS JIT memory protection.
- No functional logic change.

## Measurement
- No performance impact expected. The wrapper function's matching on the enum variant should be compiled down to optimal instructions.

---
*PR created automatically by Jules for task [10932145826395350000](https://jules.google.com/task/10932145826395350000) started by @jppittman*