### PR TITLE
⚡ Bolt: Use Vec::with_capacity in BSP builder

### DIFF
--- a/core-term/src/terminal_app.rs
+++ b/core-term/src/terminal_app.rs
@@ -288,11 +288,11 @@ impl TerminalApp {
         let default_bg = self.config.colors.background;
 
         // Build 2-level BSP: Vertical (Rows) -> Horizontal (Cells)
-        let mut row_items = Vec::new();
+        let mut row_items = Vec::with_capacity(rows);
 
         for row in 0..rows {
             let line = &snapshot.lines[row];
-            let mut cell_items = Vec::new();
+            let mut cell_items = Vec::with_capacity(cols);
 
             for col in 0..cols {
                 let glyph = &line.cells[col];


### PR DESCRIPTION
💡 What: Replace `Vec::new()` with `Vec::with_capacity()` for row and cell vectors in `TerminalApp::build_manifold`.
🎯 Why: `TerminalApp::build_manifold` allocates a vector for every row and a vector for the whole rows list on every frame. Using `Vec::new()` requires repeated reallocations as elements are inserted into these lists. Preallocating them with known `rows` and `cols` sizes eliminates this memory allocation overhead in the hot rendering loop.
📊 Impact: Reduces memory reallocations during frame preparation by preallocating exactly the number of required slots for the vectors.
🔬 Measurement: Verify compilation and tests with `cargo check` and `cargo test`.

---
*PR created automatically by Jules for task [4419155357868215014](https://jules.google.com/task/4419155357868215014) started by @jppittman*