### PR TITLE
Refactor Boolean Arguments in Cocoa FFI Wrapper Methods

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,6 @@
 ## 2025-12-28 - Rasterizer Inner Loop Hoisting
 **Learning:** The inner loop of `execute_stripe` was re-evaluating `Field::sequential(start)` on every iteration, which involves multiple SIMD instructions (broadcast/load + add).
 **Action:** Hoisted the initialization of `xs` out of the loop and updated it incrementally using a pre-computed `step` vector. This reduced the inner loop overhead significantly, yielding a ~34% improvement in rasterization throughput.
+## 2025-12-28 - Refactoring Boolean Traps in Cocoa Wrapper
+**Learning:** I learned that boolean arguments in wrapper functions (e.g., `activate_ignoring_other_apps(true)`) violate the style guidelines by obscuring intent at the call site.
+**Action:** Refactored multiple Cocoa FFI wrapper functions in `pixelflow-runtime/src/platform/macos/cocoa.rs` to split into separate methods with distinct names (e.g., `set_wants_layer()` and `clear_wants_layer()`) rather than passing a boolean flag.

--- a/pixelflow-ir/src/backend/emit/executable.rs
+++ b/pixelflow-ir/src/backend/emit/executable.rs
@@ -26,7 +26,7 @@ impl ExecutableCode {
     /// for the current architecture.
     #[cfg(unix)]
     pub unsafe fn from_code(code: &[u8]) -> Result<Self, &'static str> {
-        use libc::{mmap, mprotect, MAP_ANON, MAP_PRIVATE, PROT_EXEC, PROT_READ, PROT_WRITE};
+        use libc::{MAP_ANON, MAP_PRIVATE, PROT_EXEC, PROT_READ, PROT_WRITE, mmap, mprotect};
 
         if code.is_empty() {
             return Err("empty code buffer");
@@ -170,7 +170,7 @@ impl CodeBuffer {
     /// Returns an error if mmap fails.
     #[cfg(unix)]
     pub fn new(capacity: usize) -> Result<Self, &'static str> {
-        use libc::{mmap, MAP_ANON, MAP_PRIVATE, PROT_READ, PROT_WRITE};
+        use libc::{MAP_ANON, MAP_PRIVATE, PROT_READ, PROT_WRITE, mmap};
 
         if capacity == 0 {
             return Err("CodeBuffer capacity must be > 0");

--- a/pixelflow-runtime/src/platform/linux/platform.rs
+++ b/pixelflow-runtime/src/platform/linux/platform.rs
@@ -103,7 +103,9 @@ impl PlatformOps for LinuxOps {
                 DisplayControl::Bell => {
                     window.bell();
                 }
-                DisplayControl::ShowWindow { .. } | DisplayControl::HideWindow { .. } | DisplayControl::RequestRedraw { .. } => {
+                DisplayControl::ShowWindow { .. }
+                | DisplayControl::HideWindow { .. }
+                | DisplayControl::RequestRedraw { .. } => {
                     // Not implemented for Linux yet
                 }
             }

--- a/pixelflow-runtime/src/platform/macos/cocoa.rs
+++ b/pixelflow-runtime/src/platform/macos/cocoa.rs
@@ -136,10 +136,15 @@ impl NSApplication {
         }
     }
 
-    pub fn activate_ignoring_other_apps(&self, ignore: bool) {
+    pub fn activate_ignoring_other_apps(&self) {
         unsafe {
-            let val = if ignore { YES } else { NO };
-            sys::send_1::<(), BOOL>(self.0, sys::sel(b"activateIgnoringOtherApps:\0"), val);
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"activateIgnoringOtherApps:\0"), YES);
+        }
+    }
+
+    pub fn activate_respecting_other_apps(&self) {
+        unsafe {
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"activateIgnoringOtherApps:\0"), NO);
         }
     }
 
@@ -156,16 +161,29 @@ impl NSApplication {
     }
 
     // nextEventMatchingMask:untilDate:inMode:dequeue:
-    pub fn next_event(&self, mask: u64, date: Id, mode: Id, dequeue: bool) -> NSEvent {
+    pub fn next_event_dequeue(&self, mask: u64, date: Id, mode: Id) -> NSEvent {
         unsafe {
-            let d = if dequeue { YES } else { NO };
             let ptr: Id = sys::send_4(
                 self.0,
                 sys::sel(b"nextEventMatchingMask:untilDate:inMode:dequeue:\0"),
                 mask,
                 date,
                 mode,
-                d,
+                YES,
+            );
+            NSEvent(ptr)
+        }
+    }
+
+    pub fn next_event_peek(&self, mask: u64, date: Id, mode: Id) -> NSEvent {
+        unsafe {
+            let ptr: Id = sys::send_4(
+                self.0,
+                sys::sel(b"nextEventMatchingMask:untilDate:inMode:dequeue:\0"),
+                mask,
+                date,
+                mode,
+                NO,
             );
             NSEvent(ptr)
         }
@@ -185,22 +203,39 @@ impl NSWindow {
         }
     }
 
-    pub fn init_with_content_rect(
+    pub fn init_with_content_rect_deferred(
         &self,
         rect: NSRect,
         style_mask: u64,
         backing: u64,
-        defer: bool,
     ) -> Self {
         unsafe {
-            let d = if defer { YES } else { NO };
             let ptr: Id = sys::send_4(
                 self.0,
                 sys::sel(b"initWithContentRect:styleMask:backing:defer:\0"),
                 rect,
                 style_mask,
                 backing,
-                d,
+                YES,
+            );
+            Self(ptr)
+        }
+    }
+
+    pub fn init_with_content_rect_immediate(
+        &self,
+        rect: NSRect,
+        style_mask: u64,
+        backing: u64,
+    ) -> Self {
+        unsafe {
+            let ptr: Id = sys::send_4(
+                self.0,
+                sys::sel(b"initWithContentRect:styleMask:backing:defer:\0"),
+                rect,
+                style_mask,
+                backing,
+                NO,
             );
             Self(ptr)
         }
@@ -266,10 +301,15 @@ impl NSView {
         }
     }
 
-    pub fn set_wants_layer(&self, wants: bool) {
+    pub fn set_wants_layer(&self) {
         unsafe {
-            let val = if wants { YES } else { NO };
-            sys::send_1::<(), BOOL>(self.0, sys::sel(b"setWantsLayer:\0"), val);
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"setWantsLayer:\0"), YES);
+        }
+    }
+
+    pub fn clear_wants_layer(&self) {
+        unsafe {
+            sys::send_1::<(), BOOL>(self.0, sys::sel(b"setWantsLayer:\0"), NO);
         }
     }
 

--- a/pixelflow-runtime/src/platform/macos/platform.rs
+++ b/pixelflow-runtime/src/platform/macos/platform.rs
@@ -45,7 +45,7 @@ impl MetalOps {
             app.set_activation_policy(NS_APPLICATION_ACTIVATION_POLICY_REGULAR);
 
             app.finish_launching();
-            app.activate_ignoring_other_apps(true);
+            app.activate_ignoring_other_apps();
 
             app
         };
@@ -218,12 +218,7 @@ impl PlatformOps for MetalOps {
             }
 
             // Use wrapper for next_event
-            let event = self.app.next_event(
-                u64::MAX,
-                until_date,
-                mode,
-                true, // dequeue
-            );
+            let event = self.app.next_event_dequeue(u64::MAX, until_date, mode);
 
             // Release mode string
             sys::send::<()>(mode, sys::sel(b"release\0"));

--- a/pixelflow-runtime/src/platform/macos/window.rs
+++ b/pixelflow-runtime/src/platform/macos/window.rs
@@ -24,7 +24,7 @@ impl MacWindow {
         // NSBackingStoreBuffered = 2
         let backing = 2;
 
-        let window = NSWindow::alloc().init_with_content_rect(rect, style_mask, backing, false);
+        let window = NSWindow::alloc().init_with_content_rect_immediate(rect, style_mask, backing);
         window.set_title(&desc.title);
 
         let view = NSView::alloc().init_with_frame(rect);
@@ -60,7 +60,7 @@ impl MacWindow {
             sys::send_1::<(), Id>(view.0, sys::sel(b"setLayer:\0"), layer);
 
             // [view setWantsLayer: YES]
-            view.set_wants_layer(true);
+            view.set_wants_layer();
         }
 
         window.set_content_view(view);


### PR DESCRIPTION
This PR refactors multiple boolean traps in the Cocoa FFI bindings inside `pixelflow-runtime/src/platform/macos/cocoa.rs` based on the guidelines in `STYLE.md`.

Specifically, functions taking boolean arguments have been split into explicit intention-revealing methods:
- `set_wants_layer(bool)` -> `set_wants_layer()` & `clear_wants_layer()`
- `activate_ignoring_other_apps(bool)` -> `activate_ignoring_other_apps()` & `activate_respecting_other_apps()`
- `next_event(..., bool)` -> `next_event_dequeue()` & `next_event_peek()`
- `init_with_content_rect(..., bool)` -> `init_with_content_rect_deferred()` & `init_with_content_rect_immediate()`

All dependent call sites in `pixelflow-runtime/src/platform/macos/window.rs` and `pixelflow-runtime/src/platform/macos/platform.rs` have been updated to use the new interfaces. Verification via `cargo test` confirms everything compiles correctly.

---
*PR created automatically by Jules for task [12449031440439293850](https://jules.google.com/task/12449031440439293850) started by @jppittman*