### PR TITLE
style: enforce match over else if in cost_builder

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,6 @@
 ## 2024-07-02 - Fix Flaky Test shutdown_drain_all_timeout_fallback
 **Learning:** `shutdown_drain_all_timeout_fallback` frequently flaked on CI due to a very tight hardcoded timeout bound (`< 150ms`).
 **Action:** Relaxed the hardcoded timing threshold in flaky tests to generous values (e.g., `500ms`) when explicitly assigned to fix them, per testing resiliency rules.
+## 2024-07-03 - Enforcing Match Over Else If
+**Learning:** `STYLE.md` strictly dictates the use of `match` over `if`/`else if` chains when dealing with a fixed set of conditions (like specific string literal matching). The codebase contained instances where strings were checked sequentially using `else if`, which violates this structural style rule and is less idiomatic in Rust.
+**Action:** When adding new conditional logic checking against known literal values, proactively use `match` statements instead of chained `if`/`else if` blocks to ensure compliance with project style guidelines.

--- a/pixelflow-compiler/src/cost_builder.rs
+++ b/pixelflow-compiler/src/cost_builder.rs
@@ -40,17 +40,17 @@ fn parse_cost_model_toml(toml: &str) -> CostModel {
             let key = key.trim();
             let value = value.trim();
             if let Ok(v) = value.parse::<usize>() {
-                if key == "depth_threshold" {
-                    model.depth_threshold = v;
-                } else if key == "depth_penalty" {
-                    model.depth_penalty = v;
-                } else {
-                    // Try to match OpKind by name
-                    for i in 0..OpKind::COUNT {
-                        if let Some(op) = OpKind::from_index(i) {
-                            if op.name() == key {
-                                model.set_cost(op, v);
-                                break;
+                match key {
+                    "depth_threshold" => model.depth_threshold = v,
+                    "depth_penalty" => model.depth_penalty = v,
+                    _ => {
+                        // Try to match OpKind by name
+                        for i in 0..OpKind::COUNT {
+                            if let Some(op) = OpKind::from_index(i) {
+                                if op.name() == key {
+                                    model.set_cost(op, v);
+                                    break;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
**Scope**:
- `pixelflow-compiler/src/cost_builder.rs`
- `.jules/bolt.md`

**Fixes**:
- Replaced an idiomatic violation of chaining `if`/`else if` for checking strings with a `match` statement. This change adheres strictly to the rule set out in `docs/STYLE.md` ("Prefer `match` over `else if`").

**Unresolved Issues**:
- None.

**Verification**:
- `cargo check -p pixelflow-compiler` succeeded cleanly.
- `cargo test -p pixelflow-compiler` passed completely.

---
*PR created automatically by Jules for task [6437509316329434674](https://jules.google.com/task/6437509316329434674) started by @jppittman*