### PR TITLE
⚡ Bolt: [performance improvement] Avoid Vec allocation in OSC parsing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -24,3 +24,8 @@
 ## 2025-12-29 - Avoid Intermediate Vectors and use Vec::with_capacity
 **Learning:** Performance can be impacted by intermediate allocations like `text.chars().collect::<Vec<char>>()` when extracting small segments.
 **Action:** Avoid `.collect()` into an intermediate Vector when doing simple tasks like extracting characters or single items, and instead use the Iterator functions directly (`chars.next()`). Also use `Vec::with_capacity` when the required capacity is known ahead of time.
+
+
+## 2026-07-07 - Avoid unnecessary Vec allocations during string split
+**Learning:** `splitn(2, ';').collect::<Vec<&str>>()` performs unnecessary allocations which degrades performance in hot paths (like OSC string handling for a terminal emulator).
+**Action:** Instead of collecting into a `Vec`, use `split_once(';')` for parsing which allows extracting values without any heap allocation.

--- a/core-term/src/term/emulator/osc_handler.rs
+++ b/core-term/src/term/emulator/osc_handler.rs
@@ -2,42 +2,25 @@
 
 use super::TerminalEmulator;
 use crate::term::action::EmulatorAction;
-use log::{debug, warn};
+use log::debug;
 
 impl TerminalEmulator {
     pub(super) fn handle_osc(&mut self, data: Vec<u8>) -> Option<EmulatorAction> {
         let osc_str = String::from_utf8_lossy(&data);
-        let parts: Vec<&str> = osc_str.splitn(2, ';').collect();
 
         let ps_str: &str;
         let content_str: &str;
 
-        match parts.len() {
-            1 => {
-                // No semicolon found, treat the whole string as Ps, content is empty
-                ps_str = parts[0];
-                content_str = "";
-                // Log a debug message for this case, as it might be an implicit expectation
-                debug!(
-                    "OSC sequence without semicolon: '{}'. Interpreting Ps='{}', Pt='{}'",
-                    osc_str, ps_str, content_str
-                );
-            }
-            2 => {
-                // Semicolon found, standard case
-                ps_str = parts[0];
-                content_str = parts[1];
-            }
-            _ => {
-                // This case should ideally not be reached with splitn(2, ';')
-                // but handle defensively.
-                warn!(
-                    "Malformed OSC sequence (unexpected parts count for {}): {}",
-                    parts.len(),
-                    osc_str
-                );
-                return None;
-            }
+        if let Some((ps, content)) = osc_str.split_once(';') {
+            ps_str = ps;
+            content_str = content;
+        } else {
+            ps_str = &osc_str;
+            content_str = "";
+            debug!(
+                "OSC sequence without semicolon: '{}'. Interpreting Ps='{}', Pt='{}'",
+                osc_str, ps_str, content_str
+            );
         }
 
         // Attempt to parse Ps, default to 0 if parsing fails (e.g., "Implicit Title")


### PR DESCRIPTION
💡 **What:** Optimized the OSC terminal sequence handler by replacing `.splitn(2, ';').collect::<Vec<&str>>()` with `.split_once(';')`.
🎯 **Why:** The previous code performed a heap allocation (`Vec`) on every OSC sequence handled. Since this is on the hot path for terminal interactions, removing the allocation improves throughput and reduces latency.
📊 **Impact:** Reduces heap allocations for OSC sequence processing from 1 to 0 per sequence, lowering overhead during terminal rendering and interaction.
🔬 **Measurement:** Verified with `cargo check` and `cargo test -p core-term`, ensuring exact preservation of the implicit title fallback behaviors and edge cases.

---
*PR created automatically by Jules for task [2005917751772988028](https://jules.google.com/task/2005917751772988028) started by @jppittman*