### PR TITLE
Fix STYLE.md violations in core-term tests

### DIFF
--- a/core-term/src/ansi/tests.rs
+++ b/core-term/src/ansi/tests.rs
@@ -911,7 +911,6 @@ mod unicode_wide_tests {
         let mut expected_commands = vec![
             AnsiCommand::Print(char::REPLACEMENT_CHARACTER), // For interrupted 0xE2
         ];
-        // Check how ESC 'A' is handled (assuming it's not a defined sequence, might print 'A')
         if AnsiCommand::from_esc('A').is_none() {
             expected_commands.push(AnsiCommand::Print('A'));
         } else {
@@ -1337,7 +1336,6 @@ fn it_should_process_charset_designator_boundary_high() {
 
 #[test]
 fn it_should_process_charset_special_designators() {
-    // Test special characters that are valid charset designators
     let test_cases = [
         (':', "colon"),
         (';', "semicolon"),
@@ -1678,7 +1676,6 @@ mod mutation_tests {
 
     #[test]
     fn sgr_fg_all_eight_normal_colors() {
-        // Tests every entry in map_basic_code_to_color for Normal intensity.
         // A mutation that shifts the base constant by ±1 would fail on Black or White.
         let cases: &[(u8, NamedColor)] = &[
             (30, NamedColor::Black),
@@ -2100,7 +2097,6 @@ mod mutation_tests {
         // All 16 must be collected and processed.
         let cmds = process_bytes(b"\x1b[1;2;0;0;0;0;0;0;0;0;0;0;0;0;0;0m");
         if let Some(AnsiCommand::Csi(CsiCommand::SetGraphicsRendition(attrs))) = cmds.first() {
-            // Checking len kills mutations that reduce MAX_PARAMS below 16.
             assert_eq!(attrs.len(), 16, "all 16 params must be retained");
             assert_eq!(
                 attrs[0],

--- a/core-term/src/term/tests.rs
+++ b/core-term/src/term/tests.rs
@@ -188,7 +188,6 @@ fn assert_screen_state(
             s_col += char_width;
         }
 
-        // Check that remaining cells in the row are spaces (default fill)
         for c_fill in s_col..snapshot.dimensions.0 {
             let glyph_wrapper = get_glyph_from_snapshot(snapshot, r, c_fill)
                 .unwrap_or_else(|| panic!("Glyph ({}, {}) not found for fill check", r, c_fill));
@@ -248,7 +247,6 @@ fn newline_input() {
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('B')));
     let snapshot = term.get_render_snapshot().expect("Snapshot was None");
     // With LNM ON, LF moves to next line AND performs carriage return. 'B' prints at (1,0), cursor moves to (1,1)
-    // Testing behavior: cursor should be at column 0 after LF (that's what LNM does)
     assert_screen_state(&snapshot, &["A         ", "B         "], Some((1, 1)));
 }
 
@@ -1305,7 +1303,6 @@ mod selection_logic_tests {
         let point1 = Point { x: 2, y: 1 };
         let point2 = Point { x: 5, y: 1 };
 
-        // Test click (no drag) - selection should be cleared
         emu.interpret_input(EmulatorInput::User(start_selection_at(2, 1)));
         let snapshot1 = emu.get_render_snapshot().expect("Snapshot was None");
         assert!(snapshot1.selection.is_active);
@@ -1321,7 +1318,6 @@ mod selection_logic_tests {
             "Selection should be inactive after click"
         );
 
-        // Test drag - selection should be maintained but deactivated
         emu.interpret_input(EmulatorInput::User(start_selection_at(2, 1)));
         emu.interpret_input(EmulatorInput::User(extend_selection_to(5, 1)));
         let snapshot3 = emu.get_render_snapshot().expect("Snapshot was None");
@@ -1442,7 +1438,6 @@ mod get_selected_text_tests {
             ],
         );
 
-        // Test single line selection
         send_mouse_input(&mut emu, start_selection_at(0, 1), MouseButton::Left);
         send_mouse_input(&mut emu, extend_selection_to(7, 1), MouseButton::Left);
         send_mouse_input(
@@ -1452,7 +1447,6 @@ mod get_selected_text_tests {
         );
         assert_eq!(emu.get_selected_text(), Some("Line Two".to_string()));
 
-        // Test multi-line selection
         send_mouse_input(&mut emu, start_selection_at(0, 0), MouseButton::Left);
         send_mouse_input(&mut emu, extend_selection_to(7, 1), MouseButton::Left);
         send_mouse_input(


### PR DESCRIPTION
Removed "WHAT" and "HOW" comments from test files (`core-term/src/term/tests.rs` and `core-term/src/ansi/tests.rs`) to adhere to `STYLE.md` guidelines.

Scope: `core-term/src/term/tests.rs`, `core-term/src/ansi/tests.rs`
Fixes: Addressed `STYLE.md` violation regarding "WHAT" and "HOW" comments.
Unresolved Issues: None.
Verification: Confirmed passing `cargo check` and `cargo test`.

---
*PR created automatically by Jules for task [1509916978707276898](https://jules.google.com/task/1509916978707276898) started by @jppittman*