### PR TITLE
Refactor else if chain to match statement in osc_handler.rs

### DIFF
--- a/core-term/src/term/emulator/osc_handler.rs
+++ b/core-term/src/term/emulator/osc_handler.rs
@@ -12,28 +12,32 @@ impl TerminalEmulator {
         let ps_str: &str;
         let content_str: &str;
 
-        if parts.len() == 1 {
-            // No semicolon found, treat the whole string as Ps, content is empty
-            ps_str = parts[0];
-            content_str = "";
-            // Log a debug message for this case, as it might be an implicit expectation
-            debug!(
-                "OSC sequence without semicolon: '{}'. Interpreting Ps='{}', Pt='{}'",
-                osc_str, ps_str, content_str
-            );
-        } else if parts.len() == 2 {
-            // Semicolon found, standard case
-            ps_str = parts[0];
-            content_str = parts[1];
-        } else {
-            // This case should ideally not be reached with splitn(2, ';')
-            // but handle defensively.
-            warn!(
-                "Malformed OSC sequence (unexpected parts count for {}): {}",
-                parts.len(),
-                osc_str
-            );
-            return None;
+        match parts.len() {
+            1 => {
+                // No semicolon found, treat the whole string as Ps, content is empty
+                ps_str = parts[0];
+                content_str = "";
+                // Log a debug message for this case, as it might be an implicit expectation
+                debug!(
+                    "OSC sequence without semicolon: '{}'. Interpreting Ps='{}', Pt='{}'",
+                    osc_str, ps_str, content_str
+                );
+            }
+            2 => {
+                // Semicolon found, standard case
+                ps_str = parts[0];
+                content_str = parts[1];
+            }
+            _ => {
+                // This case should ideally not be reached with splitn(2, ';')
+                // but handle defensively.
+                warn!(
+                    "Malformed OSC sequence (unexpected parts count for {}): {}",
+                    parts.len(),
+                    osc_str
+                );
+                return None;
+            }
         }
 
         // Attempt to parse Ps, default to 0 if parsing fails (e.g., "Implicit Title")


### PR DESCRIPTION
**Scope**:
- `core-term/src/term/emulator/osc_handler.rs`

**Fixes**:
- Refactored an `else if` chain evaluating a length into an idiomatic `match` statement, complying with the "Prefer `match` over `else if`" rule in `STYLE.md`.

**Unresolved Issues**:
- None. The modification is strictly structural and safe.

**Verification**:
- `cargo check -p core-term` passes cleanly.
- `cargo test -p core-term` passes successfully with no regressions.

---
*PR created automatically by Jules for task [8150911055529045255](https://jules.google.com/task/8150911055529045255) started by @jppittman*