### PR TITLE
Refactor `req.target` evaluation to use `match`

### DIFF
--- a/pixelflow-runtime/src/platform/linux/events.rs
+++ b/pixelflow-runtime/src/platform/linux/events.rs
@@ -102,40 +102,44 @@ unsafe fn handle_selection_request(event: &xlib::XEvent, window: &mut super::win
     response.time = req.time;
     response.property = req.property;
 
-    if req.target == window.atoms.targets {
-        let targets = [
-            window.atoms.targets,
-            window.atoms.utf8_string,
-            window.atoms.text,
-            window.atoms.xa_string,
-        ];
-        xlib::XChangeProperty(
-            window.display,
-            req.requestor,
-            req.property,
-            xlib::XA_ATOM,
-            32,
-            xlib::PropModeReplace,
-            targets.as_ptr() as *const u8,
-            targets.len() as i32,
-        );
-    } else if req.target == window.atoms.utf8_string
-        || req.target == window.atoms.text
-        || req.target == window.atoms.xa_string
-    {
-        let data = window.clipboard_data.as_bytes();
-        xlib::XChangeProperty(
-            window.display,
-            req.requestor,
-            req.property,
-            req.target,
-            8,
-            xlib::PropModeReplace,
-            data.as_ptr(),
-            data.len() as i32,
-        );
-    } else {
-        response.property = 0; // Reject
+    match req.target {
+        t if t == window.atoms.targets => {
+            let targets = [
+                window.atoms.targets,
+                window.atoms.utf8_string,
+                window.atoms.text,
+                window.atoms.xa_string,
+            ];
+            xlib::XChangeProperty(
+                window.display,
+                req.requestor,
+                req.property,
+                xlib::XA_ATOM,
+                32,
+                xlib::PropModeReplace,
+                targets.as_ptr() as *const u8,
+                targets.len() as i32,
+            );
+        }
+        t if t == window.atoms.utf8_string
+            || t == window.atoms.text
+            || t == window.atoms.xa_string =>
+        {
+            let data = window.clipboard_data.as_bytes();
+            xlib::XChangeProperty(
+                window.display,
+                req.requestor,
+                req.property,
+                req.target,
+                8,
+                xlib::PropModeReplace,
+                data.as_ptr(),
+                data.len() as i32,
+            );
+        }
+        _ => {
+            response.property = 0; // Reject
+        }
     }
     xlib::XSendEvent(
         window.display,


### PR DESCRIPTION
**Scope:**
- `pixelflow-runtime/src/platform/linux/events.rs`

**Fixes:**
- Refactored the `if / else if` chain evaluating the `req.target` struct field into an idiomatic `match` expression using guard clauses (`t if t == ...`).
- This addresses the structural style rule in `docs/STYLE.md` to prefer `match` over `else if` for complex conditions, especially when evaluating multiple exclusive conditions on a single variable.

**Unresolved Issues:**
- None. The refactoring is logically equivalent and safe.

**Verification:**
- Ran `cargo check -p pixelflow-runtime`.
- Ran `cargo test -p pixelflow-runtime`. All tests pass.

---
*PR created automatically by Jules for task [424166174944954466](https://jules.google.com/task/424166174944954466) started by @jppittman*