### PR TITLE
Refactor `toggle_jit_write` to use `JitWriteState` enum instead of boolean flag

### DIFF
--- a/pixelflow-ir/src/backend/emit/executable.rs
+++ b/pixelflow-ir/src/backend/emit/executable.rs
@@ -26,7 +26,7 @@ impl ExecutableCode {
     /// for the current architecture.
     #[cfg(unix)]
     pub unsafe fn from_code(code: &[u8]) -> Result<Self, &'static str> {
-        use libc::{MAP_ANON, MAP_PRIVATE, PROT_EXEC, PROT_READ, PROT_WRITE, mmap, mprotect};
+        use libc::{mmap, mprotect, MAP_ANON, MAP_PRIVATE, PROT_EXEC, PROT_READ, PROT_WRITE};
 
         if code.is_empty() {
             return Err("empty code buffer");
@@ -166,7 +166,7 @@ impl CodeBuffer {
     /// Returns an error if mmap fails.
     #[cfg(unix)]
     pub fn new(capacity: usize) -> Result<Self, &'static str> {
-        use libc::{MAP_ANON, MAP_PRIVATE, PROT_READ, PROT_WRITE, mmap};
+        use libc::{mmap, MAP_ANON, MAP_PRIVATE, PROT_READ, PROT_WRITE};
 
         if capacity == 0 {
             return Err("CodeBuffer capacity must be > 0");
@@ -218,7 +218,7 @@ impl CodeBuffer {
         {
             // With MAP_JIT on macOS, the memory starts RW. Toggle to RX.
             unsafe {
-                toggle_jit_write(false);
+                toggle_jit_write(JitWriteState::Executable);
             }
         }
 
@@ -252,7 +252,7 @@ impl CodeBuffer {
             // Toggle to writable.
             #[cfg(target_os = "macos")]
             {
-                toggle_jit_write(true);
+                toggle_jit_write(JitWriteState::Writable);
             }
             #[cfg(not(target_os = "macos"))]
             {
@@ -273,7 +273,7 @@ impl CodeBuffer {
             // Toggle to executable.
             #[cfg(target_os = "macos")]
             {
-                toggle_jit_write(false);
+                toggle_jit_write(JitWriteState::Executable);
                 // Instruction cache coherence on Apple Silicon.
                 // sys_icache_invalidate is needed after writing code on ARM.
                 unsafe extern "C" {
@@ -330,19 +330,31 @@ impl Drop for CodeBuffer {
 /// This is much cheaper than mprotect (~0.5µs vs ~5µs) and is per-thread,
 /// so it doesn't affect other threads' ability to execute the code.
 #[cfg(target_os = "macos")]
-unsafe fn toggle_jit_write(writable: bool) {
-    // pthread_jit_write_protect_np(true) = write-protect (executable)
-    // pthread_jit_write_protect_np(false) = writable (not executable)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum JitWriteState {
+    Writable,
+    Executable,
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn toggle_jit_write(state: JitWriteState) {
+    // pthread_jit_write_protect_np(1) = write-protect (executable)
+    // pthread_jit_write_protect_np(0) = writable (not executable)
     // Note: the semantics are inverted from what you'd expect!
     unsafe extern "C" {
-        fn pthread_jit_write_protect_np(enabled: bool);
+        fn pthread_jit_write_protect_np(enabled: core::ffi::c_int);
     }
-    // writable=true → we want to write → disable write protection
-    // writable=false → we want to execute → enable write protection
+    // Writable → we want to write → disable write protection
+    // Executable → we want to execute → enable write protection
     // SAFETY: pthread_jit_write_protect_np is always safe to call — it only
     // affects the calling thread's JIT write permission.
+    let enabled = if state == JitWriteState::Executable {
+        1
+    } else {
+        0
+    };
     unsafe {
-        pthread_jit_write_protect_np(!writable);
+        pthread_jit_write_protect_np(enabled);
     }
 }
 


### PR DESCRIPTION
**What:** Replaced the `bool` parameter in `toggle_jit_write` with a `JitWriteState` enum (`Writable`, `Executable`). Also updated the FFI declaration to take `core::ffi::c_int` to match the C ABI and prevent improper ctypes warnings.
**Why:** The macOS `pthread_jit_write_protect_np` API has inverted semantics (true = write-protect/executable, false = writable/not-executable), making the boolean trap particularly dangerous. The intention-revealing enum clarifies the intent and strictly adheres to `STYLE.md` recommendations regarding boolean traps.
**Impact:** Eliminates a boolean trap and correctly enforces FFI argument type safety. No changes in functionality.
**Measurement:** `cargo test -p pixelflow-ir` and `cargo check --workspace` confirmed to be compiling properly.

---
*PR created automatically by Jules for task [17388349847401026814](https://jules.google.com/task/17388349847401026814) started by @jppittman*