### PR TITLE
Refactor window visibility API to use explicit methods

### DIFF
--- a/pixelflow-runtime/src/display/messages.rs
+++ b/pixelflow-runtime/src/display/messages.rs
@@ -167,8 +167,14 @@ pub enum DisplayControl {
     /// # Arguments
     ///
     /// - `id`: Window identifier
-    /// - `visible`: `true` to show, `false` to hide
-    SetVisible { id: WindowId, visible: bool },
+    ShowWindow { id: WindowId },
+
+    /// Hide a window.
+    ///
+    /// # Arguments
+    ///
+    /// - `id`: Window identifier
+    HideWindow { id: WindowId },
 
     /// Request an immediate redraw.
     ///

--- a/pixelflow-runtime/src/platform/linux/platform.rs
+++ b/pixelflow-runtime/src/platform/linux/platform.rs
@@ -103,7 +103,9 @@ impl PlatformOps for LinuxOps {
                 DisplayControl::Bell => {
                     window.bell();
                 }
-                DisplayControl::SetVisible { .. } | DisplayControl::RequestRedraw { .. } => {
+                DisplayControl::ShowWindow { .. }
+                | DisplayControl::HideWindow { .. }
+                | DisplayControl::RequestRedraw { .. } => {
                     // Not implemented for Linux yet
                 }
             }

--- a/pixelflow-runtime/src/platform/macos/platform.rs
+++ b/pixelflow-runtime/src/platform/macos/platform.rs
@@ -100,9 +100,14 @@ impl PlatformOps for MetalOps {
                     win.set_cursor(cursor);
                 }
             }
-            DisplayControl::SetVisible { id, visible } => {
+            DisplayControl::ShowWindow { id } => {
                 if let Some(win) = self.windows.get_mut(&id) {
-                    win.set_visible(visible);
+                    win.show();
+                }
+            }
+            DisplayControl::HideWindow { id } => {
+                if let Some(win) = self.windows.get_mut(&id) {
+                    win.hide();
                 }
             }
             DisplayControl::RequestRedraw { id } => {
@@ -164,7 +169,7 @@ impl PlatformOps for MetalOps {
             }
             DisplayMgmt::Destroy { id } => {
                 if let Some(mut win) = self.windows.remove(&id) {
-                    win.set_visible(false);
+                    win.hide();
                     // Drop closes it implicitly or we call close
                     // win.window.close(); // If we expose it
                     self.window_map.remove(&(win.window.0 as usize));

--- a/pixelflow-runtime/src/platform/macos/window.rs
+++ b/pixelflow-runtime/src/platform/macos/window.rs
@@ -122,13 +122,13 @@ impl MacWindow {
         }
     }
 
-    pub fn set_visible(&mut self, visible: bool) {
-        if visible {
-            self.window.make_key_and_order_front();
-        } else {
-            unsafe {
-                sys::send::<()>(self.window.0, sys::sel(b"orderOut:\0"));
-            }
+    pub fn show(&mut self) {
+        self.window.make_key_and_order_front();
+    }
+
+    pub fn hide(&mut self) {
+        unsafe {
+            sys::send::<()>(self.window.0, sys::sel(b"orderOut:\0"));
         }
     }
 

--- a/pixelflow-runtime/tests/jit_render.rs
+++ b/pixelflow-runtime/tests/jit_render.rs
@@ -13,8 +13,8 @@
 //! polynomial-approximation accuracy for `sin`/`sqrt`.
 
 use pixelflow_compiler::{kernel, kernel_jit};
-use pixelflow_core::{X, Y};
 use pixelflow_core::ManifoldExt;
+use pixelflow_core::{X, Y};
 use pixelflow_graphics::render::color::Rgba8;
 use pixelflow_graphics::render::frame::Frame;
 use pixelflow_graphics::render::rasterizer::rasterize;
@@ -67,7 +67,12 @@ fn colored_scene_renders_via_jit_matching_combinators() {
     // a real failure (wrong scene, wrong wiring) would be off by tens or more.
     let mut max_diff = 0u8;
     let mut worst = (0usize, 0u8, 0u8);
-    for (i, (a, b)) in frame_combo.data.iter().zip(frame_jit.data.iter()).enumerate() {
+    for (i, (a, b)) in frame_combo
+        .data
+        .iter()
+        .zip(frame_jit.data.iter())
+        .enumerate()
+    {
         for (ca, cb) in [(a.r(), b.r()), (a.g(), b.g()), (a.b(), b.b())] {
             let d = ca.abs_diff(cb);
             if d > max_diff {


### PR DESCRIPTION
Refactors MacWindow's set_visible method into explicit show and hide methods to eliminate a boolean trap per style guidelines.

---
*PR created automatically by Jules for task [15953936944103671404](https://jules.google.com/task/15953936944103671404) started by @jppittman*