### PR TITLE
⚡ Bolt: [performance improvement] Avoid unnecessary Vec heap allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,6 @@
 ## 2024-07-02 - Fix Flaky Test shutdown_drain_all_timeout_fallback
 **Learning:** `shutdown_drain_all_timeout_fallback` frequently flaked on CI due to a very tight hardcoded timeout bound (`< 150ms`).
 **Action:** Relaxed the hardcoded timing threshold in flaky tests to generous values (e.g., `500ms`) when explicitly assigned to fix them, per testing resiliency rules.
+## 2025-12-29 - Avoid Intermediate Vectors and use Vec::with_capacity
+**Learning:** Performance can be impacted by intermediate allocations like `text.chars().collect::<Vec<char>>()` when extracting small segments.
+**Action:** Avoid `.collect()` into an intermediate Vector when doing simple tasks like extracting characters or single items, and instead use the Iterator functions directly (`chars.next()`). Also use `Vec::with_capacity` when the required capacity is known ahead of time.

--- a/pixelflow-compiler/src/parser.rs
+++ b/pixelflow-compiler/src/parser.rs
@@ -328,7 +328,7 @@ fn convert_expr(expr: syn::Expr) -> syn::Result<Expr> {
 
 /// Convert a syn::Block to our BlockExpr.
 fn convert_block(block: syn::Block) -> syn::Result<BlockExpr> {
-    let mut stmts = Vec::new();
+    let mut stmts = Vec::with_capacity(block.stmts.len());
     let mut final_expr = None;
 
     for (i, stmt) in block.stmts.iter().enumerate() {

--- a/pixelflow-runtime/src/platform/linux/events.rs
+++ b/pixelflow-runtime/src/platform/linux/events.rs
@@ -264,9 +264,11 @@ fn extract_modifiers(state: u32) -> Modifiers {
 
 fn xkeysym_to_keysymbol(keysym_val: xlib::KeySym, text: &str) -> KeySymbol {
     if !text.is_empty() {
-        let chars: Vec<char> = text.chars().collect();
-        if chars.len() == 1 && chars[0] != '\u{FFFD}' {
-            return KeySymbol::Char(chars[0]);
+        let mut chars = text.chars();
+        if let Some(c) = chars.next() {
+            if chars.next().is_none() && c != '\u{FFFD}' {
+                return KeySymbol::Char(c);
+            }
         }
     }
     match keysym_val as u32 {


### PR DESCRIPTION
💡 What: Optimized two specific hot paths by eliminating unnecessary memory allocations. First, in `pixelflow-runtime/src/platform/linux/events.rs`, a string iterator was being unnecessarily collected into a dynamically allocated `Vec` just to check its length and extract the first character. This was replaced with direct `.next()` iterator calls. Second, in `pixelflow-compiler/src/parser.rs`, the `stmts` vector was initialized with `Vec::new()`, causing reallocations as elements were pushed, which was changed to `Vec::with_capacity(block.stmts.len())`.
🎯 Why: Heap allocations are comparatively expensive and these paths are called frequently.
📊 Impact: Eliminates unnecessary `Vec` heap allocations during X11 keypress translations and avoids multiple internal reallocations during AST parsing blocks.
🔬 Measurement: Verify tests run cleanly via `cargo test -p pixelflow-runtime -p pixelflow-compiler`.

---
*PR created automatically by Jules for task [12637167825216171820](https://jules.google.com/task/12637167825216171820) started by @jppittman*