### PR TITLE
Style Enforcement: Refactor `else if` to `match`

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,6 @@
 ## 2024-07-02 - Fix Flaky Test shutdown_drain_all_timeout_fallback
 **Learning:** `shutdown_drain_all_timeout_fallback` frequently flaked on CI due to a very tight hardcoded timeout bound (`< 150ms`).
 **Action:** Relaxed the hardcoded timing threshold in flaky tests to generous values (e.g., `500ms`) when explicitly assigned to fix them, per testing resiliency rules.
+## 2025-07-04 - Enforcing Style Guidelines for else if
+**Learning:** Found deep `else if` chains violating the `STYLE.md` guideline to prefer `match` over `else if`. While refactoring, it's important not to mix initial `if` with `match ()` in the `else` branch, and match directly on the subject variable.
+**Action:** Replaced `else if` chains evaluating floats with `match` blocks directly matching on the variable with guard clauses.

--- a/pixelflow-search/src/egraph/codegen.rs
+++ b/pixelflow-search/src/egraph/codegen.rs
@@ -38,25 +38,18 @@ use pixelflow_ir::EmitStyle;
 
 /// Format a constant value as Rust code.
 fn format_const(v: f32) -> String {
-    if v.is_nan() {
-        "f32::NAN".to_string()
-    } else if v.is_infinite() {
-        if v.is_sign_positive() {
-            "f32::INFINITY".to_string()
-        } else {
-            "f32::NEG_INFINITY".to_string()
+    match v {
+        _ if v.is_nan() => "f32::NAN".to_string(),
+        _ if v.is_infinite() && v.is_sign_positive() => "f32::INFINITY".to_string(),
+        _ if v.is_infinite() => "f32::NEG_INFINITY".to_string(),
+        _ if v == 0.0 => "0.0".to_string(),
+        _ if v == 1.0 => "1.0".to_string(),
+        _ if v == -1.0 => "(-1.0)".to_string(),
+        _ if v.fract() == 0.0 && v.abs() < 1000.0 => {
+            // Integer-valued floats
+            format!("{:.1}", v)
         }
-    } else if v == 0.0 {
-        "0.0".to_string()
-    } else if v == 1.0 {
-        "1.0".to_string()
-    } else if v == -1.0 {
-        "(-1.0)".to_string()
-    } else if v.fract() == 0.0 && v.abs() < 1000.0 {
-        // Integer-valued floats
-        format!("{:.1}", v)
-    } else {
-        format!("({:.6})", v)
+        _ => format!("({:.6})", v),
     }
 }
 


### PR DESCRIPTION
### Scope
- Modified `pixelflow-search/src/egraph/codegen.rs`
- Modified `.jules/bolt.md` (journaled learnings)

### Fixes
- Refactored `else if` chain in `format_const` to a `match` expression to enforce the style guideline (Prefer `match` over `else if`). Used guard clauses for `f32` pattern matching since direct matching is deprecated.

### Verification
- `cargo check --all-targets --all-features` passes.
- `cargo test --all-targets --all-features` passes.

---
*PR created automatically by Jules for task [17594321910388431678](https://jules.google.com/task/17594321910388431678) started by @jppittman*