### PR TITLE
Refactor boolean control flow to tuple match in char_processor.rs

### DIFF
--- a/core-term/src/term/emulator/char_processor.rs
+++ b/core-term/src/term/emulator/char_processor.rs
@@ -21,17 +21,17 @@ impl TerminalEmulator {
         let (cursor_x, cursor_y) = self.cursor_controller.physical_screen_pos(&screen_ctx);
 
         // Determine the position of the base character cell.
-        let (base_x, base_y) = if cursor_x > 0 {
-            (cursor_x - 1, cursor_y)
-        } else if cursor_y > 0 {
-            (screen_ctx.width.saturating_sub(1), cursor_y - 1)
-        } else {
-            // Cursor is at (0, 0) — no previous cell to attach to.
-            trace!(
-                "attach_combining_char: no previous cell at origin, discarding '{}'",
-                combining
-            );
-            return;
+        let (base_x, base_y) = match (cursor_x > 0, cursor_y > 0) {
+            (true, _) => (cursor_x - 1, cursor_y),
+            (false, true) => (screen_ctx.width.saturating_sub(1), cursor_y - 1),
+            (false, false) => {
+                // Cursor is at (0, 0) — no previous cell to attach to.
+                trace!(
+                    "attach_combining_char: no previous cell at origin, discarding '{}'",
+                    combining
+                );
+                return;
+            }
         };
 
         if base_y >= self.screen.height || base_x >= self.screen.width {


### PR DESCRIPTION
**Scope**
- Modified `core-term/src/term/emulator/char_processor.rs`

**Fixes**
- Refactored an `if / else if / else` control flow block evaluating boolean states (`cursor_x > 0`, `cursor_y > 0`) into a tuple `match` statement (`match (cursor_x > 0, cursor_y > 0)`).
- This ensures adherence to the `STYLE.md` guideline to "Prefer `match` over `else if`" and uses the idiomatic tuple matching pattern for multiple boolean flags.

**Unresolved Issues**
- None.

**Verification**
- Verified with `cargo check -p core-term` and `cargo test -p core-term` that all tests pass and logic is correctly preserved.

---
*PR created automatically by Jules for task [2468248495327937181](https://jules.google.com/task/2468248495327937181) started by @jppittman*