### PR TITLE
⚡ Bolt: [performance improvement] Replace splitn.collect with split_once in osc_handler

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -24,3 +24,6 @@
 ## 2025-12-29 - Avoid Intermediate Vectors and use Vec::with_capacity
 **Learning:** Performance can be impacted by intermediate allocations like `text.chars().collect::<Vec<char>>()` when extracting small segments.
 **Action:** Avoid `.collect()` into an intermediate Vector when doing simple tasks like extracting characters or single items, and instead use the Iterator functions directly (`chars.next()`). Also use `Vec::with_capacity` when the required capacity is known ahead of time.
+## 2025-02-19 - Avoid Heap Allocations in String Splitting
+**Learning:** Using `.splitn(...).collect::<Vec<_>>()` forces an unnecessary heap allocation for short string extractions, creating a performance bottleneck in hot paths.
+**Action:** Always prefer `.split_once()` or returning tuples over allocating intermediate `Vec` structures when the extraction bound is known and small.

--- a/core-term/src/term/emulator/osc_handler.rs
+++ b/core-term/src/term/emulator/osc_handler.rs
@@ -2,43 +2,26 @@
 
 use super::TerminalEmulator;
 use crate::term::action::EmulatorAction;
-use log::{debug, warn};
+use log::debug;
 
 impl TerminalEmulator {
     pub(super) fn handle_osc(&mut self, data: Vec<u8>) -> Option<EmulatorAction> {
         let osc_str = String::from_utf8_lossy(&data);
-        let parts: Vec<&str> = osc_str.splitn(2, ';').collect();
-
-        let ps_str: &str;
-        let content_str: &str;
-
-        match parts.len() {
-            1 => {
+        // Optimization: Use `split_once` instead of `splitn(2).collect::<Vec<_>>()`
+        // to avoid allocating an intermediate heap vector for the string parts.
+        let (ps_str, content_str) = match osc_str.split_once(';') {
+            Some((ps, pt)) => (ps, pt),
+            None => {
                 // No semicolon found, treat the whole string as Ps, content is empty
-                ps_str = parts[0];
-                content_str = "";
+                let ps = osc_str.as_ref();
                 // Log a debug message for this case, as it might be an implicit expectation
                 debug!(
-                    "OSC sequence without semicolon: '{}'. Interpreting Ps='{}', Pt='{}'",
-                    osc_str, ps_str, content_str
+                    "OSC sequence without semicolon: '{}'. Interpreting Ps='{}', Pt=''",
+                    osc_str, ps
                 );
+                (ps, "")
             }
-            2 => {
-                // Semicolon found, standard case
-                ps_str = parts[0];
-                content_str = parts[1];
-            }
-            _ => {
-                // This case should ideally not be reached with splitn(2, ';')
-                // but handle defensively.
-                warn!(
-                    "Malformed OSC sequence (unexpected parts count for {}): {}",
-                    parts.len(),
-                    osc_str
-                );
-                return None;
-            }
-        }
+        };
 
         // Attempt to parse Ps, default to 0 if parsing fails (e.g., "Implicit Title")
         // Using u32::MAX as a sentinel for unhandled 'ps' codes later is fine,


### PR DESCRIPTION
💡 What: Replaced `osc_str.splitn(2, ';').collect::<Vec<_>>()` with `osc_str.split_once(';')` and removed the unused `warn` import in `core-term/src/term/emulator/osc_handler.rs`.
🎯 Why: The previous implementation forced an unnecessary heap allocation (the `Vec`) during string parsing in the OSC (Operating System Command) handler, which can be a hot path when processing large amounts of terminal output.
📊 Impact: Eliminates heap allocation overhead during OSC string splitting, improving memory efficiency and processing speed.
🔬 Measurement: Verified with `cargo test -p core-term` and `cargo check -p core-term` ensuring no regressions in test coverage.

Scope:
- `core-term/src/term/emulator/osc_handler.rs`
- `.jules/bolt.md` (Added journal entry for learning)

Fixes:
- Avoids allocating intermediate `Vec` structures when extracting strings.

Unresolved Issues:
- None.

Verification:
- Passing `cargo check --workspace` and `cargo test --workspace`.

---
*PR created automatically by Jules for task [11437341001989996559](https://jules.google.com/task/11437341001989996559) started by @jppittman*