### PR TITLE
Refactor match expressions for style guide adherence

### DIFF
--- a/core-term/src/ansi/commands.rs
+++ b/core-term/src/ansi/commands.rs
@@ -612,7 +612,7 @@ impl AnsiCommand {
                 shape: param_or(0, 1), // Default shape 1 (blinking block) or 0 (default)
             })),
             // Handle 't' for WindowManipulation, checking intermediates for safety
-            (_, _, b't') if intermediates.is_empty() || intermediates == b" " => {
+            (_, i, b't') if i.is_empty() || i == b" " => {
                 // Ensure 't' is not part of a more complex sequence like DECSTUI
                 let ps1 = param_or(0, 0);
                 let ps2 = params.get(1).copied();

--- a/core-term/src/term/emulator/mode_handler.rs
+++ b/core-term/src/term/emulator/mode_handler.rs
@@ -125,8 +125,8 @@ impl TerminalEmulator {
                             AltScreenClear::Preserve
                         };
 
-                        if enable {
-                            if !self.dec_modes.using_alt_screen {
+                        match (enable, self.dec_modes.using_alt_screen) {
+                            (true, false) => {
                                 // Assuming this flag exists
                                 if mode_num == DecModeConstant::AltScreenBufferSaveRestore as u16 {
                                     self.save_cursor();
@@ -143,22 +143,24 @@ impl TerminalEmulator {
                                 self.screen.mark_all_dirty();
                                 action_to_return = Some(EmulatorAction::RequestRedraw);
                             }
-                        } else if self.dec_modes.using_alt_screen {
-                            self.screen.exit_alt_screen();
-                            self.dec_modes.using_alt_screen = false;
-                            if mode_num == DecModeConstant::AltScreenBufferSaveRestore as u16 {
-                                self.restore_cursor();
-                            } else {
-                                self.cursor_controller.move_to_logical(
-                                    0,
-                                    0,
-                                    &self.current_screen_context(),
-                                );
-                                self.screen.default_attributes =
-                                    self.cursor_controller.attributes();
+                            (false, true) => {
+                                self.screen.exit_alt_screen();
+                                self.dec_modes.using_alt_screen = false;
+                                if mode_num == DecModeConstant::AltScreenBufferSaveRestore as u16 {
+                                    self.restore_cursor();
+                                } else {
+                                    self.cursor_controller.move_to_logical(
+                                        0,
+                                        0,
+                                        &self.current_screen_context(),
+                                    );
+                                    self.screen.default_attributes =
+                                        self.cursor_controller.attributes();
+                                }
+                                self.screen.mark_all_dirty();
+                                action_to_return = Some(EmulatorAction::RequestRedraw);
                             }
-                            self.screen.mark_all_dirty();
-                            action_to_return = Some(EmulatorAction::RequestRedraw);
+                            _ => {}
                         }
                     }
                     Some(DecModeConstant::SaveRestoreCursor) => {


### PR DESCRIPTION
**Scope**: `core-term/src/ansi/commands.rs`, `core-term/src/term/emulator/mode_handler.rs`
**Fixes**: Refactored complex `if`/`else if` chains into `match` expressions matching tuples, and replaced match variable `intermediates` array pattern with variable binding.
**Unresolved Issues**: None.
**Verification**: `cargo check --all-targets` and `cargo test --all-targets` completed successfully.

---
*PR created automatically by Jules for task [9203439561724180603](https://jules.google.com/task/9203439561724180603) started by @jppittman*