### PR TITLE
Fix formatting and clippy warnings across the codebase

### DIFF
--- a/pixelflow-pipeline/src/training/gen_es.rs
+++ b/pixelflow-pipeline/src/training/gen_es.rs
@@ -397,25 +397,13 @@ pub fn denormalize(params: &[f32; ES_DIM]) -> BwdGenConfig {
 #[must_use]
 pub fn log_ns(ns: f64) -> f32 {
     assert!(!ns.is_nan(), "log_ns called with NaN");
-    let clamped = if ns < 1e-3 {
-        1e-3
-    } else if ns > 1e9 {
-        1e9
-    } else {
-        ns
-    };
+    let clamped = ns.clamp(1e-3, 1e9);
     libm::logf(clamped as f32)
 }
 
 /// Clamp to [0, 1].
 fn clamp01(v: f32) -> f32 {
-    if v < 0.0 {
-        0.0
-    } else if v > 1.0 {
-        1.0
-    } else {
-        v
-    }
+    v.clamp(0.0, 1.0)
 }
 
 // ============================================================================

--- a/pixelflow-pipeline/src/training/replay.rs
+++ b/pixelflow-pipeline/src/training/replay.rs
@@ -127,6 +127,11 @@ impl MmapReplayBuffer {
         self.records.len()
     }
 
+    /// True if buffer is empty.
+    pub fn is_empty(&self) -> bool {
+        self.records.is_empty()
+    }
+
     /// Push a single record. If over capacity, FIFO evict oldest.
     pub fn push(&mut self, record: ReplayRecord) {
         self.records.push(record);


### PR DESCRIPTION
Scope:
- pixelflow-pipeline (multiple modules)
- pixelflow-ir (executable.rs)
- pixelflow-runtime (linux platform.rs)

Fixes:
- Applied `cargo fmt` across all crates to resolve formatting issues.
- Fixed `clippy::manual_div_ceil` by replacing `(count + num_workers - 1) / num_workers` with `.div_ceil()`.
- Fixed `clippy::needless_range_loop` by replacing `for i in 0..DIM { arr[i]... }` with `arr.iter_mut().enumerate()`.
- Fixed `clippy::manual_clamp` by using the `.clamp()` method.
- Fixed `clippy::len_without_is_empty` by adding an `is_empty()` method to `MmapReplayBuffer`.
- Cleaned up several dead code and unused import warnings manually and via `cargo clippy --fix`.
- Restored inadvertently dropped standard `is_multiple_of` replacements with `x % y == 0` for primitive types where necessary, to maintain standard library compatibility without `num-integer`.

Unresolved Issues:
- The project references a `pixelflow: optimization model weights unavailable` warning during compilation, which suggests `git lfs pull` should be run in a fully provisioned environment for the model weights. This is an environment configuration/LFS state issue rather than a pure code error.
- Pre-existing compilation errors involving inaccessible `GRAPH_ACC_DIM` in `self_play.rs` tests were identified and fixed by correctly importing the missing constant.

Verification:
- `cargo check --all-targets --all-features` compiles successfully.
- `cargo test --all-targets --all-features` passes cleanly without regressions.

---
*PR created automatically by Jules for task [6857112133584746396](https://jules.google.com/task/6857112133584746396) started by @jppittman*