### PR TITLE
Refactor: Fix test naming convention to follow STYLE.md

### DIFF
--- a/pixelflow-core/src/naked_test.rs
+++ b/pixelflow-core/src/naked_test.rs
@@ -13,7 +13,8 @@ pub extern "C" fn dummy_jit_kernel(x: float32x4_t, y: float32x4_t, _z: float32x4
     }
 }
 
-pub fn test_naked_call() {
+#[test]
+pub fn naked_call_should_compute_correctly() {
     let x_arr = [2.0f32, 3.0, 4.0, 5.0];
     let y_arr = [10.0f32, 10.0, 10.0, 10.0];
     

--- a/pixelflow-ir/src/arena.rs
+++ b/pixelflow-ir/src/arena.rs
@@ -1048,7 +1048,7 @@ mod tests {
     }
 
     #[test]
-    fn test_buffer_and_gather() {
+    fn arena_should_create_gather_when_buffer_declared() {
         let mut arena = ExprArena::new();
         let buf = arena.declare_buffer(BufferDecl {
             width: 16,
@@ -1074,7 +1074,7 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "not declared")]
-    fn test_push_buffer_undeclared() {
+    fn push_buffer_should_panic_when_undeclared() {
         let mut arena = ExprArena::new();
         let _ = arena.push_buffer(BufferId(0));
     }


### PR DESCRIPTION
Fix test names in `pixelflow-core` and `pixelflow-ir` based on the guidelines specified in `docs/STYLE.md`.

- Scope:
  - `pixelflow-core/src/naked_test.rs`
  - `pixelflow-ir/src/arena.rs`
- Fixes:
  - Renamed `pub fn test_naked_call` to `naked_call_should_compute_correctly` and added the `#[test]` attribute. 
  - Renamed `test_buffer_and_gather` to `arena_should_create_gather_when_buffer_declared`.
  - Renamed `test_push_buffer_undeclared` to `push_buffer_should_panic_when_undeclared`.
- Unresolved Issues: None.
- Verification: Tested and verified compilation with `cargo test` and `cargo check`.

---
*PR created automatically by Jules for task [6611747507332144961](https://jules.google.com/task/6611747507332144961) started by @jppittman*