### PR TITLE
Refactor AST `if / else if` to exhaustive `match`

### DIFF
--- a/pixelflow-compiler/src/optimize.rs
+++ b/pixelflow-compiler/src/optimize.rs
@@ -1312,16 +1312,19 @@ fn optimize_unary(mut unary: UnaryExpr) -> Expr {
 fn optimize_block(mut block: BlockExpr) -> Expr {
     // Optimize statements
     for stmt in &mut block.stmts {
-        if let Stmt::Let(let_stmt) = stmt {
-            let_stmt.init = optimize_expr(std::mem::replace(
-                &mut let_stmt.init,
-                make_literal(0.0, Span::call_site()), // Dummy placeholder
-            ));
-        } else if let Stmt::Expr(expr) = stmt {
-            *expr = optimize_expr(std::mem::replace(
-                expr,
-                make_literal(0.0, Span::call_site()), // Dummy placeholder
-            ));
+        match stmt {
+            Stmt::Let(let_stmt) => {
+                let_stmt.init = optimize_expr(std::mem::replace(
+                    &mut let_stmt.init,
+                    make_literal(0.0, Span::call_site()), // Dummy placeholder
+                ));
+            }
+            Stmt::Expr(expr) => {
+                *expr = optimize_expr(std::mem::replace(
+                    expr,
+                    make_literal(0.0, Span::call_site()), // Dummy placeholder
+                ));
+            }
         }
     }
 


### PR DESCRIPTION
Replaced an `if let` / `else if let` chain with an exhaustive `match` block in `pixelflow-compiler/src/optimize.rs` when iterating over AST `Stmt`s. This addresses a style violation where `match` is strongly preferred per `docs/STYLE.md`.

Scope:
- `pixelflow-compiler/src/optimize.rs`

Fixes:
- Enforces stylistic preference for `match` over `if / else if` for enums.

Verification:
- `cargo check -p pixelflow-compiler`
- `cargo test -p pixelflow-compiler`

---
*PR created automatically by Jules for task [12521028770383112897](https://jules.google.com/task/12521028770383112897) started by @jppittman*