### PR TITLE
style: refactor else if to match in char_processor

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -24,3 +24,6 @@
 ## 2025-12-29 - Avoid Intermediate Vectors and use Vec::with_capacity
 **Learning:** Performance can be impacted by intermediate allocations like `text.chars().collect::<Vec<char>>()` when extracting small segments.
 **Action:** Avoid `.collect()` into an intermediate Vector when doing simple tasks like extracting characters or single items, and instead use the Iterator functions directly (`chars.next()`). Also use `Vec::with_capacity` when the required capacity is known ahead of time.
+## 2024-07-07 - Avoid else if chains by matching boolean tuples
+**Learning:** In Rust, complex `if / else if` chains evaluating multiple boolean conditions can be refactored into `match` expressions matching over a tuple of booleans (e.g., `match (cond1, cond2)`). This conforms to the idiom of preferring `match` over `else if`.
+**Action:** Use tuple matching for multiple condition evaluation instead of chaining `else if` statements when updating control flow.

--- a/core-term/src/term/emulator/char_processor.rs
+++ b/core-term/src/term/emulator/char_processor.rs
@@ -21,17 +21,17 @@ impl TerminalEmulator {
         let (cursor_x, cursor_y) = self.cursor_controller.physical_screen_pos(&screen_ctx);
 
         // Determine the position of the base character cell.
-        let (base_x, base_y) = if cursor_x > 0 {
-            (cursor_x - 1, cursor_y)
-        } else if cursor_y > 0 {
-            (screen_ctx.width.saturating_sub(1), cursor_y - 1)
-        } else {
-            // Cursor is at (0, 0) — no previous cell to attach to.
-            trace!(
-                "attach_combining_char: no previous cell at origin, discarding '{}'",
-                combining
-            );
-            return;
+        let (base_x, base_y) = match (cursor_x > 0, cursor_y > 0) {
+            (true, _) => (cursor_x - 1, cursor_y),
+            (false, true) => (screen_ctx.width.saturating_sub(1), cursor_y - 1),
+            (false, false) => {
+                // Cursor is at (0, 0) — no previous cell to attach to.
+                trace!(
+                    "attach_combining_char: no previous cell at origin, discarding '{}'",
+                    combining
+                );
+                return;
+            }
         };
 
         if base_y >= self.screen.height || base_x >= self.screen.width {


### PR DESCRIPTION
This PR refactors the `if / else if` chain in `core-term/src/term/emulator/char_processor.rs` to a `match` expression on a boolean tuple to comply with `STYLE.md` guidelines that advocate for avoiding deep `else if` chains when possible.

### Scope
- Modified `core-term/src/term/emulator/char_processor.rs`

### Fixes
- Removed an `else if` pattern in `attach_combining_char`.

### Unresolved Issues
- None

### Verification
- `cargo check -p core-term` and `cargo test -p core-term` passed cleanly.

---
*PR created automatically by Jules for task [8192518850168430972](https://jules.google.com/task/8192518850168430972) started by @jppittman*