### PR TITLE
Refactor: Enforce STYLE.md testing naming conventions across the workspace

### DIFF
--- a/actor-scheduler/src/lib.rs
+++ b/actor-scheduler/src/lib.rs
@@ -1938,7 +1938,7 @@ mod troupe_tests {
     /// Test the SPSC-based directory pattern: each actor gets its own Directory
     /// with dedicated SPSC handles to every other actor.
     #[test]
-    fn test_troupe_directory_pattern() {
+    fn troupe_directory_pattern() {
         // Create builders for each actor
         let mut engine_builder =
             ActorBuilder::<EngineData, EngineControl, EngineManagement>::new(1024, None);
@@ -2459,7 +2459,7 @@ mod troupe_nesting_tests {
 
     /// Test the two-phase Troupe pattern: new() → exposed() → play()
     #[test]
-    fn test_troupe_two_phase_pattern() {
+    fn troupe_two_phase_pattern() {
         // Phase 1: Create child troupe (no threads yet)
         let mut child = WorkerTroupe::new();
 
@@ -2489,7 +2489,7 @@ mod troupe_nesting_tests {
 
     /// Test that ExposedHandles can outlive the Troupe struct
     #[test]
-    fn test_exposed_handles_outlive_troupe_struct() {
+    fn exposed_handles_outlive_troupe_struct() {
         let exposed = {
             let mut child = WorkerTroupe::new();
             child.exposed() // ExposedHandles escapes
@@ -2544,7 +2544,7 @@ mod shutdown_tests {
     }
 
     #[test]
-    fn test_shutdown_immediate_exits_quickly_under_flood() {
+    fn shutdown_immediate_exits_quickly_under_flood() {
         let (tx, mut rx) =
             ActorScheduler::new_with_shutdown_mode(100, 100, ShutdownMode::Immediate);
 
@@ -2588,7 +2588,7 @@ mod shutdown_tests {
     }
 
     #[test]
-    fn test_shutdown_drain_control_processes_control_and_mgmt() {
+    fn shutdown_drain_control_processes_control_and_mgmt() {
         let (tx, mut rx) =
             ActorScheduler::new_with_shutdown_mode(100, 100, ShutdownMode::DrainControl);
 
@@ -2639,7 +2639,7 @@ mod shutdown_tests {
     }
 
     #[test]
-    fn test_shutdown_drain_all_processes_everything() {
+    fn shutdown_drain_all_processes_everything() {
         let (tx, mut rx) = ActorScheduler::new_with_shutdown_mode(
             100,
             100,
@@ -2686,7 +2686,7 @@ mod shutdown_tests {
     }
 
     #[test]
-    fn test_shutdown_drain_all_timeout_fallback() {
+    fn shutdown_drain_all_timeout_fallback() {
         let (tx, mut rx) = ActorScheduler::new_with_shutdown_mode(
             10,   // Small burst limit to check shutdown frequently
             1000, // Large buffer to avoid blocking sends

--- a/core-term/src/io/event_monitor_actor/write_thread/mod.rs
+++ b/core-term/src/io/event_monitor_actor/write_thread/mod.rs
@@ -82,7 +82,7 @@ mod tests {
     use std::sync::mpsc::sync_channel;
 
     #[test]
-    fn test_write_thread_handles_resize_command() {
+    fn write_thread_handles_resize_command() {
         // Create a real PTY for testing
         let config = PtyConfig {
             command_executable: "/bin/cat",
@@ -115,7 +115,7 @@ mod tests {
     }
 
     #[test]
-    fn test_write_thread_handles_write_command() {
+    fn write_thread_handles_write_command() {
         let config = PtyConfig {
             command_executable: "/bin/cat",
             args: &[],

--- a/core-term/src/io/pty_tests.rs
+++ b/core-term/src/io/pty_tests.rs
@@ -118,7 +118,7 @@ fn read_from_pty_with_timeout(pty: &mut NixPty, expected_str: &str) -> Result<St
 }
 
 #[test]
-fn test_pty_spawn_successful() {
+fn pty_spawn_successful() {
     // Use sh -c to be more robust across platforms and ensure output flushing
     let config = PtyConfig {
         command_executable: "/bin/sh",
@@ -156,7 +156,7 @@ fn test_pty_spawn_successful() {
 }
 
 #[test]
-fn test_pty_read_write_interaction() {
+fn pty_read_write_interaction() {
     let shell_command = "read r_line; echo \"input was: $r_line\"";
     let config = PtyConfig {
         command_executable: "/bin/sh",
@@ -197,7 +197,7 @@ fn test_pty_read_write_interaction() {
 }
 
 #[test]
-fn test_pty_resize_successful() {
+fn pty_resize_successful() {
     // Use `sleep` from PATH to be cross-platform (macOS has /bin/sleep, Linux /usr/bin/sleep)
     let config = PtyConfig {
         command_executable: "sleep",
@@ -235,7 +235,7 @@ fn test_pty_resize_successful() {
 }
 
 #[test]
-fn test_pty_child_termination_on_drop() {
+fn pty_child_termination_on_drop() {
     let config = PtyConfig {
         command_executable: "sleep",
         args: &["2"], // Arg for sleep is just the duration
@@ -298,7 +298,7 @@ fn test_pty_child_termination_on_drop() {
 }
 
 #[test]
-fn test_pty_spawn_invalid_command() {
+fn pty_spawn_invalid_command() {
     let non_existent_cmd = "/path/to/absolutely/nonexistent/command_39291az";
     let config = PtyConfig {
         command_executable: non_existent_cmd,

--- a/core-term/src/keys.rs
+++ b/core-term/src/keys.rs
@@ -42,7 +42,7 @@ mod tests {
     }
 
     #[test]
-    fn test_map_key_found() {
+    fn map_key_found() {
         let bindings = vec![
             Keybinding {
                 key: KeySymbol::Char('C'),
@@ -70,7 +70,7 @@ mod tests {
     }
 
     #[test]
-    fn test_map_key_not_found_symbol_mismatch() {
+    fn map_key_not_found_symbol_mismatch() {
         let bindings = vec![Keybinding {
             key: KeySymbol::Char('C'),
             mods: Modifiers::CONTROL | Modifiers::SHIFT,
@@ -87,7 +87,7 @@ mod tests {
     }
 
     #[test]
-    fn test_map_key_not_found_modifier_mismatch() {
+    fn map_key_not_found_modifier_mismatch() {
         let bindings = vec![Keybinding {
             key: KeySymbol::Char('C'),
             mods: Modifiers::CONTROL | Modifiers::SHIFT,
@@ -100,7 +100,7 @@ mod tests {
     }
 
     #[test]
-    fn test_map_key_not_found_empty_bindings() {
+    fn map_key_not_found_empty_bindings() {
         let config = config_with_bindings(vec![]);
         let result = map_key_event_to_action(
             KeySymbol::Char('C'),
@@ -111,7 +111,7 @@ mod tests {
     }
 
     #[test]
-    fn test_map_key_multiple_bindings_first_match() {
+    fn map_key_multiple_bindings_first_match() {
         let bindings = vec![
             Keybinding {
                 key: KeySymbol::Char('A'),

--- a/core-term/src/surface/manifold.rs
+++ b/core-term/src/surface/manifold.rs
@@ -327,7 +327,7 @@ mod tests {
     }
 
     #[test]
-    fn test_grid_construction() {
+    fn grid_construction() {
         use pixelflow_graphics::render::rasterizer::rasterize;
 
         let factory = MockFactory {
@@ -353,7 +353,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cell_channel_blending() {
+    fn cell_channel_blending() {
         use pixelflow_graphics::render::rasterizer::rasterize;
 
         let cell = Cell::new(
@@ -386,7 +386,7 @@ mod tests {
     }
 
     #[test]
-    fn test_color_manifold() {
+    fn verify_color_manifold() {
         use pixelflow_graphics::render::rasterizer::rasterize;
 
         // Color::Rgb from pixelflow-graphics implements Manifold<Output = Discrete>

--- a/core-term/src/term/emulator/input_handler.rs
+++ b/core-term/src/term/emulator/input_handler.rs
@@ -204,7 +204,7 @@ mod tests {
     }
 
     #[test]
-    fn test_paste_text_action_bracketed_on() {
+    fn paste_text_action_bracketed_on() {
         let mut emu = create_test_emu_for_input();
         // Enable bracketed paste mode via public API (CSI ? 2004 h)
         // This ensures we test the mode setting logic and state representation contract
@@ -224,7 +224,7 @@ mod tests {
     }
 
     #[test]
-    fn test_paste_text_action_bracketed_off() {
+    fn paste_text_action_bracketed_off() {
         let mut emu = create_test_emu_for_input();
         assert!(!emu.dec_modes.bracketed_paste_mode);
 
@@ -293,7 +293,7 @@ mod tests {
     }
 
     #[test]
-    fn test_control_event_resize_returns_resize_pty_action() {
+    fn control_event_resize_returns_resize_pty_action() {
         let mut emu = create_test_emu_for_input();
 
         // Default cell size is 10x16 (from config)
@@ -325,7 +325,7 @@ mod tests {
     }
 
     #[test]
-    fn test_control_event_resize_minimum_dimensions() {
+    fn control_event_resize_minimum_dimensions() {
         let mut emu = create_test_emu_for_input();
 
         // Very small resize (should clamp to MIN_GRID_DIMENSION)
@@ -357,7 +357,7 @@ mod tests {
     }
 
     #[test]
-    fn test_control_event_request_snapshot_returns_none() {
+    fn control_event_request_snapshot_returns_none() {
         let mut emu = create_test_emu_for_input();
 
         let result = process_control_event(&mut emu, ControlEvent::RequestSnapshot);
@@ -366,7 +366,7 @@ mod tests {
     }
 
     #[test]
-    fn test_control_event_pty_data_ready_returns_none() {
+    fn control_event_pty_data_ready_returns_none() {
         let mut emu = create_test_emu_for_input();
 
         let result = process_control_event(&mut emu, ControlEvent::PtyDataReady);

--- a/core-term/src/term/emulator/key_translator.rs
+++ b/core-term/src/term/emulator/key_translator.rs
@@ -162,7 +162,7 @@ mod tests {
     use crate::term::modes::DecPrivateModes;
 
     #[test]
-    fn test_simple_chars() {
+    fn simple_chars() {
         let modes = DecPrivateModes::default();
         assert_eq!(
             translate_key_input(
@@ -180,7 +180,7 @@ mod tests {
     }
 
     #[test]
-    fn test_ctrl_chars() {
+    fn ctrl_chars() {
         let modes = DecPrivateModes::default();
         // Test Ctrl+c
         assert_eq!(
@@ -195,7 +195,7 @@ mod tests {
     }
 
     #[test]
-    fn test_alt_chars() {
+    fn alt_chars() {
         let modes = DecPrivateModes::default();
         assert_eq!(
             translate_key_input(KeySymbol::Char('a'), Modifiers::ALT, None, &modes),
@@ -204,7 +204,7 @@ mod tests {
     }
 
     #[test]
-    fn test_arrow_keys_normal_mode() {
+    fn arrow_keys_normal_mode() {
         let modes = DecPrivateModes {
             cursor_keys_app_mode: false,
             ..Default::default()
@@ -228,7 +228,7 @@ mod tests {
     }
 
     #[test]
-    fn test_arrow_keys_app_mode() {
+    fn arrow_keys_app_mode() {
         let modes = DecPrivateModes {
             cursor_keys_app_mode: true,
             ..Default::default()
@@ -252,7 +252,7 @@ mod tests {
     }
 
     #[test]
-    fn test_shift_tab() {
+    fn shift_tab() {
         let modes = DecPrivateModes::default();
         assert_eq!(
             translate_key_input(KeySymbol::Tab, Modifiers::SHIFT, None, &modes),

--- a/core-term/src/term/layout.rs
+++ b/core-term/src/term/layout.rs
@@ -129,7 +129,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_pixels_to_cells_basic() {
+    fn pixels_to_cells_basic() {
         let layout = Layout {
             cols: 80,
             rows: 24,
@@ -154,7 +154,7 @@ mod tests {
     }
 
     #[test]
-    fn test_pixels_to_cells_with_padding() {
+    fn pixels_to_cells_with_padding() {
         let layout = Layout {
             cols: 80,
             rows: 24,
@@ -176,7 +176,7 @@ mod tests {
     }
 
     #[test]
-    fn test_pixels_to_cells_out_of_bounds() {
+    fn pixels_to_cells_out_of_bounds() {
         let layout = Layout {
             cols: 80,
             rows: 24,
@@ -197,7 +197,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cells_to_pixels() {
+    fn verify_cells_to_pixels() {
         let layout = Layout {
             cols: 80,
             rows: 24,
@@ -214,7 +214,7 @@ mod tests {
     }
 
     #[test]
-    fn test_pixel_dimensions() {
+    fn verify_pixel_dimensions() {
         let layout = Layout {
             cols: 80,
             rows: 24,
@@ -230,7 +230,7 @@ mod tests {
     }
 
     #[test]
-    fn test_resize() {
+    fn verify_resize() {
         let mut layout = Layout::new(80, 24);
 
         assert_eq!(layout.cols, 80);

--- a/core-term/src/term/screen.rs
+++ b/core-term/src/term/screen.rs
@@ -1205,13 +1205,13 @@ mod tests {
     }
 
     #[test]
-    fn test_selection_default_state() {
+    fn selection_default_state() {
         let screen = create_test_screen(10, 5);
         assert_eq!(screen.selection, Selection::default());
     }
 
     #[test]
-    fn test_start_selection() {
+    fn verify_start_selection() {
         let mut screen = create_test_screen(10, 5);
         let start_point = Point { x: 1, y: 1 };
         screen.dirty.fill(0);
@@ -1228,7 +1228,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_selection() {
+    fn verify_update_selection() {
         let mut screen = create_test_screen(10, 5);
         let start_point = Point { x: 1, y: 1 };
         let update_point = Point { x: 5, y: 2 };
@@ -1242,7 +1242,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_selection_marks_old_and_new_lines_dirty() {
+    fn update_selection_marks_old_and_new_lines_dirty() {
         let mut screen = create_test_screen(10, 5);
         screen.start_selection(Point { x: 1, y: 1 }, SelectionMode::Cell); // Replaced Normal with Cell
         screen.update_selection(Point { x: 3, y: 1 });
@@ -1253,7 +1253,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_selection_when_not_active() {
+    fn update_selection_when_not_active() {
         let mut screen = create_test_screen(10, 5);
         screen.start_selection(Point { x: 1, y: 1 }, SelectionMode::Cell); // Replaced Normal with Cell
         screen.selection.is_active = false;
@@ -1263,7 +1263,7 @@ mod tests {
     }
 
     #[test]
-    fn test_end_selection() {
+    fn verify_end_selection() {
         let mut screen = create_test_screen(10, 5);
         screen.start_selection(Point { x: 1, y: 1 }, SelectionMode::Cell); // Replaced Normal with Cell
         screen.end_selection();
@@ -1271,7 +1271,7 @@ mod tests {
     }
 
     #[test]
-    fn test_clear_selection() {
+    fn verify_clear_selection() {
         let mut screen = create_test_screen(10, 5);
         screen.start_selection(Point { x: 1, y: 1 }, SelectionMode::Cell); // Replaced Normal with Cell
         screen.update_selection(Point { x: 3, y: 2 });
@@ -1283,13 +1283,13 @@ mod tests {
     }
 
     #[test]
-    fn test_is_selected_normal_no_selection() {
+    fn is_selected_normal_no_selection() {
         let screen = create_test_screen(10, 5);
         assert!(!screen.is_selected(Point { x: 1, y: 1 }));
     }
 
     #[test]
-    fn test_is_selected_normal_single_line() {
+    fn is_selected_normal_single_line() {
         let mut screen = create_test_screen(10, 5);
         screen.start_selection(Point { x: 2, y: 1 }, SelectionMode::Cell); // Replaced Normal with Cell
         screen.update_selection(Point { x: 5, y: 1 });
@@ -1300,7 +1300,7 @@ mod tests {
     }
 
     #[test]
-    fn test_is_selected_normal_multi_line() {
+    fn is_selected_normal_multi_line() {
         let mut screen = create_test_screen(10, 5);
         screen.start_selection(Point { x: 3, y: 1 }, SelectionMode::Cell); // Replaced Normal with Cell
         screen.update_selection(Point { x: 2, y: 3 });
@@ -1312,7 +1312,7 @@ mod tests {
     }
 
     #[test]
-    fn test_is_selected_normal_multi_line_selection_ends_at_width_minus_1() {
+    fn is_selected_normal_multi_line_selection_ends_at_width_minus_1() {
         let mut screen = create_test_screen(10, 5);
         screen.start_selection(Point { x: 8, y: 0 }, SelectionMode::Cell); // Replaced Normal with Cell
         screen.update_selection(Point { x: 2, y: 2 });
@@ -1324,7 +1324,7 @@ mod tests {
     }
 
     #[test]
-    fn test_is_selected_normal_reverse_selection_points() {
+    fn is_selected_normal_reverse_selection_points() {
         let mut screen = create_test_screen(10, 5);
         screen.start_selection(Point { x: 5, y: 2 }, SelectionMode::Cell); // Replaced Normal with Cell
         screen.update_selection(Point { x: 1, y: 1 });
@@ -1337,7 +1337,7 @@ mod tests {
     }
 
     #[test]
-    fn test_is_selected_point_equals_start_or_end() {
+    fn is_selected_point_equals_start_or_end() {
         let mut screen = create_test_screen(10, 5);
         screen.start_selection(Point { x: 2, y: 2 }, SelectionMode::Cell); // Replaced Normal with Cell
         assert!(screen.is_selected(Point { x: 2, y: 2 }));
@@ -1347,7 +1347,7 @@ mod tests {
     }
 
     #[test]
-    fn test_is_selected_out_of_bounds_point() {
+    fn is_selected_out_of_bounds_point() {
         let mut screen = create_test_screen(10, 5);
         screen.start_selection(Point { x: 0, y: 0 }, SelectionMode::Cell); // Replaced Normal with Cell
         screen.update_selection(Point {
@@ -1365,13 +1365,13 @@ mod tests {
     }
 
     #[test]
-    fn test_is_selected_block_no_selection() {
+    fn is_selected_block_no_selection() {
         let screen = create_test_screen(10, 5);
         assert!(!screen.is_selected(Point { x: 1, y: 1 }));
     }
 
     #[test]
-    fn test_is_selected_block_simple() {
+    fn is_selected_block_simple() {
         let mut screen = create_test_screen(10, 5);
         screen.start_selection(Point { x: 1, y: 1 }, SelectionMode::Block);
         screen.update_selection(Point { x: 3, y: 3 });
@@ -1380,7 +1380,7 @@ mod tests {
     }
 
     #[test]
-    fn test_is_selected_block_reverse_points() {
+    fn is_selected_block_reverse_points() {
         let mut screen = create_test_screen(10, 5);
         screen.start_selection(Point { x: 3, y: 3 }, SelectionMode::Block);
         screen.update_selection(Point { x: 1, y: 1 });
@@ -1388,13 +1388,13 @@ mod tests {
     }
 
     #[test]
-    fn test_get_selected_text_normal_no_selection() {
+    fn get_selected_text_normal_no_selection() {
         let screen = create_test_screen(10, 5);
         assert_eq!(screen.get_selected_text(), None);
     }
 
     #[test]
-    fn test_get_selected_text_normal_single_char() {
+    fn get_selected_text_normal_single_char() {
         let mut screen = create_test_screen(5, 3);
         fill_screen_with_pattern(&mut screen);
         screen.start_selection(Point { x: 1, y: 1 }, SelectionMode::Cell); // Replaced Normal with Cell
@@ -1402,7 +1402,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_selected_text_normal_single_line_partial() {
+    fn get_selected_text_normal_single_line_partial() {
         let mut screen = create_test_screen(5, 3);
         fill_screen_with_pattern(&mut screen);
         screen.start_selection(Point { x: 1, y: 0 }, SelectionMode::Cell); // Replaced Normal with Cell
@@ -1411,7 +1411,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_selected_text_normal_single_line_full() {
+    fn get_selected_text_normal_single_line_full() {
         let mut screen = create_test_screen(5, 3);
         fill_screen_with_pattern(&mut screen);
         screen.start_selection(Point { x: 0, y: 0 }, SelectionMode::Cell); // Replaced Normal with Cell
@@ -1423,7 +1423,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_selected_text_normal_multi_line() {
+    fn get_selected_text_normal_multi_line() {
         let mut screen = create_test_screen(3, 3);
         fill_screen_with_pattern(&mut screen);
         screen.start_selection(Point { x: 1, y: 0 }, SelectionMode::Cell); // Replaced Normal with Cell
@@ -1432,7 +1432,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_selected_text_normal_multi_line_reversed_points() {
+    fn get_selected_text_normal_multi_line_reversed_points() {
         let mut screen = create_test_screen(3, 3);
         fill_screen_with_pattern(&mut screen);
         screen.start_selection(Point { x: 1, y: 2 }, SelectionMode::Cell); // Replaced Normal with Cell
@@ -1441,7 +1441,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_selected_text_normal_trailing_spaces_behavior() {
+    fn get_selected_text_normal_trailing_spaces_behavior() {
         let mut screen = create_test_screen(5, 2);
         {
             let row0 = Arc::make_mut(&mut screen.grid[0]);
@@ -1510,14 +1510,14 @@ mod tests {
     }
 
     #[test]
-    fn test_get_selected_text_block_no_selection() {
+    fn get_selected_text_block_no_selection() {
         let mut screen = create_test_screen(10, 5);
         screen.selection.mode = SelectionMode::Block;
         assert_eq!(screen.get_selected_text(), None);
     }
 
     #[test]
-    fn test_get_selected_text_block_simple() {
+    fn get_selected_text_block_simple() {
         let mut screen = create_test_screen(5, 4);
         fill_screen_with_pattern(&mut screen);
         screen.start_selection(Point { x: 1, y: 0 }, SelectionMode::Block);
@@ -1529,7 +1529,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_selected_text_block_reversed_points() {
+    fn get_selected_text_block_reversed_points() {
         let mut screen = create_test_screen(5, 4);
         fill_screen_with_pattern(&mut screen);
         screen.start_selection(Point { x: 3, y: 2 }, SelectionMode::Block);
@@ -1541,7 +1541,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_selected_text_block_one_column() {
+    fn get_selected_text_block_one_column() {
         let mut screen = create_test_screen(5, 4);
         fill_screen_with_pattern(&mut screen);
         screen.start_selection(Point { x: 1, y: 0 }, SelectionMode::Block);
@@ -1550,7 +1550,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_selected_text_block_one_row() {
+    fn get_selected_text_block_one_row() {
         let mut screen = create_test_screen(5, 4);
         fill_screen_with_pattern(&mut screen);
         screen.start_selection(Point { x: 1, y: 1 }, SelectionMode::Block);
@@ -1559,7 +1559,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_selected_text_block_beyond_line_length() {
+    fn get_selected_text_block_beyond_line_length() {
         let mut screen = create_test_screen(3, 2);
         {
             let row0 = Arc::make_mut(&mut screen.grid[0]);
@@ -1606,7 +1606,7 @@ mod tests {
     }
 
     #[test]
-    fn test_selection_cleared_on_resize() {
+    fn selection_cleared_on_resize() {
         let mut screen = create_test_screen(10, 5);
         screen.start_selection(Point { x: 1, y: 1 }, SelectionMode::Cell); // Replaced Normal with Cell
         screen.update_selection(Point { x: 5, y: 2 });
@@ -1616,7 +1616,7 @@ mod tests {
     }
 
     #[test]
-    fn test_scroll_up_populates_scrollback() {
+    fn scroll_up_populates_scrollback() {
         let mut screen = create_test_screen_with_scrollback(10, 5, 10);
         fill_screen_with_pattern(&mut screen);
         // scroll up 1 line. Top line should go to scrollback.
@@ -1659,7 +1659,7 @@ mod tests {
     }
 
     #[test]
-    fn test_block_selection_wide_char_full() {
+    fn block_selection_wide_char_full() {
         let mut screen = create_screen_with_wide_char();
         // Select "b" "你" "c" (columns 1 to 4)
         screen.start_selection(Point { x: 1, y: 0 }, SelectionMode::Block);
@@ -1670,7 +1670,7 @@ mod tests {
     }
 
     #[test]
-    fn test_block_selection_wide_char_partial_left() {
+    fn block_selection_wide_char_partial_left() {
         let mut screen = create_screen_with_wide_char();
         // Select "b" "你" (primary only) (columns 1 to 2)
         screen.start_selection(Point { x: 1, y: 0 }, SelectionMode::Block);
@@ -1682,7 +1682,7 @@ mod tests {
     }
 
     #[test]
-    fn test_block_selection_wide_char_partial_right() {
+    fn block_selection_wide_char_partial_right() {
         let mut screen = create_screen_with_wide_char();
         // Select spacer of "你" and "c" (columns 3 to 4)
         screen.start_selection(Point { x: 3, y: 0 }, SelectionMode::Block);

--- a/core-term/src/term/tests.rs
+++ b/core-term/src/term/tests.rs
@@ -223,7 +223,7 @@ fn assert_screen_state(
 }
 
 #[test]
-fn test_simple_char_input() {
+fn simple_char_input() {
     let mut term = create_test_emulator(10, 1);
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('A')));
     let snapshot = term.get_render_snapshot().expect("Snapshot was None");
@@ -236,7 +236,7 @@ fn test_simple_char_input() {
 }
 
 #[test]
-fn test_newline_input() {
+fn newline_input() {
     let mut term = create_test_emulator(10, 2);
     // Enable Linefeed/Newline Mode (LNM)
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Csi(CsiCommand::SetMode(
@@ -253,7 +253,7 @@ fn test_newline_input() {
 }
 
 #[test]
-fn test_carriage_return_input() {
+fn carriage_return_input() {
     let mut term = create_test_emulator(10, 1);
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('A')));
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('B')));
@@ -266,7 +266,7 @@ fn test_carriage_return_input() {
 }
 
 #[test]
-fn test_csi_cursor_forward_cuf() {
+fn csi_cursor_forward_cuf() {
     let mut term = create_test_emulator(10, 1); // Cursor at (0,0)
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Csi(
         CsiCommand::CursorForward(1),
@@ -282,7 +282,7 @@ fn test_csi_cursor_forward_cuf() {
 }
 
 #[test]
-fn test_csi_ed_clear_below_csi_j() {
+fn csi_ed_clear_below_csi_j() {
     let mut term = create_test_emulator(3, 2);
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('A')));
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('B')));
@@ -310,7 +310,7 @@ fn test_csi_ed_clear_below_csi_j() {
 }
 
 #[test]
-fn test_csi_sgr_fg_color() {
+fn csi_sgr_fg_color() {
     let mut term = create_test_emulator(5, 1);
     let red_attr = vec![Attribute::Foreground(Color::Named(NamedColor::Red))];
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Csi(
@@ -388,7 +388,7 @@ fn fill_emulator_screen(emu: &mut TerminalEmulator, text_lines: Vec<String>) {
 
 // --- Basic Selection Flow Tests ---
 #[test]
-fn test_mouse_press_starts_selection() {
+fn mouse_press_starts_selection() {
     let mut emu = create_test_emulator(10, 5);
     let action = send_mouse_input(&mut emu, start_selection_at(1, 1), MouseButton::Left);
 
@@ -420,7 +420,7 @@ fn test_mouse_press_starts_selection() {
 }
 
 #[test]
-fn test_mouse_drag_updates_selection() {
+fn mouse_drag_updates_selection() {
     let mut emu = create_test_emulator(10, 5);
     send_mouse_input(&mut emu, start_selection_at(1, 1), MouseButton::Left);
     let action = send_mouse_input(&mut emu, extend_selection_to(5, 2), MouseButton::Left);
@@ -448,7 +448,7 @@ fn test_mouse_drag_updates_selection() {
 }
 
 #[test]
-fn test_mouse_release_ends_selection_activity() {
+fn mouse_release_ends_selection_activity() {
     let mut emu = create_test_emulator(10, 5);
     send_mouse_input(&mut emu, start_selection_at(1, 1), MouseButton::Left);
     send_mouse_input(&mut emu, extend_selection_to(5, 2), MouseButton::Left);
@@ -488,14 +488,14 @@ fn test_mouse_release_ends_selection_activity() {
 
 // --- Copy Action Tests ---
 #[test]
-fn test_initiate_copy_no_selection() {
+fn initiate_copy_no_selection() {
     let mut emu = create_test_emulator(10, 5);
     let action = emu.interpret_input(EmulatorInput::User(UserInputAction::InitiateCopy));
     assert_eq!(action, None, "Should return None if no selection exists.");
 }
 
 #[test]
-fn test_initiate_copy_with_selection() {
+fn initiate_copy_with_selection() {
     let mut emu = create_test_emulator(10, 2);
     fill_emulator_screen(&mut emu, vec!["Hello".to_string(), "World".to_string()]);
 
@@ -516,7 +516,7 @@ fn test_initiate_copy_with_selection() {
 }
 
 #[test]
-fn test_initiate_copy_block_selection() {
+fn initiate_copy_block_selection() {
     let mut emu = create_test_emulator(3, 3);
     fill_emulator_screen(
         &mut emu,
@@ -543,7 +543,7 @@ fn test_initiate_copy_block_selection() {
 
 // --- Selection Clearing Tests ---
 #[test]
-fn test_new_mouse_press_clears_old_selection() {
+fn new_mouse_press_clears_old_selection() {
     let mut emu = create_test_emulator(10, 5);
 
     send_mouse_input(&mut emu, start_selection_at(0, 0), MouseButton::Left);
@@ -591,7 +591,7 @@ fn test_new_mouse_press_clears_old_selection() {
 
 // --- Selection Interaction with Scrolling Test ---
 #[test]
-fn test_selection_coordinates_adjust_on_scroll() {
+fn selection_coordinates_adjust_on_scroll() {
     let mut emu = create_test_emulator(10, 3);
     fill_emulator_screen(
         &mut emu,
@@ -649,7 +649,7 @@ fn test_selection_coordinates_adjust_on_scroll() {
 
 // --- Selection with Alternate Screen Test ---
 #[test]
-fn test_selection_on_alt_screen_then_exit() {
+fn selection_on_alt_screen_then_exit() {
     let mut emu = create_test_emulator(10, 3);
     fill_emulator_screen(
         &mut emu,
@@ -702,7 +702,7 @@ fn test_selection_on_alt_screen_then_exit() {
 // --- End of Selection with Alternate Screen Test ---
 
 #[test]
-fn test_resize_larger() {
+fn resize_larger() {
     let mut term = create_test_emulator(5, 2);
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('1')));
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('2')));
@@ -727,7 +727,7 @@ fn test_resize_larger() {
 }
 
 #[test]
-fn test_resize_smaller_content_truncation() {
+fn resize_smaller_content_truncation() {
     let mut term = create_test_emulator(5, 2);
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('H')));
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('e')));
@@ -744,7 +744,7 @@ fn test_resize_smaller_content_truncation() {
 }
 
 #[test]
-fn test_osc_set_window_title() {
+fn osc_set_window_title() {
     let mut term = create_test_emulator(10, 1);
 
     let action = term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Osc(
@@ -765,7 +765,7 @@ fn test_osc_set_window_title() {
 }
 
 #[test]
-fn test_key_event_printable_char() {
+fn key_event_printable_char() {
     let mut term = create_test_emulator(5, 1);
     let key_input = UserInputAction::KeyInput {
         symbol: KeySymbol::Char('x'),
@@ -784,7 +784,7 @@ fn test_key_event_printable_char() {
 }
 
 #[test]
-fn test_key_event_arrow_up() {
+fn key_event_arrow_up() {
     let mut term = create_test_emulator(5, 1);
     let key_input = UserInputAction::KeyInput {
         symbol: KeySymbol::Up,
@@ -801,7 +801,7 @@ fn test_key_event_arrow_up() {
 }
 
 #[test]
-fn test_snapshot_with_selection() {
+fn snapshot_with_selection() {
     let num_cols = 10;
     let num_rows = 2;
     let default_glyph = Glyph::Single(ContentCell {
@@ -860,7 +860,7 @@ fn test_snapshot_with_selection() {
 }
 
 #[test]
-fn test_mode_show_cursor_dectcem() {
+fn mode_show_cursor_dectcem() {
     let mut term = create_test_emulator(5, 1);
 
     let snap_default = term.get_render_snapshot().expect("Snapshot was None");
@@ -897,7 +897,7 @@ fn test_mode_show_cursor_dectcem() {
 // --- PS1 Multi-line Prompt Tests ---
 
 #[test]
-fn test_ps1_multiline_prompt_at_bottom_causes_scroll() {
+fn ps1_multiline_prompt_at_bottom_causes_scroll() {
     let mut term = create_test_emulator(5, 3);
 
     for _ in 0..5 {
@@ -927,7 +927,7 @@ fn test_ps1_multiline_prompt_at_bottom_causes_scroll() {
 }
 
 #[test]
-fn test_ps1_multiline_prompt_ends_on_last_line_no_scroll_by_prompt() {
+fn ps1_multiline_prompt_ends_on_last_line_no_scroll_by_prompt() {
     let mut term = create_test_emulator(5, 3);
 
     for _ in 0..5 {
@@ -950,7 +950,7 @@ fn test_ps1_multiline_prompt_ends_on_last_line_no_scroll_by_prompt() {
 }
 
 #[test]
-fn test_ps1_multiline_prompt_last_line_fills_screen_then_input() {
+fn ps1_multiline_prompt_last_line_fills_screen_then_input() {
     let mut term = create_test_emulator(3, 2);
 
     for _ in 0..3 {
@@ -980,7 +980,7 @@ fn test_ps1_multiline_prompt_last_line_fills_screen_then_input() {
 }
 
 #[test]
-fn test_ps1_prompt_causes_multiple_scrolls() {
+fn ps1_prompt_causes_multiple_scrolls() {
     let mut term = create_test_emulator(3, 2);
 
     for _ in 0..3 {
@@ -1009,7 +1009,7 @@ fn test_ps1_prompt_causes_multiple_scrolls() {
 }
 
 #[test]
-fn test_ps1_prompt_with_internal_wrapping_and_scrolling() {
+fn ps1_prompt_with_internal_wrapping_and_scrolling() {
     let mut term = create_test_emulator(3, 2);
     for _ in 0..3 {
         term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('A')));
@@ -1044,7 +1044,7 @@ fn test_ps1_prompt_with_internal_wrapping_and_scrolling() {
 }
 
 #[test]
-fn test_ps1_multiline_exact_fill_then_scroll_on_final_lf() {
+fn ps1_multiline_exact_fill_then_scroll_on_final_lf() {
     let mut term = create_test_emulator(3, 2);
 
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('P')));
@@ -1064,7 +1064,7 @@ fn test_ps1_multiline_exact_fill_then_scroll_on_final_lf() {
 }
 
 #[test]
-fn test_ps1_multiline_with_sgr_at_bottom_scrolls() {
+fn ps1_multiline_with_sgr_at_bottom_scrolls() {
     let mut term = create_test_emulator(5, 2);
 
     for _ in 0..5 {
@@ -1148,7 +1148,7 @@ fn test_ps1_multiline_with_sgr_at_bottom_scrolls() {
 }
 
 #[test]
-fn test_lf_at_bottom_of_partial_scrolling_region_no_origin_mode() {
+fn lf_at_bottom_of_partial_scrolling_region_no_origin_mode() {
     let cols = 10;
     let rows = 5;
     let mut emu = create_test_emulator(cols, rows);
@@ -1232,7 +1232,7 @@ fn test_lf_at_bottom_of_partial_scrolling_region_no_origin_mode() {
     );
 }
 #[test]
-fn test_primary_device_attributes_response() {
+fn primary_device_attributes_response() {
     let mut term = create_test_emulator(80, 24);
 
     let input_da = EmulatorInput::Ansi(AnsiCommand::Csi(CsiCommand::PrimaryDeviceAttributes));
@@ -1254,7 +1254,7 @@ mod selection_logic_tests {
     use crate::term::snapshot::SelectionRange;
 
     #[test]
-    fn test_start_selection() {
+    fn start_selection() {
         let mut emu = create_test_emulator(10, 5);
         let point = Point { x: 2, y: 1 };
 
@@ -1274,7 +1274,7 @@ mod selection_logic_tests {
     }
 
     #[test]
-    fn test_extend_selection_active_and_inactive() {
+    fn extend_selection_active_and_inactive() {
         let mut emu = create_test_emulator(10, 5);
         let start_point = Point { x: 2, y: 1 };
         let extend_point = Point { x: 5, y: 2 };
@@ -1300,7 +1300,7 @@ mod selection_logic_tests {
     }
 
     #[test]
-    fn test_apply_selection_clear_click_and_drag() {
+    fn apply_selection_clear_click_and_drag() {
         let mut emu = create_test_emulator(10, 5);
         let point1 = Point { x: 2, y: 1 };
         let point2 = Point { x: 5, y: 1 };
@@ -1344,7 +1344,7 @@ mod selection_logic_tests {
     }
 
     #[test]
-    fn test_clear_selection() {
+    fn verify_clear_selection() {
         let mut emu = create_test_emulator(10, 5);
 
         // Create and deactivate a selection
@@ -1369,13 +1369,13 @@ mod get_selected_text_tests {
     use super::*;
 
     #[test]
-    fn test_get_selected_text_no_selection() {
+    fn get_selected_text_no_selection() {
         let emu = create_test_emulator(10, 5);
         assert_eq!(emu.get_selected_text(), None);
     }
 
     #[test]
-    fn test_get_selected_text_single_line() {
+    fn get_selected_text_single_line() {
         let mut emu = create_test_emulator(10, 5);
         fill_emulator_screen(&mut emu, vec!["Hello World".to_string()]);
 
@@ -1392,7 +1392,7 @@ mod get_selected_text_tests {
     }
 
     #[test]
-    fn test_get_selected_text_single_line_trailing_spaces_in_selection() {
+    fn get_selected_text_single_line_trailing_spaces_in_selection() {
         let mut emu = create_test_emulator(10, 1);
         fill_emulator_screen(&mut emu, vec!["Hi   ".to_string()]);
 
@@ -1408,7 +1408,7 @@ mod get_selected_text_tests {
     }
 
     #[test]
-    fn test_get_selected_text_multi_line() {
+    fn get_selected_text_multi_line() {
         let mut emu = create_test_emulator(10, 5);
         fill_emulator_screen(
             &mut emu,
@@ -1431,7 +1431,7 @@ mod get_selected_text_tests {
     }
 
     #[test]
-    fn test_get_selected_text_multi_line_full_lines() {
+    fn get_selected_text_multi_line_full_lines() {
         let mut emu = create_test_emulator(10, 3);
         fill_emulator_screen(
             &mut emu,
@@ -1467,7 +1467,7 @@ mod get_selected_text_tests {
     }
 
     #[test]
-    fn test_get_selected_text_line_boundaries() {
+    fn get_selected_text_line_boundaries() {
         let mut emu = create_test_emulator(10, 2);
         fill_emulator_screen(
             &mut emu,
@@ -1486,7 +1486,7 @@ mod get_selected_text_tests {
     }
 
     #[test]
-    fn test_get_selected_text_empty_cells_within_grid() {
+    fn get_selected_text_empty_cells_within_grid() {
         let mut emu = create_test_emulator(5, 1);
         // Create sparse content: "A   E" by printing A, moving cursor to col 4, then printing E
         emu.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('A')));
@@ -1507,7 +1507,7 @@ mod get_selected_text_tests {
     }
 
     #[test]
-    fn test_get_selected_text_selection_beyond_line_length() {
+    fn get_selected_text_selection_beyond_line_length() {
         let mut emu = create_test_emulator(10, 1);
         fill_emulator_screen(&mut emu, vec!["Test".to_string()]);
 
@@ -1523,7 +1523,7 @@ mod get_selected_text_tests {
     }
 
     #[test]
-    fn test_get_selected_text_reversed_points() {
+    fn get_selected_text_reversed_points() {
         let mut emu = create_test_emulator(10, 5);
         fill_emulator_screen(&mut emu, vec!["Hello World".to_string()]);
 
@@ -1545,7 +1545,7 @@ mod paste_text_tests {
     use super::*;
 
     #[test]
-    fn test_paste_text_bracketed_off_simple() {
+    fn paste_text_bracketed_off_simple() {
         let mut emu = create_test_emulator(20, 1);
         // Bracketed paste mode is off by default - just verify behavior
 
@@ -1562,7 +1562,7 @@ mod paste_text_tests {
     }
 
     #[test]
-    fn test_paste_text_bracketed_off_with_newline() {
+    fn paste_text_bracketed_off_with_newline() {
         let mut emu = create_test_emulator(20, 2);
         // Bracketed paste mode is off by default - just verify behavior
 
@@ -1576,7 +1576,7 @@ mod paste_text_tests {
     }
 
     #[test]
-    fn test_paste_text_bracketed_off_causes_wrap() {
+    fn paste_text_bracketed_off_causes_wrap() {
         let mut emu = create_test_emulator(5, 2);
         // Bracketed paste mode is off by default - just verify wrapping behavior
 
@@ -1592,7 +1592,7 @@ mod paste_text_tests {
     }
 
     #[test]
-    fn test_paste_text_bracketed_on_logs_warning_processes_chars() {
+    fn paste_text_bracketed_on_logs_warning_processes_chars() {
         let mut emu = create_test_emulator(20, 1);
         // Enable bracketed paste mode
         emu.interpret_input(EmulatorInput::Ansi(AnsiCommand::Csi(
@@ -1612,7 +1612,7 @@ mod paste_text_tests {
     }
 
     #[test]
-    fn test_ansi_resize_sets_terminal_dimensions() {
+    fn ansi_resize_sets_terminal_dimensions() {
         let mut emu = create_test_emulator(80, 24);
         assert_eq!(emu.dimensions(), (80, 24));
 
@@ -1631,7 +1631,7 @@ mod paste_text_tests {
     }
 
     #[test]
-    fn test_ansi_resize_updates_snapshot_dimensions() {
+    fn ansi_resize_updates_snapshot_dimensions() {
         let mut emu = create_test_emulator(80, 24);
 
         let resize_command = AnsiCommand::Csi(CsiCommand::WindowManipulation {
@@ -1650,7 +1650,7 @@ mod paste_text_tests {
     }
 
     #[test]
-    fn test_ansi_resize_with_zero_rows_ignored() {
+    fn ansi_resize_with_zero_rows_ignored() {
         let mut emu = create_test_emulator(80, 24);
 
         let resize_command = AnsiCommand::Csi(CsiCommand::WindowManipulation {
@@ -1668,7 +1668,7 @@ mod paste_text_tests {
     }
 
     #[test]
-    fn test_ansi_resize_with_zero_cols_ignored() {
+    fn ansi_resize_with_zero_cols_ignored() {
         let mut emu = create_test_emulator(80, 24);
 
         let resize_command = AnsiCommand::Csi(CsiCommand::WindowManipulation {
@@ -1686,7 +1686,7 @@ mod paste_text_tests {
     }
 
     #[test]
-    fn test_ansi_resize_with_missing_params_ignored() {
+    fn ansi_resize_with_missing_params_ignored() {
         let mut emu = create_test_emulator(80, 24);
 
         let resize_command = AnsiCommand::Csi(CsiCommand::WindowManipulation {
@@ -1717,7 +1717,7 @@ mod paste_text_tests {
     }
 
     #[test]
-    fn test_window_manipulation_report_size() {
+    fn window_manipulation_report_size() {
         let mut emu = create_test_emulator(80, 24);
 
         let report_command = AnsiCommand::Csi(CsiCommand::WindowManipulation {

--- a/core-term/src/term/unicode.rs
+++ b/core-term/src/term/unicode.rs
@@ -77,14 +77,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_ascii_char_width() {
+    fn ascii_char_width() {
         assert_eq!(get_char_display_width('A'), 1, "Width of 'A' should be 1");
         assert_eq!(get_char_display_width(' '), 1, "Width of space should be 1");
         assert_eq!(get_char_display_width('~'), 1, "Width of '~' should be 1");
     }
 
     #[test]
-    fn test_box_drawing_char_widths() {
+    fn box_drawing_char_widths() {
         assert_eq!(
             get_char_display_width('─'),
             1,
@@ -144,7 +144,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cjk_wide_char_widths() {
+    fn cjk_wide_char_widths() {
         assert_eq!(
             get_char_display_width('世'),
             2,
@@ -168,7 +168,7 @@ mod tests {
     }
 
     #[test]
-    fn test_control_char_widths() {
+    fn control_char_widths() {
         assert_eq!(
             get_char_display_width('\u{0000}'),
             0,
@@ -194,7 +194,7 @@ mod tests {
     }
 
     #[test]
-    fn test_zero_width_chars() {
+    fn zero_width_chars() {
         assert_eq!(
             get_char_display_width('\u{200D}'),
             0,
@@ -208,7 +208,7 @@ mod tests {
     }
 
     #[test]
-    fn test_locale_initializer_called() {
+    fn locale_initializer_called() {
         // Ensure OnceLock mechanism is engaged
         let _ = get_char_display_width(' ');
         assert!(

--- a/core-term/src/terminal_app.rs
+++ b/core-term/src/terminal_app.rs
@@ -896,7 +896,7 @@ mod tests {
     }
 
     #[test]
-    fn test_handle_control_resize() {
+    fn handle_control_resize() {
         let (mut app, pty_rx, _, _scheduler) = match create_test_app() {
             Some(v) => v,
             None => return,
@@ -938,7 +938,7 @@ mod tests {
     }
 
     #[test]
-    fn test_handle_management_keydown() {
+    fn handle_management_keydown() {
         let (mut app, pty_rx, _, _scheduler) = match create_test_app() {
             Some(v) => v,
             None => return,

--- a/core-term/tests/ansi_to_grid_integration.rs
+++ b/core-term/tests/ansi_to_grid_integration.rs
@@ -9,7 +9,7 @@ use core_term::ansi::commands::{AnsiCommand, C0Control, CsiCommand};
 use support::minimal_test_harness::MinimalTestHarness;
 
 #[test]
-fn test_single_character_print() {
+fn single_character_print() {
     let mut harness = MinimalTestHarness::new();
 
     // TEST: Print a single character
@@ -34,7 +34,7 @@ fn test_single_character_print() {
 }
 
 #[test]
-fn test_multiple_characters() {
+fn multiple_characters() {
     let mut harness = MinimalTestHarness::new();
 
     // TEST: Print multiple characters
@@ -60,7 +60,7 @@ fn test_multiple_characters() {
 }
 
 #[test]
-fn test_newline_advances_row() {
+fn newline_advances_row() {
     let mut harness = MinimalTestHarness::new();
 
     // TEST: Print, newline, print again
@@ -78,7 +78,7 @@ fn test_newline_advances_row() {
 }
 
 #[test]
-fn test_cursor_position_command() {
+fn cursor_position_command() {
     let mut harness = MinimalTestHarness::new();
 
     // TEST: Move cursor to (5, 10), then print
@@ -95,7 +95,7 @@ fn test_cursor_position_command() {
 }
 
 #[test]
-fn test_multiline_text() {
+fn multiline_text() {
     let mut harness = MinimalTestHarness::new();
 
     // TEST: Print text with newlines
@@ -143,7 +143,7 @@ fn test_multiline_text() {
 // =============================================================================
 
 #[test]
-fn test_grid_checksum_changes_on_input() {
+fn grid_checksum_changes_on_input() {
     let mut harness = MinimalTestHarness::new();
 
     // Get initial checksum (empty grid)
@@ -174,7 +174,7 @@ fn test_grid_checksum_changes_on_input() {
 }
 
 #[test]
-fn test_grid_checksum_stable_without_changes() {
+fn grid_checksum_stable_without_changes() {
     let mut harness = MinimalTestHarness::new();
 
     // Print a character
@@ -192,7 +192,7 @@ fn test_grid_checksum_stable_without_changes() {
 }
 
 #[test]
-fn test_multiple_characters_change_checksum() {
+fn multiple_characters_change_checksum() {
     let mut harness = MinimalTestHarness::new();
 
     let mut checksums = Vec::new();
@@ -220,7 +220,7 @@ fn test_multiple_characters_change_checksum() {
 // =============================================================================
 
 #[test]
-fn test_bug_grid_changes_without_render_trigger() {
+fn bug_grid_changes_without_render_trigger() {
     // This test documents the ACTUAL BUG:
     // Grid state changes when ANSI commands are processed,
     // but send_frame() is never called, so the display doesn't update.

--- a/pixelflow-compiler/src/codegen/leveled.rs
+++ b/pixelflow-compiler/src/codegen/leveled.rs
@@ -606,13 +606,13 @@ mod tests {
     }
 
     #[test]
-    fn test_node_ref_var_name() {
+    fn node_ref_var_name() {
         let r = NodeRef::new(2, 3);
         assert_eq!(r.var_name().to_string(), "__l2_3");
     }
 
     #[test]
-    fn test_deps_const_only() {
+    fn deps_const_only() {
         // Pure constant expression: 1.0 + 2.0
         let stats = analyze_input(quote! { || 1.0 + 2.0 });
         assert!(stats.varying_nodes == 0, "Expected no varying nodes");
@@ -621,7 +621,7 @@ mod tests {
     }
 
     #[test]
-    fn test_deps_varying_only() {
+    fn deps_varying_only() {
         // Pure varying: X + Y
         let stats = analyze_input(quote! { || X + Y });
         assert!(stats.varying_nodes > 0, "Expected varying nodes");
@@ -630,7 +630,7 @@ mod tests {
     }
 
     #[test]
-    fn test_deps_uniform_only() {
+    fn deps_uniform_only() {
         // Pure uniform: W * 2.0
         let stats = analyze_input(quote! { || W * 2.0 });
         assert!(stats.const_nodes > 0, "Expected const nodes (2.0)");
@@ -639,7 +639,7 @@ mod tests {
     }
 
     #[test]
-    fn test_deps_mixed() {
+    fn deps_mixed() {
         // Mixed: (W * 0.5).sin() + X
         // W*0.5 and sin(...) are uniform
         // X is varying
@@ -653,7 +653,7 @@ mod tests {
     }
 
     #[test]
-    fn test_deps_scalar_params_are_const() {
+    fn deps_scalar_params_are_const() {
         // Scalar parameters captured at kernel creation are Const
         let stats = analyze_input(quote! { |r: f32| X - r });
         // r is Const (scalar param)
@@ -664,7 +664,7 @@ mod tests {
     }
 
     #[test]
-    fn test_deps_lattice_join() {
+    fn deps_lattice_join() {
         assert_eq!(Deps::Const.join(Deps::Const), Deps::Const);
         assert_eq!(Deps::Const.join(Deps::Uniform), Deps::Uniform);
         assert_eq!(Deps::Const.join(Deps::Varying), Deps::Varying);

--- a/pixelflow-compiler/src/cost_builder.rs
+++ b/pixelflow-compiler/src/cost_builder.rs
@@ -67,7 +67,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_load_learned_weights() {
+    fn load_learned_weights() {
         let model = build_learned_cost_model();
 
         // Sanity checks: expensive ops should cost more than cheap ones
@@ -82,7 +82,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_toml() {
+    fn parse_toml() {
         let toml = r#"
             # Comment
             add = 10

--- a/pixelflow-compiler/src/optimize.rs
+++ b/pixelflow-compiler/src/optimize.rs
@@ -1479,7 +1479,7 @@ mod tests {
 
     /// Test DAG optimization with shared subexpressions.
     #[test]
-    fn test_dag_optimization_shared_subexpr() {
+    fn dag_optimization_shared_subexpr() {
         // sin(X) * sin(X) should emit a let-binding
         let input = quote! { || X.sin() * X.sin() };
         let kernel = parse(input).unwrap();
@@ -1504,7 +1504,7 @@ mod tests {
 
     /// Test DAG optimization with triple use of shared subexpr.
     #[test]
-    fn test_dag_optimization_triple_shared() {
+    fn dag_optimization_triple_shared() {
         // sqrt(X) * sqrt(X) + sqrt(X) should emit let-binding
         let input = quote! { || X.sqrt() * X.sqrt() + X.sqrt() };
         let kernel = parse(input).unwrap();
@@ -1522,7 +1522,7 @@ mod tests {
 
     /// Test that simple expressions without sharing don't get wrapped in blocks.
     #[test]
-    fn test_dag_optimization_no_sharing() {
+    fn dag_optimization_no_sharing() {
         // X + Y has no sharing, should remain simple
         let input = quote! { || X + Y };
         let kernel = parse(input).unwrap();
@@ -1542,7 +1542,7 @@ mod tests {
     }
 
     #[test]
-    fn test_full_pipeline_discriminant() {
+    fn full_pipeline_discriminant() {
         use crate::codegen;
 
         // Full pipeline test matching actual kernel! macro

--- a/pixelflow-compiler/tests/kernel_jit.rs
+++ b/pixelflow-compiler/tests/kernel_jit.rs
@@ -53,38 +53,38 @@ fn eval3(
 // ============================================================================
 
 #[test]
-fn test_jit_macro_return_x() {
+fn jit_macro_return_x() {
     let m = kernel_jit!(|| X);
     assert_eq!(eval1(&m, 42.0), 42.0);
 }
 
 #[test]
-fn test_jit_macro_add_xy() {
+fn jit_macro_add_xy() {
     let m = kernel_jit!(|| X + Y);
     assert_eq!(eval2(&m, 10.0, 32.0), 42.0);
 }
 
 #[test]
-fn test_jit_macro_complex_expr() {
+fn jit_macro_complex_expr() {
     // (X + Y) * Z
     let m = kernel_jit!(|| (X + Y) * Z);
     assert_eq!(eval3(&m, 2.0, 5.0, 6.0), 42.0); // (2+5)*6 = 42
 }
 
 #[test]
-fn test_jit_macro_subtraction() {
+fn jit_macro_subtraction() {
     let m = kernel_jit!(|| X - Y);
     assert_eq!(eval2(&m, 100.0, 58.0), 42.0);
 }
 
 #[test]
-fn test_jit_macro_division() {
+fn jit_macro_division() {
     let m = kernel_jit!(|| X / Y);
     assert_eq!(eval2(&m, 84.0, 2.0), 42.0);
 }
 
 #[test]
-fn test_jit_macro_negation() {
+fn jit_macro_negation() {
     let m = kernel_jit!(|| -X);
     assert_eq!(eval1(&m, -42.0), 42.0);
 }
@@ -121,20 +121,20 @@ fn test_jit_macro_cos() {
 }
 
 #[test]
-fn test_jit_macro_sqrt() {
+fn jit_macro_sqrt() {
     // sqrt(1764) = 42
     let m = kernel_jit!(|| X.sqrt());
     assert_eq!(eval1(&m, 1764.0), 42.0);
 }
 
 #[test]
-fn test_jit_macro_abs() {
+fn jit_macro_abs() {
     let m = kernel_jit!(|| X.abs());
     assert_eq!(eval1(&m, -42.0), 42.0);
 }
 
 #[test]
-fn test_jit_macro_min_max() {
+fn jit_macro_min_max() {
     let m_min = kernel_jit!(|| X.min(Y));
     let m_max = kernel_jit!(|| X.max(Y));
     assert_eq!(eval2(&m_min, 10.0, 42.0), 10.0);

--- a/pixelflow-core/src/algebra.rs
+++ b/pixelflow-core/src/algebra.rs
@@ -513,7 +513,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_f32_algebra() {
+    fn f32_algebra() {
         // Ring operations
         assert_eq!(f32::zero(), 0.0);
         assert_eq!(f32::one(), 1.0);
@@ -537,7 +537,7 @@ mod tests {
     // Transcendental tests only run on scalar fallback platforms
     #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
     #[test]
-    fn test_f32_transcendental() {
+    fn f32_transcendental() {
         let epsilon = 1e-6;
 
         assert!((4.0f32.sqrt() - 2.0).abs() < epsilon);
@@ -558,7 +558,7 @@ mod tests {
     }
 
     #[test]
-    fn test_bool_algebra() {
+    fn bool_algebra() {
         assert!(!bool::zero());
         assert!(bool::one());
 
@@ -577,7 +577,7 @@ mod tests {
     }
 
     #[test]
-    fn test_u32_algebra() {
+    fn u32_algebra() {
         assert_eq!(u32::zero(), 0);
         assert_eq!(u32::one(), 1);
         assert_eq!(2u32.add(3), 5);

--- a/pixelflow-core/src/combinators/binding.rs
+++ b/pixelflow-core/src/combinators/binding.rs
@@ -499,7 +499,7 @@ mod tests {
     use crate::{Field, X};
 
     #[test]
-    fn test_let_binding_new_style() {
+    fn let_binding_new_style() {
         // let v = 10.0; v + 5.0
         let expr = Let::new(10.0f32, Var::<N0>::new() + 5.0f32);
 
@@ -513,7 +513,7 @@ mod tests {
     }
 
     #[test]
-    fn test_let_with_spatial() {
+    fn let_with_spatial() {
         // let dist = x; dist * 2
         let expr = Let::new(X, Var::<N0>::new() * 2.0f32);
 
@@ -526,7 +526,7 @@ mod tests {
     }
 
     #[test]
-    fn test_nested_let_new_style() {
+    fn nested_let_new_style() {
         // let a = 3.0; let b = 4.0; a + b
         let expr = Let::new(
             3.0f32, // a = 3.0 (becomes Var<1> after second let)
@@ -549,7 +549,7 @@ mod tests {
     // Commented out until legacy binding system is fixed or removed.
     /*
     #[test]
-    fn test_legacy_peano_get() {
+    fn legacy_peano_get() {
         let ctx: (Field, (Field, Empty)) = (Field::from(10.0), (Field::from(20.0), Empty));
 
         // Index 0 should get 10.0 (head)
@@ -566,7 +566,7 @@ mod tests {
     */
 
     #[test]
-    fn test_legacy_let_binding() {
+    fn legacy_let_binding() {
         // let x = 5.0; x + x
         let graph = Let::new(Lift(5.0f32), GAdd(Var::<N0>::new(), Var::<N0>::new()));
 

--- a/pixelflow-core/src/combinators/block.rs
+++ b/pixelflow-core/src/combinators/block.rs
@@ -82,7 +82,7 @@ mod tests {
     use crate::variables::{X, Y};
 
     #[test]
-    fn test_block_compiles_and_runs() {
+    fn block_compiles_and_runs() {
         let inner = X + Y;
         let blocked = Block::new(inner);
 
@@ -99,7 +99,7 @@ mod tests {
     }
 
     #[test]
-    fn test_block_nested() {
+    fn block_nested() {
         // Block of a Block should still work
         let inner = X * Y;
         let blocked = Block::new(Block::new(inner));
@@ -114,7 +114,7 @@ mod tests {
     }
 
     #[test]
-    fn test_block_with_complex_expr() {
+    fn block_with_complex_expr() {
         // More complex expression to verify register pressure scenario
         let expr = (X + Y) * (X - Y);
         let blocked = Block::new(expr);

--- a/pixelflow-core/src/combinators/computed.rs
+++ b/pixelflow-core/src/combinators/computed.rs
@@ -150,7 +150,7 @@ mod tests {
     use crate::variables::X;
 
     #[test]
-    fn test_computed_basic() {
+    fn computed_basic() {
         // Use an expression tree (X) that gets evaluated
         let expr = X;
         let computed = Computed::new(move |p: Field4| -> Field { expr.eval(p) });
@@ -170,7 +170,7 @@ mod tests {
     }
 
     #[test]
-    fn test_computed_captures() {
+    fn computed_captures() {
         let scale = 2.0f32;
         // Use expression tree X * scale
         let expr = X * scale;

--- a/pixelflow-core/src/combinators/context.rs
+++ b/pixelflow-core/src/combinators/context.rs
@@ -643,33 +643,33 @@ mod context_domain_tests {
     fn check_manifold<P: Copy + Send + Sync, M: Manifold<P>>(_m: &M) {}
 
     #[test]
-    fn test_x_in_context_domain() {
+    fn x_in_context_domain() {
         // X should work in context-extended domain via Spatial impl
         check_manifold::<CtxDomain, _>(&X);
     }
 
     #[test]
-    fn test_dz_x_in_context_domain() {
+    fn dz_x_in_context_domain() {
         // DZ(X) should work since X::Output = Jet3: HasDz
         check_manifold::<CtxDomain, _>(&DZ(X));
     }
 
     #[test]
-    fn test_ctxvar_in_context_domain() {
+    fn ctxvar_in_context_domain() {
         // CtxVar should read from context
         let cv = CtxVar::<A0, 0>::new();
         check_manifold::<CtxDomain, _>(&cv);
     }
 
     #[test]
-    fn test_mul_dz_x_in_context_domain() {
+    fn mul_dz_x_in_context_domain() {
         // DZ(X) * DZ(X) should work
         let expr = crate::Mul(DZ(X), DZ(X));
         check_manifold::<CtxDomain, _>(&expr);
     }
 
     #[test]
-    fn test_muladd_dz_in_context_domain() {
+    fn muladd_dz_in_context_domain() {
         // mul_add(DZ(X), DZ(X), Mul(DX(X), DX(X))) should work - all Field outputs
         let expr = MulAdd(
             DZ(X),
@@ -680,7 +680,7 @@ mod context_domain_tests {
     }
 
     #[test]
-    fn test_comparison_in_context_domain() {
+    fn comparison_in_context_domain() {
         // CtxVar.gt(CtxVar) should work
         let a = CtxVar::<A0, 0>::new();
         let b = CtxVar::<A0, 1>::new();
@@ -689,7 +689,7 @@ mod context_domain_tests {
     }
 
     #[test]
-    fn test_and_in_context_domain() {
+    fn and_in_context_domain() {
         // (a > b) & (a < c) should work
         let a = CtxVar::<A0, 0>::new();
         let b = CtxVar::<A0, 1>::new();
@@ -700,7 +700,7 @@ mod context_domain_tests {
 
     // Test matching the GeometryMask kernel pattern
     #[test]
-    fn test_geometry_mask_pattern() {
+    fn geometry_mask_pattern() {
         // geometry: kernel is ContextFree<&M> where M: Manifold<Jet3_4, Output = Jet3>
         // DZ(geometry) should work, returning Field
         fn check_geometry_mask<M>(geometry: &M)
@@ -734,7 +734,7 @@ mod context_domain_tests {
     }
 
     #[test]
-    fn test_select_in_context_domain() {
+    fn select_in_context_domain() {
         // Select requires branches with matching output types
         use crate::combinators::Select;
 
@@ -752,7 +752,7 @@ mod context_domain_tests {
     }
 
     #[test]
-    fn test_select_with_valof_in_context_domain() {
+    fn select_with_valof_in_context_domain() {
         // More complex: Select with ValOf branches
         use crate::combinators::Select;
         use crate::ops::derivative::V;
@@ -770,7 +770,7 @@ mod context_domain_tests {
     }
 
     #[test]
-    fn test_checker_like_pattern() {
+    fn checker_like_pattern() {
         // Replicate the Checker kernel pattern with 12 context elements
         // Uses Field coordinates since V() extracts the value component (Field)
         use crate::Z;
@@ -814,7 +814,7 @@ mod context_domain_tests {
     }
 
     #[test]
-    fn test_muladd_select_pattern() {
+    fn muladd_select_pattern() {
         // Test MulAdd with Select - this is the exact pattern failing
         // Uses Field coordinates since V() extracts the value component (Field)
         use crate::combinators::Select;

--- a/pixelflow-core/src/combinators/spherical.rs
+++ b/pixelflow-core/src/combinators/spherical.rs
@@ -647,7 +647,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_sh_orthonormality() {
+    fn sh_orthonormality() {
         // Y_0^0 should be constant = 1/(2√π) ≈ 0.282
         let y00 = SphericalHarmonic::<0, 0>;
         let val = y00.eval((
@@ -662,7 +662,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sh_coeffs_dot() {
+    fn sh_coeffs_dot() {
         let a = Sh2 {
             coeffs: [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
         };

--- a/pixelflow-core/src/combinators/texture.rs
+++ b/pixelflow-core/src/combinators/texture.rs
@@ -143,7 +143,7 @@ mod tests {
     use crate::PARALLELISM;
 
     #[test]
-    fn test_texture_creation() {
+    fn texture_creation() {
         let data: Vec<f32> = (0..16).map(|i| i as f32).collect();
         let tex = Texture::new(data, 4, 4);
         assert_eq!(tex.width(), 4);
@@ -151,7 +151,7 @@ mod tests {
     }
 
     #[test]
-    fn test_texture_sample() {
+    fn texture_sample() {
         // Create 4x4 texture with values 0-15
         let data: Vec<f32> = (0..16).map(|i| i as f32).collect();
         let tex = Texture::new(data, 4, 4);
@@ -189,7 +189,7 @@ mod tests {
     }
 
     #[test]
-    fn test_texture_clamping() {
+    fn texture_clamping() {
         let data: Vec<f32> = (0..16).map(|i| i as f32).collect();
         let tex = Texture::new(data, 4, 4);
 

--- a/pixelflow-core/src/combinators/with_gradient.rs
+++ b/pixelflow-core/src/combinators/with_gradient.rs
@@ -198,7 +198,7 @@ mod tests {
     }
 
     #[test]
-    fn test_with_gradient_2d_distance() {
+    fn with_gradient_2d_distance() {
         // Distance from origin: sqrt(x² + y²)
         // At (3, 4): value = 5
         // Gradient: (x/r, y/r) = (3/5, 4/5) = (0.6, 0.8)
@@ -228,7 +228,7 @@ mod tests {
     }
 
     #[test]
-    fn test_with_gradient_2d_quadratic() {
+    fn with_gradient_2d_quadratic() {
         // Quadratic: x² + y²
         // At (2, 3): value = 4 + 9 = 13
         // Gradient: (2x, 2y) = (4, 6)
@@ -256,7 +256,7 @@ mod tests {
     }
 
     #[test]
-    fn test_with_gradient_2d_product() {
+    fn with_gradient_2d_product() {
         // Product: x * y
         // At (3, 5): value = 15
         // Gradient: (y, x) = (5, 3)
@@ -284,7 +284,7 @@ mod tests {
     }
 
     #[test]
-    fn test_with_gradient_3d_distance() {
+    fn with_gradient_3d_distance() {
         // 3D distance from origin: sqrt(x² + y² + z²)
         // At (1, 2, 2): r = 3, value = 3
         // Gradient: (x/r, y/r, z/r) = (1/3, 2/3, 2/3)
@@ -324,7 +324,7 @@ mod tests {
     }
 
     #[test]
-    fn test_with_gradient_3d_product() {
+    fn with_gradient_3d_product() {
         // 3D product: x * y * z
         // At (2, 3, 4): value = 24
         // Gradient: (yz, xz, xy) = (12, 8, 6)

--- a/pixelflow-core/src/domain.rs
+++ b/pixelflow-core/src/domain.rs
@@ -274,7 +274,7 @@ mod tests {
     use crate::Field;
 
     #[test]
-    fn test_2d_spatial() {
+    fn verify_2d_spatial() {
         let domain = (Field::from(3.0), Field::from(4.0));
         let mut buf = [0.0f32; crate::PARALLELISM];
 
@@ -293,7 +293,7 @@ mod tests {
     }
 
     #[test]
-    fn test_4d_spatial() {
+    fn verify_4d_spatial() {
         let domain = (
             Field::from(1.0),
             Field::from(2.0),
@@ -316,7 +316,7 @@ mod tests {
     }
 
     #[test]
-    fn test_let_extended() {
+    fn let_extended() {
         // Simulate: let v = 10.0 in ... on 2D domain
         let base = (Field::from(3.0), Field::from(4.0));
         let extended = LetExtended(Field::from(10.0), base);
@@ -336,7 +336,7 @@ mod tests {
     }
 
     #[test]
-    fn test_nested_let() {
+    fn nested_let() {
         // let a = 10.0 in let b = 20.0 in ... on 2D domain
         let base = (Field::from(3.0), Field::from(4.0));
         let inner = LetExtended(Field::from(20.0), base); // b = 20.0

--- a/pixelflow-core/src/dual.rs
+++ b/pixelflow-core/src/dual.rs
@@ -534,7 +534,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_dual2_arithmetic() {
+    fn dual2_arithmetic() {
         let x = Dual2::<f32>::x(3.0);
         let y = Dual2::<f32>::y(4.0);
 
@@ -554,7 +554,7 @@ mod tests {
     // Transcendental tests only run on scalar fallback platforms
     #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
     #[test]
-    fn test_dual2_sqrt() {
+    fn dual2_sqrt() {
         let x = Dual2::<f32>::x(3.0);
         let y = Dual2::<f32>::y(4.0);
 
@@ -573,7 +573,7 @@ mod tests {
     // Transcendental tests only run on scalar fallback platforms
     #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
     #[test]
-    fn test_dual3_normal() {
+    fn dual3_normal() {
         // Sphere SDF: f(x,y,z) = sqrt(x² + y² + z²) - 1
         // At point (1, 0, 0), gradient is (1, 0, 0)
         let x = Dual3::<f32>::x(1.0);
@@ -591,7 +591,7 @@ mod tests {
     }
 
     #[test]
-    fn test_dual_select() {
+    fn dual_select() {
         let a = Dual2::<f32>::x(1.0);
         let b = Dual2::<f32>::y(2.0);
 
@@ -607,7 +607,7 @@ mod tests {
     }
 
     #[test]
-    fn test_dual_comparison() {
+    fn dual_comparison() {
         let x = Dual2::<f32>::x(3.0);
         let y = Dual2::<f32>::y(4.0);
 
@@ -619,7 +619,7 @@ mod tests {
     }
 
     #[test]
-    fn test_dual_chain_rule_mul() {
+    fn dual_chain_rule_mul() {
         // Test: f(x) = x², f'(x) = 2x
         // At x = 3: x² = 9, 2x = 6
         let x = Dual1::<f32>::var::<0>(3.0);
@@ -633,7 +633,7 @@ mod tests {
     // Transcendental chain rule test only runs on scalar fallback
     #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
     #[test]
-    fn test_dual_chain_rule_sin() {
+    fn dual_chain_rule_sin() {
         // Test: f(x) = sin(x), f'(x) = cos(x)
         // At x = 0: sin(0) = 0, cos(0) = 1
         let x = Dual1::<f32>::var::<0>(0.0);

--- a/pixelflow-core/src/lib.rs
+++ b/pixelflow-core/src/lib.rs
@@ -2235,7 +2235,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_gather_behavior() {
+    fn gather_behavior() {
         let data = [10.0, 20.0, 30.0, 40.0, 50.0];
         // Indices: 0.0, 1.9 (trunc to 1), 2.1 (trunc to 2), 4.0
         // We expect: data[0], data[1], data[2], data[4]

--- a/pixelflow-core/src/variables.rs
+++ b/pixelflow-core/src/variables.rs
@@ -153,7 +153,7 @@ mod tests {
     use crate::Field;
 
     #[test]
-    fn test_x_on_2d() {
+    fn x_on_2d() {
         let domain = (Field::from(3.0), Field::from(4.0));
         let result = X.eval(domain);
         let mut buf = [0.0f32; crate::PARALLELISM];
@@ -162,7 +162,7 @@ mod tests {
     }
 
     #[test]
-    fn test_y_on_2d() {
+    fn y_on_2d() {
         let domain = (Field::from(3.0), Field::from(4.0));
         let result = Y.eval(domain);
         let mut buf = [0.0f32; crate::PARALLELISM];
@@ -171,7 +171,7 @@ mod tests {
     }
 
     #[test]
-    fn test_z_on_2d_is_zero() {
+    fn z_on_2d_is_zero() {
         let domain = (Field::from(3.0), Field::from(4.0));
         let result = Z.eval(domain);
         let mut buf = [0.0f32; crate::PARALLELISM];
@@ -180,7 +180,7 @@ mod tests {
     }
 
     #[test]
-    fn test_on_4d() {
+    fn on_4d() {
         let domain = (
             Field::from(1.0),
             Field::from(2.0),

--- a/pixelflow-core/src/zst.rs
+++ b/pixelflow-core/src/zst.rs
@@ -580,7 +580,7 @@ mod tests {
     }
 
     #[test]
-    fn test_coordinate_variables_are_zst() {
+    fn coordinate_variables_are_zst() {
         assert_zst::<crate::variables::X>();
         assert_zst::<crate::variables::Y>();
         assert_zst::<crate::variables::Z>();
@@ -588,7 +588,7 @@ mod tests {
     }
 
     #[test]
-    fn test_spherical_harmonics_are_zst() {
+    fn spherical_harmonics_are_zst() {
         assert_zst::<crate::combinators::SphericalHarmonic<0, 0>>();
         assert_zst::<crate::combinators::SphericalHarmonic<1, -1>>();
         assert_zst::<crate::combinators::ZonalHarmonic<0>>();
@@ -597,7 +597,7 @@ mod tests {
     }
 
     #[test]
-    fn test_operators_with_zst_operands_are_zst() {
+    fn operators_with_zst_operands_are_zst() {
         use crate::variables::{X, Y};
 
         // Binary operators
@@ -618,7 +618,7 @@ mod tests {
     }
 
     #[test]
-    fn test_complex_expression_is_zst() {
+    fn complex_expression_is_zst() {
         use crate::variables::{X, Y};
 
         // Test that (X * X + Y * Y).sqrt() is a ZST
@@ -631,7 +631,7 @@ mod tests {
     }
 
     #[test]
-    fn test_combinators_with_zst_operands_are_zst() {
+    fn combinators_with_zst_operands_are_zst() {
         use crate::variables::{X, Y, Z};
 
         // Select combinator

--- a/pixelflow-core/tests/naked_scale.rs
+++ b/pixelflow-core/tests/naked_scale.rs
@@ -58,7 +58,7 @@ unsafe fn invoke_naked_kernel(
 }
 
 #[test]
-fn test_naked_abi_multithreaded_scale() {
+fn naked_abi_multithreaded_scale() {
     #[cfg(target_arch = "aarch64")]
     {
         let num_threads = 16;

--- a/pixelflow-core/tests/reference.rs
+++ b/pixelflow-core/tests/reference.rs
@@ -142,7 +142,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_ref_unpack_4bit() {
+    fn verify_ref_unpack_4bit() {
         // Test data: 0x12 = high:1, low:2 -> 17, 34
         let packed = [0x12u8];
         let result = ref_unpack_4bit(&packed, 2, 1);
@@ -150,7 +150,7 @@ mod tests {
     }
 
     #[test]
-    fn test_ref_gather_4bit_single() {
+    fn verify_ref_gather_4bit_single() {
         // [0x12, 0x34] represents [1*17, 2*17, 3*17, 4*17]
         let packed = [0x12u8, 0x34];
         let stride = 2; // 2 bytes per row, so 4 pixels per row
@@ -161,7 +161,7 @@ mod tests {
     }
 
     #[test]
-    fn test_ref_bilinear_interpolate() {
+    fn verify_ref_bilinear_interpolate() {
         // 50% blend horizontally and vertically
         let result = ref_bilinear_interpolate(0, 100, 100, 200, 0.5, 0.5);
         // Average of [0, 100, 100, 200] = 100
@@ -173,7 +173,7 @@ mod tests {
     }
 
     #[test]
-    fn test_ref_blend_alpha() {
+    fn ref_blend_alpha() {
         // White fg, black bg, 50% alpha in all channels
         let fg = 0xFF_FF_FF_FF;
         let bg = 0x00_00_00_00;
@@ -186,7 +186,7 @@ mod tests {
     }
 
     #[test]
-    fn test_ref_saturating_operations() {
+    fn ref_saturating_operations() {
         assert_eq!(ref_saturating_add_u32(u32::MAX, 1), u32::MAX);
         assert_eq!(ref_saturating_sub_u32(0, 1), 0);
         assert_eq!(ref_saturating_add_u32(100, 50), 150);

--- a/pixelflow-core/tests/test_context_tuple.rs
+++ b/pixelflow-core/tests/test_context_tuple.rs
@@ -6,7 +6,7 @@
 use pixelflow_core::{WithContext, X, Y};
 
 #[test]
-fn test_with_context_5_params_compiles() {
+fn with_context_5_params_compiles() {
     // THE KEY TEST: This compiles with 5 params where nested Let fails!
     //
     // WithContext creates: WithContext<(V0, V1, V2, V3, V4), Body>
@@ -30,7 +30,7 @@ fn test_with_context_5_params_compiles() {
 }
 
 #[test]
-fn test_with_context_constructs() {
+fn with_context_constructs() {
     // Just verify it constructs correctly
     let v0 = X;
     let v1 = Y;

--- a/pixelflow-core/tests/test_jet2h.rs
+++ b/pixelflow-core/tests/test_jet2h.rs
@@ -9,7 +9,7 @@ use pixelflow_core::jet::Jet2H;
 
 /// Verify that Jet2H seeding operations compile and produce values.
 #[test]
-fn test_jet2h_seeding() {
+fn jet2h_seeding() {
     let x = Jet2H::x(Field::from(2.0));
     let _ = x.val;
     let _ = x.dx;
@@ -27,7 +27,7 @@ fn test_jet2h_seeding() {
 
 /// Verify that Jet2H arithmetic operations work.
 #[test]
-fn test_jet2h_arithmetic() {
+fn jet2h_arithmetic() {
     let x = Jet2H::x(Field::from(2.0));
     let y = Jet2H::y(Field::from(3.0));
 
@@ -46,7 +46,7 @@ fn test_jet2h_arithmetic() {
 
 /// Verify that Jet2H unary operations work.
 #[test]
-fn test_jet2h_unary_ops() {
+fn jet2h_unary_ops() {
     let x = Jet2H::x(Field::from(4.0));
 
     let sqrt_result = x.sqrt();
@@ -61,7 +61,7 @@ fn test_jet2h_unary_ops() {
 
 /// Verify that Jet2H comparison operations work.
 #[test]
-fn test_jet2h_comparison() {
+fn jet2h_comparison() {
     let x = Jet2H::x(Field::from(2.0));
     let y = Jet2H::y(Field::from(3.0));
 
@@ -73,7 +73,7 @@ fn test_jet2h_comparison() {
 
 /// Verify that Jet2H bitwise operations work.
 #[test]
-fn test_jet2h_bitwise() {
+fn jet2h_bitwise() {
     let x = Jet2H::x(Field::from(2.0));
     let y = Jet2H::y(Field::from(3.0));
 
@@ -84,7 +84,7 @@ fn test_jet2h_bitwise() {
 
 /// Verify that Jet2H select works.
 #[test]
-fn test_jet2h_select() {
+fn jet2h_select() {
     let x = Jet2H::x(Field::from(2.0));
     let y = Jet2H::y(Field::from(3.0));
     let mask = x.lt(y);
@@ -95,7 +95,7 @@ fn test_jet2h_select() {
 
 /// Verify that complex Jet2H expressions compile.
 #[test]
-fn test_jet2h_complex_expression() {
+fn jet2h_complex_expression() {
     let x = Jet2H::x(Field::from(3.0));
     let y = Jet2H::y(Field::from(4.0));
 

--- a/pixelflow-core/tests/test_jet_sqrt_correctness.rs
+++ b/pixelflow-core/tests/test_jet_sqrt_correctness.rs
@@ -2,7 +2,7 @@ use pixelflow_core::Jet2; // Use Alias
 use pixelflow_core::{Field, ManifoldExt};
 
 #[test]
-fn test_sqrt_derivative() {
+fn sqrt_derivative() {
     // Test at x=4.0
     let x_val = Field::from(4.0);
     let x_jet = Jet2::x(x_val);
@@ -30,7 +30,7 @@ fn test_sqrt_derivative() {
 }
 
 #[test]
-fn test_sqrt_derivative_zero() {
+fn sqrt_derivative_zero() {
     // Check behavior at 0.0
     let x_val = Field::from(0.0);
     let x_jet = Jet2::x(x_val);

--- a/pixelflow-core/tests/test_kernel_5params.rs
+++ b/pixelflow-core/tests/test_kernel_5params.rs
@@ -5,7 +5,7 @@
 use pixelflow_compiler::kernel;
 
 #[test]
-fn test_kernel_5_params_compiles() {
+fn kernel_5_params_compiles() {
     // THE KEY TEST: This should now compile with 5 params!
     // The old nested Let approach caused trait solver explosion at this point.
 
@@ -18,7 +18,7 @@ fn test_kernel_5_params_compiles() {
 }
 
 #[test]
-fn test_kernel_6_params_compiles() {
+fn kernel_6_params_compiles() {
     // Test 6 parameters
     let k = kernel!(|a: f32, b: f32, c: f32, d: f32, e: f32, f: f32| { a + b + c + d + e + f });
 
@@ -26,7 +26,7 @@ fn test_kernel_6_params_compiles() {
 }
 
 #[test]
-fn test_kernel_7_params_compiles() {
+fn kernel_7_params_compiles() {
     // Test 7 parameters
     let k = kernel!(|a: f32, b: f32, c: f32, d: f32, e: f32, f: f32, g: f32| {
         a + b + c + d + e + f + g
@@ -36,7 +36,7 @@ fn test_kernel_7_params_compiles() {
 }
 
 #[test]
-fn test_kernel_8_params_compiles() {
+fn kernel_8_params_compiles() {
     // Even more ambitious - 8 parameters!
     // This would definitely fail with nested Let.
 
@@ -52,7 +52,7 @@ fn test_kernel_8_params_compiles() {
 }
 
 #[test]
-fn test_jet_kernel_with_param() {
+fn jet_kernel_with_param() {
     use pixelflow_compiler::kernel;
     use pixelflow_core::{Field, Manifold, jet::Jet3};
 

--- a/pixelflow-core/tests/test_log2.rs
+++ b/pixelflow-core/tests/test_log2.rs
@@ -18,7 +18,7 @@ fn eval_to_f32<M: Manifold<(Field, Field, Field, Field), Output = Field>>(m: M) 
 }
 
 #[test]
-fn test_log2_powers_of_two() {
+fn log2_powers_of_two() {
     // log2(2^n) should equal approximately n for integer powers
     // Our polynomial approximation achieves ~1e-4 accuracy
     for n in -10..=10 {
@@ -37,7 +37,7 @@ fn test_log2_powers_of_two() {
 }
 
 #[test]
-fn test_log2_known_values() {
+fn log2_known_values() {
     let test_cases = [
         (1.0, 0.0),
         (2.0, 1.0),
@@ -75,7 +75,7 @@ fn test_log2_known_values() {
 }
 
 #[test]
-fn test_log2_accuracy_sweep() {
+fn log2_accuracy_sweep() {
     // Test accuracy across a wide range using std::f32 as reference
     let mut max_abs_error = 0.0f32;
     let mut max_rel_error = 0.0f32;
@@ -119,7 +119,7 @@ fn test_log2_accuracy_sweep() {
 }
 
 #[test]
-fn test_log2_mantissa_range() {
+fn log2_mantissa_range() {
     // Thorough test of the polynomial approximation in [1, 2) range
     let mut max_error = 0.0f32;
     let mut worst_input = 1.0f32;
@@ -151,7 +151,7 @@ fn test_log2_mantissa_range() {
 }
 
 #[test]
-fn test_log2_exp2_roundtrip() {
+fn log2_exp2_roundtrip() {
     // log2(2^x) should equal x (within floating point precision)
     // Errors compound in roundtrip, so threshold is 2e-4
     let test_values = [
@@ -184,7 +184,7 @@ fn test_log2_exp2_roundtrip() {
 }
 
 #[test]
-fn test_exp2_log2_roundtrip() {
+fn exp2_log2_roundtrip() {
     // 2^(log2(x)) should equal x
     // Errors compound in roundtrip, so threshold is 2e-4
     let test_values = [
@@ -215,7 +215,7 @@ fn test_exp2_log2_roundtrip() {
 }
 
 #[test]
-fn test_log2_simd_consistency() {
+fn log2_simd_consistency() {
     // Test that all SIMD lanes produce consistent results
     let test_value = std::f32::consts::PI;
     let zero = Field::from(0.0);
@@ -245,7 +245,7 @@ fn test_log2_simd_consistency() {
 }
 
 #[test]
-fn test_log2_special_values() {
+fn log2_special_values() {
     // Test edge cases
     let one_f32 = eval_to_f32(Field::from(1.0).log2());
     assert!(
@@ -263,7 +263,7 @@ fn test_log2_special_values() {
 }
 
 #[test]
-fn test_exp2_powers() {
+fn exp2_powers() {
     // exp2(n) should equal 2^n exactly for small integers
     for n in -5..=5 {
         let result_f32 = eval_to_f32(Field::from(n as f32).exp2());
@@ -282,7 +282,7 @@ fn test_exp2_powers() {
 }
 
 #[test]
-fn test_exp2_accuracy_sweep() {
+fn exp2_accuracy_sweep() {
     let mut max_error = 0.0f32;
     let mut worst_input = 0.0f32;
 
@@ -312,7 +312,7 @@ fn test_exp2_accuracy_sweep() {
 }
 
 #[test]
-fn test_polynomial_coefficients_range() {
+fn polynomial_coefficients_range() {
     // Verify polynomial works correctly in [1, 2) by testing many points
     // This is the critical range where the polynomial approximation is applied
 

--- a/pixelflow-core/tests/test_sphere_debug.rs
+++ b/pixelflow-core/tests/test_sphere_debug.rs
@@ -28,7 +28,7 @@ fn x_plus_param(val: f32) -> impl Manifold<Jet3_4, Output = Jet3> + Clone {
 }
 
 #[test]
-fn test_simple_param() {
+fn simple_param() {
     let k = simple_return_param(42.0);
     let rx = Jet3::constant(Field::from(1.0));
     let ry = Jet3::constant(Field::from(2.0));
@@ -48,7 +48,7 @@ fn test_simple_param() {
 }
 
 #[test]
-fn test_x_plus_param() {
+fn verify_x_plus_param() {
     let k = x_plus_param(10.0);
     // X = 5.0, so result should be 15.0
     let rx = Jet3::constant(Field::from(5.0));
@@ -126,7 +126,7 @@ fn test_discriminant(
 }
 
 #[test]
-fn test_step1_d_dot_c() {
+fn step1_d_dot_c() {
     let k = test_d_dot_c(0.0, 0.0, 4.0);
     // Ray direction: (0, 0, 1)
     let rx = Jet3::constant(Field::from(0.0));
@@ -144,7 +144,7 @@ fn test_step1_d_dot_c() {
 }
 
 #[test]
-fn test_step2_c_sq() {
+fn step2_c_sq() {
     let k = test_c_sq(0.0, 0.0, 4.0);
     let rx = Jet3::constant(Field::from(0.0));
     let ry = Jet3::constant(Field::from(0.0));
@@ -161,7 +161,7 @@ fn test_step2_c_sq() {
 }
 
 #[test]
-fn test_step3a_r_sq() {
+fn step3a_r_sq() {
     let k = test_r_sq(1.0);
     let rx = Jet3::constant(Field::from(0.0));
     let ry = Jet3::constant(Field::from(0.0));
@@ -178,7 +178,7 @@ fn test_step3a_r_sq() {
 }
 
 #[test]
-fn test_step3b_c_sq_minus_r_sq() {
+fn step3b_c_sq_minus_r_sq() {
     let k = test_c_sq_minus_r_sq(0.0, 0.0, 4.0, 1.0);
     let rx = Jet3::constant(Field::from(0.0));
     let ry = Jet3::constant(Field::from(0.0));
@@ -195,7 +195,7 @@ fn test_step3b_c_sq_minus_r_sq() {
 }
 
 #[test]
-fn test_step3c_d_dot_c_sq() {
+fn step3c_d_dot_c_sq() {
     let k = test_d_dot_c_sq(0.0, 0.0, 4.0);
     let rx = Jet3::constant(Field::from(0.0));
     let ry = Jet3::constant(Field::from(0.0));
@@ -212,7 +212,7 @@ fn test_step3c_d_dot_c_sq() {
 }
 
 #[test]
-fn test_step3_discriminant() {
+fn step3_discriminant() {
     let k = test_discriminant(0.0, 0.0, 4.0, 1.0);
     let rx = Jet3::constant(Field::from(0.0));
     let ry = Jet3::constant(Field::from(0.0));
@@ -229,7 +229,7 @@ fn test_step3_discriminant() {
 }
 
 #[test]
-fn test_sphere_hit() {
+fn sphere_hit() {
     // Sphere at (0, 0, 4) with radius 1
     let sphere = sphere_at(0.0, 0.0, 4.0, 1.0);
 

--- a/pixelflow-core/tests/x86_backend_tests.rs
+++ b/pixelflow-core/tests/x86_backend_tests.rs
@@ -7,7 +7,7 @@ mod tests {
     use std::prelude::v1::*;
 
     #[test]
-    fn test_sse2_arithmetic() {
+    fn sse2_arithmetic() {
         let a = F32x4::splat(2.0);
         let b = F32x4::splat(3.0);
 
@@ -30,7 +30,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sse2_sequential() {
+    fn sse2_sequential() {
         let seq = F32x4::sequential(10.0);
         let mut out = [0.0; 4];
         seq.store(&mut out);
@@ -38,7 +38,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sse2_logic() {
+    fn sse2_logic() {
         let a = F32x4::splat(1.0);
         let b = F32x4::splat(2.0);
 
@@ -62,7 +62,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sse2_bitwise() {
+    fn sse2_bitwise() {
         let a = F32x4::splat(1.0); // 1.0 is 0x3f800000
         let b = F32x4::splat(2.0); // 2.0 is 0x40000000
         let c = a & b;
@@ -72,7 +72,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sse2_math() {
+    fn sse2_math() {
         let a = F32x4::splat(4.0);
         let sqrt = a.simd_sqrt();
         let mut out = [0.0; 4];
@@ -90,7 +90,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sse2_mask_any_all() {
+    fn sse2_mask_any_all() {
         // Test MaskOps methods directly on masks
         let zero = F32x4::splat(0.0);
         let zero_mask = zero.float_to_mask();
@@ -109,14 +109,14 @@ mod tests {
 
     #[test]
     #[should_panic]
-    fn test_sse2_store_panic() {
+    fn sse2_store_panic() {
         let a = F32x4::default();
         let mut out = [0.0; 3]; // Too small
         a.store(&mut out);
     }
 
     #[test]
-    fn test_sse2_reciprocal_math() {
+    fn sse2_reciprocal_math() {
         let a = F32x4::splat(4.0);
         let mut out = [0.0; 4];
 

--- a/pixelflow-graphics/src/baked.rs
+++ b/pixelflow-graphics/src/baked.rs
@@ -171,7 +171,7 @@ mod tests {
     }
 
     #[test]
-    fn test_baked_creation() {
+    fn baked_creation() {
         let color = SolidColor(255, 128, 64, 255);
         let baked: Baked<_, Rgba8> = Baked::new(color, 8, 8);
 
@@ -180,7 +180,7 @@ mod tests {
     }
 
     #[test]
-    fn test_baked_eval() {
+    fn baked_eval() {
         let color = SolidColor(255, 0, 0, 255);
         let baked: Baked<_, Rgba8> = Baked::new(color, 4, 4);
 
@@ -196,7 +196,7 @@ mod tests {
     }
 
     #[test]
-    fn test_baked_sequential_sampling() {
+    fn baked_sequential_sampling() {
         // Create a gradient: red increases with x
         struct Gradient;
         impl Manifold<Field4> for Gradient {

--- a/pixelflow-graphics/src/fonts/cache.rs
+++ b/pixelflow-graphics/src/fonts/cache.rs
@@ -371,7 +371,7 @@ mod tests {
     const FONT_DATA: &[u8] = include_bytes!("../../assets/DejaVuSansMono-Fallback.ttf");
 
     #[test]
-    fn test_size_bucket() {
+    fn verify_size_bucket() {
         assert_eq!(size_bucket(8.0), 8);
         assert_eq!(size_bucket(9.0), 12);
         assert_eq!(size_bucket(12.0), 12);
@@ -381,7 +381,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cached_glyph_creation() {
+    fn cached_glyph_creation() {
         let font = Font::parse(FONT_DATA).unwrap();
         let glyph = font.glyph_scaled('A', 32.0).unwrap();
         let cached = CachedGlyph::new(&glyph, 32);
@@ -391,7 +391,7 @@ mod tests {
     }
 
     #[test]
-    fn test_glyph_cache_get() {
+    fn glyph_cache_get() {
         let font = Font::parse(FONT_DATA).unwrap();
         let mut cache = GlyphCache::new();
 
@@ -412,7 +412,7 @@ mod tests {
     }
 
     #[test]
-    fn test_glyph_cache_warm() {
+    fn glyph_cache_warm() {
         let font = Font::parse(FONT_DATA).unwrap();
         let mut cache = GlyphCache::new();
 
@@ -428,7 +428,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cached_glyph_eval() {
+    fn cached_glyph_eval() {
         use pixelflow_core::Field;
 
         let font = Font::parse(FONT_DATA).unwrap();
@@ -449,7 +449,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cached_text_creation() {
+    fn cached_text_creation() {
         use pixelflow_core::Field;
 
         let font = Font::parse(FONT_DATA).unwrap();
@@ -474,7 +474,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cache_memory_usage() {
+    fn cache_memory_usage() {
         let font = Font::parse(FONT_DATA).unwrap();
         let mut cache = GlyphCache::new();
 

--- a/pixelflow-graphics/src/fonts/loader.rs
+++ b/pixelflow-graphics/src/fonts/loader.rs
@@ -382,7 +382,7 @@ mod tests {
     const FONT_DATA: &[u8] = include_bytes!("../../assets/DejaVuSansMono-Fallback.ttf");
 
     #[test]
-    fn test_embedded_source() {
+    fn embedded_source() {
         let source = EmbeddedSource::new(FONT_DATA);
         assert_eq!(source.as_bytes().len(), FONT_DATA.len());
 
@@ -392,7 +392,7 @@ mod tests {
     }
 
     #[test]
-    fn test_data_source() {
+    fn data_source() {
         let source = DataSource::new(FONT_DATA.to_vec());
         assert_eq!(source.as_bytes().len(), FONT_DATA.len());
 
@@ -402,19 +402,19 @@ mod tests {
     }
 
     #[test]
-    fn test_invalid_font_returns_none() {
+    fn invalid_font_returns_none() {
         let source = DataSource::new(vec![0, 1, 2, 3]);
         assert!(LoadedFont::new(source).is_none());
     }
 
     #[test]
-    fn test_empty_data_returns_none() {
+    fn empty_data_returns_none() {
         let source = DataSource::new(vec![]);
         assert!(LoadedFont::new(source).is_none());
     }
 
     #[test]
-    fn test_glyph_access_through_loaded_font() {
+    fn glyph_access_through_loaded_font() {
         let source = EmbeddedSource::new(FONT_DATA);
         let loaded = LoadedFont::new(source).expect("should parse font");
 
@@ -428,7 +428,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn test_mmap_source() {
+    fn mmap_source() {
         use std::io::Write;
         use tempfile::NamedTempFile;
 

--- a/pixelflow-graphics/src/mesh.rs
+++ b/pixelflow-graphics/src/mesh.rs
@@ -201,7 +201,7 @@ mod tests {
     use std::io::Cursor;
 
     #[test]
-    fn test_parse_simple_quad() {
+    fn parse_simple_quad() {
         let obj = "
 # Simple cube (partial)
 v 0.0 0.0 0.0
@@ -217,7 +217,7 @@ f 1 2 3 4
     }
 
     #[test]
-    fn test_valence_computation() {
+    fn valence_computation() {
         let obj = "
 v 0.0 0.0 0.0
 v 1.0 0.0 0.0
@@ -235,7 +235,7 @@ f 4 1 5 5
     }
 
     #[test]
-    fn test_reject_triangles() {
+    fn reject_triangles() {
         let obj = "
 v 0.0 0.0 0.0
 v 1.0 0.0 0.0
@@ -248,7 +248,7 @@ f 1 2 3
     }
 
     #[test]
-    fn test_texture_coordinates_ignored() {
+    fn texture_coordinates_ignored() {
         let obj = "
 v 0.0 0.0 0.0
 v 1.0 0.0 0.0

--- a/pixelflow-graphics/src/patch.rs
+++ b/pixelflow-graphics/src/patch.rs
@@ -122,7 +122,7 @@ mod tests {
     use pixelflow_core::ManifoldCompat;
 
     #[test]
-    fn test_flat_patch() {
+    fn flat_patch() {
         let patch = BezierPatch::flat(1.0);
         let z = Field::from(0.0);
         let result = patch.eval_raw(Field::from(0.5), Field::from(0.5), z, z);
@@ -130,7 +130,7 @@ mod tests {
     }
 
     #[test]
-    fn test_derivatives() {
+    fn derivatives() {
         let patch = BezierPatch::paraboloid(2.0, 1.0);
         let u = Jet2H::x(Field::from(0.5));
         let v = Jet2H::y(Field::from(0.5));

--- a/pixelflow-graphics/src/render/color.rs
+++ b/pixelflow-graphics/src/render/color.rs
@@ -605,7 +605,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_rgba8_components() {
+    fn rgba8_components() {
         let c = Rgba8::new(0x11, 0x22, 0x33, 0xFF);
         assert_eq!(c.r(), 0x11);
         assert_eq!(c.g(), 0x22);
@@ -614,7 +614,7 @@ mod tests {
     }
 
     #[test]
-    fn test_bgra8_components() {
+    fn bgra8_components() {
         let c = Bgra8::new(0x33, 0x22, 0x11, 0xFF);
         assert_eq!(c.b(), 0x33);
         assert_eq!(c.g(), 0x22);
@@ -623,7 +623,7 @@ mod tests {
     }
 
     #[test]
-    fn test_rgba8_to_bgra8() {
+    fn rgba8_to_bgra8() {
         let rgba = Rgba8::new(0x11, 0x22, 0x33, 0xFF);
         let bgra = Bgra8::from(rgba);
         assert_eq!(bgra.r(), 0x11);
@@ -633,7 +633,7 @@ mod tests {
     }
 
     #[test]
-    fn test_named_color_manifold() {
+    fn named_color_manifold() {
         use pixelflow_core::{materialize_discrete, PARALLELISM};
         let red = NamedColor::Red;
         let mut out = vec![0u32; PARALLELISM];
@@ -653,7 +653,7 @@ mod tests {
     }
 
     #[test]
-    fn test_color_manifold() {
+    fn verify_color_manifold() {
         use pixelflow_core::{materialize_discrete, PARALLELISM};
         let c = Color::Rgb(10, 20, 30);
         let mut out = vec![0u32; PARALLELISM];

--- a/pixelflow-graphics/src/render/rasterizer/actor.rs
+++ b/pixelflow-graphics/src/render/rasterizer/actor.rs
@@ -234,7 +234,7 @@ mod tests {
     use std::sync::{mpsc, Arc};
 
     #[test]
-    fn test_rasterizer_actor_basic() {
+    fn rasterizer_actor_basic() {
         // Step 1: Spawn with setup handle
         let (setup_handle, actor_thread) = RasterizerActor::<Rgba8>::spawn_with_setup(1);
 
@@ -275,7 +275,7 @@ mod tests {
     }
 
     #[test]
-    fn test_rasterizer_actor_thread_count_update() {
+    fn rasterizer_actor_thread_count_update() {
         // Spawn with setup
         let (setup_handle, actor_thread) = RasterizerActor::<Rgba8>::spawn_with_setup(2);
 
@@ -312,7 +312,7 @@ mod tests {
     }
 
     #[test]
-    fn test_rasterizer_actor_pause_resume() {
+    fn rasterizer_actor_pause_resume() {
         // Spawn with setup
         let (setup_handle, actor_thread) = RasterizerActor::<Rgba8>::spawn_with_setup(1);
 

--- a/pixelflow-graphics/src/spatial_bsp.rs
+++ b/pixelflow-graphics/src/spatial_bsp.rs
@@ -349,7 +349,7 @@ mod tests {
     }
 
     #[test]
-    fn test_single_leaf() {
+    fn single_leaf() {
         let bsp = SpatialBSP::single(SolidColor::new(255, 0, 0, 255));
 
         assert_eq!(
@@ -369,7 +369,7 @@ mod tests {
     }
 
     #[test]
-    fn test_two_leaves() {
+    fn two_leaves() {
         let items = vec![
             Positioned {
                 bounds: (0.0, 0.0, 50.0, 100.0),
@@ -388,7 +388,7 @@ mod tests {
     }
 
     #[test]
-    fn test_empty_bsp() {
+    fn empty_bsp() {
         let bsp: SpatialBSP<SolidColor> = SpatialBSP::from_positioned(vec![]);
 
         assert_eq!(bsp.interior_count(), 0, "Empty BSP has no interior nodes");
@@ -400,7 +400,7 @@ mod tests {
     }
 
     #[test]
-    fn test_four_leaves_grid() {
+    fn four_leaves_grid() {
         // 2x2 grid
         let items = vec![
             Positioned {
@@ -1797,7 +1797,7 @@ mod tests {
     }
 
     #[test]
-    fn test_stack_of_wide_strips() {
+    fn stack_of_wide_strips() {
         use pixelflow_core::{materialize_discrete, PARALLELISM};
 
         // Create 2 wide, short items, stacked vertically.

--- a/pixelflow-graphics/src/subdiv/mod.rs
+++ b/pixelflow-graphics/src/subdiv/mod.rs
@@ -492,7 +492,7 @@ mod tests {
     }
 
     #[test]
-    fn test_bicubic_constant() {
+    fn bicubic_constant() {
         // Constant polynomial: c00 = 5.0, all others 0
         let mut coeffs = [0.0f32; 16];
         coeffs[0] = 5.0;
@@ -503,7 +503,7 @@ mod tests {
     }
 
     #[test]
-    fn test_bicubic_linear() {
+    fn bicubic_linear() {
         // P(u,v) = 1 + 2u + 3v
         let mut coeffs = [0.0f32; 16];
         coeffs[0] = 1.0; // c00 = 1
@@ -517,7 +517,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_eigen_valence_4() {
+    fn get_eigen_valence_4() {
         // Regular vertex (valence 4) should have eigenstructure
         let eigen = get_eigen(4).expect("valence 4 should exist");
         assert_eq!(eigen.valence, 4);
@@ -526,7 +526,7 @@ mod tests {
     }
 
     #[test]
-    fn test_eigen_first_eigenvalue_is_one() {
+    fn eigen_first_eigenvalue_is_one() {
         // First eigenvalue should always be 1.0 (limit surface property)
         for valence in 3..=10 {
             let eigen = get_eigen(valence).unwrap();
@@ -539,7 +539,7 @@ mod tests {
     }
 
     #[test]
-    fn test_bspline_patch_flat_plane() {
+    fn bspline_patch_flat_plane() {
         // Create a flat 4x4 grid of control points at z=0
         // Points span [0,3] x [0,3] in x,y
         let mut control_points = [[0.0f32; 3]; 16];
@@ -567,7 +567,7 @@ mod tests {
     }
 
     #[test]
-    fn test_bspline_patch_corners() {
+    fn bspline_patch_corners() {
         // Flat grid
         let mut control_points = [[0.0f32; 3]; 16];
         for i in 0..4 {
@@ -603,7 +603,7 @@ mod tests {
     }
 
     #[test]
-    fn test_eigen_trivial_case() {
+    fn eigen_trivial_case() {
         // If all control points are at the SAME location,
         // the surface should evaluate to that location everywhere.
         // This tests affine invariance.
@@ -719,7 +719,7 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_eigen_domain_accepts_valid() {
+    fn validate_eigen_domain_accepts_valid() {
         // Origin is valid (exact limit position)
         validate_eigen_domain(0.0, 0.0);
 
@@ -735,7 +735,7 @@ mod tests {
     }
 
     #[test]
-    fn test_eigen_patch_subpatch_routing() {
+    fn eigen_patch_subpatch_routing() {
         // Constant control points - surface should be constant everywhere
         let const_points = [[3.0f32, 5.0, 7.0]; 16];
         let (ex, ey, ez) = eigen_patch(&const_points, 4).unwrap();
@@ -769,7 +769,7 @@ mod tests {
     }
 
     #[test]
-    fn test_bspline_symmetry() {
+    fn bspline_symmetry() {
         // Symmetric grid centered at origin
         let mut control_points = [[0.0f32; 3]; 16];
         for i in 0..4 {
@@ -799,7 +799,7 @@ mod tests {
     }
 
     #[test]
-    fn test_recursive_tiling_constant_surface() {
+    fn recursive_tiling_constant_surface() {
         // Constant control points - surface should be constant everywhere
         // including at deeper tiles
         let const_points = [[5.0f32, 7.0, 9.0]; 16];
@@ -845,7 +845,7 @@ mod tests {
     }
 
     #[test]
-    fn test_tile_scale_values() {
+    fn tile_scale_values() {
         // Test that tile_scale computes correct powers of 2
         let scale = tile_scale();
 

--- a/pixelflow-graphics/src/subdivision.rs
+++ b/pixelflow-graphics/src/subdivision.rs
@@ -474,7 +474,7 @@ mod tests {
     use std::io::Cursor;
 
     #[test]
-    fn test_regular_patch() {
+    fn regular_patch() {
         let obj = "
 v 0.0 0.0 0.0
 v 1.0 0.0 0.0
@@ -491,7 +491,7 @@ f 1 2 3 4
     }
 
     #[test]
-    fn test_limit_eval() {
+    fn limit_eval() {
         let obj = "
 v 0.0 0.0 0.0
 v 1.0 0.0 0.0
@@ -518,7 +518,7 @@ f 1 2 3 4
     }
 
     #[test]
-    fn test_surface_stats() {
+    fn surface_stats() {
         let obj = "
 v 0.0 0.0 0.0
 v 1.0 0.0 0.0

--- a/pixelflow-graphics/tests/kernel_macro.rs
+++ b/pixelflow-graphics/tests/kernel_macro.rs
@@ -57,7 +57,7 @@ fn fields_close(a: Field, b: Field, epsilon: f32) -> bool {
 
 /// Test a kernel with one parameter.
 #[test]
-fn test_one_param_kernel() {
+fn one_param_kernel() {
     // X offset by a parameter
     let offset_x = kernel!(|dx: f32| X + dx);
     let k = offset_x(10.0);
@@ -73,7 +73,7 @@ fn test_one_param_kernel() {
 
 /// Test a kernel with two parameters.
 #[test]
-fn test_two_param_kernel() {
+fn two_param_kernel() {
     // Offset both X and Y
     let offset_xy = kernel!(|dx: f32, dy: f32| (X + dx) + (Y + dy));
     let k = offset_xy(10.0, 20.0);
@@ -89,7 +89,7 @@ fn test_two_param_kernel() {
 
 /// Test a kernel with no parameters.
 #[test]
-fn test_zero_param_kernel() {
+fn zero_param_kernel() {
     // Simple distance from origin (no params)
     let dist = kernel!(|| (X * X + Y * Y).sqrt());
     let k = dist();
@@ -105,7 +105,7 @@ fn test_zero_param_kernel() {
 
 /// Test method chaining (ManifoldExt integration).
 #[test]
-fn test_method_chaining() {
+fn method_chaining() {
     // Clamped value using .max().min()
     let clamp = kernel!(|lo: f32, hi: f32| X.max(lo).min(hi));
     let k = clamp(0.0, 1.0);
@@ -134,7 +134,7 @@ fn test_method_chaining() {
 
 /// Test that kernels are Clone (not Copy, since they hold data).
 #[test]
-fn test_kernel_is_clone() {
+fn kernel_is_clone() {
     let scale = kernel!(|factor: f32| X * factor);
     let k1 = scale(2.0);
     let k2 = k1;
@@ -148,7 +148,7 @@ fn test_kernel_is_clone() {
 
 /// Test that different instantiations are independent.
 #[test]
-fn test_independent_instantiations() {
+fn independent_instantiations() {
     let scale = kernel!(|factor: f32| X * factor);
 
     let double = scale(2.0);
@@ -169,7 +169,7 @@ fn test_independent_instantiations() {
 
 /// Test sqrt method.
 #[test]
-fn test_sqrt() {
+fn verify_sqrt() {
     let root = kernel!(|val: f32| (X + val).sqrt());
     let k = root(7.0);
 
@@ -180,7 +180,7 @@ fn test_sqrt() {
 
 /// Test floor method.
 #[test]
-fn test_floor() {
+fn verify_floor() {
     let floored = kernel!(|| X.floor());
     let k = floored();
 
@@ -193,7 +193,7 @@ fn test_floor() {
 
 /// Test abs method.
 #[test]
-fn test_abs() {
+fn verify_abs() {
     let absolute = kernel!(|offset: f32| (X - offset).abs());
     let k = absolute(5.0);
 
@@ -210,7 +210,7 @@ fn test_abs() {
 /// This is verified by the fact that the kernel compiles at all -
 /// if parameters were injected directly, the expression wouldn't be Copy.
 #[test]
-fn test_zst_expression_is_copy() {
+fn zst_expression_is_copy() {
     // This kernel uses the parameter twice in the expression.
     // If the expression weren't Copy (ZST-based), this wouldn't compile
     // because the parameter would be moved on first use.
@@ -229,7 +229,7 @@ fn test_zst_expression_is_copy() {
 /// Test a kernel with three parameters.
 /// This demonstrates the new Let/Var binding system since Z/W slots only support 2.
 #[test]
-fn test_three_param_kernel() {
+fn three_param_kernel() {
     // Translate point by (dx, dy) and add z offset
     let translate_3d = kernel!(|dx: f32, dy: f32, dz: f32| (X + dx) + (Y + dy) + dz);
     let k = translate_3d(10.0, 20.0, 30.0);
@@ -246,7 +246,7 @@ fn test_three_param_kernel() {
 /// Test a kernel with four parameters.
 /// Demonstrates full 4-parameter support.
 #[test]
-fn test_four_param_kernel() {
+fn four_param_kernel() {
     // Combine all four parameters with coordinates
     let quad_combine = kernel!(|a: f32, b: f32, c: f32, d: f32| a + b + c + d + X + Y);
     let k = quad_combine(1.0, 2.0, 3.0, 4.0);
@@ -263,7 +263,7 @@ fn test_four_param_kernel() {
 /// Test a 4-parameter sphere SDF kernel.
 /// This is a practical example: signed distance from a sphere at (cx, cy, cz) with radius r.
 #[test]
-fn test_sphere_sdf_kernel() {
+fn sphere_sdf_kernel() {
     // Sphere SDF: distance from center minus radius
     let sphere_sdf = kernel!(|cx: f32, cy: f32, cz: f32, r: f32| {
         let dx = X - cx;
@@ -295,7 +295,7 @@ fn test_sphere_sdf_kernel() {
 /// Test parameter ordering with 3 parameters.
 /// Verifies that parameters are correctly bound (first param deepest in stack).
 #[test]
-fn test_parameter_ordering_three() {
+fn parameter_ordering_three() {
     // Each parameter has a different multiplier to verify correct binding
     let order_test = kernel!(|a: f32, b: f32, c: f32| a * 100.0 + b * 10.0 + c);
     let k = order_test(1.0, 2.0, 3.0);
@@ -311,7 +311,7 @@ fn test_parameter_ordering_three() {
 
 /// Test that parameters can be used multiple times in 3+ param kernels.
 #[test]
-fn test_param_reuse_three() {
+fn param_reuse_three() {
     // Use each parameter twice
     let reuse = kernel!(|a: f32, b: f32, c: f32| (a + a) + (b + b) + (c + c));
     let k = reuse(1.0, 2.0, 3.0);
@@ -343,7 +343,7 @@ fn jet3_4(x: f32, y: f32, z: f32, w: f32) -> Jet3_4 {
 
 /// Test a simple Jet3 kernel (domain inferred from output type).
 #[test]
-fn test_jet3_simple() {
+fn jet3_simple() {
     // X + Y with Jet3 output → domain is Jet3_4
     let add_xy = kernel!(|| -> Jet3 X + Y);
     let k = add_xy();
@@ -363,7 +363,7 @@ fn test_jet3_simple() {
 
 /// Test Jet3 kernel with parameters (sphere SDF).
 #[test]
-fn test_jet3_sphere_sdf() {
+fn jet3_sphere_sdf() {
     // Sphere SDF: distance from center minus radius
     // Using Jet3 for automatic differentiation (normals)
     let sphere_sdf = kernel!(|cx: f32, cy: f32, cz: f32, r: f32| -> Jet3 {
@@ -396,7 +396,7 @@ fn test_jet3_sphere_sdf() {
 /// Test basic kernel composition with a single manifold parameter.
 /// This is the core use case: composing a distance function with a circle SDF.
 #[test]
-fn test_simple_kernel_composition() {
+fn simple_kernel_composition() {
     // Distance from a point (parametric)
     let dist = kernel!(|cx: f32, cy: f32| {
         let dx = X - cx;
@@ -429,7 +429,7 @@ fn test_simple_kernel_composition() {
 
 /// Test kernel composition with offset centers.
 #[test]
-fn test_kernel_composition_with_offset() {
+fn kernel_composition_with_offset() {
     let dist = kernel!(|cx: f32, cy: f32| {
         let dx = X - cx;
         let dy = Y - cy;
@@ -479,7 +479,7 @@ fn test_two_manifold_params() {
 
 /// Test mixed manifold and scalar parameters.
 #[test]
-fn test_mixed_manifold_scalar_params() {
+fn mixed_manifold_scalar_params() {
     // Scale an SDF by a factor
     let scale_sdf = kernel!(|inner: kernel, factor: f32| inner * factor);
 
@@ -499,7 +499,7 @@ fn test_mixed_manifold_scalar_params() {
 
 /// Test chained kernel composition (three levels deep).
 #[test]
-fn test_chained_composition() {
+fn chained_composition() {
     // Basic X coordinate
     let get_x = kernel!(|| X);
 
@@ -522,7 +522,7 @@ fn test_chained_composition() {
 
 /// Test that composed kernels can be cloned (the inner kernel is owned).
 #[test]
-fn test_composed_kernel_ownership() {
+fn composed_kernel_ownership() {
     let dist = kernel!(|cx: f32, cy: f32| {
         let dx = X - cx;
         let dy = Y - cy;
@@ -548,7 +548,7 @@ fn test_composed_kernel_ownership() {
 /// creating type mismatches with ZST expression tree types.
 /// With the annotation pass, literals become Var<N> references bound via Let.
 #[test]
-fn test_jet3_with_literals() {
+fn jet3_with_literals() {
     // Inverse square root with literal numerator
     // This expression: 1.0 / (X*X + Y*Y + Z*Z).sqrt()
     // Tests that the literal 1.0 is properly handled in Jet3 mode
@@ -581,7 +581,7 @@ fn test_jet3_with_literals() {
 /// Test Jet3 kernel with multiple literals.
 /// Verifies that multiple literals each get their own Var<N> binding.
 #[test]
-fn test_jet3_multiple_literals() {
+fn jet3_multiple_literals() {
     // Expression with multiple literals: 2.0 * X + 3.0
     let affine = kernel!(|| -> Jet3 2.0 * X + 3.0);
     let k = affine();
@@ -600,7 +600,7 @@ fn test_jet3_multiple_literals() {
 /// Test Jet3 kernel with literals AND parameters.
 /// Both literals and params become Var<N> - they should coexist correctly.
 #[test]
-fn test_jet3_literals_and_params() {
+fn jet3_literals_and_params() {
     // offset + 2.0 * X - 0.5
     let kernel = kernel!(|offset: f32| -> Jet3 offset + 2.0 * X - 0.5);
     let k = kernel(10.0);
@@ -655,7 +655,7 @@ fn jet3_4_seeded(x: f32, y: f32, z: f32) -> Jet3_4 {
 
 /// Test GradientMag2D computes √(dx² + dy²) with single eval.
 #[test]
-fn test_gradient_mag_2d() {
+fn gradient_mag_2d() {
     // For f(x,y) = sqrt(x² + y²), the gradient is (x/r, y/r) where r = sqrt(x²+y²)
     // Gradient magnitude is always 1.0 for distance fields
     let dist =
@@ -673,7 +673,7 @@ fn test_gradient_mag_2d() {
 
 /// Test GradientMag3D computes √(dx² + dy² + dz²) with single eval.
 #[test]
-fn test_gradient_mag_3d() {
+fn gradient_mag_3d() {
     // For f(x,y,z) = sqrt(x² + y² + z²), gradient magnitude is 1.0
     let dist = (pixelflow_core::X * pixelflow_core::X
         + pixelflow_core::Y * pixelflow_core::Y
@@ -692,7 +692,7 @@ fn test_gradient_mag_3d() {
 
 /// Test Antialias2D computes val / √(dx² + dy²) with single eval.
 #[test]
-fn test_antialias_2d() {
+fn antialias_2d() {
     // Circle SDF using kernel! macro (handles literal promotion)
     // At (2, 0): val = 1.0, gradient = (1, 0), so antialias = 1.0 / 1.0 = 1.0
     let circle_sdf = kernel!(|| -> Jet2 { (X * X + Y * Y).sqrt() - 1.0 });
@@ -709,7 +709,7 @@ fn test_antialias_2d() {
 
 /// Test Antialias3D computes val / √(dx² + dy² + dz²) with single eval.
 #[test]
-fn test_antialias_3d() {
+fn antialias_3d() {
     // Sphere SDF using kernel! macro
     // At (2, 0, 0): val = 1.0, gradient = (1, 0, 0), so antialias = 1.0 / 1.0 = 1.0
     let sphere_sdf = kernel!(|| -> Jet3 { (X * X + Y * Y + Z * Z).sqrt() - 1.0 });
@@ -726,7 +726,7 @@ fn test_antialias_3d() {
 
 /// Test Normalized2D returns unit gradient vector with single eval.
 #[test]
-fn test_normalized_2d() {
+fn normalized_2d() {
     // Distance field: sqrt(x² + y²)
     // At (3, 4): gradient = (3/5, 4/5) = (0.6, 0.8)
     let dist =
@@ -747,7 +747,7 @@ fn test_normalized_2d() {
 
 /// Test fused combinators with kernel-composed manifolds.
 #[test]
-fn test_fused_combinators_with_kernel_composition() {
+fn fused_combinators_with_kernel_composition() {
     // Create a circle SDF kernel
     let circle_sdf = kernel!(|cx: f32, cy: f32, r: f32| -> Jet2 {
         let dx = X - cx;
@@ -795,7 +795,7 @@ use pixelflow_core::{DX, DY, DZ, V};
 
 /// Test V accessor extracts the value component from Jet2.
 #[test]
-fn test_v_accessor() {
+fn v_accessor() {
     // Distance from origin: sqrt(x² + y²)
     let dist =
         (pixelflow_core::X * pixelflow_core::X + pixelflow_core::Y * pixelflow_core::Y).sqrt();
@@ -813,7 +813,7 @@ fn test_v_accessor() {
 
 /// Test DX accessor extracts ∂f/∂x from Jet2.
 #[test]
-fn test_dx_accessor() {
+fn dx_accessor() {
     // Distance from origin: sqrt(x² + y²)
     // ∂dist/∂x = x / sqrt(x² + y²) = x / dist
     let dist =
@@ -832,7 +832,7 @@ fn test_dx_accessor() {
 
 /// Test DY accessor extracts ∂f/∂y from Jet2.
 #[test]
-fn test_dy_accessor() {
+fn dy_accessor() {
     // Distance from origin: sqrt(x² + y²)
     // ∂dist/∂y = y / sqrt(x² + y²) = y / dist
     let dist =
@@ -851,7 +851,7 @@ fn test_dy_accessor() {
 
 /// Test DZ accessor extracts ∂f/∂z from Jet3.
 #[test]
-fn test_dz_accessor() {
+fn dz_accessor() {
     // 3D distance from origin: sqrt(x² + y² + z²)
     // ∂dist/∂z = z / sqrt(x² + y² + z²)
     let dist = (pixelflow_core::X * pixelflow_core::X
@@ -876,7 +876,7 @@ fn test_dz_accessor() {
 /// `(DX(sdf) * DX(sdf) + DY(sdf) * DY(sdf)).sqrt()` now work with ManifoldExt.
 /// CSE (Phase 6) will optimize away redundant evaluations.
 #[test]
-fn test_manual_gradient_magnitude() {
+fn manual_gradient_magnitude() {
     // Distance from origin
     let dist =
         (pixelflow_core::X * pixelflow_core::X + pixelflow_core::Y * pixelflow_core::Y).sqrt();

--- a/pixelflow-graphics/tests/pixel_contract.rs
+++ b/pixelflow-graphics/tests/pixel_contract.rs
@@ -6,7 +6,7 @@ use pixelflow_graphics::render::color::{Bgra8, Rgba8};
 use pixelflow_graphics::render::pixel::Pixel;
 
 #[test]
-fn test_rgba8_components() {
+fn rgba8_components() {
     let rgba = Rgba8::new(0x11, 0x22, 0x33, 0x44);
     assert_eq!(rgba.r(), 0x11);
     assert_eq!(rgba.g(), 0x22);
@@ -15,7 +15,7 @@ fn test_rgba8_components() {
 }
 
 #[test]
-fn test_bgra8_components() {
+fn bgra8_components() {
     let bgra = Bgra8::new(0x33, 0x22, 0x11, 0x44);
     assert_eq!(bgra.b(), 0x33);
     assert_eq!(bgra.g(), 0x22);
@@ -24,7 +24,7 @@ fn test_bgra8_components() {
 }
 
 #[test]
-fn test_swizzle_correctness() {
+fn swizzle_correctness() {
     let rgba = Rgba8::new(0x11, 0x22, 0x33, 0x44);
     let bgra = Bgra8::from(rgba);
 
@@ -35,7 +35,7 @@ fn test_swizzle_correctness() {
 }
 
 #[test]
-fn test_pixel_from_rgba_f32() {
+fn pixel_from_rgba_f32() {
     let rgba = Rgba8::from_rgba(1.0, 0.5, 0.0, 1.0);
     assert_eq!(rgba.r(), 255);
     assert!(rgba.g() > 120 && rgba.g() < 140); // ~127
@@ -44,7 +44,7 @@ fn test_pixel_from_rgba_f32() {
 }
 
 #[test]
-fn test_pixel_from_u32() {
+fn pixel_from_u32() {
     let packed: u32 = 0xFF332211; // ABGR in memory = RGBA little-endian
     let rgba = Rgba8::from_u32(packed);
     assert_eq!(rgba.to_u32(), packed);

--- a/pixelflow-graphics/tests/raster_parallel.rs
+++ b/pixelflow-graphics/tests/raster_parallel.rs
@@ -5,7 +5,7 @@ use pixelflow_graphics::render::frame::Frame;
 use pixelflow_graphics::render::rasterizer::rasterize;
 
 #[test]
-fn test_parallel_rasterization_matches_sequential() {
+fn parallel_rasterization_matches_sequential() {
     let width = 100;
     let height = 100;
     let color = Color::Named(NamedColor::Green);

--- a/pixelflow-graphics/tests/raymarch_sphere.rs
+++ b/pixelflow-graphics/tests/raymarch_sphere.rs
@@ -76,7 +76,7 @@ impl<M: ManifoldCompat<Field, Output = Discrete>> Manifold<Field4> for ColorScre
 }
 
 #[test]
-fn test_sphere_on_floor() {
+fn sphere_on_floor() {
     const W: usize = 400;
     const H: usize = 300;
 
@@ -127,7 +127,7 @@ fn test_sphere_on_floor() {
 
 /// Test with solid gray material (non-reflective)
 #[test]
-fn test_sphere_on_matte_floor() {
+fn sphere_on_matte_floor() {
     const W: usize = 400;
     const H: usize = 300;
 
@@ -191,7 +191,7 @@ fn test_sphere_on_matte_floor() {
 
 /// Chrome sphere on checkerboard floor
 #[test]
-fn test_chrome_sphere_on_checkerboard() {
+fn chrome_sphere_on_checkerboard() {
     const WIDTH: usize = 400;
     const HEIGHT: usize = 300;
 

--- a/pixelflow-graphics/tests/scene3d_test.rs
+++ b/pixelflow-graphics/tests/scene3d_test.rs
@@ -101,7 +101,7 @@ impl<M: ManifoldCompat<Field, Output = Field> + ManifoldExt> Manifold<Field4> fo
 /// - Surface<SphereAt, Reflect<world>, world>: sphere reflecting world
 /// - world = Surface<plane, Checker, Sky>: floor + sky
 #[test]
-fn test_chrome_unit_sphere() {
+fn chrome_unit_sphere() {
     const W: usize = 400;
     const H: usize = 300;
 
@@ -176,7 +176,7 @@ fn test_chrome_unit_sphere() {
 
 /// Test: Just the sky (no geometry)
 #[test]
-fn test_sky_only() {
+fn sky_only() {
     const W: usize = 200;
     const H: usize = 150;
 
@@ -228,7 +228,7 @@ fn test_sky_only() {
 
 /// Test: Floor only (plane with checker pattern)
 #[test]
-fn test_floor_only() {
+fn floor_only() {
     const W: usize = 400;
     const H: usize = 300;
 
@@ -276,7 +276,7 @@ fn test_floor_only() {
 /// Test: Color chrome sphere with blue sky (MULLET ARCHITECTURE)
 /// Geometry runs ONCE, colors flow as packed RGBA. 3x speedup!
 #[test]
-fn test_color_chrome_sphere() {
+fn color_chrome_sphere() {
     const W: usize = 1920;
     const H: usize = 1080;
 
@@ -366,7 +366,7 @@ fn test_color_chrome_sphere() {
 /// Test: Compare 3-channel vs mullet rendering to ensure they match.
 /// This verifies the mullet architecture produces identical results.
 #[test]
-fn test_mullet_vs_3channel_comparison() {
+fn mullet_vs_3channel_comparison() {
     const W: usize = 200;
     const H: usize = 150;
 
@@ -602,7 +602,7 @@ fn test_mullet_vs_3channel_comparison() {
 
 /// Benchmark: Compare work-stealing vs single-threaded at 1080p
 #[test]
-fn test_work_stealing_benchmark() {
+fn work_stealing_benchmark() {
     const W: usize = 1920;
     const H: usize = 1080;
 

--- a/pixelflow-ir/src/arena.rs
+++ b/pixelflow-ir/src/arena.rs
@@ -742,7 +742,7 @@ mod tests {
 
     // 1. test_push_and_access
     #[test]
-    fn test_push_and_access() {
+    fn push_and_access() {
         let mut arena = ExprArena::new();
 
         let v = arena.push_var(0);
@@ -775,7 +775,7 @@ mod tests {
 
     // 2. test_node_count
     #[test]
-    fn test_node_count() {
+    fn node_count() {
         let mut arena = ExprArena::new();
         let v0 = arena.push_var(0);
         let c1 = arena.push_const(1.0);
@@ -795,7 +795,7 @@ mod tests {
 
     // 3. test_depth
     #[test]
-    fn test_depth() {
+    fn verify_depth() {
         let mut arena = ExprArena::new();
         let v0 = arena.push_var(0);
         let v1 = arena.push_var(1);
@@ -807,7 +807,7 @@ mod tests {
 
     // 4. test_has_var
     #[test]
-    fn test_has_var() {
+    fn verify_has_var() {
         let mut arena1 = ExprArena::new();
         let v0 = arena1.push_var(0);
         let c1 = arena1.push_const(1.0);
@@ -823,7 +823,7 @@ mod tests {
 
     // 5. test_has_degenerate
     #[test]
-    fn test_has_degenerate() {
+    fn verify_has_degenerate() {
         let mut arena1 = ExprArena::new();
         let root1 = arena1.push_const(f32::NAN);
         assert!(arena1.has_degenerate(root1));
@@ -852,7 +852,7 @@ mod tests {
 
     // 7. test_clear_preserves_capacity
     #[test]
-    fn test_clear_preserves_capacity() {
+    fn clear_preserves_capacity() {
         let mut arena = ExprArena::with_capacity(64);
         let _v = arena.push_var(0);
         let _c = arena.push_const(1.0);
@@ -870,7 +870,7 @@ mod tests {
 
     // 7. test_substitute_params
     #[test]
-    fn test_substitute_params() {
+    fn verify_substitute_params() {
         let mut arena = ExprArena::new();
         let p0 = arena.push_param(0);
         let p1 = arena.push_param(1);
@@ -889,7 +889,7 @@ mod tests {
 
     // 8. test_nary
     #[test]
-    fn test_nary() {
+    fn nary() {
         let mut arena = ExprArena::new();
         let v0 = arena.push_var(0);
         let v1 = arena.push_var(1);
@@ -905,7 +905,7 @@ mod tests {
 
     // 9. test_display
     #[test]
-    fn test_display() {
+    fn verify_display() {
         let mut arena = ExprArena::new();
         let v0 = arena.push_var(0);
         let v1 = arena.push_var(1);
@@ -919,7 +919,7 @@ mod tests {
     }
 
     #[test]
-    fn test_size_of_expr_node() {
+    fn size_of_expr_node() {
         // Compile-time assertion exists above, but also verify at runtime.
         assert!(
             core::mem::size_of::<ExprNode>() <= 16,
@@ -929,7 +929,7 @@ mod tests {
     }
 
     #[test]
-    fn test_expr_children_exact_size() {
+    fn expr_children_exact_size() {
         let mut arena = ExprArena::new();
         let v = arena.push_var(0);
         let c = arena.push_const(1.0);

--- a/pixelflow-ir/src/backend/emit/mod.rs
+++ b/pixelflow-ir/src/backend/emit/mod.rs
@@ -3881,21 +3881,21 @@ mod tests {
     // =========================================================================
 
     #[test]
-    fn test_frame_layout_empty() {
+    fn frame_layout_empty() {
         let layout = FrameLayout::from_allocation(&[]).unwrap();
         assert_eq!(layout.frame_size, 0);
         assert!(layout.spill_slots.is_empty());
     }
 
     #[test]
-    fn test_frame_layout_one_spill() {
+    fn frame_layout_one_spill() {
         let layout = FrameLayout::from_allocation(&[regalloc::ValueId(5)]).unwrap();
         assert_eq!(layout.frame_size, 16);
         assert_eq!(layout.spill_slots[&regalloc::ValueId(5)], 0);
     }
 
     #[test]
-    fn test_frame_layout_alignment() {
+    fn frame_layout_alignment() {
         let spilled = [
             regalloc::ValueId(1),
             regalloc::ValueId(2),
@@ -3935,7 +3935,7 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_binary_no_spills() {
+    fn resolve_binary_no_spills() {
         // left=v4, right=v5, dst=v6 — all in registers
         let (assign, spills, remat) = make_maps(&[(0, 4), (1, 5), (2, 6)], &[]);
         let op = ScheduledOp::Binary(OpKind::Add, regalloc::ValueId(0), regalloc::ValueId(1));
@@ -3955,7 +3955,7 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_binary_left_spilled() {
+    fn resolve_binary_left_spilled() {
         // left spilled at offset 0, right in v5
         let (assign, spills, remat) = make_maps(&[(1, 5), (2, 6)], &[(0, 0)]);
         let op = ScheduledOp::Binary(OpKind::Add, regalloc::ValueId(0), regalloc::ValueId(1));
@@ -3981,7 +3981,7 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_binary_both_spilled() {
+    fn resolve_binary_both_spilled() {
         // Both spilled: left → dst (temp trick), right → tmp_op
         let (assign, spills, remat) = make_maps(&[(2, 6)], &[(0, 0), (1, 16)]);
         let op = ScheduledOp::Binary(OpKind::Mul, regalloc::ValueId(0), regalloc::ValueId(1));
@@ -4015,7 +4015,7 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_dst_spilled_generates_store() {
+    fn resolve_dst_spilled_generates_store() {
         // dst is spilled → compute into RELOAD_REGS[0], then store
         let (assign, spills, remat) = make_maps(&[(0, 4), (1, 5)], &[(2, 32)]);
         let op = ScheduledOp::Binary(OpKind::Add, regalloc::ValueId(0), regalloc::ValueId(1));
@@ -4041,7 +4041,7 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_muladd_fmla_path() {
+    fn resolve_muladd_fmla_path() {
         // a in reg, b in reg, c in reg → FMLA with setup_mov for c→dst
         let (assign, spills, remat) = make_maps(&[(0, 4), (1, 5), (2, 7), (3, 8)], &[]);
         let op = ScheduledOp::Ternary(
@@ -4066,7 +4066,7 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_muladd_decomposed_both_ab_spilled() {
+    fn resolve_muladd_decomposed_both_ab_spilled() {
         // a and b both spilled → decomposed FMUL+FADD path
         // c in register
         let (assign, spills, remat) = make_maps(&[(2, 7), (3, 8)], &[(0, 0), (1, 16)]);
@@ -4114,7 +4114,7 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_muladd_decomposed_all_three_spilled() {
+    fn resolve_muladd_decomposed_all_three_spilled() {
         // a, b, c all spilled → decomposed with deferred c reload
         let (assign, spills, remat) = make_maps(&[(3, 8)], &[(0, 0), (1, 16), (2, 32)]);
         let op = ScheduledOp::Ternary(
@@ -4137,7 +4137,7 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_var_is_nop() {
+    fn resolve_var_is_nop() {
         let (assign, spills, remat) = make_maps(&[(0, 0)], &[]);
         let op = ScheduledOp::Var(0);
         let plan = resolve_operands(&op, Loc::Reg(Reg(0)), &assign, &spills, &remat).unwrap();
@@ -4147,7 +4147,7 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_const() {
+    fn resolve_const() {
         let (assign, spills, remat) = make_maps(&[(0, 6)], &[]);
         let op = ScheduledOp::Const(core::f32::consts::PI);
         let plan = resolve_operands(&op, Loc::Reg(Reg(6)), &assign, &spills, &remat).unwrap();
@@ -4173,7 +4173,7 @@ mod tests {
     // =========================================================================
 
     #[test]
-    fn test_arena_to_schedule_simple() {
+    fn arena_to_schedule_simple() {
         use crate::arena::ExprArena;
 
         let mut arena = ExprArena::new();
@@ -4201,7 +4201,7 @@ mod tests {
     }
 
     #[test]
-    fn test_arena_to_schedule_filters_unreachable() {
+    fn arena_to_schedule_filters_unreachable() {
         use crate::arena::ExprArena;
 
         let mut arena = ExprArena::new();
@@ -4221,7 +4221,7 @@ mod tests {
     }
 
     #[test]
-    fn test_arena_to_uses() {
+    fn verify_arena_to_uses() {
         use crate::arena::ExprArena;
 
         let mut arena = ExprArena::new();

--- a/pixelflow-ir/src/backend/emit/regalloc.rs
+++ b/pixelflow-ir/src/backend/emit/regalloc.rs
@@ -632,7 +632,7 @@ mod tests {
     use alloc::collections::BTreeSet;
 
     #[test]
-    fn test_empty_graph() {
+    fn empty_graph() {
         let graph = InterferenceGraph::new();
         let alloc = color_graph(&graph, 8, 4);
         assert!(alloc.assignment.is_empty());
@@ -640,7 +640,7 @@ mod tests {
     }
 
     #[test]
-    fn test_no_interference() {
+    fn no_interference() {
         let mut graph = InterferenceGraph::new();
         graph.add_value(ValueId(0));
         graph.add_value(ValueId(1));
@@ -654,7 +654,7 @@ mod tests {
     }
 
     #[test]
-    fn test_chain_interference() {
+    fn chain_interference() {
         let mut graph = InterferenceGraph::new();
         // Linear chain: 0 -- 1 -- 2
         graph.add_value(ValueId(0));
@@ -678,7 +678,7 @@ mod tests {
     }
 
     #[test]
-    fn test_clique_needs_more_colors() {
+    fn clique_needs_more_colors() {
         let mut graph = InterferenceGraph::new();
         // Triangle (3-clique): all interfere with all
         for i in 0..3 {
@@ -699,7 +699,7 @@ mod tests {
     }
 
     #[test]
-    fn test_precolored() {
+    fn precolored() {
         let mut graph = InterferenceGraph::new();
         graph.precolor(ValueId(0), Reg(0)); // Input register
         graph.add_value(ValueId(1));
@@ -711,7 +711,7 @@ mod tests {
     }
 
     #[test]
-    fn test_spilling() {
+    fn spilling() {
         let mut graph = InterferenceGraph::new();
         // 4-clique with only 2 registers available
         for i in 0..4 {

--- a/pixelflow-ir/src/variance.rs
+++ b/pixelflow-ir/src/variance.rs
@@ -371,7 +371,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_from_var() {
+    fn verify_from_var() {
         assert_eq!(Variance::from_var(0), Variance::X);
         assert_eq!(Variance::from_var(1), Variance::Y);
         assert_eq!(Variance::from_var(2), Variance::Z);
@@ -379,7 +379,7 @@ mod tests {
     }
 
     #[test]
-    fn test_union() {
+    fn verify_union() {
         assert_eq!(Variance::X.union(Variance::Y), Variance::from_bits(0b0011));
         assert_eq!(Variance::CONST.union(Variance::Z), Variance::Z);
         assert_eq!(Variance::X.union(Variance::X), Variance::X);
@@ -390,7 +390,7 @@ mod tests {
     }
 
     #[test]
-    fn test_meet() {
+    fn verify_meet() {
         // Fewer deps wins
         assert_eq!(Variance::CONST.meet(Variance::X), Variance::CONST);
         assert_eq!(Variance::X.meet(Variance::CONST), Variance::CONST);
@@ -405,7 +405,7 @@ mod tests {
     }
 
     #[test]
-    fn test_queries() {
+    fn queries() {
         assert!(Variance::CONST.is_const());
         assert!(!Variance::X.is_const());
 
@@ -425,7 +425,7 @@ mod tests {
     }
 
     #[test]
-    fn test_debug_format() {
+    fn debug_format() {
         assert_eq!(format!("{:?}", Variance::CONST), "Variance(CONST)");
         assert_eq!(format!("{:?}", Variance::X), "Variance{X}");
         assert_eq!(
@@ -436,7 +436,7 @@ mod tests {
     }
 
     #[test]
-    fn test_popcount() {
+    fn verify_popcount() {
         assert_eq!(Variance::CONST.popcount(), 0);
         assert_eq!(Variance::X.popcount(), 1);
         assert_eq!(Variance::X.union(Variance::Y).popcount(), 2);
@@ -444,7 +444,7 @@ mod tests {
     }
 
     #[test]
-    fn test_compute_arena_variance() {
+    fn verify_compute_arena_variance() {
         use crate::arena::ExprArena;
         use crate::kind::OpKind;
 
@@ -476,7 +476,7 @@ mod tests {
     }
 
     #[test]
-    fn test_find_hoistable_arena_nodes() {
+    fn verify_find_hoistable_arena_nodes() {
         use crate::arena::ExprArena;
         use crate::kind::OpKind;
 
@@ -518,7 +518,7 @@ mod tests {
     /// (sin(Z*0.3) is used by the loop's multiply, and Z*0.3 is used by sin
     /// which is itself in setup, so only sin(Z*0.3) crosses).
     #[test]
-    fn test_hoisted_schedule_partitioning() {
+    fn hoisted_schedule_partitioning() {
         use crate::arena::ExprArena;
         use crate::backend::emit;
         use crate::kind::OpKind;
@@ -606,7 +606,7 @@ mod tests {
 
     /// Verify that a purely X-dependent expression produces an empty setup phase.
     #[test]
-    fn test_hoisted_schedule_no_setup_for_x_only() {
+    fn hoisted_schedule_no_setup_for_x_only() {
         use crate::arena::ExprArena;
         use crate::backend::emit;
         use crate::kind::OpKind;
@@ -636,7 +636,7 @@ mod tests {
 
     /// Verify that constants alone do not trigger hoisting (they are rematerialized).
     #[test]
-    fn test_hoisted_schedule_constants_not_hoisted() {
+    fn hoisted_schedule_constants_not_hoisted() {
         use crate::arena::ExprArena;
         use crate::backend::emit;
         use crate::kind::OpKind;

--- a/pixelflow-ml/src/graphics.rs
+++ b/pixelflow-ml/src/graphics.rs
@@ -297,32 +297,32 @@ mod tests {
     use pixelflow_core::Sh2;
 
     #[test]
-    fn test_elu_feature_positive() {
+    fn elu_feature_positive() {
         let f = EluFeature;
         let result = f.apply(Field::from(0.0));
         let _ = result;
     }
 
     #[test]
-    fn test_elu_feature_dimension() {
+    fn elu_feature_dimension() {
         let f = EluFeature;
         assert_eq!(f.dim(), 1);
     }
 
     #[test]
-    fn test_elu_feature_is_send_sync() {
+    fn elu_feature_is_send_sync() {
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<EluFeature>();
     }
 
     #[test]
-    fn test_random_fourier_feature_dimension_correct() {
+    fn random_fourier_feature_dimension_correct() {
         let rff = RandomFourierFeature::new(vec![1.0, 2.0, 3.0]);
         assert_eq!(rff.num_features, 6);
     }
 
     #[test]
-    fn test_harmonic_attention_accumulate() {
+    fn harmonic_attention_accumulate() {
         let mut attn: HarmonicAttention<9> = HarmonicAttention::new(3);
         let key_sh = Sh2 {
             coeffs: [0.282, 0.0, 0.489, 0.0, 0.0, 0.0, 0.315, 0.0, 0.0],
@@ -335,7 +335,7 @@ mod tests {
     }
 
     #[test]
-    fn test_harmonic_attention_reset() {
+    fn harmonic_attention_reset() {
         let mut attn: HarmonicAttention<9> = HarmonicAttention::new(3);
         let key_sh = Sh2 {
             coeffs: [1.0, 0.5, 0.3, 0.1, 0.0, 0.0, 0.0, 0.0, 0.0],
@@ -350,21 +350,21 @@ mod tests {
     }
 
     #[test]
-    fn test_sh_feature_map_projects_direction() {
+    fn sh_feature_map_projects_direction() {
         let result =
             ShFeatureMap::<9>::project(Field::from(0.0), Field::from(0.0), Field::from(1.0));
         assert_eq!(result.len(), 9);
     }
 
     #[test]
-    fn test_linear_attention_new() {
+    fn linear_attention_new() {
         let attn = LinearAttention::new(EluFeature, 4, 3);
         assert_eq!(attn.feature_dim, 4);
         assert_eq!(attn.value_dim, 3);
     }
 
     #[test]
-    fn test_correspondence_doc() {
+    fn correspondence_doc() {
         let correspondence = HarmonicAttentionIsGlobalIllumination::CORRESPONDENCE;
         assert!(correspondence.contains("Linear Attention"));
     }

--- a/pixelflow-pipeline/src/training/factored.rs
+++ b/pixelflow-pipeline/src/training/factored.rs
@@ -704,7 +704,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_kernel_code_arena_basic() {
+    fn parse_kernel_code_arena_basic() {
         // Simple expression: no structural sharing expected.
         let (arena, root) = parse_kernel_code_arena("(X + Y)").unwrap();
         assert!(
@@ -716,7 +716,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_kernel_code_arena_structural_sharing() {
+    fn parse_kernel_code_arena_structural_sharing() {
         // (X + X): the two X leaves are structurally identical and should share an id.
         let (arena, _root) = parse_kernel_code_arena("(X + X)").unwrap();
         // Without sharing: 3 nodes (X, X, Add). With sharing: 2 nodes (X, Add).
@@ -729,7 +729,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_kernel_code_arena_deeply_shared() {
+    fn parse_kernel_code_arena_deeply_shared() {
         // ((X + Y) * (X + Y)): the (X + Y) subtree appears twice — should be shared.
         // Without sharing: 7 nodes. With sharing: 4 nodes (X, Y, Add, Mul).
         let (arena, _root) = parse_kernel_code_arena("((X + Y) * (X + Y))").unwrap();
@@ -742,7 +742,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_kernel_code_arena_round_trip() {
+    fn parse_kernel_code_arena_round_trip() {
         // Arena parse + arena_to_kernel_code should re-parse cleanly.
         let src = "((X * Y) + (X * Y))";
         let (arena, root) = parse_kernel_code_arena(src).unwrap();
@@ -754,7 +754,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_kernel_code_arena_methods() {
+    fn parse_kernel_code_arena_methods() {
         let src = "(((X).abs()).min(Y)).mul_add(Z, W)";
         let (arena, root) = parse_kernel_code_arena(src).unwrap();
         let code = arena_to_kernel_code(&arena, root);
@@ -775,7 +775,7 @@ mod tests {
     // ================================================================
 
     #[test]
-    fn test_seed_42_t1_pair_is_close_under_scalar_semantics() {
+    fn seed_42_t1_pair_is_close_under_scalar_semantics() {
         let initial = "log2(add(abs(neg(atan2(pow(add(abs(neg(pow(add(abs(neg(neg(Const(-0.9631642)))), Const(0.001)), Const(-1)))), Const(0.001)), Const(-1)), mul(exp(add(pow(add(abs(neg(neg(atan2(Const(0.1167655), Var(1))))), Const(0.001)), Const(-1)), add(min(Var(3), Var(1)), log2(add(abs(neg(Var(3))), Const(0.001)))))), min(min(sub(cos(neg(Const(1.5691397))), add(Const(-1.1460416), Var(2))), abs(exp(Var(0)))), log10(add(abs(min(sub(Const(0.1855638), Var(1)), exp(Var(1)))), Const(0.001)))))))), Const(0.001)))";
         let final_ = "log2(add(Const(0.001), abs(atan2(pow(add(abs(neg(pow(add(abs(Const(-0.9631642)), Const(0.001)), Const(-1)))), Const(0.001)), Const(-1)), mul(mul(min(min(sub(cos(neg(Const(1.5691397))), add(Const(-1.1460416), Var(2))), abs(exp(Var(0)))), log10(add(abs(min(sub(Const(0.1855638), Var(1)), exp(Var(1)))), Const(0.001)))), exp(pow(add(abs(atan2(Const(0.1167655), Var(1))), Const(0.001)), Const(-1)))), exp(add(min(Var(3), Var(1)), log2(add(abs(neg(Var(3))), Const(0.001))))))))))";
         let initial = logged_expr_scalar_output(initial);
@@ -798,7 +798,7 @@ mod tests {
     }
 
     #[test]
-    fn test_seed_42_t1_initial_roundtrip_scalar_matches_tree_scalar() {
+    fn seed_42_t1_initial_roundtrip_scalar_matches_tree_scalar() {
         let initial = "log2(add(abs(neg(atan2(pow(add(abs(neg(pow(add(abs(neg(neg(Const(-0.9631642)))), Const(0.001)), Const(-1)))), Const(0.001)), Const(-1)), mul(exp(add(pow(add(abs(neg(neg(atan2(Const(0.1167655), Var(1))))), Const(0.001)), Const(-1)), add(min(Var(3), Var(1)), log2(add(abs(neg(Var(3))), Const(0.001)))))), min(min(sub(cos(neg(Const(1.5691397))), add(Const(-1.1460416), Var(2))), abs(exp(Var(0)))), log10(add(abs(min(sub(Const(0.1855638), Var(1)), exp(Var(1)))), Const(0.001)))))))), Const(0.001)))";
         let tree = logged_expr_scalar_output(initial);
         let roundtrip = logged_expr_roundtrip_scalar_output(initial);
@@ -819,7 +819,7 @@ mod tests {
     }
 
     #[test]
-    fn test_seed_24042_t52_pair_is_close_under_scalar_semantics() {
+    fn seed_24042_t52_pair_is_close_under_scalar_semantics() {
         let initial = "div(min(add(mul(min(pow(add(abs(neg(neg(abs(neg(neg(add(mul(cos(neg(neg(Var(1)))), Const(0.52093434)), Const(-1.414685)))))))), Const(0.001)), Const(-1)), Var(1)), log10(add(abs(neg(neg(add(add(max(add(mul(Var(2), Var(2)), Var(3)), Var(1)), atan2(atan2(Var(0), Var(3)), add(Var(1), neg(Var(3))))), mul(ln(add(abs(neg(neg(neg(Const(0.12621832))))), Const(0.001))), mul_add(Var(0), cos(neg(neg(Var(3)))), pow(add(abs(neg(neg(Const(-0.20414245)))), Const(0.001)), Const(-0.5)))))))), Const(0.001)))), pow(add(abs(neg(neg(atan2(Var(2), log10(add(abs(neg(neg(tan(Var(1))))), Const(0.001))))))), Const(0.001)), Const(-0.5))), log2(add(abs(neg(neg(Var(0)))), Const(0.001)))), add(abs(neg(pow(add(abs(neg(pow(add(abs(neg(log2(add(abs(neg(mul(min(add(mul(log10(add(abs(neg(neg(Const(1.2403846)))), Const(0.001))), Var(2)), mul(log10(add(abs(neg(neg(Const(1.2403846)))), Const(0.001))), Var(3))), max(ln(add(abs(neg(neg(Const(0.2514913)))), Const(0.001))), mul(Var(0), Const(0.5072496)))), mul(pow(abs(neg(neg(log10(add(abs(neg(neg(Var(3)))), Const(0.001)))))), Const(0.5)), ln(add(abs(neg(sin(Var(2)))), Const(0.001))))))), Const(0.001))))), Const(0.001)), mul(add(add(mul(div(add(Const(0.61049294), Const(1.354384)), add(abs(neg(mul(Var(0), Var(0)))), Const(0.001))), mul(tan(Const(-1.6860065)), recip(add(abs(neg(Const(-1.7208018))), Const(0.001))))), add(mul(max(Var(3), Var(0)), cos(neg(Var(0)))), mul_add(Var(3), Var(1), Var(0)))), log10(add(abs(neg(Const(-1.1988422))), Const(0.001)))), max(abs(neg(ln(add(abs(neg(pow(add(abs(Var(1)), Const(0.001)), Var(2)))), Const(0.001))))), ln(add(abs(mul(Const(-0.47071946), pow(add(abs(neg(Const(-1.670574))), Const(0.001)), Var(0)))), Const(0.001)))))))), Const(0.001)), Const(-1)))), Const(0.001)))";
         let final_ = "div(min(add(mul(min(pow(add(abs(neg(neg(abs(neg(neg(add(mul(cos(neg(neg(Var(1)))), Const(0.52093434)), Const(-1.414685)))))))), Const(0.001)), Const(-1)), Var(1)), log10(add(abs(neg(neg(add(add(max(add(mul(Var(2), Var(2)), Var(3)), Var(1)), atan2(atan2(Var(0), Var(3)), add(Var(1), neg(Var(3))))), mul(ln(add(Const(0.12621832), Const(0.001))), mul_add(Var(0), cos(neg(neg(Var(3)))), pow(add(Const(0.20414245), Const(0.001)), Const(-0.5)))))))), Const(0.001)))), pow(add(abs(neg(neg(atan2(Var(2), log10(add(abs(neg(neg(tan(Var(1))))), Const(0.001))))))), Const(0.001)), Const(-0.5))), log2(add(abs(neg(neg(Var(0)))), Const(0.001)))), add(abs(neg(pow(add(abs(neg(pow(add(abs(neg(log2(add(abs(neg(mul(min(add(mul(Const(0.093906365), Var(2)), mul(Const(0.093906365), Var(3))), max(Const(-1.3763785), mul(Var(0), Const(0.5072496)))), mul(pow(abs(neg(neg(log10(add(abs(neg(neg(Var(3)))), Const(0.001)))))), Const(0.5)), ln(add(abs(neg(sin(Var(2)))), Const(0.001))))))), Const(0.001))))), Const(0.001)), mul(add(add(mul(div(add(Const(0.61049294), Const(1.354384)), add(abs(neg(mul(Var(0), Var(0)))), Const(0.001))), mul(Const(8.641348), recip(add(Const(1.7208018), Const(0.001))))), add(mul(max(Var(3), Var(0)), cos(neg(Var(0)))), mul_add(Var(3), Var(1), Var(0)))), log10(add(Const(1.1988422), Const(0.001)))), max(abs(neg(ln(add(abs(neg(pow(add(abs(Var(1)), Const(0.001)), Var(2)))), Const(0.001))))), ln(add(abs(mul(Const(-0.47071946), pow(add(Const(1.670574), Const(0.001)), Var(0)))), Const(0.001)))))))), Const(0.001)), Const(-1)))), Const(0.001)))";
         let initial = logged_expr_scalar_output(initial);
@@ -842,7 +842,7 @@ mod tests {
     }
 
     #[test]
-    fn test_seed_24042_t52_initial_roundtrip_scalar_matches_tree_scalar() {
+    fn seed_24042_t52_initial_roundtrip_scalar_matches_tree_scalar() {
         let initial = "div(min(add(mul(min(pow(add(abs(neg(neg(abs(neg(neg(add(mul(cos(neg(neg(Var(1)))), Const(0.52093434)), Const(-1.414685)))))))), Const(0.001)), Const(-1)), Var(1)), log10(add(abs(neg(neg(add(add(max(add(mul(Var(2), Var(2)), Var(3)), Var(1)), atan2(atan2(Var(0), Var(3)), add(Var(1), neg(Var(3))))), mul(ln(add(abs(neg(neg(neg(Const(0.12621832))))), Const(0.001))), mul_add(Var(0), cos(neg(neg(Var(3)))), pow(add(abs(neg(neg(Const(-0.20414245)))), Const(0.001)), Const(-0.5)))))))), Const(0.001)))), pow(add(abs(neg(neg(atan2(Var(2), log10(add(abs(neg(neg(tan(Var(1))))), Const(0.001))))))), Const(0.001)), Const(-0.5))), log2(add(abs(neg(neg(Var(0)))), Const(0.001)))), add(abs(neg(pow(add(abs(neg(pow(add(abs(neg(log2(add(abs(neg(mul(min(add(mul(log10(add(abs(neg(neg(Const(1.2403846)))), Const(0.001))), Var(2)), mul(log10(add(abs(neg(neg(Const(1.2403846)))), Const(0.001))), Var(3))), max(ln(add(abs(neg(neg(Const(0.2514913)))), Const(0.001))), mul(Var(0), Const(0.5072496)))), mul(pow(abs(neg(neg(log10(add(abs(neg(neg(Var(3)))), Const(0.001)))))), Const(0.5)), ln(add(abs(neg(sin(Var(2)))), Const(0.001))))))), Const(0.001))))), Const(0.001)), mul(add(add(mul(div(add(Const(0.61049294), Const(1.354384)), add(abs(neg(mul(Var(0), Var(0)))), Const(0.001))), mul(tan(Const(-1.6860065)), recip(add(abs(neg(Const(-1.7208018))), Const(0.001))))), add(mul(max(Var(3), Var(0)), cos(neg(Var(0)))), mul_add(Var(3), Var(1), Var(0)))), log10(add(abs(neg(Const(-1.1988422))), Const(0.001)))), max(abs(neg(ln(add(abs(neg(pow(add(abs(Var(1)), Const(0.001)), Var(2)))), Const(0.001))))), ln(add(abs(mul(Const(-0.47071946), pow(add(abs(neg(Const(-1.670574))), Const(0.001)), Var(0)))), Const(0.001)))))))), Const(0.001)), Const(-1)))), Const(0.001)))";
         let tree = logged_expr_scalar_output(initial);
         let roundtrip = logged_expr_roundtrip_scalar_output(initial);

--- a/pixelflow-pipeline/src/training/gen_es.rs
+++ b/pixelflow-pipeline/src/training/gen_es.rs
@@ -427,7 +427,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_normalize_denormalize_roundtrip() {
+    fn normalize_denormalize_roundtrip() {
         let original = BwdGenConfig {
             max_depth: 10, // Within ES range [5, 20]
             ..BwdGenConfig::default()
@@ -481,7 +481,7 @@ mod tests {
     }
 
     #[test]
-    fn test_denormalize_clamps() {
+    fn denormalize_clamps() {
         // All below minimum → should clamp to range minimums.
         let below = [-1.0, -1.0, -1.0, -1.0, -1.0, -1.0];
         let config = denormalize(&below);
@@ -554,7 +554,7 @@ mod tests {
     }
 
     #[test]
-    fn test_box_muller_distribution() {
+    fn box_muller_distribution() {
         let mut es = GenEs {
             mu: [0.5; ES_DIM],
             sigma: 0.1,
@@ -593,7 +593,7 @@ mod tests {
     }
 
     #[test]
-    fn test_log_ns() {
+    fn verify_log_ns() {
         // log(1.0) = 0.0
         let v = log_ns(1.0);
         assert!(
@@ -622,7 +622,7 @@ mod tests {
     }
 
     #[test]
-    fn test_clamp01() {
+    fn verify_clamp01() {
         assert_eq!(clamp01(-0.5), 0.0);
         assert_eq!(clamp01(0.0), 0.0);
         assert_eq!(clamp01(0.5), 0.5);
@@ -631,7 +631,7 @@ mod tests {
     }
 
     #[test]
-    fn test_gen_es_new_initializes_from_defaults() {
+    fn gen_es_new_initializes_from_defaults() {
         let es = GenEs::new(GenEsConfig::default(), RuleTemplates::new());
 
         // mu should be the normalized defaults.
@@ -650,7 +650,7 @@ mod tests {
     }
 
     #[test]
-    fn test_rand_normal_no_nan_with_interleaved_rng() {
+    fn rand_normal_no_nan_with_interleaved_rng() {
         // Reproduce the actual training seed and interleave rand_u64 calls
         // between rand_normal batches (simulating evaluate_candidate flow).
         let mut es = GenEs {

--- a/pixelflow-runtime/src/frame.rs
+++ b/pixelflow-runtime/src/frame.rs
@@ -147,13 +147,13 @@ mod tests {
     }
 
     #[test]
-    fn test_create_channels() {
+    fn create_channels() {
         let (_handle, _rx) = create_frame_channel::<TestSurface>();
         let (_recycle_tx, _recycle_rx) = create_recycle_channel::<TestSurface>();
     }
 
     #[test]
-    fn test_submit_and_receive() {
+    fn submit_and_receive() {
         let (handle, rx) = create_frame_channel::<TestSurface>();
         let (recycle_tx, _recycle_rx) = create_recycle_channel::<TestSurface>();
 
@@ -167,7 +167,7 @@ mod tests {
     }
 
     #[test]
-    fn test_recycle_loop() {
+    fn recycle_loop() {
         let (handle, rx) = create_frame_channel::<TestSurface>();
         let (recycle_tx, recycle_rx) = create_recycle_channel::<TestSurface>();
 

--- a/pixelflow-runtime/src/platform/macos/window.rs
+++ b/pixelflow-runtime/src/platform/macos/window.rs
@@ -303,7 +303,7 @@ mod tests {
     }
 
     #[test]
-    fn test_abi_alignment() {
+    fn abi_alignment() {
         // Verify our assumption about ABI alignment for MTLSize vs CGSize
         // This is a static check of our struct definitions vs likely platform values
         use std::mem;

--- a/pixelflow-runtime/src/vsync_actor_test.rs
+++ b/pixelflow-runtime/src/vsync_actor_test.rs
@@ -31,7 +31,7 @@ mod tests {
     // we will rely on 'cargo check' which we already ran.
 
     #[test]
-    fn test_vsync_command_debug() {
+    fn vsync_command_debug() {
         let (tx, _rx) = mpsc::channel();
         let cmd = VsyncCommand::RequestCurrentFPS(tx);
         let debug_str = format!("{:?}", cmd);

--- a/pixelflow-runtime/tests/platform_actor_tests.rs
+++ b/pixelflow-runtime/tests/platform_actor_tests.rs
@@ -63,7 +63,7 @@ impl PlatformOps for MockOps {
 }
 
 #[test]
-fn test_platform_actor_delegation() {
+fn platform_actor_delegation() {
     // 1. Create MockOps
     let ops = MockOps::new();
     let log_ref = ops.log.clone();

--- a/pixelflow-search/src/egraph/codegen.rs
+++ b/pixelflow-search/src/egraph/codegen.rs
@@ -303,7 +303,7 @@ mod tests {
     use super::super::ops;
 
     #[test]
-    fn test_dag_simple_no_sharing() {
+    fn dag_simple_no_sharing() {
         // X + Y: no sharing, should produce simple expression
         let mut egraph = EGraph::new();
         let x = egraph.add(ENode::Var(0));
@@ -322,7 +322,7 @@ mod tests {
     }
 
     #[test]
-    fn test_dag_shared_var() {
+    fn dag_shared_var() {
         // X * X: X is shared, but variables don't need let-bindings
         // (they're already O(1) to access)
         let mut egraph = EGraph::new();
@@ -342,7 +342,7 @@ mod tests {
     }
 
     #[test]
-    fn test_dag_shared_subexpr() {
+    fn dag_shared_subexpr() {
         // sqrt(X) * sqrt(X): sqrt(X) is an expensive shared subexpr
         let mut egraph = EGraph::new();
         let x = egraph.add(ENode::Var(0));
@@ -374,7 +374,7 @@ mod tests {
     }
 
     #[test]
-    fn test_dag_triple_shared() {
+    fn dag_triple_shared() {
         // sqrt(X) * sqrt(X) + sqrt(X): sqrt(X) used 3 times
         let mut egraph = EGraph::new();
         let x = egraph.add(ENode::Var(0));
@@ -407,7 +407,7 @@ mod tests {
     }
 
     #[test]
-    fn test_dag_nested_sharing() {
+    fn dag_nested_sharing() {
         // (X + Y) * (X + Y) + (X + Y): (X + Y) used 3 times
         let mut egraph = EGraph::new();
         let x = egraph.add(ENode::Var(0));
@@ -440,7 +440,7 @@ mod tests {
     }
 
     #[test]
-    fn test_dag_to_kernel_code() {
+    fn verify_dag_to_kernel_code() {
         // Test the full kernel code generation
         let mut egraph = EGraph::new();
         let x = egraph.add(ENode::Var(0));
@@ -461,7 +461,7 @@ mod tests {
     }
 
     #[test]
-    fn test_dag_complex_expression() {
+    fn dag_complex_expression() {
         // Build: (X * Y) + (X * Y) * (Z + W)
         // (X * Y) is shared between two uses
         let mut egraph = EGraph::new();

--- a/pixelflow-search/src/egraph/deps.rs
+++ b/pixelflow-search/src/egraph/deps.rs
@@ -271,7 +271,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_variance_union() {
+    fn variance_union() {
         assert_eq!(Variance::CONST.union(Variance::CONST), Variance::CONST);
         assert_eq!(Variance::CONST.union(Variance::W), Variance::W);
         assert_eq!(Variance::CONST.union(Variance::X), Variance::X);
@@ -284,7 +284,7 @@ mod tests {
     }
 
     #[test]
-    fn test_var_variance() {
+    fn verify_var_variance() {
         assert_eq!(var_variance(0), Variance::X);
         assert_eq!(var_variance(1), Variance::Y);
         assert_eq!(var_variance(2), Variance::Z);
@@ -292,7 +292,7 @@ mod tests {
     }
 
     #[test]
-    fn test_const_analysis() {
+    fn const_analysis() {
         let mut eg = EGraph::new();
         let c = eg.add(ENode::constant(42.0));
 
@@ -301,7 +301,7 @@ mod tests {
     }
 
     #[test]
-    fn test_w_only_analysis() {
+    fn w_only_analysis() {
         let mut eg = EGraph::new();
         let w = eg.add(ENode::Var(3)); // W
         let two = eg.add(ENode::constant(2.0));
@@ -323,7 +323,7 @@ mod tests {
     }
 
     #[test]
-    fn test_xy_analysis() {
+    fn xy_analysis() {
         let mut eg = EGraph::new();
         let x = eg.add(ENode::Var(0)); // X
         let y = eg.add(ENode::Var(1)); // Y
@@ -342,7 +342,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mixed_deps_hoistable() {
+    fn mixed_deps_hoistable() {
         // sin(W * 2.0) + X:
         //   sin(W * 2.0) has variance {W} (X-invariant, hoistable)
         //   X has variance {X}
@@ -376,7 +376,7 @@ mod tests {
     }
 
     #[test]
-    fn test_y_only_is_hoistable() {
+    fn y_only_is_hoistable() {
         // sin(Y) + X: sin(Y) has variance {Y}, is X-invariant, should be hoistable
         let mut eg = EGraph::new();
         let y = eg.add(ENode::Var(1));
@@ -409,7 +409,7 @@ mod tests {
     /// - Const(0)  has variance = {}
     /// - class variance = meet({X}, {}) = {} (CONST)
     #[test]
-    fn test_meet_across_enodes_x_minus_x_is_const() {
+    fn meet_across_enodes_x_minus_x_is_const() {
         let mut eg = EGraph::new();
 
         let x = eg.add(ENode::Var(0));
@@ -438,7 +438,7 @@ mod tests {
 
     /// Meet of {X,Y} and {W} should give {W} (fewer deps).
     #[test]
-    fn test_meet_xy_and_w_gives_w() {
+    fn meet_xy_and_w_gives_w() {
         let mut eg = EGraph::new();
 
         let x = eg.add(ENode::Var(0));
@@ -464,7 +464,7 @@ mod tests {
 
     /// Parent benefits from meet-reduced child.
     #[test]
-    fn test_meet_propagates_to_parents() {
+    fn meet_propagates_to_parents() {
         let mut eg = EGraph::new();
 
         let x = eg.add(ENode::Var(0));

--- a/pixelflow-search/src/egraph/extract.rs
+++ b/pixelflow-search/src/egraph/extract.rs
@@ -1187,7 +1187,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_extract_simple() {
+    fn extract_simple() {
         let mut egraph = EGraph::new();
         let x = egraph.add(ENode::Var(0));
 
@@ -1200,7 +1200,7 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_with_ops() {
+    fn extract_with_ops() {
         let mut egraph = EGraph::new();
         let x = egraph.add(ENode::Var(0));
         let y = egraph.add(ENode::Var(1));
@@ -1221,7 +1221,7 @@ mod tests {
     // ========================================================================
 
     #[test]
-    fn test_extract_dag_simple() {
+    fn extract_dag_simple() {
         // X + Y: no sharing
         let mut egraph = EGraph::new();
         let x = egraph.add(ENode::Var(0));
@@ -1242,7 +1242,7 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_dag_shared_subexpr() {
+    fn extract_dag_shared_subexpr() {
         // X * X: X is used twice
         let mut egraph = EGraph::new();
         let x = egraph.add(ENode::Var(0));
@@ -1261,7 +1261,7 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_dag_triple_use() {
+    fn extract_dag_triple_use() {
         // sin(X) * sin(X) + sin(X): sin(X) used 3 times
         // We simulate this structure without actual sin
         let mut egraph = EGraph::new();
@@ -1296,7 +1296,7 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_dag_nested_sharing() {
+    fn extract_dag_nested_sharing() {
         // (X + Y) * (X + Y): (X + Y) is shared
         let mut egraph = EGraph::new();
         let x = egraph.add(ENode::Var(0));
@@ -1323,7 +1323,7 @@ mod tests {
     // ========================================================================
 
     #[test]
-    fn test_compute_ref_counts_no_sharing() {
+    fn compute_ref_counts_no_sharing() {
         // X + Y: no sharing
         let mut egraph = EGraph::new();
         let x = egraph.add(ENode::Var(0));
@@ -1358,7 +1358,7 @@ mod tests {
     }
 
     #[test]
-    fn test_compute_ref_counts_shared() {
+    fn compute_ref_counts_shared() {
         // X * X: X is used twice
         let mut egraph = EGraph::new();
         let x = egraph.add(ENode::Var(0));
@@ -1382,7 +1382,7 @@ mod tests {
     }
 
     #[test]
-    fn test_compute_ref_counts_triple_use() {
+    fn compute_ref_counts_triple_use() {
         // sqrt(X) * sqrt(X) + sqrt(X): sqrt(X) referenced 3 times
         let mut egraph = EGraph::new();
         let x = egraph.add(ENode::Var(0));
@@ -1420,7 +1420,7 @@ mod tests {
     }
 
     #[test]
-    fn test_dag_accumulator_handles_shared_subexpressions() {
+    fn dag_accumulator_handles_shared_subexpressions() {
         use crate::nnue::{EdgeAccumulator, ExprNnue};
 
         // sin(X) * sin(X): tree has 2x sin edges, DAG has 1x sin + 1x var_ref
@@ -1466,7 +1466,7 @@ mod tests {
 
     /// X + Y should produce an arena with exactly 3 nodes: Var(0), Var(1), Add.
     #[test]
-    fn test_choices_to_arena_simple() {
+    fn choices_to_arena_simple() {
         let mut egraph = EGraph::new();
         let x = egraph.add(ENode::Var(0));
         let y = egraph.add(ENode::Var(1));
@@ -1491,7 +1491,7 @@ mod tests {
     /// X * X should produce an arena with exactly 2 nodes: Var(0) and Mul.
     /// The shared Var(0) e-class must reuse one ExprId rather than being duplicated.
     #[test]
-    fn test_choices_to_arena_shared() {
+    fn choices_to_arena_shared() {
         let mut egraph = EGraph::new();
         let x = egraph.add(ENode::Var(0));
         let mul = egraph.add(ENode::Op {
@@ -1516,7 +1516,7 @@ mod tests {
 
     /// Direct extraction and explicit `choices_to_arena` should agree for tree-shaped inputs.
     #[test]
-    fn test_extract_matches_choices_to_arena() {
+    fn extract_matches_choices_to_arena() {
         let mut egraph = EGraph::new();
         let x = egraph.add(ENode::Var(0));
         let y = egraph.add(ENode::Var(1));

--- a/pixelflow-search/src/egraph/graph.rs
+++ b/pixelflow-search/src/egraph/graph.rs
@@ -1542,7 +1542,7 @@ mod tests {
     }
 
     #[test]
-    fn test_inverse_add() {
+    fn inverse_add() {
         let mut eg = egraph_with_rules();
         let x = eg.add(ENode::Var(0));
         let neg_x = eg.add(ENode::Op {
@@ -1559,7 +1559,7 @@ mod tests {
     }
 
     #[test]
-    fn test_inverse_mul() {
+    fn inverse_mul() {
         let mut eg = egraph_with_rules();
         let x = eg.add(ENode::Var(0));
         let recip_x = eg.add(ENode::Op {
@@ -1576,7 +1576,7 @@ mod tests {
     }
 
     #[test]
-    fn test_complex_inverse() {
+    fn complex_inverse() {
         let mut eg = egraph_with_rules();
         let x = eg.add(ENode::Var(0));
         let five = eg.add(ENode::constant(5.0));
@@ -1593,7 +1593,7 @@ mod tests {
     }
 
     #[test]
-    fn test_nested_subtraction() {
+    fn nested_subtraction() {
         // a - (b - c) should equal a - b + c
         // Test: 10 - (6 - 2) = 10 - 4 = 6
         let mut eg = egraph_with_rules();
@@ -1621,7 +1621,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mul_sub_pattern() {
+    fn mul_sub_pattern() {
         // This is the problematic pattern from discriminant:
         // d*d - (c - r) where d=4, c=16, r=1
         let mut eg = egraph_with_rules();
@@ -1651,7 +1651,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mul_sub_pattern_with_vars() {
+    fn mul_sub_pattern_with_vars() {
         // x*x - (y - z)
         let mut eg = egraph_with_rules();
         let x = eg.add(ENode::Var(0));
@@ -1684,7 +1684,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mul_sub_pattern_with_fma() {
+    fn mul_sub_pattern_with_fma() {
         // Same pattern but with FMA costs (what the kernel! macro uses)
         let mut eg = egraph_with_rules();
         let x = eg.add(ENode::Var(0));
@@ -1718,7 +1718,7 @@ mod tests {
     }
 
     #[test]
-    fn test_discriminant_structure() {
+    fn discriminant_structure() {
         // Match the actual discriminant structure:
         // d_dot_c² - (c_sq - r_sq) where c_sq = a² + b² and r_sq = r²
         let mut eg = egraph_with_rules();
@@ -1765,7 +1765,7 @@ mod tests {
     }
 
     #[test]
-    fn test_depth_penalty_calculation() {
+    fn depth_penalty_calculation() {
         // Test the hinge penalty function
         let mut costs = CostModel::new();
         costs.depth_threshold = 5;
@@ -1782,7 +1782,7 @@ mod tests {
     }
 
     #[test]
-    fn test_shallow_cost_model() {
+    fn shallow_cost_model() {
         // Shallow model should have aggressive depth penalty
         let costs = CostModel::shallow();
         assert_eq!(costs.depth_threshold, 16);
@@ -1795,7 +1795,7 @@ mod tests {
     }
 
     #[test]
-    fn test_depth_aware_extraction() {
+    fn depth_aware_extraction() {
         // Build a deep expression: ((((x + 1) + 1) + 1) + 1)
         let mut eg = egraph_with_rules();
         let x = eg.add(ENode::Var(0));

--- a/pixelflow-search/src/egraph/saturate.rs
+++ b/pixelflow-search/src/egraph/saturate.rs
@@ -231,7 +231,7 @@ mod tests {
     }
 
     #[test]
-    fn test_saturate_with_budget_simple() {
+    fn saturate_with_budget_simple() {
         let mut eg = egraph_with_rules();
         let x = eg.add(ENode::Var(0));
         let zero = eg.add(ENode::constant(0.0));
@@ -248,7 +248,7 @@ mod tests {
     }
 
     #[test]
-    fn test_saturate_with_budget_exhausted() {
+    fn saturate_with_budget_exhausted() {
         let mut eg = egraph_with_rules();
         // Create a moderately complex expression
         let x = eg.add(ENode::Var(0));
@@ -274,7 +274,7 @@ mod tests {
     }
 
     #[test]
-    fn test_achievable_cost() {
+    fn achievable_cost() {
         let mut eg = egraph_with_rules();
         let x = eg.add(ENode::Var(0));
         let zero = eg.add(ENode::constant(0.0));
@@ -292,7 +292,7 @@ mod tests {
     }
 
     #[test]
-    fn test_saturation_result_growth_ratio() {
+    fn saturation_result_growth_ratio() {
         let result = SaturationResult {
             iterations: 5,
             total_unions: 10,

--- a/pixelflow-search/src/math/mod.rs
+++ b/pixelflow-search/src/math/mod.rs
@@ -337,7 +337,7 @@ mod tests {
     }
 
     #[test]
-    fn test_algebraic_rules_preserve_semantics() {
+    fn algebraic_rules_preserve_semantics() {
         let pts = standard_test_points();
         let mut a = ExprArena::new();
 
@@ -371,7 +371,7 @@ mod tests {
     }
 
     #[test]
-    fn test_trig_rules_preserve_semantics() {
+    fn trig_rules_preserve_semantics() {
         let pts = standard_test_points();
         let mut a = ExprArena::new();
 
@@ -393,7 +393,7 @@ mod tests {
     }
 
     #[test]
-    fn test_associativity_left_to_right() {
+    fn associativity_left_to_right() {
         // (v0 + v1) + v2 should produce v0 + (v1 + v2) in the e-graph
         let mut a = ExprArena::new();
         let e = arena_pat!(&mut a, bin OpKind::Add, (bin OpKind::Add, (var 0), (var 1)), (var 2));
@@ -401,7 +401,7 @@ mod tests {
     }
 
     #[test]
-    fn test_associativity_right_to_left() {
+    fn associativity_right_to_left() {
         // v0 + (v1 + v2) should produce (v0 + v1) + v2 in the e-graph
         let mut a = ExprArena::new();
         let e = arena_pat!(&mut a, bin OpKind::Add, (var 0), (bin OpKind::Add, (var 1), (var 2)));
@@ -409,7 +409,7 @@ mod tests {
     }
 
     #[test]
-    fn test_associativity_mul() {
+    fn associativity_mul() {
         // (v0 * v1) * v2 should produce v0 * (v1 * v2) and vice versa
         let mut a = ExprArena::new();
         let e = arena_pat!(&mut a, bin OpKind::Mul, (bin OpKind::Mul, (var 0), (var 1)), (var 2));
@@ -417,7 +417,7 @@ mod tests {
     }
 
     #[test]
-    fn test_associativity_min_max() {
+    fn associativity_min_max() {
         let pts = standard_test_points();
         let mut a = ExprArena::new();
 
@@ -431,7 +431,7 @@ mod tests {
     }
 
     #[test]
-    fn test_associativity_templates() {
+    fn associativity_templates() {
         // Verify all associativity rules have valid lhs/rhs templates and that
         // Associative LHS == ReverseAssociative RHS (and vice versa) structurally.
         let assoc = Associative::new(&crate::egraph::ops::Add);
@@ -462,7 +462,7 @@ mod tests {
     }
 
     #[test]
-    fn test_all_rules_count() {
+    fn all_rules_count() {
         // Verify we have the expected number of rules after removal.
         let rules = all_rules();
         assert_eq!(

--- a/pixelflow-search/src/nnue/factored.rs
+++ b/pixelflow-search/src/nnue/factored.rs
@@ -3472,7 +3472,7 @@ mod tests {
     use alloc::sync::Arc;
 
     #[test]
-    fn test_param_count() {
+    fn verify_param_count() {
         // Verify parameter count is reasonable and finite
         let count = ExprNnue::param_count();
         assert!(count > 0, "Should have parameters");
@@ -3488,7 +3488,7 @@ mod tests {
     // ========================================================================
 
     #[test]
-    fn test_consolidated_param_count() {
+    fn consolidated_param_count() {
         // Param count should include backbone + all unified heads
         let count = ExprNnue::param_count();
         // Backbone: embeddings + w1 + b1 = ~9,728
@@ -3506,7 +3506,7 @@ mod tests {
     // ========================================================================
 
     #[test]
-    fn test_rule_features_initialization() {
+    fn rule_features_initialization() {
         let mut rule_features = RuleFeatures::new();
 
         // All features should be zero initially
@@ -3527,7 +3527,7 @@ mod tests {
     }
 
     #[test]
-    fn test_encode_rule_deterministic() {
+    fn encode_rule_deterministic() {
         let net = ExprNnue::new_random(42);
         let features = [0.25, 0.3, 1.0, 1.0, 0.0, 1.0, 0.5, 1.0];
 
@@ -3554,7 +3554,7 @@ mod tests {
     }
 
     #[test]
-    fn test_encode_all_rules() {
+    fn verify_encode_all_rules() {
         let net = ExprNnue::new_random(42);
         let mut rule_features = RuleFeatures::new();
 
@@ -3597,7 +3597,7 @@ mod tests {
     }
 
     #[test]
-    fn test_bilinear_score_computation() {
+    fn bilinear_score_computation() {
         let net = ExprNnue::new_random(42);
 
         // Create test vectors
@@ -3628,7 +3628,7 @@ mod tests {
     }
 
     #[test]
-    fn test_randomize_mask_only() {
+    fn verify_randomize_mask_only() {
         let mut net = ExprNnue::new();
 
         // Set some backbone values that should be preserved
@@ -3683,7 +3683,7 @@ mod tests {
     // ========================================================================
 
     #[test]
-    fn test_complex_pe_roundtrip() {
+    fn complex_pe_roundtrip() {
         // add_edge + remove_edge should return the accumulator to zero.
         let emb = OpEmbeddings::new_random(42);
         let mut acc = EdgeAccumulator::new();
@@ -3718,7 +3718,7 @@ mod tests {
     // ========================================================================
 
     #[test]
-    fn test_graph_acc_normalize_unit_norm_per_section() {
+    fn graph_acc_normalize_unit_norm_per_section() {
         let emb = OpEmbeddings::new_random(42);
         let mut gacc = GraphAccumulator::new();
         // Build a non-trivial accumulator: several edges
@@ -3756,7 +3756,7 @@ mod tests {
     }
 
     #[test]
-    fn test_graph_acc_normalize_scalars_preserved() {
+    fn graph_acc_normalize_scalars_preserved() {
         let emb = OpEmbeddings::new_random(42);
         let mut gacc = GraphAccumulator::new();
         gacc.add_edge(&emb, OpKind::Add, OpKind::Mul);
@@ -3785,7 +3785,7 @@ mod tests {
     }
 
     #[test]
-    fn test_graph_acc_normalize_zero_is_safe() {
+    fn graph_acc_normalize_zero_is_safe() {
         // A fresh (zero) accumulator should normalize without NaN/Inf.
         let gacc = GraphAccumulator::new();
         let normed = gacc.normalized();
@@ -3799,7 +3799,7 @@ mod tests {
     }
 
     #[test]
-    fn test_graph_acc_normalize_in_place_matches_normalized() {
+    fn graph_acc_normalize_in_place_matches_normalized() {
         let emb = OpEmbeddings::new_random(42);
         let mut gacc = GraphAccumulator::new();
         gacc.add_edge(&emb, OpKind::Add, OpKind::Mul);
@@ -3821,7 +3821,7 @@ mod tests {
     }
 
     #[test]
-    fn test_graph_acc_normalize_scale_invariance() {
+    fn graph_acc_normalize_scale_invariance() {
         // Doubling all edges (adding each edge twice) should yield the same
         // normalized vector, proving scale invariance.
         let emb = OpEmbeddings::new_random(42);
@@ -3850,7 +3850,7 @@ mod tests {
     }
 
     #[test]
-    fn test_graph_acc_normalize_idempotent() {
+    fn graph_acc_normalize_idempotent() {
         // Normalizing twice should produce the same result.
         let emb = OpEmbeddings::new_random(42);
         let mut gacc = GraphAccumulator::new();
@@ -3875,7 +3875,7 @@ mod tests {
     // ========================================================================
 
     #[test]
-    fn test_graph_acc_remove_leaf_saturates_at_zero() {
+    fn graph_acc_remove_leaf_saturates_at_zero() {
         let mut acc = GraphAccumulator::new();
         acc.remove_leaf();
         assert_eq!(acc.node_count, 0, "node_count must not underflow");

--- a/pixelflow-search/src/nnue/mod.rs
+++ b/pixelflow-search/src/nnue/mod.rs
@@ -1151,7 +1151,7 @@ mod tests {
     use libm::fabsf;
 
     #[test]
-    fn test_op_type_roundtrip() {
+    fn op_type_roundtrip() {
         for i in 0..OpKind::COUNT {
             let op = OpKind::from_index(i).unwrap();
             assert_eq!(op.index(), i);
@@ -1167,7 +1167,7 @@ mod tests {
     // ========================================================================
 
     #[test]
-    fn test_bwd_generator_produces_valid_pairs() {
+    fn bwd_generator_produces_valid_pairs() {
         use crate::egraph::collect_rule_templates;
         let templates = collect_rule_templates();
         let config = BwdGenConfig::default();
@@ -1189,7 +1189,7 @@ mod tests {
     }
 
     #[test]
-    fn test_bwd_generator_has_fused_ops() {
+    fn bwd_generator_has_fused_ops() {
         use crate::egraph::collect_rule_templates;
         let templates = collect_rule_templates();
         let config = BwdGenConfig {
@@ -1219,7 +1219,7 @@ mod tests {
     }
 
     #[test]
-    fn test_bwd_generator_with_templates() {
+    fn bwd_generator_with_templates() {
         use crate::egraph::collect_rule_templates;
         let templates = collect_rule_templates();
         let config = BwdGenConfig::default();

--- a/pixelflow-search/src/nnue/training.rs
+++ b/pixelflow-search/src/nnue/training.rs
@@ -233,7 +233,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_metrics() {
+    fn metrics() {
         let mut metrics = Metrics::new();
 
         // Record some results
@@ -251,7 +251,7 @@ mod tests {
     }
 
     #[test]
-    fn test_resource_configs() {
+    fn resource_configs() {
         let oracle = ResourceConfig::oracle();
         let constrained = ResourceConfig::constrained();
         let eval = ResourceConfig::evaluation();
@@ -266,7 +266,7 @@ mod tests {
     }
 
     #[test]
-    fn test_training_result() {
+    fn training_result() {
         let result = TrainingResult {
             oracle_cost: 100,
             initial_guided_cost: 150,

--- a/pixelflow-search/src/nnue/window.rs
+++ b/pixelflow-search/src/nnue/window.rs
@@ -271,7 +271,7 @@ mod tests {
     }
 
     #[test]
-    fn test_empty_window() {
+    fn empty_window() {
         let w = InstructionWindow::new(8);
         assert_eq!(w.len(), 0);
         assert!(w.is_empty());
@@ -290,7 +290,7 @@ mod tests {
     }
 
     #[test]
-    fn test_push_and_capacity() {
+    fn push_and_capacity() {
         let emb = make_emb();
         let mut w = InstructionWindow::new(4);
 
@@ -303,7 +303,7 @@ mod tests {
     }
 
     #[test]
-    fn test_eviction() {
+    fn eviction() {
         let emb = make_emb();
         let mut w = InstructionWindow::new(4);
 
@@ -318,7 +318,7 @@ mod tests {
     }
 
     #[test]
-    fn test_eviction_undoes_contribution() {
+    fn eviction_undoes_contribution() {
         let emb = make_emb();
 
         // Strategy: push A, B, C, D into a cap-4 window.
@@ -357,7 +357,7 @@ mod tests {
     }
 
     #[test]
-    fn test_phase_invariance() {
+    fn phase_invariance() {
         // Push the same 4-instruction sequence at two different starting offsets.
         // The canonicalized accumulators should be equal.
         let emb = make_emb();
@@ -420,7 +420,7 @@ mod tests {
     }
 
     #[test]
-    fn test_evaluate_schedule() {
+    fn verify_evaluate_schedule() {
         let nnue = ExprNnue::new_random(42);
         let emb = OpEmbeddings::new_random(42);
 


### PR DESCRIPTION
Scope (crates/modules modified):
- `pixelflow-runtime`
- `pixelflow-compiler`
- `pixelflow-graphics`
- `pixelflow-core`
- `pixelflow-ir`
- `pixelflow-search`
- `pixelflow-pipeline`
- `core-term`
- `actor-scheduler`
- `pixelflow-ml`

Fixes (specific lints/tests resolved):
- Removed unidiomatic `test_` prefixes from test function names throughout the entire codebase, effectively complying with `STYLE.md` requirements for Rust tests.
- Replaced cases where removing `test_` would cause naming collisions (such as `test_manifold` -> `manifold()` which shadows an existing function in the same module) with `verify_manifold()`.
- Removed entirely empty test bodies.

Unresolved Issues:
- None

Verification:
- Checked with `cargo check --all-targets` and `cargo test --all-targets` to confirm no logic regressions or test discovery issues.

---
*PR created automatically by Jules for task [5981768710289180340](https://jules.google.com/task/5981768710289180340) started by @jppittman*