### PR TITLE
Rename tests in arena.rs to follow STYLE.md

### DIFF
--- a/pixelflow-ir/src/arena.rs
+++ b/pixelflow-ir/src/arena.rs
@@ -1048,7 +1048,7 @@ mod tests {
     }
 
     #[test]
-    fn test_buffer_and_gather() {
+    fn push_gather_should_create_node_when_valid() {
         let mut arena = ExprArena::new();
         let buf = arena.declare_buffer(BufferDecl {
             width: 16,
@@ -1074,7 +1074,7 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "not declared")]
-    fn test_push_buffer_undeclared() {
+    fn push_buffer_should_panic_when_undeclared() {
         let mut arena = ExprArena::new();
         let _ = arena.push_buffer(BufferId(0));
     }


### PR DESCRIPTION
**Scope:**
- `pixelflow-ir/src/arena.rs`

**Fixes:**
- Renamed `test_buffer_and_gather` to `push_gather_should_create_node_when_valid`
- Renamed `test_push_buffer_undeclared` to `push_buffer_should_panic_when_undeclared`
- Fixes violations of the test naming guidelines in `STYLE.md`

**Unresolved Issues:**
- None

**Verification:**
- `cargo check -p pixelflow-ir` passes
- `cargo test -p pixelflow-ir` passes

---
*PR created automatically by Jules for task [9510466545319991144](https://jules.google.com/task/9510466545319991144) started by @jppittman*