### PR TITLE
⚡ Bolt: [Avoid intermediate heap allocations for string splitting]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -24,3 +24,6 @@
 ## 2025-12-29 - Avoid Intermediate Vectors and use Vec::with_capacity
 **Learning:** Performance can be impacted by intermediate allocations like `text.chars().collect::<Vec<char>>()` when extracting small segments.
 **Action:** Avoid `.collect()` into an intermediate Vector when doing simple tasks like extracting characters or single items, and instead use the Iterator functions directly (`chars.next()`). Also use `Vec::with_capacity` when the required capacity is known ahead of time.
+## 2025-02-23 - Avoid intermediate allocations for string splitting
+**Learning:** In performance-critical hot paths, avoid collecting string splitting results into an intermediate heap-allocated `Vec` (e.g., `.splitn(2, ';').collect::<Vec<_>>()`) when extracting a limited number of segments.
+**Action:** Use `.split_once()` (or similar tuple-returning methods) instead of `collect::<Vec<_>>()` to prevent unnecessary heap allocations and improve performance, which is especially important for frequently executed code like OSC sequence parsing.

--- a/core-term/src/ansi/lexer.rs
+++ b/core-term/src/ansi/lexer.rs
@@ -268,7 +268,7 @@ impl AnsiLexer {
 
     /// Consumes and returns all accumulated tokens.
     pub fn take_tokens(&mut self) -> Vec<AnsiToken> {
-        trace!("taking {:?} tokens from lexer", &self.tokens);
+        trace!("taking {:?} tokens from lexer", self.tokens);
         mem::take(&mut self.tokens)
     }
 

--- a/core-term/src/term/emulator/osc_handler.rs
+++ b/core-term/src/term/emulator/osc_handler.rs
@@ -2,43 +2,24 @@
 
 use super::TerminalEmulator;
 use crate::term::action::EmulatorAction;
-use log::{debug, warn};
+use log::debug;
 
 impl TerminalEmulator {
     pub(super) fn handle_osc(&mut self, data: Vec<u8>) -> Option<EmulatorAction> {
         let osc_str = String::from_utf8_lossy(&data);
-        let parts: Vec<&str> = osc_str.splitn(2, ';').collect();
-
-        let ps_str: &str;
-        let content_str: &str;
-
-        match parts.len() {
-            1 => {
+        // PERFORMANCE: Use `split_once` instead of `.splitn(2, ';').collect::<Vec<_>>()`
+        // to avoid allocating an intermediate heap vector for extracting two string segments.
+        let (ps_str, content_str) = match osc_str.split_once(';') {
+            Some((ps, content)) => (ps, content),
+            None => {
                 // No semicolon found, treat the whole string as Ps, content is empty
-                ps_str = parts[0];
-                content_str = "";
-                // Log a debug message for this case, as it might be an implicit expectation
                 debug!(
-                    "OSC sequence without semicolon: '{}'. Interpreting Ps='{}', Pt='{}'",
-                    osc_str, ps_str, content_str
+                    "OSC sequence without semicolon: '{}'. Interpreting Ps='{}', Pt=''",
+                    osc_str, osc_str
                 );
+                (osc_str.as_ref(), "")
             }
-            2 => {
-                // Semicolon found, standard case
-                ps_str = parts[0];
-                content_str = parts[1];
-            }
-            _ => {
-                // This case should ideally not be reached with splitn(2, ';')
-                // but handle defensively.
-                warn!(
-                    "Malformed OSC sequence (unexpected parts count for {}): {}",
-                    parts.len(),
-                    osc_str
-                );
-                return None;
-            }
-        }
+        };
 
         // Attempt to parse Ps, default to 0 if parsing fails (e.g., "Implicit Title")
         // Using u32::MAX as a sentinel for unhandled 'ps' codes later is fine,

--- a/pixelflow-compiler/src/codegen/emitter.rs
+++ b/pixelflow-compiler/src/codegen/emitter.rs
@@ -283,7 +283,7 @@ impl<'a> CodeEmitter<'a> {
         // Always adjust param indices to account for literals in context
         // Literals go into A0 (Scalars), so only adjust scalar params (ArrayID 0)
         let literal_count = self.collected_literals.len();
-        for (_, (array_id, idx)) in self.param_indices.iter_mut() {
+        for (array_id, idx) in self.param_indices.values_mut() {
             if *array_id == 0 {
                 *idx += literal_count;
             }
@@ -511,7 +511,7 @@ impl<'a> CodeEmitter<'a> {
         // Always adjust param indices to account for literals in context
         // Literals go into A0 (Scalars), so only adjust scalar params (ArrayID 0)
         let literal_count = self.collected_literals.len();
-        for (_, (array_id, idx)) in self.param_indices.iter_mut() {
+        for (array_id, idx) in self.param_indices.values_mut() {
             if *array_id == 0 {
                 *idx += literal_count;
             }


### PR DESCRIPTION
💡 What: Replaced `.splitn(2, ';').collect::<Vec<_>>()` with `.split_once(';')` in the OSC handler.
🎯 Why: Collecting a split iterator into an intermediate heap-allocated `Vec` is unnecessary when extracting exactly two segments. Avoiding this allocation speeds up OSC sequence parsing in the hot path.
📊 Impact: Reduces heap allocations during OSC sequence handling.
🔬 Measurement: Verify tests still pass via `cargo test -p core-term`. Included a journal entry documenting the learning regarding string splitting optimizations.

---
*PR created automatically by Jules for task [10019895342753843927](https://jules.google.com/task/10019895342753843927) started by @jppittman*