### PR TITLE
refactor: Clean up empty test and fix test naming in `frame.rs`

### DIFF
--- a/pixelflow-ir/src/backend/emit/executable.rs
+++ b/pixelflow-ir/src/backend/emit/executable.rs
@@ -26,7 +26,7 @@ impl ExecutableCode {
     /// for the current architecture.
     #[cfg(unix)]
     pub unsafe fn from_code(code: &[u8]) -> Result<Self, &'static str> {
-        use libc::{mmap, mprotect, MAP_ANON, MAP_PRIVATE, PROT_EXEC, PROT_READ, PROT_WRITE};
+        use libc::{MAP_ANON, MAP_PRIVATE, PROT_EXEC, PROT_READ, PROT_WRITE, mmap, mprotect};
 
         if code.is_empty() {
             return Err("empty code buffer");
@@ -170,7 +170,7 @@ impl CodeBuffer {
     /// Returns an error if mmap fails.
     #[cfg(unix)]
     pub fn new(capacity: usize) -> Result<Self, &'static str> {
-        use libc::{mmap, MAP_ANON, MAP_PRIVATE, PROT_READ, PROT_WRITE};
+        use libc::{MAP_ANON, MAP_PRIVATE, PROT_READ, PROT_WRITE, mmap};
 
         if capacity == 0 {
             return Err("CodeBuffer capacity must be > 0");

--- a/pixelflow-runtime/src/frame.rs
+++ b/pixelflow-runtime/src/frame.rs
@@ -147,13 +147,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_channels() {
-        let (_handle, _rx) = create_frame_channel::<TestSurface>();
-        let (_recycle_tx, _recycle_rx) = create_recycle_channel::<TestSurface>();
-    }
-
-    #[test]
-    fn test_submit_and_receive() {
+    fn submit_frame_should_transmit_packet_successfully() {
         let (handle, rx) = create_frame_channel::<TestSurface>();
         let (recycle_tx, _recycle_rx) = create_recycle_channel::<TestSurface>();
 
@@ -167,7 +161,7 @@ mod tests {
     }
 
     #[test]
-    fn test_recycle_loop() {
+    fn recycle_should_return_packet_to_sender() {
         let (handle, rx) = create_frame_channel::<TestSurface>();
         let (recycle_tx, recycle_rx) = create_recycle_channel::<TestSurface>();
 

--- a/pixelflow-runtime/src/platform/linux/platform.rs
+++ b/pixelflow-runtime/src/platform/linux/platform.rs
@@ -103,7 +103,9 @@ impl PlatformOps for LinuxOps {
                 DisplayControl::Bell => {
                     window.bell();
                 }
-                DisplayControl::ShowWindow { .. } | DisplayControl::HideWindow { .. } | DisplayControl::RequestRedraw { .. } => {
+                DisplayControl::ShowWindow { .. }
+                | DisplayControl::HideWindow { .. }
+                | DisplayControl::RequestRedraw { .. } => {
                     // Not implemented for Linux yet
                 }
             }


### PR DESCRIPTION
refactor: Clean up empty test and fix test naming in `frame.rs`

Scope: Modified `pixelflow-runtime/src/frame.rs`.

Fixes: 
- Removed `test_create_channels` which violated `STYLE.md` by containing no assertions.
- Renamed `test_submit_and_receive` to `submit_frame_should_transmit_packet_successfully` to comply with the naming convention `[method]_should_[outcome]_when_[condition]`.
- Renamed `test_recycle_loop` to `recycle_should_return_packet_to_sender` to follow the same naming convention.

Unresolved Issues: None.

Verification: Confirmed that `cargo check` and `cargo test -p pixelflow-runtime` pass. The tests renamed execute properly, and the removed test is no longer in the suite.

---
*PR created automatically by Jules for task [9460576861414910507](https://jules.google.com/task/9460576861414910507) started by @jppittman*