### PR TITLE
⚡ Bolt: Use split_once to prevent Vec allocation in OSC handler

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -24,3 +24,6 @@
 ## 2025-12-29 - Avoid Intermediate Vectors and use Vec::with_capacity
 **Learning:** Performance can be impacted by intermediate allocations like `text.chars().collect::<Vec<char>>()` when extracting small segments.
 **Action:** Avoid `.collect()` into an intermediate Vector when doing simple tasks like extracting characters or single items, and instead use the Iterator functions directly (`chars.next()`). Also use `Vec::with_capacity` when the required capacity is known ahead of time.
+## 2024-12-07 - Avoid Vec Allocation in String Parsing
+**Learning:** In hot paths like the OSC handler `core-term/src/term/emulator/osc_handler.rs`, using `.splitn(2, delim).collect::<Vec<&str>>()` introduces unnecessary heap allocations which can degrade performance, especially when parsing large amounts of escape sequences.
+**Action:** Always prefer `.split_once(delim)` or similar tuple-returning methods to extract substrings without allocating an intermediate `Vec`.

--- a/core-term/src/term/emulator/osc_handler.rs
+++ b/core-term/src/term/emulator/osc_handler.rs
@@ -2,43 +2,24 @@
 
 use super::TerminalEmulator;
 use crate::term::action::EmulatorAction;
-use log::{debug, warn};
+use log::debug;
 
 impl TerminalEmulator {
     pub(super) fn handle_osc(&mut self, data: Vec<u8>) -> Option<EmulatorAction> {
         let osc_str = String::from_utf8_lossy(&data);
-        let parts: Vec<&str> = osc_str.splitn(2, ';').collect();
 
-        let ps_str: &str;
-        let content_str: &str;
-
-        match parts.len() {
-            1 => {
+        let (ps_str, content_str) = match osc_str.split_once(';') {
+            Some((ps, pt)) => (ps, pt),
+            None => {
                 // No semicolon found, treat the whole string as Ps, content is empty
-                ps_str = parts[0];
-                content_str = "";
                 // Log a debug message for this case, as it might be an implicit expectation
                 debug!(
-                    "OSC sequence without semicolon: '{}'. Interpreting Ps='{}', Pt='{}'",
-                    osc_str, ps_str, content_str
+                    "OSC sequence without semicolon: '{}'. Interpreting Ps='{}', Pt=''",
+                    osc_str, osc_str
                 );
+                (osc_str.as_ref(), "")
             }
-            2 => {
-                // Semicolon found, standard case
-                ps_str = parts[0];
-                content_str = parts[1];
-            }
-            _ => {
-                // This case should ideally not be reached with splitn(2, ';')
-                // but handle defensively.
-                warn!(
-                    "Malformed OSC sequence (unexpected parts count for {}): {}",
-                    parts.len(),
-                    osc_str
-                );
-                return None;
-            }
-        }
+        };
 
         // Attempt to parse Ps, default to 0 if parsing fails (e.g., "Implicit Title")
         // Using u32::MAX as a sentinel for unhandled 'ps' codes later is fine,


### PR DESCRIPTION
💡 **What**: Replaced `.splitn(2, ';').collect::<Vec<&str>>()` with `.split_once(';')` in `core-term/src/term/emulator/osc_handler.rs`.
🎯 **Why**: To avoid an unnecessary heap allocation when processing OSC terminal sequences.
📊 **Impact**: Prevents a temporary vector allocation every time an OSC sequence is handled, improving parser throughput for heavily styled applications.
🔬 **Measurement**: Verified correct functionality using `cargo test -p core-term`. Performance improvement is structural (zero-allocation vs heap-allocation).

---
*PR created automatically by Jules for task [9569455045386079992](https://jules.google.com/task/9569455045386079992) started by @jppittman*