### PR TITLE
Close mutation-testing gaps and private-API test violations in core-term/pixelflow-graphics

### DIFF
--- a/core-term/src/ansi/tests.rs
+++ b/core-term/src/ansi/tests.rs
@@ -49,6 +49,77 @@ fn it_should_process_c0_bel() {
 }
 
 #[test]
+fn c0control_from_byte_accepts_only_the_documented_control_range() {
+    // Valid C0 range (0x00..=0x1F) except ESC, which is handled separately,
+    // plus DEL (0x7F). `from_byte` transmutes the byte into `C0Control`, so
+    // any byte outside this exact set must return `None` rather than
+    // reinterpreting an arbitrary byte as an enum discriminant.
+    for byte in 0u8..=0xFF {
+        let expected_valid = (byte <= 0x1F && byte != 0x1B) || byte == 0x7F;
+        assert_eq!(
+            C0Control::from_byte(byte).is_some(),
+            expected_valid,
+            "byte {:#04x} validity mismatch",
+            byte
+        );
+    }
+
+    assert_eq!(
+        C0Control::from_byte(0x1B),
+        None,
+        "ESC is handled separately"
+    );
+    assert_eq!(C0Control::from_byte(0x7F), Some(C0Control::DEL));
+    assert_eq!(
+        C0Control::from_byte(b'A'),
+        None,
+        "printable ASCII is not a C0 control"
+    );
+}
+
+#[test]
+fn c0control_display_prints_the_mnemonic_for_every_variant() {
+    let expected: &[(C0Control, &str)] = &[
+        (C0Control::NUL, "NUL"),
+        (C0Control::SOH, "SOH"),
+        (C0Control::STX, "STX"),
+        (C0Control::ETX, "ETX"),
+        (C0Control::EOT, "EOT"),
+        (C0Control::ENQ, "ENQ"),
+        (C0Control::ACK, "ACK"),
+        (C0Control::BEL, "BEL"),
+        (C0Control::BS, "BS"),
+        (C0Control::HT, "HT"),
+        (C0Control::LF, "LF"),
+        (C0Control::VT, "VT"),
+        (C0Control::FF, "FF"),
+        (C0Control::CR, "CR"),
+        (C0Control::SO, "SO"),
+        (C0Control::SI, "SI"),
+        (C0Control::DLE, "DLE"),
+        (C0Control::DC1, "DC1"),
+        (C0Control::DC2, "DC2"),
+        (C0Control::DC3, "DC3"),
+        (C0Control::DC4, "DC4"),
+        (C0Control::NAK, "NAK"),
+        (C0Control::SYN, "SYN"),
+        (C0Control::ETB, "ETB"),
+        (C0Control::CAN, "CAN"),
+        (C0Control::EM, "EM"),
+        (C0Control::SUB, "SUB"),
+        (C0Control::ESC, "ESC"),
+        (C0Control::FS, "FS"),
+        (C0Control::GS, "GS"),
+        (C0Control::RS, "RS"),
+        (C0Control::US, "US"),
+        (C0Control::DEL, "DEL"),
+    ];
+    for (control, mnemonic) in expected {
+        assert_eq!(&control.to_string(), mnemonic);
+    }
+}
+
+#[test]
 fn it_should_process_csi_h_as_cup_1_1() {
     let bytes = b"\x1B[H"; // CSI H -> CUP (1, 1)
     let commands = process_bytes(bytes);
@@ -266,6 +337,43 @@ fn it_should_process_csi_window_manipulation_t() {
             ps3: None
         })],
         "Expected WindowManipulation for CSI 14t"
+    );
+}
+
+#[test]
+fn it_should_not_treat_a_t_with_other_intermediates_as_window_manipulation() {
+    // 't' is only WindowManipulation with no intermediate or a single space
+    // intermediate; any other intermediate belongs to a different (currently
+    // unsupported) sequence and must not be misparsed as WindowManipulation.
+    // The parser remaps the resulting `CsiCommand::Unsupported` to `Error`.
+    let commands = process_bytes(b"\x1b[1$t");
+    assert_eq!(
+        commands,
+        vec![AnsiCommand::Error(b't')],
+        "CSI 1 $ t should not be parsed as WindowManipulation"
+    );
+}
+
+#[test]
+fn it_should_process_csi_set_and_reset_mode() {
+    // CSI 4 h -> SetMode(IRM), CSI 4 l -> ResetMode(IRM)
+    assert_eq!(
+        process_bytes(b"\x1b[4h"),
+        vec![AnsiCommand::Csi(CsiCommand::SetMode(4))]
+    );
+    assert_eq!(
+        process_bytes(b"\x1b[4l"),
+        vec![AnsiCommand::Csi(CsiCommand::ResetMode(4))]
+    );
+}
+
+#[test]
+fn it_should_process_csi_clear_tab_stops_via_g() {
+    // CSI 3 g -> ClearTabStops(3), distinct from the CSI...W (TBC) path
+    let commands = process_bytes(b"\x1b[3g");
+    assert_eq!(
+        commands,
+        vec![AnsiCommand::Csi(CsiCommand::ClearTabStops(3))]
     );
 }
 
@@ -603,6 +711,66 @@ fn it_should_abort_csi_on_esc_and_process_subsequent_csi() {
             Attribute::Italic
         ]))]
     );
+}
+
+#[test]
+fn it_should_abort_csi_entry_on_esc_and_process_subsequent_csi() {
+    // ESC aborts the CSI before any params/intermediates are collected.
+    let bytes = b"\x1B[\x1B[3m";
+    let commands = process_bytes(bytes);
+    assert_eq!(
+        commands,
+        vec![AnsiCommand::Csi(CsiCommand::SetGraphicsRendition(vec![
+            Attribute::Italic
+        ]))]
+    );
+}
+
+#[test]
+fn it_should_abort_csi_intermediate_on_esc_and_process_subsequent_csi() {
+    // ' ' pushes into CsiIntermediate state (DECSCUSR-style), then ESC aborts.
+    let bytes = b"\x1B[ \x1B[3m";
+    let commands = process_bytes(bytes);
+    assert_eq!(
+        commands,
+        vec![AnsiCommand::Csi(CsiCommand::SetGraphicsRendition(vec![
+            Attribute::Italic
+        ]))]
+    );
+}
+
+#[test]
+fn it_should_stay_in_escape_state_on_repeated_esc() {
+    // A second ESC while already in the Escape state re-arms rather than
+    // being dispatched as an (invalid) C0 control.
+    let bytes = b"\x1B\x1Bc"; // ESC ESC c -> RIS, no stray C0Control(ESC) command
+    let commands = process_bytes(bytes);
+    assert_eq!(
+        commands,
+        vec![AnsiCommand::Esc(EscCommand::ResetToInitialState)]
+    );
+}
+
+#[test]
+fn it_should_ignore_invalid_esc_intermediate_charset_designator() {
+    // ' ' (0x20) is below the valid charset-designator range ('0'..='~'),
+    // so both the intermediate and the final byte are reported as Ignored
+    // rather than forming a SelectCharacterSet command.
+    let bytes = b"\x1B( ";
+    let commands = process_bytes(bytes);
+    assert_eq!(
+        commands,
+        vec![AnsiCommand::Ignore(b'('), AnsiCommand::Ignore(b' ')]
+    );
+}
+
+#[test]
+fn it_should_dispatch_non_esc_c0_control_received_in_escape_state() {
+    // A C0 control other than ESC, received right after a bare ESC, aborts
+    // the pending escape sequence and is dispatched as its own command.
+    let bytes = b"\x1B\x07"; // ESC BEL
+    let commands = process_bytes(bytes);
+    assert_eq!(commands, vec![AnsiCommand::C0Control(C0Control::BEL)]);
 }
 
 #[cfg(test)]
@@ -1416,6 +1584,38 @@ mod mutation_tests {
             cmds,
             vec![AnsiCommand::Csi(CsiCommand::SetGraphicsRendition(vec![
                 Attribute::NoOverlined
+            ]))]
+        );
+    }
+
+    #[test]
+    fn sgr_underline_color_set_is_58() {
+        // 58;5;42 -> UnderlineColor(Indexed(42))
+        let cmds = process_bytes(b"\x1b[58;5;42m");
+        assert_eq!(
+            cmds,
+            vec![AnsiCommand::Csi(CsiCommand::SetGraphicsRendition(vec![
+                Attribute::UnderlineColor(Color::Indexed(42))
+            ]))]
+        );
+
+        // 58;2;10;20;30 -> UnderlineColor(Rgb(10, 20, 30))
+        let cmds = process_bytes(b"\x1b[58;2;10;20;30m");
+        assert_eq!(
+            cmds,
+            vec![AnsiCommand::Csi(CsiCommand::SetGraphicsRendition(vec![
+                Attribute::UnderlineColor(Color::Rgb(10, 20, 30))
+            ]))]
+        );
+    }
+
+    #[test]
+    fn sgr_underline_color_default_is_59() {
+        let cmds = process_bytes(b"\x1b[59m");
+        assert_eq!(
+            cmds,
+            vec![AnsiCommand::Csi(CsiCommand::SetGraphicsRendition(vec![
+                Attribute::UnderlineColor(Color::Default)
             ]))]
         );
     }

--- a/core-term/src/ansi/tests.rs
+++ b/core-term/src/ansi/tests.rs
@@ -740,6 +740,57 @@ fn it_should_abort_csi_intermediate_on_esc_and_process_subsequent_csi() {
 }
 
 #[test]
+fn it_should_dispatch_non_esc_c0_control_received_in_csi_entry() {
+    // A C0 control other than ESC, received before any CSI params, is
+    // dispatched as its own command (and the CSI is dropped) rather than
+    // being treated as an ESC-abort into the Escape state.
+    let bytes = b"\x1B[\x07A"; // ESC [ BEL A
+    let commands = process_bytes(bytes);
+    assert_eq!(
+        commands,
+        vec![
+            AnsiCommand::C0Control(C0Control::BEL),
+            AnsiCommand::Print('A')
+        ]
+    );
+}
+
+#[test]
+fn it_should_dispatch_non_esc_c0_control_received_in_csi_param() {
+    let bytes = b"\x1B[1\x07A"; // ESC [ 1 BEL A
+    let commands = process_bytes(bytes);
+    assert_eq!(
+        commands,
+        vec![
+            AnsiCommand::C0Control(C0Control::BEL),
+            AnsiCommand::Print('A')
+        ]
+    );
+}
+
+#[test]
+fn it_should_dispatch_non_esc_c0_control_received_in_csi_intermediate() {
+    let bytes = b"\x1B[ \x07A"; // ESC [ ' ' BEL A
+    let commands = process_bytes(bytes);
+    assert_eq!(
+        commands,
+        vec![
+            AnsiCommand::C0Control(C0Control::BEL),
+            AnsiCommand::Print('A')
+        ]
+    );
+}
+
+#[test]
+fn it_should_report_error_for_unexpected_char_in_csi_entry() {
+    // ':' is not a digit, ';', private marker, intermediate, or final byte,
+    // so it hits the CsiEntry fallback and is reported as an Error.
+    let bytes = b"\x1B[:";
+    let commands = process_bytes(bytes);
+    assert_eq!(commands, vec![AnsiCommand::Error(b':')]);
+}
+
+#[test]
 fn it_should_stay_in_escape_state_on_repeated_esc() {
     // A second ESC while already in the Escape state re-arms rather than
     // being dispatched as an (invalid) C0 control.

--- a/core-term/src/io/waker.rs
+++ b/core-term/src/io/waker.rs
@@ -163,8 +163,12 @@ mod tests {
     use crate::io::event::KqueueFlags as EventFlags;
 
     fn pipe_has_byte(waker: &FdWaker) -> bool {
+        use std::os::fd::BorrowedFd;
         let mut buf = [0u8; 8];
-        nix::unistd::read(&waker.read, &mut buf).is_ok_and(|n| n > 0)
+        // SAFETY: `waker` is borrowed for the duration of this call, so its
+        // read fd stays open and valid for the lifetime of `fd`.
+        let fd = unsafe { BorrowedFd::borrow_raw(waker.as_raw_fd()) };
+        nix::unistd::read(fd, &mut buf).is_ok_and(|n| n > 0)
     }
 
     #[test]

--- a/core-term/src/term/core_tests.rs
+++ b/core-term/src/term/core_tests.rs
@@ -780,9 +780,12 @@ fn it_should_move_cursor_up_by_n_lines_on_csi_cuu() {
         CsiCommand::CursorPosition(3, 3),
     )));
     assert_eq!(
-        term.cursor_controller.logical_pos(),
-        (2, 2),
-        "Initial cursor pos YX mismatch"
+        term.get_render_snapshot()
+            .expect("Snapshot was None")
+            .cursor_state
+            .map(|cs| (cs.x, cs.y)),
+        Some((2, 2)),
+        "Initial cursor pos XY mismatch"
     );
 
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Csi(CsiCommand::CursorUp(
@@ -1992,8 +1995,7 @@ fn it_should_enable_and_disable_autowrap_mode_on_decawm() {
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('1')));
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('2')));
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('3'))); // Fills line 0: "123"
-    assert_eq!(term.cursor_controller.logical_pos(), (3, 0)); // Corrected: logical_pos is (x,y) -> (3,0)
-                                                              // After filling line, next char will wrap
+                                                                        // After filling line, next char will wrap
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('4'))); // Wraps to line 1
     assert_screen_state(
         &term.get_render_snapshot().expect("Snapshot was None"),
@@ -2011,8 +2013,7 @@ fn it_should_enable_and_disable_autowrap_mode_on_decawm() {
         CsiCommand::CursorPosition(2, 3),
     ))); // Cursor to (1,2) on line "4  "
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('5'))); // Prints '5' at (1,2). Line "4 5". Cursor (1,3).
-    assert_eq!(term.cursor_controller.logical_pos(), (3, 1)); // Corrected: logical_pos is (x,y) -> (3,1)
-                                                              // With autowrap off, cursor stays at right edge
+                                                                        // With autowrap off, cursor stays at right edge (verified below via the overwrite behavior)
 
     // Try to print past end of line with autowrap off
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('6')));

--- a/core-term/src/term/tests.rs
+++ b/core-term/src/term/tests.rs
@@ -1614,7 +1614,12 @@ mod paste_text_tests {
     #[test]
     fn ansi_resize_sets_terminal_dimensions() {
         let mut emu = create_test_emulator(80, 24);
-        assert_eq!(emu.dimensions(), (80, 24));
+        assert_eq!(
+            emu.get_render_snapshot()
+                .expect("Snapshot was None")
+                .dimensions,
+            (80, 24)
+        );
 
         let resize_command = AnsiCommand::Csi(CsiCommand::WindowManipulation {
             ps1: 8,
@@ -1624,7 +1629,9 @@ mod paste_text_tests {
         emu.interpret_input(EmulatorInput::Ansi(resize_command));
 
         assert_eq!(
-            emu.dimensions(),
+            emu.get_render_snapshot()
+                .expect("Snapshot was None")
+                .dimensions,
             (100, 30),
             "Terminal should resize to 100 cols x 30 rows"
         );
@@ -1661,7 +1668,9 @@ mod paste_text_tests {
         emu.interpret_input(EmulatorInput::Ansi(resize_command));
 
         assert_eq!(
-            emu.dimensions(),
+            emu.get_render_snapshot()
+                .expect("Snapshot was None")
+                .dimensions,
             (80, 24),
             "Terminal should ignore resize with zero rows"
         );
@@ -1679,7 +1688,9 @@ mod paste_text_tests {
         emu.interpret_input(EmulatorInput::Ansi(resize_command));
 
         assert_eq!(
-            emu.dimensions(),
+            emu.get_render_snapshot()
+                .expect("Snapshot was None")
+                .dimensions,
             (80, 24),
             "Terminal should ignore resize with zero cols"
         );
@@ -1697,7 +1708,9 @@ mod paste_text_tests {
         emu.interpret_input(EmulatorInput::Ansi(resize_command));
 
         assert_eq!(
-            emu.dimensions(),
+            emu.get_render_snapshot()
+                .expect("Snapshot was None")
+                .dimensions,
             (80, 24),
             "Terminal should ignore resize with missing rows parameter"
         );
@@ -1710,7 +1723,9 @@ mod paste_text_tests {
         emu.interpret_input(EmulatorInput::Ansi(resize_command2));
 
         assert_eq!(
-            emu.dimensions(),
+            emu.get_render_snapshot()
+                .expect("Snapshot was None")
+                .dimensions,
             (80, 24),
             "Terminal should ignore resize with missing cols parameter"
         );

--- a/pixelflow-graphics/src/fonts/cache.rs
+++ b/pixelflow-graphics/src/fonts/cache.rs
@@ -371,13 +371,32 @@ mod tests {
     const FONT_DATA: &[u8] = include_bytes!("../../assets/DejaVuSansMono-Fallback.ttf");
 
     #[test]
-    fn verify_size_bucket() {
-        assert_eq!(size_bucket(8.0), 8);
-        assert_eq!(size_bucket(9.0), 12);
-        assert_eq!(size_bucket(12.0), 12);
-        assert_eq!(size_bucket(13.0), 16);
-        assert_eq!(size_bucket(16.0), 16);
-        assert_eq!(size_bucket(17.0), 20);
+    fn glyph_cache_buckets_sizes_within_4px_together() {
+        let font = Font::parse(FONT_DATA).unwrap();
+        let mut cache = GlyphCache::new();
+
+        // 9.0 and 12.0 both round up into the 12px bucket, so caching one
+        // makes the cache report the other as already cached.
+        cache.get(&font, 'A', 9.0);
+        assert_eq!(cache.len(), 1);
+        assert!(
+            cache.contains('A', 12.0),
+            "9.0 and 12.0 should share the 12px bucket"
+        );
+
+        // 13.0 rounds up to the next bucket (16px), so it must not collide
+        // with the 12px bucket.
+        assert!(
+            !cache.contains('A', 13.0),
+            "13.0 should land in a different bucket than 12.0"
+        );
+
+        // Sizes at or below the minimum clamp to the 8px bucket.
+        cache.get(&font, 'B', 1.0);
+        assert!(
+            cache.contains('B', 8.0),
+            "sub-minimum sizes should clamp to the 8px bucket"
+        );
     }
 
     #[test]


### PR DESCRIPTION
cargo-mutants against core-term/src/ansi/{parser,commands}.rs surfaced several
untested behaviors, including a real soundness risk: C0Control::from_byte's
unsafe transmute had no direct test of its byte-validity guard, so a broken
guard (e.g. && flipped to ||) would silently transmute arbitrary bytes into
an out-of-range enum discriminant. Also added coverage for: SGR underline-color
codes (58/59), non-private SetMode/ResetMode/ClearTabStops (CSI h/l/g), the
WindowManipulation intermediate-byte guard, C0Control's Display impl, ESC
aborting CSI mid-entry/intermediate, ESC re-arming in the Escape state vs.
dispatching a trailing C0 control, and an invalid ESC-intermediate charset
designator.

Also fixed several tests that violated STYLE.md's "test public API" rule by
reaching into pub(super)/private fields instead of the crate's real contract:
core_tests.rs and tests.rs read `cursor_controller`/called `dimensions()`
directly instead of going through `get_render_snapshot()`; io/waker.rs's test
read FdWaker's private `read` fd field instead of using the public `AsRawFd`
impl; pixelflow-graphics's fonts/cache.rs test called the private
`size_bucket()` helper instead of exercising the documented bucketing
contract through `GlyphCache::get`/`contains`.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ER5XkBTJs3EoK9efjrea6f