### PR TITLE
Add PICT-style pairwise testing POC for the ANSI/SGR layer

### DIFF
--- a/core-term/src/ansi/commands.rs
+++ b/core-term/src/ansi/commands.rs
@@ -519,11 +519,13 @@ impl AnsiCommand {
                 }
             }
         }
-        // Consolidate multiple Resets or Reset followed by nothing else into a single Reset.
-        if attrs.is_empty() || (attrs.len() == 1 && attrs[0] == Attribute::Reset) {
-            attrs.clear(); // Ensure it's clean if it was just a single reset
-            attrs.push(Attribute::Reset);
-        } else if attrs.iter().all(|&a| a == Attribute::Reset) && attrs.len() > 1 {
+        // Collapse a run of only-`Reset` attributes (e.g. `SGR 0;0`) into one.
+        // An *empty* result means every parameter was unrecognized: that must be
+        // a no-op, never a reset. The genuine reset — an empty parameter list
+        // (`ESC[m`) — is already handled at the top of this function, so an
+        // unknown code such as `ESC[73m` must not be allowed to fall through
+        // into a full attribute reset here.
+        if !attrs.is_empty() && attrs.iter().all(|&a| a == Attribute::Reset) {
             attrs.clear();
             attrs.push(Attribute::Reset);
         }

--- a/core-term/src/ansi/lexer.rs
+++ b/core-term/src/ansi/lexer.rs
@@ -268,7 +268,7 @@ impl AnsiLexer {
 
     /// Consumes and returns all accumulated tokens.
     pub fn take_tokens(&mut self) -> Vec<AnsiToken> {
-        trace!("taking {:?} tokens from lexer", &self.tokens);
+        trace!("taking {:?} tokens from lexer", self.tokens);
         mem::take(&mut self.tokens)
     }
 

--- a/core-term/src/ansi/mod.rs
+++ b/core-term/src/ansi/mod.rs
@@ -349,3 +349,8 @@ impl AnsiParser for AnsiProcessor {
 // Include tests module if defined in this file
 #[cfg(test)]
 mod tests; // Assuming tests are in ansi/tests.rs
+
+#[cfg(test)]
+mod pict; // PICT-style pairwise covering-array generator (POC)
+#[cfg(test)]
+mod pict_sgr_tests; // Pairwise SGR parser testing built on `pict`

--- a/core-term/src/ansi/pict.rs
+++ b/core-term/src/ansi/pict.rs
@@ -1,0 +1,170 @@
+// src/ansi/pict.rs
+
+//! Proof-of-concept: PICT-style pairwise (combinatorial) testing for the ANSI
+//! layer.
+//!
+//! # Why this exists
+//!
+//! Microsoft's [PICT](https://github.com/microsoft/pict) generates a compact
+//! set of test cases that covers every *pair* of parameter values across a
+//! high-dimensional input space. The insight (empirically well-supported) is
+//! that the large majority of real defects are triggered by the interaction of
+//! at most two parameters, so a pairwise ("2-way") covering array finds most
+//! interaction bugs at a tiny fraction of the cost of exhaustive testing.
+//!
+//! The Rust ecosystem has no established crate for this (only very early ports
+//! like `pict-engine`), and per this repo's "suckless dependencies" rule we do
+//! not want one. This module is a small, dependency-free covering-array
+//! generator plus a worked example that models SGR (Select Graphic Rendition)
+//! sequences as a set of independent factors and checks the parser against a
+//! reference oracle for every generated case.
+//!
+//! An SGR sequence like `ESC[1;38;5;5;4;7m` is exactly the shape PICT targets:
+//! many independent, order-preserving parameters (intensity, color, underline,
+//! blink, ...) whose combinations are far too numerous to enumerate by hand.
+
+/// A pairwise (2-way) covering-array generator.
+///
+/// Given the number of levels (distinct values) of each factor, returns a set
+/// of rows — each row assigns one level index to every factor — such that for
+/// any two factors `i, j` and any pair of levels `(a, b)`, at least one row has
+/// `row[i] == a && row[j] == b`.
+///
+/// The algorithm is the deterministic one-row-at-a-time greedy heuristic (the
+/// core of AETG/PICT): seed each new row with a still-uncovered pair, then fill
+/// the remaining factors by greedily choosing the level that covers the most
+/// currently-uncovered pairs against the already-assigned factors. It is
+/// deterministic (no RNG) so failures reproduce exactly.
+pub fn pairwise(level_counts: &[usize]) -> Vec<Vec<usize>> {
+    use std::collections::BTreeSet;
+
+    let n = level_counts.len();
+    assert!(n >= 2, "pairwise testing needs at least two factors");
+    assert!(
+        level_counts.iter().all(|&c| c >= 1),
+        "every factor needs at least one level"
+    );
+
+    // A pair is keyed (factor_i, level_a, factor_j, level_b) with i < j. Using a
+    // BTreeSet keeps seed selection deterministic (always the smallest key).
+    let mut uncovered: BTreeSet<(usize, usize, usize, usize)> = BTreeSet::new();
+    for i in 0..n {
+        for j in (i + 1)..n {
+            for a in 0..level_counts[i] {
+                for b in 0..level_counts[j] {
+                    uncovered.insert((i, a, j, b));
+                }
+            }
+        }
+    }
+
+    let pair_key = |i: usize, a: usize, j: usize, b: usize| {
+        if i < j {
+            (i, a, j, b)
+        } else {
+            (j, b, i, a)
+        }
+    };
+
+    let mut rows: Vec<Vec<usize>> = Vec::new();
+
+    while let Some(&(si, sa, sj, sb)) = uncovered.iter().next() {
+        // Seed the row with the smallest still-uncovered pair.
+        let mut row: Vec<Option<usize>> = vec![None; n];
+        row[si] = Some(sa);
+        row[sj] = Some(sb);
+
+        // Fill remaining factors in index order, greedily.
+        for f in 0..n {
+            if row[f].is_some() {
+                continue;
+            }
+            let mut best_level = 0;
+            let mut best_gain = usize::MAX; // sentinel forcing first real compare
+            for level in 0..level_counts[f] {
+                let mut gain = 0;
+                for (g, assigned) in row.iter().enumerate() {
+                    let Some(av) = *assigned else { continue };
+                    let (i, a, j, b) = pair_key(f, level, g, av);
+                    if uncovered.contains(&(i, a, j, b)) {
+                        gain += 1;
+                    }
+                }
+                if best_gain == usize::MAX || gain > best_gain {
+                    best_gain = gain;
+                    best_level = level;
+                }
+            }
+            row[f] = Some(best_level);
+        }
+
+        let row: Vec<usize> = row.into_iter().map(|v| v.expect("row fully assigned")).collect();
+
+        // Mark every pair this row realizes as covered.
+        for i in 0..n {
+            for j in (i + 1)..n {
+                uncovered.remove(&(i, row[i], j, row[j]));
+            }
+        }
+        rows.push(row);
+    }
+
+    rows
+}
+
+#[cfg(test)]
+mod generator_tests {
+    use super::pairwise;
+    use std::collections::HashSet;
+
+    /// The generated array must actually cover every pair — the whole point.
+    fn assert_covers_all_pairs(level_counts: &[usize]) {
+        let rows = pairwise(level_counts);
+        let n = level_counts.len();
+        for i in 0..n {
+            for j in (i + 1)..n {
+                let mut seen: HashSet<(usize, usize)> = HashSet::new();
+                for row in &rows {
+                    seen.insert((row[i], row[j]));
+                }
+                for a in 0..level_counts[i] {
+                    for b in 0..level_counts[j] {
+                        assert!(
+                            seen.contains(&(a, b)),
+                            "pair (f{i}={a}, f{j}={b}) never covered for {level_counts:?}",
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn covers_uniform_factors() {
+        assert_covers_all_pairs(&[3, 3, 3, 3]);
+        assert_covers_all_pairs(&[4, 4, 4, 4, 4]);
+    }
+
+    #[test]
+    fn covers_mixed_arity_factors() {
+        assert_covers_all_pairs(&[2, 3, 4, 5, 2, 1]);
+    }
+
+    #[test]
+    fn is_far_smaller_than_exhaustive() {
+        let counts = [4, 4, 4, 4, 4, 4];
+        let rows = pairwise(&counts);
+        let exhaustive: usize = counts.iter().product();
+        // Pairwise should be a tiny fraction of the full 4^6 = 4096 cross product.
+        assert!(
+            rows.len() < exhaustive / 10,
+            "expected a compact array, got {} rows vs {exhaustive} exhaustive",
+            rows.len(),
+        );
+    }
+
+    #[test]
+    fn is_deterministic() {
+        assert_eq!(pairwise(&[3, 4, 2, 5]), pairwise(&[3, 4, 2, 5]));
+    }
+}

--- a/core-term/src/ansi/pict_sgr_tests.rs
+++ b/core-term/src/ansi/pict_sgr_tests.rs
@@ -1,0 +1,194 @@
+// src/ansi/pict_sgr_tests.rs
+
+//! Worked example for the PICT-style generator in [`super::pict`]: model SGR
+//! sequences as independent factors, generate a pairwise covering array, and
+//! check the parser against a reference oracle for every generated case.
+//!
+//! SGR is an ideal target — a single `ESC[...m` carries many independent,
+//! order-preserving parameters (intensity, italic, underline, blink,
+//! foreground, background, ...). The number of combinations is astronomical;
+//! pairwise coverage exercises every 2-way interaction with a handful of cases.
+
+use super::pict::pairwise;
+use super::{
+    commands::{AnsiCommand, Attribute, CsiCommand},
+    AnsiParser, AnsiProcessor,
+};
+use crate::color::{Color, NamedColor};
+use test_log::test;
+
+/// One selectable value of a factor: the SGR fragment it emits (if any) and the
+/// attributes a correct parser must produce for it, in order.
+struct Level {
+    /// SGR text this level contributes, e.g. `"38;5;5"`. `None` means "absent".
+    fragment: Option<&'static str>,
+    /// Reference output: what a correct parser yields for this fragment alone.
+    expected: Vec<Attribute>,
+}
+
+fn lvl(fragment: Option<&'static str>, expected: &[Attribute]) -> Level {
+    Level {
+        fragment,
+        expected: expected.to_vec(),
+    }
+}
+
+/// The SGR factor model. Each inner slice is one factor and its levels.
+fn sgr_factors() -> Vec<Vec<Level>> {
+    use Attribute::*;
+    let red = Color::Named(NamedColor::Red);
+    let bright_red = Color::Named(NamedColor::BrightRed);
+    vec![
+        // Intensity
+        vec![
+            lvl(None, &[]),
+            lvl(Some("1"), &[Bold]),
+            lvl(Some("2"), &[Faint]),
+            lvl(Some("22"), &[NoBold]),
+        ],
+        // Italic
+        vec![
+            lvl(None, &[]),
+            lvl(Some("3"), &[Italic]),
+            lvl(Some("23"), &[NoItalic]),
+        ],
+        // Underline
+        vec![
+            lvl(None, &[]),
+            lvl(Some("4"), &[Underline]),
+            lvl(Some("21"), &[UnderlineDouble]),
+            lvl(Some("24"), &[NoUnderline]),
+        ],
+        // Blink
+        vec![
+            lvl(None, &[]),
+            lvl(Some("5"), &[BlinkSlow]),
+            lvl(Some("25"), &[NoBlink]),
+        ],
+        // Foreground (basic / bright / default / 256 / truecolor)
+        vec![
+            lvl(None, &[]),
+            lvl(Some("31"), &[Foreground(red)]),
+            lvl(Some("91"), &[Foreground(bright_red)]),
+            lvl(Some("39"), &[Foreground(Color::Default)]),
+            lvl(Some("38;5;5"), &[Foreground(Color::Indexed(5))]),
+            lvl(Some("38;2;10;20;30"), &[Foreground(Color::Rgb(10, 20, 30))]),
+        ],
+        // Background
+        vec![
+            lvl(None, &[]),
+            lvl(Some("41"), &[Background(red)]),
+            lvl(Some("49"), &[Background(Color::Default)]),
+            lvl(Some("48;5;7"), &[Background(Color::Indexed(7))]),
+        ],
+        // Miscellaneous, including an SGR code the emulator does not implement.
+        vec![
+            lvl(None, &[]),
+            lvl(Some("7"), &[Reverse]),
+            lvl(Some("9"), &[Strikethrough]),
+            lvl(Some("53"), &[Overlined]),
+            // 73 = "superscript" (mintty/ECMA-48:2024). Unimplemented here; a
+            // correct parser must *ignore* an unknown SGR code, never reset.
+            lvl(Some("73"), &[]),
+        ],
+    ]
+}
+
+fn process(bytes: &[u8]) -> Vec<AnsiCommand> {
+    AnsiProcessor::new().process_bytes(bytes)
+}
+
+/// Build the `ESC[...m` byte sequence for a chosen row, and its oracle output.
+fn build_case(factors: &[Vec<Level>], row: &[usize]) -> (Vec<u8>, Vec<Attribute>) {
+    let mut fragments: Vec<&str> = Vec::new();
+    let mut expected: Vec<Attribute> = Vec::new();
+    for (factor, &level_idx) in factors.iter().zip(row) {
+        let level = &factor[level_idx];
+        if let Some(frag) = level.fragment {
+            fragments.push(frag);
+            expected.extend_from_slice(&level.expected);
+        }
+    }
+
+    let mut seq = b"\x1b[".to_vec();
+    seq.extend_from_slice(fragments.join(";").as_bytes());
+    seq.push(b'm');
+
+    // Oracle: an empty parameter list (`ESC[m`) is the spec-defined full reset.
+    // Any non-empty list of *recognized* attributes yields exactly those
+    // attributes; a list of only-unrecognized codes must be a no-op (`[]`).
+    let oracle = if fragments.is_empty() {
+        vec![Attribute::Reset]
+    } else {
+        expected
+    };
+    (seq, oracle)
+}
+
+/// Extract the SGR attribute list a sequence parses to, or `None` if the parse
+/// did not yield a single SGR command.
+fn parsed_attrs(seq: &[u8]) -> Option<Vec<Attribute>> {
+    let commands = process(seq);
+    match commands.as_slice() {
+        [AnsiCommand::Csi(CsiCommand::SetGraphicsRendition(attrs))] => Some(attrs.clone()),
+        _ => None,
+    }
+}
+
+#[test]
+fn pict_sgr_pairwise_matches_oracle() {
+    let factors = sgr_factors();
+    let level_counts: Vec<usize> = factors.iter().map(Vec::len).collect();
+    let rows = pairwise(&level_counts);
+
+    let mut failures: Vec<String> = Vec::new();
+    for row in &rows {
+        let (seq, oracle) = build_case(&factors, row);
+        let actual = parsed_attrs(&seq);
+        let seq_str = String::from_utf8_lossy(&seq).replace('\x1b', "ESC");
+        match actual {
+            Some(attrs) if attrs == oracle => {}
+            Some(attrs) => failures.push(format!(
+                "  {seq_str:<28} expected {oracle:?}\n{:>32}got      {attrs:?}",
+                ""
+            )),
+            None => failures.push(format!(
+                "  {seq_str:<28} expected {oracle:?}\n{:>32}got      <not a single SGR command>",
+                ""
+            )),
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "PICT pairwise SGR testing found {} of {} generated cases mismatched:\n{}",
+        failures.len(),
+        rows.len(),
+        failures.join("\n"),
+    );
+}
+
+/// Focused regression for the defect the pairwise sweep surfaces: an SGR
+/// sequence whose codes are all *unrecognized* must be ignored, not turned into
+/// a full attribute reset.
+#[test]
+fn unknown_only_sgr_is_ignored_not_reset() {
+    // `ESC[73m` — a single unimplemented code. Correct behavior: no-op.
+    assert_eq!(
+        parsed_attrs(b"\x1b[73m"),
+        Some(vec![]),
+        "an unknown SGR code must be ignored, but it was rewritten into a reset",
+    );
+}
+
+/// Sibling to the above that exposes the *inconsistency*: the same unknown code
+/// is silently dropped when it shares the sequence with a recognized attribute,
+/// so `ESC[73m` and `ESC[1;73m` disagree on how `73` is handled.
+#[test]
+fn unknown_sgr_is_dropped_when_mixed_with_known() {
+    assert_eq!(
+        parsed_attrs(b"\x1b[1;73m"),
+        Some(vec![Attribute::Bold]),
+        "unknown code alongside a known one should drop to just the known attribute",
+    );
+}

--- a/pixelflow-compiler/src/codegen/emitter.rs
+++ b/pixelflow-compiler/src/codegen/emitter.rs
@@ -283,7 +283,7 @@ impl<'a> CodeEmitter<'a> {
         // Always adjust param indices to account for literals in context
         // Literals go into A0 (Scalars), so only adjust scalar params (ArrayID 0)
         let literal_count = self.collected_literals.len();
-        for (_, (array_id, idx)) in self.param_indices.iter_mut() {
+        for (array_id, idx) in self.param_indices.values_mut() {
             if *array_id == 0 {
                 *idx += literal_count;
             }
@@ -511,7 +511,7 @@ impl<'a> CodeEmitter<'a> {
         // Always adjust param indices to account for literals in context
         // Literals go into A0 (Scalars), so only adjust scalar params (ArrayID 0)
         let literal_count = self.collected_literals.len();
-        for (_, (array_id, idx)) in self.param_indices.iter_mut() {
+        for (array_id, idx) in self.param_indices.values_mut() {
             if *array_id == 0 {
                 *idx += literal_count;
             }

--- a/pixelflow-graphics/src/render/mod.rs
+++ b/pixelflow-graphics/src/render/mod.rs
@@ -4,6 +4,11 @@ pub mod frame;
 pub mod pixel;
 pub mod rasterizer;
 
+#[cfg(test)]
+mod pict; // PICT-style pairwise covering-array generator (POC)
+#[cfg(test)]
+mod pict_color_tests; // Pairwise color/pixel testing built on `pict`
+
 pub use aa::aa_coverage;
 pub use color::{
     AttrFlags, Bgra8, BgraColorCube, CocoaPixel, Color, ColorCube, ColorManifold, Grayscale,

--- a/pixelflow-graphics/src/render/pict.rs
+++ b/pixelflow-graphics/src/render/pict.rs
@@ -1,0 +1,141 @@
+// src/render/pict.rs
+
+//! Proof-of-concept #2: PICT-style pairwise (combinatorial) testing for the
+//! color/pixel layer of the renderer.
+//!
+//! This is the same dependency-free pairwise covering-array generator first
+//! introduced for the ANSI/SGR layer (`core-term`'s `ansi::pict`). It is
+//! duplicated here rather than shared through a crate because the workspace
+//! deliberately keeps its dependency graph minimal — a ~90-line test helper
+//! does not justify a new shared crate. If a third consumer appears, that is
+//! the moment to extract it.
+//!
+//! See [`pairwise`] for the algorithm; the worked example lives in
+//! [`super::pict_color_tests`].
+
+/// A pairwise (2-way) covering-array generator.
+///
+/// Given the number of levels (distinct values) of each factor, returns a set
+/// of rows — each row assigns one level index to every factor — such that for
+/// any two factors `i, j` and any pair of levels `(a, b)`, at least one row has
+/// `row[i] == a && row[j] == b`.
+///
+/// Deterministic one-row-at-a-time greedy heuristic (the core of AETG/PICT):
+/// seed each new row with a still-uncovered pair, then fill the remaining
+/// factors by greedily choosing the level that covers the most currently
+/// uncovered pairs against the already-assigned factors. No RNG, so failures
+/// reproduce exactly.
+pub fn pairwise(level_counts: &[usize]) -> Vec<Vec<usize>> {
+    use std::collections::BTreeSet;
+
+    let n = level_counts.len();
+    assert!(n >= 2, "pairwise testing needs at least two factors");
+    assert!(
+        level_counts.iter().all(|&c| c >= 1),
+        "every factor needs at least one level"
+    );
+
+    // A pair is keyed (factor_i, level_a, factor_j, level_b) with i < j. Using a
+    // BTreeSet keeps seed selection deterministic (always the smallest key).
+    let mut uncovered: BTreeSet<(usize, usize, usize, usize)> = BTreeSet::new();
+    for i in 0..n {
+        for j in (i + 1)..n {
+            for a in 0..level_counts[i] {
+                for b in 0..level_counts[j] {
+                    uncovered.insert((i, a, j, b));
+                }
+            }
+        }
+    }
+
+    let pair_key = |i: usize, a: usize, j: usize, b: usize| {
+        if i < j {
+            (i, a, j, b)
+        } else {
+            (j, b, i, a)
+        }
+    };
+
+    let mut rows: Vec<Vec<usize>> = Vec::new();
+
+    while let Some(&(si, sa, sj, sb)) = uncovered.iter().next() {
+        // Seed the row with the smallest still-uncovered pair.
+        let mut row: Vec<Option<usize>> = vec![None; n];
+        row[si] = Some(sa);
+        row[sj] = Some(sb);
+
+        // Fill remaining factors in index order, greedily.
+        for f in 0..n {
+            if row[f].is_some() {
+                continue;
+            }
+            let mut best_level = 0;
+            let mut best_gain = usize::MAX; // sentinel forcing first real compare
+            for level in 0..level_counts[f] {
+                let mut gain = 0;
+                for (g, assigned) in row.iter().enumerate() {
+                    let Some(av) = *assigned else { continue };
+                    let (i, a, j, b) = pair_key(f, level, g, av);
+                    if uncovered.contains(&(i, a, j, b)) {
+                        gain += 1;
+                    }
+                }
+                if best_gain == usize::MAX || gain > best_gain {
+                    best_gain = gain;
+                    best_level = level;
+                }
+            }
+            row[f] = Some(best_level);
+        }
+
+        let row: Vec<usize> = row.into_iter().map(|v| v.expect("row fully assigned")).collect();
+
+        // Mark every pair this row realizes as covered.
+        for i in 0..n {
+            for j in (i + 1)..n {
+                uncovered.remove(&(i, row[i], j, row[j]));
+            }
+        }
+        rows.push(row);
+    }
+
+    rows
+}
+
+#[cfg(test)]
+mod generator_tests {
+    use super::pairwise;
+    use std::collections::HashSet;
+
+    fn assert_covers_all_pairs(level_counts: &[usize]) {
+        let rows = pairwise(level_counts);
+        let n = level_counts.len();
+        for i in 0..n {
+            for j in (i + 1)..n {
+                let mut seen: HashSet<(usize, usize)> = HashSet::new();
+                for row in &rows {
+                    seen.insert((row[i], row[j]));
+                }
+                for a in 0..level_counts[i] {
+                    for b in 0..level_counts[j] {
+                        assert!(
+                            seen.contains(&(a, b)),
+                            "pair (f{i}={a}, f{j}={b}) never covered for {level_counts:?}",
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn covers_uniform_and_mixed_factors() {
+        assert_covers_all_pairs(&[8, 8, 8, 8]);
+        assert_covers_all_pairs(&[6, 4, 8, 2, 3]);
+    }
+
+    #[test]
+    fn is_deterministic() {
+        assert_eq!(pairwise(&[6, 6, 6]), pairwise(&[6, 6, 6]));
+    }
+}

--- a/pixelflow-graphics/src/render/pict_color_tests.rs
+++ b/pixelflow-graphics/src/render/pict_color_tests.rs
@@ -1,0 +1,180 @@
+// src/render/pict_color_tests.rs
+
+//! Worked example for the PICT-style generator in [`super::pict`], applied to
+//! the renderer's color/pixel layer.
+//!
+//! Two models are exercised:
+//!
+//! 1. **Packing algebra** — treat the four channels `(R, G, B, A)` as factors
+//!    and check the byte-level pixel operations (`Rgba8`/`Bgra8` construction,
+//!    accessors, channel-order conversion, the `Pixel` trait) against algebraic
+//!    oracles: round-trips and channel-preservation identities.
+//!
+//! 2. **Render-pipeline cross-check** — treat `(R, G, B)` as factors and, for
+//!    each generated color, compare the two independent implementations of
+//!    "what pixel is this color": the direct `u32::from(Color)` pack and the
+//!    full pull-based manifold render through the SIMD backend
+//!    (`materialize_discrete`). They must agree bit-for-bit.
+//!
+//! Color packing is a natural fit for combinatorial testing: channel order and
+//! endianness bugs are exactly the kind of 2-way interaction PICT targets, and
+//! the number of `(R, G, B, A)` combinations (256^4) is far too large to
+//! enumerate.
+
+use super::color::{Bgra8, Color, Rgba8};
+use super::pict::pairwise;
+use super::pixel::Pixel;
+use pixelflow_core::{materialize_discrete, PARALLELISM};
+
+/// Representative channel values: the byte-range boundaries plus the midpoint
+/// split (127/128) where rounding and sign handling tend to break.
+const LEVELS: [u8; 8] = [0, 1, 64, 127, 128, 191, 254, 255];
+
+/// Render a color through the full pull-based manifold pipeline and return the
+/// first lane's packed pixel (RGBA byte order: `0xAABBGGRR`).
+fn render_color(color: Color) -> u32 {
+    let mut out = vec![0u32; PARALLELISM];
+    materialize_discrete(&color, 0.0, 0.0, &mut out);
+    out[0]
+}
+
+fn channels(packed: u32) -> (u8, u8, u8, u8) {
+    (
+        (packed & 0xFF) as u8,
+        ((packed >> 8) & 0xFF) as u8,
+        ((packed >> 16) & 0xFF) as u8,
+        ((packed >> 24) & 0xFF) as u8,
+    )
+}
+
+/// Model 1: the byte-packing algebra over four channel factors.
+#[test]
+fn pict_pixel_packing_algebra() {
+    let rows = pairwise(&[LEVELS.len(); 4]);
+    let mut failures: Vec<String> = Vec::new();
+
+    let mut check = |cond: bool, msg: String| {
+        if !cond {
+            failures.push(msg);
+        }
+    };
+
+    for row in &rows {
+        let (r, g, b, a) = (LEVELS[row[0]], LEVELS[row[1]], LEVELS[row[2]], LEVELS[row[3]]);
+
+        // Rgba8 construction and accessors round-trip.
+        let rgba = Rgba8::new(r, g, b, a);
+        check(
+            (rgba.r(), rgba.g(), rgba.b(), rgba.a()) == (r, g, b, a),
+            format!("Rgba8::new accessors: ({r},{g},{b},{a}) -> {:?}", (rgba.r(), rgba.g(), rgba.b(), rgba.a())),
+        );
+
+        // Bgra8 stores the same logical channels (note the (b,g,r,a) arg order).
+        let bgra = Bgra8::new(b, g, r, a);
+        check(
+            (bgra.r(), bgra.g(), bgra.b(), bgra.a()) == (r, g, b, a),
+            format!("Bgra8::new accessors: logical ({r},{g},{b},{a}) -> {:?}", (bgra.r(), bgra.g(), bgra.b(), bgra.a())),
+        );
+
+        // Rgba8 <-> Bgra8 preserves logical channels and is involutive.
+        let to_bgra = Bgra8::from(rgba);
+        check(
+            (to_bgra.r(), to_bgra.g(), to_bgra.b(), to_bgra.a()) == (r, g, b, a),
+            format!("Rgba8->Bgra8 channel preservation for ({r},{g},{b},{a})"),
+        );
+        check(
+            Rgba8::from(to_bgra) == rgba,
+            format!("Rgba8->Bgra8->Rgba8 not involutive for ({r},{g},{b},{a})"),
+        );
+
+        // Pixel::from_u32/to_u32 round-trip.
+        check(
+            Rgba8::from_u32(rgba.to_u32()) == rgba,
+            format!("Rgba8 u32 round-trip for ({r},{g},{b},{a})"),
+        );
+
+        // Pixel::from_rgba matches direct construction for both formats.
+        let norm = |v: u8| v as f32 / 255.0;
+        check(
+            <Rgba8 as Pixel>::from_rgba(norm(r), norm(g), norm(b), norm(a)) == rgba,
+            format!("Rgba8::from_rgba mismatch for ({r},{g},{b},{a})"),
+        );
+        check(
+            <Bgra8 as Pixel>::from_rgba(norm(r), norm(g), norm(b), norm(a)) == bgra,
+            format!("Bgra8::from_rgba mismatch for ({r},{g},{b},{a})"),
+        );
+    }
+
+    assert!(
+        failures.is_empty(),
+        "PICT pairwise pixel-packing testing found {} failing invariants over {} cases:\n  {}",
+        failures.len(),
+        rows.len(),
+        failures.join("\n  "),
+    );
+}
+
+/// Model 2: the direct pack and the manifold render must agree, for every
+/// pairwise `(R, G, B)` combination.
+#[test]
+fn pict_render_pipeline_matches_direct_pack() {
+    let rows = pairwise(&[LEVELS.len(); 3]);
+    let mut failures: Vec<String> = Vec::new();
+
+    for row in &rows {
+        let (r, g, b) = (LEVELS[row[0]], LEVELS[row[1]], LEVELS[row[2]]);
+        let color = Color::Rgb(r, g, b);
+
+        let direct = u32::from(color);
+        let rendered = render_color(color);
+
+        if direct != rendered {
+            failures.push(format!(
+                "Rgb({r},{g},{b}): direct pack {:?} != rendered {:?}",
+                channels(direct),
+                channels(rendered),
+            ));
+            continue;
+        }
+        // And the rendered pixel must actually carry the requested channels.
+        if channels(rendered) != (r, g, b, 255) {
+            failures.push(format!(
+                "Rgb({r},{g},{b}): rendered channels {:?} != expected ({r},{g},{b},255)",
+                channels(rendered),
+            ));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "PICT pairwise render cross-check found {} mismatches over {} cases:\n  {}",
+        failures.len(),
+        rows.len(),
+        failures.join("\n  "),
+    );
+}
+
+/// Exhaustive 1-way sweep of the 256-color palette: the direct pack and the
+/// manifold render must agree for every indexed color, too.
+#[test]
+fn palette_render_matches_direct_pack() {
+    let mut failures: Vec<String> = Vec::new();
+    for idx in 0u16..=255 {
+        let color = Color::Indexed(idx as u8);
+        let direct = u32::from(color);
+        let rendered = render_color(color);
+        if direct != rendered {
+            failures.push(format!(
+                "Indexed({idx}): direct {:?} != rendered {:?}",
+                channels(direct),
+                channels(rendered),
+            ));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "indexed-color render cross-check found {} mismatches:\n  {}",
+        failures.len(),
+        failures.join("\n  "),
+    );
+}

--- a/pixelflow-search/src/math/mod.rs
+++ b/pixelflow-search/src/math/mod.rs
@@ -59,6 +59,9 @@ pub mod parity;
 pub mod power;
 pub mod trig;
 
+#[cfg(test)]
+mod pict_rewrite_tests; // PICT-style pairwise testing of the rewrite rules (POC)
+
 use crate::egraph::rewrite::Rewrite;
 
 // Re-export key types for convenience

--- a/pixelflow-search/src/math/pict_rewrite_tests.rs
+++ b/pixelflow-search/src/math/pict_rewrite_tests.rs
@@ -1,0 +1,367 @@
+// src/math/pict_rewrite_tests.rs
+
+//! Proof-of-concept #3: PICT-style pairwise (combinatorial) testing for the
+//! e-graph rewrite rules.
+//!
+//! The existing `algebraic_rules_preserve_semantics` test hand-picks a handful
+//! of expression templates and checks that optimization preserves semantics.
+//! That is exactly the situation PICT is built for: the space of expression
+//! *shapes* — (outer op) × (unary wrapper) × (left subtree) × (right subtree) ×
+//! (constant) — is far too large to enumerate (4 × 5 × 7 × 7 × 5 = 4900 here),
+//! yet most rewrite bugs are triggered by the interaction of at most two of
+//! those choices. A pairwise covering array exercises every 2-way interaction
+//! in a few dozen cases.
+//!
+//! ## Oracle: algebraic equivalence, not bit-exact FP
+//!
+//! The rewrite rules are explicitly allowed to reassociate, distribute, and
+//! fuse (`a*b + c → fma(a,b,c)`), all of which change floating-point rounding.
+//! So the oracle compares the optimized expression against the original with a
+//! generous *relative* tolerance and ignores any sample point where either
+//! side is non-finite (a singularity such as `recip(0)`, where "algebra
+//! allows" the two forms to differ). Only a genuine change in the mathematical
+//! value — a divergence between two finite results — is a failure.
+//!
+//! The generator is the same dependency-free pairwise routine used by the
+//! other two POCs, duplicated per the workspace's minimal-dependency policy.
+
+use crate::egraph::{saturate_with_budget, EGraph, ENode};
+use crate::math::all_rules;
+use pixelflow_ir::arena::{ExprArena, ExprId, ExprNode};
+use pixelflow_ir::OpKind;
+
+// ============================================================================
+// Pairwise covering-array generator (see the ANSI/SGR POC for the annotated
+// version; this is a verbatim copy).
+// ============================================================================
+
+fn pairwise(level_counts: &[usize]) -> Vec<Vec<usize>> {
+    use std::collections::BTreeSet;
+
+    let n = level_counts.len();
+    assert!(n >= 2);
+    assert!(level_counts.iter().all(|&c| c >= 1));
+
+    let mut uncovered: BTreeSet<(usize, usize, usize, usize)> = BTreeSet::new();
+    for i in 0..n {
+        for j in (i + 1)..n {
+            for a in 0..level_counts[i] {
+                for b in 0..level_counts[j] {
+                    uncovered.insert((i, a, j, b));
+                }
+            }
+        }
+    }
+
+    let pair_key = |i: usize, a: usize, j: usize, b: usize| {
+        if i < j { (i, a, j, b) } else { (j, b, i, a) }
+    };
+
+    let mut rows: Vec<Vec<usize>> = Vec::new();
+    while let Some(&(si, sa, sj, sb)) = uncovered.iter().next() {
+        let mut row: Vec<Option<usize>> = vec![None; n];
+        row[si] = Some(sa);
+        row[sj] = Some(sb);
+
+        for f in 0..n {
+            if row[f].is_some() {
+                continue;
+            }
+            let mut best_level = 0;
+            let mut best_gain = usize::MAX;
+            for level in 0..level_counts[f] {
+                let mut gain = 0;
+                for (g, assigned) in row.iter().enumerate() {
+                    let Some(av) = *assigned else { continue };
+                    let (i, a, j, b) = pair_key(f, level, g, av);
+                    if uncovered.contains(&(i, a, j, b)) {
+                        gain += 1;
+                    }
+                }
+                if best_gain == usize::MAX || gain > best_gain {
+                    best_gain = gain;
+                    best_level = level;
+                }
+            }
+            row[f] = Some(best_level);
+        }
+
+        let row: Vec<usize> = row.into_iter().map(|v| v.unwrap()).collect();
+        for i in 0..n {
+            for j in (i + 1)..n {
+                uncovered.remove(&(i, row[i], j, row[j]));
+            }
+        }
+        rows.push(row);
+    }
+    rows
+}
+
+// ============================================================================
+// E-graph plumbing (mirrors the harness in `math::tests`).
+// ============================================================================
+
+fn expr_to_egraph(arena: &ExprArena, id: ExprId, egraph: &mut EGraph) -> crate::egraph::EClassId {
+    match *arena.node(id) {
+        ExprNode::Var(idx) => egraph.add(ENode::Var(idx)),
+        ExprNode::Const(val) => egraph.add(ENode::Const(val.to_bits())),
+        ExprNode::Unary(kind, a) => {
+            let ca = expr_to_egraph(arena, a, egraph);
+            let op = crate::egraph::ops::op_from_kind(kind).expect("op");
+            egraph.add(ENode::Op { op, children: vec![ca] })
+        }
+        ExprNode::Binary(kind, a, b) => {
+            let ca = expr_to_egraph(arena, a, egraph);
+            let cb = expr_to_egraph(arena, b, egraph);
+            let op = crate::egraph::ops::op_from_kind(kind).expect("op");
+            egraph.add(ENode::Op { op, children: vec![ca, cb] })
+        }
+        ExprNode::Ternary(kind, a, b, c) => {
+            let ca = expr_to_egraph(arena, a, egraph);
+            let cb = expr_to_egraph(arena, b, egraph);
+            let cc = expr_to_egraph(arena, c, egraph);
+            let op = crate::egraph::ops::op_from_kind(kind).expect("op");
+            egraph.add(ENode::Op { op, children: vec![ca, cb, cc] })
+        }
+        ExprNode::Param(_) | ExprNode::Buffer(_) | ExprNode::Nary(..) => {
+            panic!("unsupported node in rewrite POC")
+        }
+    }
+}
+
+fn eval_arena(arena: &ExprArena, id: ExprId, vars: &[f32; 4]) -> f32 {
+    match *arena.node(id) {
+        ExprNode::Var(i) => vars[i as usize],
+        ExprNode::Const(c) => c,
+        ExprNode::Unary(op, a) => op.eval_unary(eval_arena(arena, a, vars)).expect("unary"),
+        ExprNode::Binary(op, a, b) => {
+            op.eval_binary(eval_arena(arena, a, vars), eval_arena(arena, b, vars)).expect("binary")
+        }
+        ExprNode::Ternary(op, a, b, c) => op
+            .eval_ternary(
+                eval_arena(arena, a, vars),
+                eval_arena(arena, b, vars),
+                eval_arena(arena, c, vars),
+            )
+            .expect("ternary"),
+        _ => panic!("unsupported node in eval"),
+    }
+}
+
+// ============================================================================
+// The combinatorial model of expression shapes.
+// ============================================================================
+
+const OUTER_OPS: [OpKind; 4] = [OpKind::Add, OpKind::Sub, OpKind::Mul, OpKind::Div];
+
+/// Unary wrapper applied to the whole expression. `None` means "no wrapper".
+/// Includes transcendentals to engage the parity/trig/exp rewrite rules.
+const UNARY_WRAPPERS: [Option<OpKind>; 8] = [
+    None,
+    Some(OpKind::Neg),
+    Some(OpKind::Abs),
+    Some(OpKind::Sqrt),
+    Some(OpKind::Recip),
+    Some(OpKind::Sin),
+    Some(OpKind::Cos),
+    Some(OpKind::Exp),
+];
+
+const CONSTS: [f32; 5] = [0.0, 1.0, 2.0, -1.0, 0.5];
+
+const SHAPE_COUNT: usize = 10;
+
+/// Build one operand subtree. `konst` is used by the constant-bearing shapes.
+fn build_shape(a: &mut ExprArena, shape: usize, konst: f32) -> ExprId {
+    match shape {
+        0 => a.push_var(0),
+        1 => a.push_var(1),
+        2 => {
+            let (l, r) = (a.push_var(0), a.push_var(1));
+            a.push_binary(OpKind::Add, l, r)
+        }
+        3 => {
+            let (l, r) = (a.push_var(0), a.push_var(2));
+            a.push_binary(OpKind::Mul, l, r)
+        }
+        4 => {
+            let v = a.push_var(0);
+            a.push_unary(OpKind::Neg, v)
+        }
+        5 => {
+            let (l, r) = (a.push_var(0), a.push_const(konst));
+            a.push_binary(OpKind::Sub, l, r)
+        }
+        6 => {
+            let (l, r) = (a.push_var(1), a.push_const(konst));
+            a.push_binary(OpKind::Mul, l, r)
+        }
+        // Shapes that hand the parity/trig rules their exact rewrite patterns.
+        7 => {
+            let v = a.push_var(0);
+            a.push_unary(OpKind::Sin, v)
+        }
+        8 => {
+            // sin(neg(x)) — parity rule should rewrite to neg(sin(x)).
+            let v = a.push_var(0);
+            let n = a.push_unary(OpKind::Neg, v);
+            a.push_unary(OpKind::Sin, n)
+        }
+        9 => {
+            // cos(neg(x)) — parity rule should rewrite to cos(x).
+            let v = a.push_var(1);
+            let n = a.push_unary(OpKind::Neg, v);
+            a.push_unary(OpKind::Cos, n)
+        }
+        _ => unreachable!(),
+    }
+}
+
+fn build_expr(
+    a: &mut ExprArena,
+    outer: OpKind,
+    wrapper: Option<OpKind>,
+    left: usize,
+    right: usize,
+    konst: f32,
+) -> ExprId {
+    let l = build_shape(a, left, konst);
+    let r = build_shape(a, right, konst);
+    let inner = a.push_binary(outer, l, r);
+    match wrapper {
+        None => inner,
+        Some(op) => a.push_unary(op, inner),
+    }
+}
+
+/// A deterministic spread of sample points (no RNG — reproducible failures).
+fn test_points() -> Vec<[f32; 4]> {
+    let base = [-2.0f32, -0.75, -0.1, 0.1, 0.5, 1.0, 1.5, 3.0];
+    let mut pts = Vec::new();
+    for (i, &x) in base.iter().enumerate() {
+        let y = base[(i + 1) % base.len()];
+        let z = base[(i + 3) % base.len()];
+        let w = base[(i + 5) % base.len()];
+        pts.push([x, y, z, w]);
+    }
+    // A few explicit edge points.
+    pts.push([0.0, 1.0, -1.0, 2.0]);
+    pts.push([1.0, 1.0, 1.0, 1.0]);
+    pts.push([-1.0, -1.0, -1.0, -1.0]);
+    pts
+}
+
+/// Relative tolerance: rewrites may reassociate/fuse, so only a genuine change
+/// in mathematical value (well beyond FP rounding) counts as a failure.
+const REL_EPS: f32 = 1e-3;
+
+/// Adversarial cost models. Extracting the same saturated e-graph under each
+/// pulls out a *different* rewritten form (the fma-favoring model extracts the
+/// fused version, the neg/recip-favoring model extracts the canonicalized
+/// `a + neg(b)` / `a * recip(b)` forms, and so on), so a single saturation
+/// exercises many more rewrite rules than one extraction would.
+fn adversarial_cost_models() -> Vec<(&'static str, crate::egraph::CostModel)> {
+    use crate::egraph::CostModel;
+    let cheap = 1;
+    let dear = 1000;
+
+    let mut fma = CostModel::new();
+    fma.set_cost(OpKind::MulAdd, cheap);
+
+    let mut canonical = CostModel::new();
+    canonical.set_cost(OpKind::Neg, cheap);
+    canonical.set_cost(OpKind::Recip, cheap);
+    canonical.set_cost(OpKind::Sub, dear);
+    canonical.set_cost(OpKind::Div, dear);
+
+    let mut cheap_add = CostModel::new();
+    cheap_add.set_cost(OpKind::Add, cheap);
+    cheap_add.set_cost(OpKind::Mul, dear);
+
+    let mut cheap_mul = CostModel::new();
+    cheap_mul.set_cost(OpKind::Mul, cheap);
+    cheap_mul.set_cost(OpKind::Add, dear);
+
+    vec![
+        ("default", CostModel::new()),
+        ("fma", fma),
+        ("canonical", canonical),
+        ("cheap_add", cheap_add),
+        ("cheap_mul", cheap_mul),
+    ]
+}
+
+#[test]
+fn pict_rewrite_rules_preserve_semantics() {
+    let level_counts = [OUTER_OPS.len(), UNARY_WRAPPERS.len(), SHAPE_COUNT, SHAPE_COUNT, CONSTS.len()];
+    let rows = pairwise(&level_counts);
+    let exhaustive: usize = level_counts.iter().product();
+    let points = test_points();
+
+    assert!(!all_rules().is_empty(), "expected a non-empty rule set");
+    let mut failures: Vec<String> = Vec::new();
+    let mut changed = 0usize; // how many cases the optimizer actually rewrote
+
+    for row in &rows {
+        let outer = OUTER_OPS[row[0]];
+        let wrapper = UNARY_WRAPPERS[row[1]];
+        let (left, right) = (row[2], row[3]);
+        let konst = CONSTS[row[4]];
+
+        let mut arena = ExprArena::new();
+        let root = build_expr(&mut arena, outer, wrapper, left, right, konst);
+        let orig_str = arena.display(root).to_string();
+
+        // Optimize the way the compiler does: build e-graph, saturate once,
+        // then extract under several cost models — each pulls out a different
+        // rewritten form from the same saturated graph.
+        let mut eg = EGraph::with_rules(all_rules());
+        let root_class = expr_to_egraph(&arena, root, &mut eg);
+        let _ = saturate_with_budget(&mut eg, 25);
+        let canon_root = eg.find(root_class);
+
+        for (model_name, costs) in adversarial_cost_models() {
+            let (opt_arena, opt_root, _cost) =
+                crate::egraph::extract::extract(&eg, canon_root, &costs);
+            let opt_str = opt_arena.display(opt_root).to_string();
+            if opt_str != orig_str {
+                changed += 1;
+            }
+
+            for point in &points {
+                let original = eval_arena(&arena, root, point);
+                let optimized = eval_arena(&opt_arena, opt_root, point);
+
+                // Singularities and overflow: "algebra allows" the two forms to
+                // differ here, so this point does not constrain correctness.
+                if !original.is_finite() || !optimized.is_finite() {
+                    continue;
+                }
+
+                let diff = (original - optimized).abs();
+                let denom = original.abs().max(1.0);
+                if diff / denom > REL_EPS {
+                    failures.push(format!(
+                        "  [{model_name}] {orig_str}\n    rewrote to {opt_str}\n    at {point:?}: {original} vs {optimized} (rel diff {:.3e})",
+                        diff / denom,
+                    ));
+                    break;
+                }
+            }
+        }
+    }
+
+    eprintln!(
+        "PICT rewrite sweep: {} pairwise cases (vs {exhaustive} exhaustive), \
+         extracted under {} cost models; {} extractions differed from input",
+        rows.len(),
+        adversarial_cost_models().len(),
+        changed,
+    );
+    assert!(
+        failures.is_empty(),
+        "PICT pairwise rewrite testing found {} algebraically-unsound rewrite(s):\n{}",
+        failures.len(),
+        failures.join("\n"),
+    );
+}


### PR DESCRIPTION
Introduce a small, dependency-free pairwise (2-way) covering-array
generator and use it to model SGR sequences as independent factors,
checking the parser against a reference oracle for every generated case.

The Rust ecosystem has no established PICT/combinatorial-testing crate, and
the repo's dependency policy rules one out, so the generator is implemented
in-tree with the deterministic greedy AETG heuristic.

Building the SGR oracle surfaced a real parser bug: parse_sgr collapsed an
all-unrecognized parameter list (e.g. `ESC[73m`) into a full attribute
Reset instead of ignoring it, wiping the terminal's graphic state. Fix it so
an unknown-only sequence is a no-op; the genuine reset (empty parameter list,
`ESC[m`) is still handled separately. Regression tests cover both the
unknown-alone case and the prior inconsistency where the same code was
silently dropped when mixed with a recognized attribute.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HEQLkTcNZgWPtENreW2sWL