### PR TITLE
Style: fix test naming violations in arena.rs

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,6 @@
 ## 2024-07-02 - Fix Flaky Test shutdown_drain_all_timeout_fallback
 **Learning:** `shutdown_drain_all_timeout_fallback` frequently flaked on CI due to a very tight hardcoded timeout bound (`< 150ms`).
 **Action:** Relaxed the hardcoded timing threshold in flaky tests to generous values (e.g., `500ms`) when explicitly assigned to fix them, per testing resiliency rules.
+## 2026-07-02 - Test Naming Style Enforcement
+**Learning:** The project's style guidelines strictly prohibit the use of generic `test_` prefixes for test function names.
+**Action:** When creating new tests or refactoring existing ones, always strip the `test_` prefix. If the resulting name starts with a digit or shadows an existing symbol, prepend `verify_` instead.

--- a/pixelflow-ir/src/arena.rs
+++ b/pixelflow-ir/src/arena.rs
@@ -1048,7 +1048,7 @@ mod tests {
     }
 
     #[test]
-    fn test_buffer_and_gather() {
+    fn buffer_and_gather() {
         let mut arena = ExprArena::new();
         let buf = arena.declare_buffer(BufferDecl {
             width: 16,
@@ -1074,7 +1074,7 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "not declared")]
-    fn test_push_buffer_undeclared() {
+    fn push_buffer_undeclared() {
         let mut arena = ExprArena::new();
         let _ = arena.push_buffer(BufferId(0));
     }


### PR DESCRIPTION
### Scope
- Modified `pixelflow-ir/src/arena.rs`.

### Fixes
- Removed the `test_` prefix from test function names to conform to the style guidelines detailed in `docs/STYLE.md`.
- `test_buffer_and_gather` was renamed to `buffer_and_gather`.
- `test_push_buffer_undeclared` was renamed to `push_buffer_undeclared`.

### Verification
- Ran `cargo check -p pixelflow-ir` and `cargo test -p pixelflow-ir` successfully.
- Conducted a workspace-wide check via `cargo test --all-targets --all-features`.
- Documented findings in `.jules/bolt.md`.

---
*PR created automatically by Jules for task [7569399911525874375](https://jules.google.com/task/7569399911525874375) started by @jppittman*