### PR TITLE
Cleanup: Remove empty test in pixelflow-graphics

### DIFF
--- a/pixelflow-graphics/src/shapes.rs
+++ b/pixelflow-graphics/src/shapes.rs
@@ -196,11 +196,6 @@ mod tests {
         tex.data()[0]
     }
 
-    #[test]
-    fn circle_at_origin() {
-        // Point at origin should be inside
-        // Point at (2, 0) should be outside
-    }
 
     #[test]
     fn composition_works() {


### PR DESCRIPTION
### Scope
- Modified `pixelflow-graphics/src/shapes.rs`

### Fixes
- Addressed a `STYLE.md` violation by removing an empty test function (`circle_at_origin`) that contained no assertions, conforming to the "Scorched Earth Policy" for tests.

### Unresolved Issues
- Pre-existing warnings in unrelated crates (e.g. `pixelflow-pipeline`). No logic-breaking changes introduced.

### Verification
- Verified by running `cargo check -p pixelflow-graphics --all-targets --all-features` and `cargo test -p pixelflow-graphics`, all tests passed.

---
*PR created automatically by Jules for task [3028108052186769574](https://jules.google.com/task/3028108052186769574) started by @jppittman*