### PR TITLE
⚡ Bolt: Remove unnecessary HashSet allocation in kqueue event loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2025-12-28 - Rasterizer Inner Loop Hoisting
 **Learning:** The inner loop of `execute_stripe` was re-evaluating `Field::sequential(start)` on every iteration, which involves multiple SIMD instructions (broadcast/load + add).
 **Action:** Hoisted the initialization of `xs` out of the loop and updated it incrementally using a pre-computed `step` vector. This reduced the inner loop overhead significantly, yielding a ~34% improvement in rasterization throughput.
+
+## 2025-12-28 - Kqueue Event Loop HashSet Allocation Overhead
+**Learning:** The macOS kqueue event loop in `core-term` was allocating a `HashSet` (`std::collections::HashSet::new()`) on every polling iteration to track seen event tokens. This caused unnecessary heap allocations in a hot path, impacting performance.
+**Action:** For small collections like returned event tokens, use a simple vector search (`.iter_mut().find()`) to check for existence instead of instantiating a `HashSet`. This eliminates the allocation overhead while maintaining correctness.

--- a/core-term/src/io/kqueue.rs
+++ b/core-term/src/io/kqueue.rs
@@ -201,14 +201,20 @@ impl EventMonitor {
 
         // Convert kernel events to our events
         events_out.clear();
-        let mut seen_tokens = std::collections::HashSet::new();
 
         for i in 0..nev as usize {
             let kev = &kevents[i];
             let token = kev.udata as u64;
 
-            // Only add each token once (might have both read and write events)
-            if seen_tokens.insert(token) {
+            if let Some(event) = events_out.iter_mut().find(|e| e.token == token) {
+                // Update flags for existing token
+                if kev.filter == libc::EVFILT_READ {
+                    event.flags |= KqueueFlags::EPOLLIN;
+                }
+                if kev.filter == libc::EVFILT_WRITE {
+                    event.flags |= KqueueFlags::EPOLLOUT;
+                }
+            } else {
                 let mut flags = KqueueFlags::empty();
                 if kev.filter == libc::EVFILT_READ {
                     flags |= KqueueFlags::EPOLLIN;
@@ -218,16 +224,6 @@ impl EventMonitor {
                 }
 
                 events_out.push(KqueueEvent { token, flags });
-            } else {
-                // Update flags for existing token
-                if let Some(event) = events_out.iter_mut().find(|e| e.token == token) {
-                    if kev.filter == libc::EVFILT_READ {
-                        event.flags |= KqueueFlags::EPOLLIN;
-                    }
-                    if kev.filter == libc::EVFILT_WRITE {
-                        event.flags |= KqueueFlags::EPOLLOUT;
-                    }
-                }
             }
         }
 


### PR DESCRIPTION
### Scope
- Modified `core-term/src/io/kqueue.rs`.

### Fixes
- Removed a `HashSet` allocation occurring on every tick of the macOS `kqueue` event polling loop.

### Impact
- Eliminates a heap allocation from a critical hot path (PTY read thread).
- Expected measurable reduction in memory overhead and CPU cycles spent during terminal I/O processing on macOS.

### Verification
- `cargo check -p core-term` completes without errors.
- `cargo test -p core-term` passes successfully.

---
*PR created automatically by Jules for task [9819695477684174377](https://jules.google.com/task/9819695477684174377) started by @jppittman*