### PR TITLE
Refactor SemanticAnalyzer constructor to use strongly typed enum

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2025-12-28 - Rasterizer Inner Loop Hoisting
 **Learning:** The inner loop of `execute_stripe` was re-evaluating `Field::sequential(start)` on every iteration, which involves multiple SIMD instructions (broadcast/load + add).
 **Action:** Hoisted the initialization of `xs` out of the loop and updated it incrementally using a pre-computed `step` vector. This reduced the inner loop overhead significantly, yielding a ~34% improvement in rasterization throughput.
+
+## 2025-01-20 - Boolean Arguments in APIs
+**Learning:** Found a boolean argument violation in `pixelflow-compiler/src/sema.rs` (`SemanticAnalyzer::new(is_anonymous: bool)`).
+**Action:** Replaced the boolean argument with a strongly typed enum (`KernelType { Anonymous, Named }`) to adhere to `STYLE.md` guidelines for better readability and API safety.

--- a/pixelflow-compiler/src/sema.rs
+++ b/pixelflow-compiler/src/sema.rs
@@ -49,8 +49,12 @@ pub struct AnalyzedKernel {
 /// Perform semantic analysis on a parsed kernel.
 pub fn analyze(kernel: KernelDef) -> syn::Result<AnalyzedKernel> {
     // Anonymous kernels (no struct_decl) allow captured variables from environment
-    let is_anonymous = kernel.struct_decl.is_none();
-    let mut analyzer = SemanticAnalyzer::new(is_anonymous);
+    let kernel_type = if kernel.struct_decl.is_none() {
+        KernelType::Anonymous
+    } else {
+        KernelType::Named
+    };
+    let mut analyzer = SemanticAnalyzer::new(kernel_type);
 
     // Register all parameters in the symbol table
     for param in &kernel.params {
@@ -66,6 +70,12 @@ pub fn analyze(kernel: KernelDef) -> syn::Result<AnalyzedKernel> {
     })
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum KernelType {
+    Anonymous,
+    Named,
+}
+
 /// The semantic analyzer state.
 struct SemanticAnalyzer {
     symbols: SymbolTable,
@@ -74,10 +84,10 @@ struct SemanticAnalyzer {
 }
 
 impl SemanticAnalyzer {
-    fn new(is_anonymous: bool) -> Self {
+    fn new(kernel_type: KernelType) -> Self {
         SemanticAnalyzer {
             symbols: SymbolTable::new(),
-            is_anonymous,
+            is_anonymous: kernel_type == KernelType::Anonymous,
         }
     }
 


### PR DESCRIPTION
**Scope:** Modified `pixelflow-compiler/src/sema.rs`.
**Fixes:** Replaced the boolean argument `is_anonymous: bool` in `SemanticAnalyzer::new` with a strongly typed enum `KernelType { Anonymous, Named }` to comply with the `STYLE.md` guideline avoiding boolean arguments in APIs.
**Unresolved Issues:** None.
**Verification:** Confirmed that `cargo check -p pixelflow-compiler` and `cargo test -p pixelflow-compiler` both complete successfully.

---
*PR created automatically by Jules for task [1124085698599034917](https://jules.google.com/task/1124085698599034917) started by @jppittman*