### PR TITLE
Refactor boolean trap in activate_ignoring_other_apps

### DIFF
--- a/pixelflow-runtime/src/platform/macos/cocoa.rs
+++ b/pixelflow-runtime/src/platform/macos/cocoa.rs
@@ -136,10 +136,15 @@ impl NSApplication {
         }
     }
 
-    pub fn activate_ignoring_other_apps(&self, ignore: bool) {
+    pub fn activate_ignoring_other_apps(&self) {
         unsafe {
-            let val = if ignore { YES } else { NO };
-            sys::send_1::<(), BOOL>(self.0, sys::sel(b"activateIgnoringOtherApps:\0"), val);
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"activateIgnoringOtherApps:\0"), YES);
+        }
+    }
+
+    pub fn activate_respecting_other_apps(&self) {
+        unsafe {
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"activateIgnoringOtherApps:\0"), NO);
         }
     }
 

--- a/pixelflow-runtime/src/platform/macos/platform.rs
+++ b/pixelflow-runtime/src/platform/macos/platform.rs
@@ -45,7 +45,7 @@ impl MetalOps {
             app.set_activation_policy(NS_APPLICATION_ACTIVATION_POLICY_REGULAR);
 
             app.finish_launching();
-            app.activate_ignoring_other_apps(true);
+            app.activate_ignoring_other_apps();
 
             app
         };


### PR DESCRIPTION
Refactored `activate_ignoring_other_apps(ignore: bool)` in `pixelflow-runtime/src/platform/macos/cocoa.rs` into two distinct parameter-less methods (`activate_ignoring_other_apps()` and `activate_respecting_other_apps()`) to improve call-site clarity and avoid boolean traps, conforming to `STYLE.md`.

* Replaced `activate_ignoring_other_apps(true)` with `activate_ignoring_other_apps()` in `platform.rs`.
* Tested via `cargo test -p pixelflow-runtime`.

---
*PR created automatically by Jules for task [515029695611964460](https://jules.google.com/task/515029695611964460) started by @jppittman*