### PR TITLE
Refactor `else if` chains to `match` in `core-term`

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,7 @@
 ## 2024-07-02 - Fix Flaky Test shutdown_drain_all_timeout_fallback
 **Learning:** `shutdown_drain_all_timeout_fallback` frequently flaked on CI due to a very tight hardcoded timeout bound (`< 150ms`).
 **Action:** Relaxed the hardcoded timing threshold in flaky tests to generous values (e.g., `500ms`) when explicitly assigned to fix them, per testing resiliency rules.
+
+## 2024-07-05 - Refactoring Control Flow in core-term
+**Learning:** Rust's `match` expressions offer safer and more idiomatic control flow than `else if` chains, especially when matching on multiple boolean flags (which can be grouped into tuples) or fixed conditions.
+**Action:** Always prefer `match` over `else if` when dealing with multiple interrelated conditions. When converting, ensure direct matching on variables or tuples rather than using the `match () { _ if condition => }` anti-pattern.

--- a/core-term/src/ansi/commands.rs
+++ b/core-term/src/ansi/commands.rs
@@ -520,12 +520,20 @@ impl AnsiCommand {
             }
         }
         // Consolidate multiple Resets or Reset followed by nothing else into a single Reset.
-        if attrs.is_empty() || (attrs.len() == 1 && attrs[0] == Attribute::Reset) {
-            attrs.clear(); // Ensure it's clean if it was just a single reset
-            attrs.push(Attribute::Reset);
-        } else if attrs.iter().all(|&a| a == Attribute::Reset) && attrs.len() > 1 {
-            attrs.clear();
-            attrs.push(Attribute::Reset);
+        match attrs.len() {
+            0 => {
+                attrs.clear(); // Ensure it's clean if it was just a single reset
+                attrs.push(Attribute::Reset);
+            }
+            1 if attrs[0] == Attribute::Reset => {
+                attrs.clear(); // Ensure it's clean if it was just a single reset
+                attrs.push(Attribute::Reset);
+            }
+            _ if attrs.iter().all(|&a| a == Attribute::Reset) => {
+                attrs.clear();
+                attrs.push(Attribute::Reset);
+            }
+            _ => {}
         }
         attrs
     }

--- a/core-term/src/term/emulator/char_processor.rs
+++ b/core-term/src/term/emulator/char_processor.rs
@@ -21,17 +21,17 @@ impl TerminalEmulator {
         let (cursor_x, cursor_y) = self.cursor_controller.physical_screen_pos(&screen_ctx);
 
         // Determine the position of the base character cell.
-        let (base_x, base_y) = if cursor_x > 0 {
-            (cursor_x - 1, cursor_y)
-        } else if cursor_y > 0 {
-            (screen_ctx.width.saturating_sub(1), cursor_y - 1)
-        } else {
-            // Cursor is at (0, 0) — no previous cell to attach to.
-            trace!(
-                "attach_combining_char: no previous cell at origin, discarding '{}'",
-                combining
-            );
-            return;
+        let (base_x, base_y) = match (cursor_x > 0, cursor_y > 0) {
+            (true, _) => (cursor_x - 1, cursor_y),
+            (false, true) => (screen_ctx.width.saturating_sub(1), cursor_y - 1),
+            (false, false) => {
+                // Cursor is at (0, 0) — no previous cell to attach to.
+                trace!(
+                    "attach_combining_char: no previous cell at origin, discarding '{}'",
+                    combining
+                );
+                return;
+            }
         };
 
         if base_y >= self.screen.height || base_x >= self.screen.width {

--- a/core-term/src/term/emulator/methods.rs
+++ b/core-term/src/term/emulator/methods.rs
@@ -74,10 +74,14 @@ impl TerminalEmulator {
         let screen_ctx = self.current_screen_context();
         let (_, current_physical_y) = self.cursor_controller.physical_screen_pos(&screen_ctx);
 
-        if current_physical_y == screen_ctx.scroll_bot {
-            self.screen.scroll_up(1, ScrollHistory::Save);
-        } else if current_physical_y < screen_ctx.height.saturating_sub(1) {
-            self.cursor_controller.move_down(1, &screen_ctx);
+        match current_physical_y {
+            y if y == screen_ctx.scroll_bot => {
+                self.screen.scroll_up(1, ScrollHistory::Save);
+            }
+            y if y < screen_ctx.height.saturating_sub(1) => {
+                self.cursor_controller.move_down(1, &screen_ctx);
+            }
+            _ => {}
         }
         if current_physical_y < self.screen.height {
             self.screen.mark_line_dirty(current_physical_y);

--- a/core-term/src/term/emulator/mod.rs
+++ b/core-term/src/term/emulator/mod.rs
@@ -279,13 +279,17 @@ impl TerminalEmulator {
         let old_offset = self.viewport_offset;
         let max_offset = self.screen.scrollback.len();
 
-        if lines > 0 {
-            // Scroll up into history
-            self.viewport_offset = (self.viewport_offset + lines as usize).min(max_offset);
-        } else if lines < 0 {
-            // Scroll down toward live screen
-            let abs_lines = (-lines) as usize;
-            self.viewport_offset = self.viewport_offset.saturating_sub(abs_lines);
+        match lines.cmp(&0) {
+            std::cmp::Ordering::Greater => {
+                // Scroll up into history
+                self.viewport_offset = (self.viewport_offset + lines as usize).min(max_offset);
+            }
+            std::cmp::Ordering::Less => {
+                // Scroll down toward live screen
+                let abs_lines = (-lines) as usize;
+                self.viewport_offset = self.viewport_offset.saturating_sub(abs_lines);
+            }
+            std::cmp::Ordering::Equal => {}
         }
 
         // Mark all lines dirty if viewport changed

--- a/core-term/src/term/emulator/mode_handler.rs
+++ b/core-term/src/term/emulator/mode_handler.rs
@@ -125,8 +125,8 @@ impl TerminalEmulator {
                             AltScreenClear::Preserve
                         };
 
-                        if enable {
-                            if !self.dec_modes.using_alt_screen {
+                        match (enable, self.dec_modes.using_alt_screen) {
+                            (true, false) => {
                                 // Assuming this flag exists
                                 if mode_num == DecModeConstant::AltScreenBufferSaveRestore as u16 {
                                     self.save_cursor();
@@ -143,22 +143,24 @@ impl TerminalEmulator {
                                 self.screen.mark_all_dirty();
                                 action_to_return = Some(EmulatorAction::RequestRedraw);
                             }
-                        } else if self.dec_modes.using_alt_screen {
-                            self.screen.exit_alt_screen();
-                            self.dec_modes.using_alt_screen = false;
-                            if mode_num == DecModeConstant::AltScreenBufferSaveRestore as u16 {
-                                self.restore_cursor();
-                            } else {
-                                self.cursor_controller.move_to_logical(
-                                    0,
-                                    0,
-                                    &self.current_screen_context(),
-                                );
-                                self.screen.default_attributes =
-                                    self.cursor_controller.attributes();
+                            (false, true) => {
+                                self.screen.exit_alt_screen();
+                                self.dec_modes.using_alt_screen = false;
+                                if mode_num == DecModeConstant::AltScreenBufferSaveRestore as u16 {
+                                    self.restore_cursor();
+                                } else {
+                                    self.cursor_controller.move_to_logical(
+                                        0,
+                                        0,
+                                        &self.current_screen_context(),
+                                    );
+                                    self.screen.default_attributes =
+                                        self.cursor_controller.attributes();
+                                }
+                                self.screen.mark_all_dirty();
+                                action_to_return = Some(EmulatorAction::RequestRedraw);
                             }
-                            self.screen.mark_all_dirty();
-                            action_to_return = Some(EmulatorAction::RequestRedraw);
+                            _ => {}
                         }
                     }
                     Some(DecModeConstant::SaveRestoreCursor) => {

--- a/core-term/src/term/emulator/osc_handler.rs
+++ b/core-term/src/term/emulator/osc_handler.rs
@@ -12,28 +12,32 @@ impl TerminalEmulator {
         let ps_str: &str;
         let content_str: &str;
 
-        if parts.len() == 1 {
-            // No semicolon found, treat the whole string as Ps, content is empty
-            ps_str = parts[0];
-            content_str = "";
-            // Log a debug message for this case, as it might be an implicit expectation
-            debug!(
-                "OSC sequence without semicolon: '{}'. Interpreting Ps='{}', Pt='{}'",
-                osc_str, ps_str, content_str
-            );
-        } else if parts.len() == 2 {
-            // Semicolon found, standard case
-            ps_str = parts[0];
-            content_str = parts[1];
-        } else {
-            // This case should ideally not be reached with splitn(2, ';')
-            // but handle defensively.
-            warn!(
-                "Malformed OSC sequence (unexpected parts count for {}): {}",
-                parts.len(),
-                osc_str
-            );
-            return None;
+        match parts.len() {
+            1 => {
+                // No semicolon found, treat the whole string as Ps, content is empty
+                ps_str = parts[0];
+                content_str = "";
+                // Log a debug message for this case, as it might be an implicit expectation
+                debug!(
+                    "OSC sequence without semicolon: '{}'. Interpreting Ps='{}', Pt='{}'",
+                    osc_str, ps_str, content_str
+                );
+            }
+            2 => {
+                // Semicolon found, standard case
+                ps_str = parts[0];
+                content_str = parts[1];
+            }
+            _ => {
+                // This case should ideally not be reached with splitn(2, ';')
+                // but handle defensively.
+                warn!(
+                    "Malformed OSC sequence (unexpected parts count for {}): {}",
+                    parts.len(),
+                    osc_str
+                );
+                return None;
+            }
         }
 
         // Attempt to parse Ps, default to 0 if parsing fails (e.g., "Implicit Title")

--- a/core-term/src/term/emulator/screen_ops.rs
+++ b/core-term/src/term/emulator/screen_ops.rs
@@ -14,10 +14,14 @@ impl TerminalEmulator {
         let screen_ctx = self.current_screen_context();
         let (_, current_physical_y) = self.cursor_controller.physical_screen_pos(&screen_ctx);
 
-        if current_physical_y == screen_ctx.scroll_top {
-            self.screen.scroll_down(1);
-        } else if current_physical_y > 0 {
-            self.cursor_controller.move_up(1);
+        match current_physical_y {
+            y if y == screen_ctx.scroll_top => {
+                self.screen.scroll_down(1);
+            }
+            y if y > 0 => {
+                self.cursor_controller.move_up(1);
+            }
+            _ => {}
         }
         if current_physical_y < self.screen.height {
             self.screen.mark_line_dirty(current_physical_y);
@@ -233,19 +237,23 @@ impl TerminalEmulator {
             // Cursor logical_y is the same as physical_y.
             // Scrolling should occur if the cursor is at the bottom of the active scrolling region (scroll_bot).
             // This aligns with st.c's tnewline behavior: `if (y == term.bot) tscrollup(term.top, 1);`
-            if current_physical_y == screen_ctx.scroll_bot {
-                self.screen.scroll_up(1, ScrollHistory::Save); // scroll_up uses screen.scroll_top and screen.scroll_bot
-                scrolled_this_op = true;
-                log::trace!(
-                    "move_down_one_line (origin_mode OFF): Scrolled region [{},{}] due to cursor at scroll_bot ({})",
-                    screen_ctx.scroll_top, screen_ctx.scroll_bot, current_physical_y
-                );
-                // Cursor logical_y (and physical_y) effectively stays on this line (screen_ctx.scroll_bot),
-                // which is now blanked due to the scroll. The subsequent carriage_return (if part of LF handling)
-                // will move the cursor to column 0 of this line.
-            } else if current_physical_y < screen_ctx.height.saturating_sub(1) {
-                // Not at scroll_bot, and also not at the very last physical line of the screen, so simply move down.
-                self.cursor_controller.move_down(1, &screen_ctx);
+            match current_physical_y {
+                y if y == screen_ctx.scroll_bot => {
+                    self.screen.scroll_up(1, ScrollHistory::Save); // scroll_up uses screen.scroll_top and screen.scroll_bot
+                    scrolled_this_op = true;
+                    log::trace!(
+                        "move_down_one_line (origin_mode OFF): Scrolled region [{},{}] due to cursor at scroll_bot ({})",
+                        screen_ctx.scroll_top, screen_ctx.scroll_bot, current_physical_y
+                    );
+                    // Cursor logical_y (and physical_y) effectively stays on this line (screen_ctx.scroll_bot),
+                    // which is now blanked due to the scroll. The subsequent carriage_return (if part of LF handling)
+                    // will move the cursor to column 0 of this line.
+                }
+                y if y < screen_ctx.height.saturating_sub(1) => {
+                    // Not at scroll_bot, and also not at the very last physical line of the screen, so simply move down.
+                    self.cursor_controller.move_down(1, &screen_ctx);
+                }
+                _ => {}
             }
             // If current_physical_y == screen_ctx.height.saturating_sub(1) AND it was NOT screen_ctx.scroll_bot
             // (i.e., cursor is on physical last line, but this line is *below* a smaller active scroll region),

--- a/core-term/src/terminal_app.rs
+++ b/core-term/src/terminal_app.rs
@@ -614,26 +614,11 @@ impl Actor<TerminalData, EngineEventControl, EngineEventManagement> for Terminal
                 log::trace!("Mouse move: cell ({}, {})", col, row);
                 // any-event mode (1003) reports all motion;
                 // button-event mode (1002) only reports motion while a button is held
-                if self.emulator.reports_all_motion() {
-                    let button = self
-                        .pressed_mouse_button
-                        .unwrap_or(pixelflow_runtime::input::MouseButton::Left);
-                    if let Some(bytes) =
-                        self.emulator
-                            .encode_mouse_event(crate::term::MouseEncodingParams {
-                                button,
-                                col,
-                                row,
-                                kind: crate::term::MouseEventKind::Motion,
-                            })
-                    {
-                        if let Err(e) = self.pty_tx.send(PtyCommand::Write(bytes)) {
-                            log::warn!("Failed to send mouse motion to PTY: {}", e);
-                        }
-                    }
-                } else if self.emulator.reports_button_motion() {
-                    // button-event mode: only report when a button is held
-                    if let Some(button) = self.pressed_mouse_button {
+                match (self.emulator.reports_all_motion(), self.emulator.reports_button_motion()) {
+                    (true, _) => {
+                        let button = self
+                            .pressed_mouse_button
+                            .unwrap_or(pixelflow_runtime::input::MouseButton::Left);
                         if let Some(bytes) =
                             self.emulator
                                 .encode_mouse_event(crate::term::MouseEncodingParams {
@@ -648,6 +633,25 @@ impl Actor<TerminalData, EngineEventControl, EngineEventManagement> for Terminal
                             }
                         }
                     }
+                    (false, true) => {
+                        // button-event mode: only report when a button is held
+                        if let Some(button) = self.pressed_mouse_button {
+                            if let Some(bytes) =
+                                self.emulator
+                                    .encode_mouse_event(crate::term::MouseEncodingParams {
+                                        button,
+                                        col,
+                                        row,
+                                        kind: crate::term::MouseEventKind::Motion,
+                                    })
+                            {
+                                if let Err(e) = self.pty_tx.send(PtyCommand::Write(bytes)) {
+                                    log::warn!("Failed to send mouse motion to PTY: {}", e);
+                                }
+                            }
+                        }
+                    }
+                    _ => {}
                 }
             }
             EngineEventManagement::MouseScroll {


### PR DESCRIPTION
Scope: Modified various emulator logic and ansi handling files within `core-term/src/`.
Fixes: Replaced `else if` chains with `match` blocks to align with `STYLE.md` preferences, particularly for state flags and discrete cases.
Unresolved Issues: None.
Verification: Passed `cargo check -p core-term` and `cargo test -p core-term` without new failures.

---
*PR created automatically by Jules for task [1694921056462902183](https://jules.google.com/task/1694921056462902183) started by @jppittman*