### PR TITLE
Refactor toggle_jit_write to use JitWriteState enum

### DIFF
--- a/pixelflow-ir/src/backend/emit/executable.rs
+++ b/pixelflow-ir/src/backend/emit/executable.rs
@@ -216,7 +216,7 @@ impl CodeBuffer {
         {
             // With MAP_JIT on macOS, the memory starts RW. Toggle to RX.
             unsafe {
-                toggle_jit_write(false);
+                toggle_jit_write(JitWriteState::Executable);
             }
         }
 
@@ -250,7 +250,7 @@ impl CodeBuffer {
             // Toggle to writable.
             #[cfg(target_os = "macos")]
             {
-                toggle_jit_write(true);
+                toggle_jit_write(JitWriteState::Writable);
             }
             #[cfg(not(target_os = "macos"))]
             {
@@ -271,7 +271,7 @@ impl CodeBuffer {
             // Toggle to executable.
             #[cfg(target_os = "macos")]
             {
-                toggle_jit_write(false);
+                toggle_jit_write(JitWriteState::Executable);
                 // Instruction cache coherence on Apple Silicon.
                 // sys_icache_invalidate is needed after writing code on ARM.
                 unsafe extern "C" {
@@ -330,8 +330,19 @@ impl Drop for CodeBuffer {
 ///
 /// This is much cheaper than mprotect (~0.5µs vs ~5µs) and is per-thread,
 /// so it doesn't affect other threads' ability to execute the code.
+
+/// JIT memory protection state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg(target_os = "macos")]
-unsafe fn toggle_jit_write(writable: bool) {
+pub enum JitWriteState {
+    /// Writable (not executable)
+    Writable,
+    /// Executable (not writable)
+    Executable,
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn toggle_jit_write(state: JitWriteState) {
     // pthread_jit_write_protect_np(true) = write-protect (executable)
     // pthread_jit_write_protect_np(false) = writable (not executable)
     // Note: the semantics are inverted from what you'd expect!
@@ -343,7 +354,10 @@ unsafe fn toggle_jit_write(writable: bool) {
     // SAFETY: pthread_jit_write_protect_np is always safe to call — it only
     // affects the calling thread's JIT write permission.
     unsafe {
-        pthread_jit_write_protect_np(!writable);
+        pthread_jit_write_protect_np(match state {
+            JitWriteState::Writable => false,
+            JitWriteState::Executable => true,
+        });
     }
 }
 


### PR DESCRIPTION
Refactored `toggle_jit_write` to use a `JitWriteState` enum instead of a boolean to avoid boolean traps and improve intent clarity per the STYLE.md guide.

---
*PR created automatically by Jules for task [1962194974908597513](https://jules.google.com/task/1962194974908597513) started by @jppittman*