### PR TITLE
Refactor: Replace `.unwrap()` with `.expect()` in mock_engine.rs

### DIFF
--- a/pixelflow-runtime/src/testing/mock_engine.rs
+++ b/pixelflow-runtime/src/testing/mock_engine.rs
@@ -64,7 +64,7 @@ impl MockEngine {
     }
 
     pub fn messages(&self) -> std::sync::MutexGuard<'_, Vec<ReceivedMessage>> {
-        self.messages.lock().unwrap()
+        self.messages.lock().expect("Mutex should not be poisoned")
     }
 }
 
@@ -77,7 +77,7 @@ impl Actor<EngineData, EngineControl, AppManagement> for MessageCollector {
     fn handle_data(&mut self, msg: EngineData) -> HandlerResult {
         self.messages
             .lock()
-            .unwrap()
+            .expect("Mutex should not be poisoned")
             .push(ReceivedMessage::Data(msg));
         Ok(())
     }
@@ -85,7 +85,7 @@ impl Actor<EngineData, EngineControl, AppManagement> for MessageCollector {
     fn handle_control(&mut self, msg: EngineControl) -> HandlerResult {
         self.messages
             .lock()
-            .unwrap()
+            .expect("Mutex should not be poisoned")
             .push(ReceivedMessage::Control(msg));
         Ok(())
     }
@@ -93,7 +93,7 @@ impl Actor<EngineData, EngineControl, AppManagement> for MessageCollector {
     fn handle_management(&mut self, msg: AppManagement) -> HandlerResult {
         self.messages
             .lock()
-            .unwrap()
+            .expect("Mutex should not be poisoned")
             .push(ReceivedMessage::Management(msg));
         Ok(())
     }


### PR DESCRIPTION
**Scope:** `pixelflow-runtime/src/testing/mock_engine.rs`
**Fixes:** Replaced `.unwrap()` calls on Mutex locks with `.expect("Mutex should not be poisoned")` to adhere to style guidelines regarding explicit error contexts.
**Unresolved Issues:** None.
**Verification:** `cargo check -p pixelflow-runtime` and `cargo test -p pixelflow-runtime` pass cleanly.

---
*PR created automatically by Jules for task [2136724126108292564](https://jules.google.com/task/2136724126108292564) started by @jppittman*