### PR TITLE
⚡ Bolt: [performance improvement] Optimize IO multiplexer token deduplication hot paths

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -24,3 +24,7 @@
 ## 2025-12-29 - Avoid Intermediate Vectors and use Vec::with_capacity
 **Learning:** Performance can be impacted by intermediate allocations like `text.chars().collect::<Vec<char>>()` when extracting small segments.
 **Action:** Avoid `.collect()` into an intermediate Vector when doing simple tasks like extracting characters or single items, and instead use the Iterator functions directly (`chars.next()`). Also use `Vec::with_capacity` when the required capacity is known ahead of time.
+
+## 2024-07-08 - Small collection O(N) deduplication optimization
+**Learning:** In hot I/O multiplexing event loops (kqueue/epoll) within the core-term crate, `std::collections::HashSet` was being initialized repeatedly to track seen file descriptor tokens. Constructing and dropping a `HashSet` involves significant heap allocation and hashing overhead which is entirely unjustified for small arrays (`MAX_EVENTS = 32`). A simple O(N) linear search using `iter_mut().find()` over a pre-existing vector avoids dynamic allocations and is dramatically faster at this scale.
+**Action:** When tracking seen elements or deduplicating small collections (N <= 32) in performance-critical paths, avoid `HashSet::new()` completely. Instead, use a pre-existing vector and perform a linear search (e.g. `.find()`), relying on L1 cache speed.

--- a/core-term/src/io/epoll.rs
+++ b/core-term/src/io/epoll.rs
@@ -153,13 +153,14 @@ impl EventMonitor {
         );
 
         // Use a fixed-size buffer for libc calls
-        let mut libc_events: [libc::epoll_event; 32] = unsafe { std::mem::zeroed() };
+        const MAX_EVENTS: usize = 32;
+        let mut libc_events: [libc::epoll_event; MAX_EVENTS] = unsafe { std::mem::zeroed() };
 
         let num_events = unsafe {
             libc::epoll_wait(
                 self.epoll_fd,
                 libc_events.as_mut_ptr(),
-                32,
+                MAX_EVENTS as i32,
                 timeout_ms as libc::c_int,
             )
         };

--- a/core-term/src/io/kqueue.rs
+++ b/core-term/src/io/kqueue.rs
@@ -201,14 +201,21 @@ impl EventMonitor {
 
         // Convert kernel events to our events
         events_out.clear();
-        let mut seen_tokens = std::collections::HashSet::new();
 
         for i in 0..nev as usize {
             let kev = &kevents[i];
             let token = kev.udata as u64;
 
-            // Only add each token once (might have both read and write events)
-            if seen_tokens.insert(token) {
+            if let Some(event) = events_out.iter_mut().find(|e| e.token == token) {
+                // Update flags for existing token
+                if kev.filter == libc::EVFILT_READ {
+                    event.flags |= KqueueFlags::EPOLLIN;
+                }
+                if kev.filter == libc::EVFILT_WRITE {
+                    event.flags |= KqueueFlags::EPOLLOUT;
+                }
+            } else {
+                // Only add each token once (might have both read and write events)
                 let mut flags = KqueueFlags::empty();
                 if kev.filter == libc::EVFILT_READ {
                     flags |= KqueueFlags::EPOLLIN;
@@ -218,16 +225,6 @@ impl EventMonitor {
                 }
 
                 events_out.push(KqueueEvent { token, flags });
-            } else {
-                // Update flags for existing token
-                if let Some(event) = events_out.iter_mut().find(|e| e.token == token) {
-                    if kev.filter == libc::EVFILT_READ {
-                        event.flags |= KqueueFlags::EPOLLIN;
-                    }
-                    if kev.filter == libc::EVFILT_WRITE {
-                        event.flags |= KqueueFlags::EPOLLOUT;
-                    }
-                }
             }
         }
 


### PR DESCRIPTION
💡 **What:** 
Replaced `HashSet::new()` initialization and `.insert()` deduplication in `core-term/src/io/kqueue.rs` with a linear O(N) search over the pre-existing `events_out` vector using `.iter_mut().find()`. Also introduced the `MAX_EVENTS` constant in `core-term/src/io/epoll.rs` replacing the magic number `32` for fixed-size buffer allocations.

🎯 **Why:** 
Constructing a `HashSet` involves significant heap allocation and hashing overhead which is entirely unjustified for deduplicating small collections (N <= 32). The I/O multiplexing loops (`epoll_wait` / `kevent`) represent extremely hot execution paths where minimizing dynamic allocations is crucial.

📊 **Impact:** 
Eliminates a `HashSet` heap allocation on every single I/O event poll loop (which happens thousands of times a second). Substantially decreases CPU overhead of tracking seen tokens.

🔬 **Measurement:** 
Run terminal application workloads and profile heap allocations to observe the elimination of `HashSet` construction from the `kqueue` event handling paths.

---
*PR created automatically by Jules for task [15165553332980580016](https://jules.google.com/task/15165553332980580016) started by @jppittman*