### PR TITLE
Refactor `if/else if` chain to `match` in linux events.rs

### DIFF
--- a/pixelflow-runtime/src/platform/linux/events.rs
+++ b/pixelflow-runtime/src/platform/linux/events.rs
@@ -102,40 +102,44 @@ unsafe fn handle_selection_request(event: &xlib::XEvent, window: &mut super::win
     response.time = req.time;
     response.property = req.property;
 
-    if req.target == window.atoms.targets {
-        let targets = [
-            window.atoms.targets,
-            window.atoms.utf8_string,
-            window.atoms.text,
-            window.atoms.xa_string,
-        ];
-        xlib::XChangeProperty(
-            window.display,
-            req.requestor,
-            req.property,
-            xlib::XA_ATOM,
-            32,
-            xlib::PropModeReplace,
-            targets.as_ptr() as *const u8,
-            targets.len() as i32,
-        );
-    } else if req.target == window.atoms.utf8_string
-        || req.target == window.atoms.text
-        || req.target == window.atoms.xa_string
-    {
-        let data = window.clipboard_data.as_bytes();
-        xlib::XChangeProperty(
-            window.display,
-            req.requestor,
-            req.property,
-            req.target,
-            8,
-            xlib::PropModeReplace,
-            data.as_ptr(),
-            data.len() as i32,
-        );
-    } else {
-        response.property = 0; // Reject
+    match req.target {
+        t if t == window.atoms.targets => {
+            let targets = [
+                window.atoms.targets,
+                window.atoms.utf8_string,
+                window.atoms.text,
+                window.atoms.xa_string,
+            ];
+            xlib::XChangeProperty(
+                window.display,
+                req.requestor,
+                req.property,
+                xlib::XA_ATOM,
+                32,
+                xlib::PropModeReplace,
+                targets.as_ptr() as *const u8,
+                targets.len() as i32,
+            );
+        }
+        t if t == window.atoms.utf8_string
+            || t == window.atoms.text
+            || t == window.atoms.xa_string =>
+        {
+            let data = window.clipboard_data.as_bytes();
+            xlib::XChangeProperty(
+                window.display,
+                req.requestor,
+                req.property,
+                req.target,
+                8,
+                xlib::PropModeReplace,
+                data.as_ptr(),
+                data.len() as i32,
+            );
+        }
+        _ => {
+            response.property = 0; // Reject
+        }
     }
     xlib::XSendEvent(
         window.display,


### PR DESCRIPTION
## Scope
- `pixelflow-runtime::platform::linux::events`

## Fixes
- Addressed a style violation outlined in `docs/STYLE.md`: "Prefer `match` over `else if`: When choosing between complex `if`/`else if`/`else` chains and a `match` statement, prefer `match`, especially when dealing with enums or a fixed set of conditions."
- Replaced the `if / else if` chain for matching `req.target` against various window atoms in `handle_selection_request` with a `match` expression and guard clauses.

## Unresolved Issues
- None

## Verification
- Clean run of `cargo check -p pixelflow-runtime`
- Clean run of `cargo test -p pixelflow-runtime`

---
*PR created automatically by Jules for task [13281593155490997609](https://jules.google.com/task/13281593155490997609) started by @jppittman*