### PR TITLE
StyleEnforcer: Refactor `else if` to `match` in `mode_handler.rs`

### DIFF
--- a/core-term/src/term/emulator/mode_handler.rs
+++ b/core-term/src/term/emulator/mode_handler.rs
@@ -125,9 +125,8 @@ impl TerminalEmulator {
                             AltScreenClear::Preserve
                         };
 
-                        if enable {
-                            if !self.dec_modes.using_alt_screen {
-                                // Assuming this flag exists
+                        match (enable, self.dec_modes.using_alt_screen) {
+                            (true, false) => {
                                 if mode_num == DecModeConstant::AltScreenBufferSaveRestore as u16 {
                                     self.save_cursor();
                                 }
@@ -143,22 +142,24 @@ impl TerminalEmulator {
                                 self.screen.mark_all_dirty();
                                 action_to_return = Some(EmulatorAction::RequestRedraw);
                             }
-                        } else if self.dec_modes.using_alt_screen {
-                            self.screen.exit_alt_screen();
-                            self.dec_modes.using_alt_screen = false;
-                            if mode_num == DecModeConstant::AltScreenBufferSaveRestore as u16 {
-                                self.restore_cursor();
-                            } else {
-                                self.cursor_controller.move_to_logical(
-                                    0,
-                                    0,
-                                    &self.current_screen_context(),
-                                );
-                                self.screen.default_attributes =
-                                    self.cursor_controller.attributes();
+                            (false, true) => {
+                                self.screen.exit_alt_screen();
+                                self.dec_modes.using_alt_screen = false;
+                                if mode_num == DecModeConstant::AltScreenBufferSaveRestore as u16 {
+                                    self.restore_cursor();
+                                } else {
+                                    self.cursor_controller.move_to_logical(
+                                        0,
+                                        0,
+                                        &self.current_screen_context(),
+                                    );
+                                    self.screen.default_attributes =
+                                        self.cursor_controller.attributes();
+                                }
+                                self.screen.mark_all_dirty();
+                                action_to_return = Some(EmulatorAction::RequestRedraw);
                             }
-                            self.screen.mark_all_dirty();
-                            action_to_return = Some(EmulatorAction::RequestRedraw);
+                            _ => {}
                         }
                     }
                     Some(DecModeConstant::SaveRestoreCursor) => {


### PR DESCRIPTION
- Scope: `core-term/src/term/emulator/mode_handler.rs`
- Fixes: Refactored `else if` logic to use a `match` expression for better alignment with STYLE.md guidelines.
- Unresolved Issues: None.
- Verification: Passed `cargo check` and `cargo test` on `core-term`.

---
*PR created automatically by Jules for task [5673362370138985235](https://jules.google.com/task/5673362370138985235) started by @jppittman*