### PR TITLE
Refactor: enforce Style.md match usage in pixelflow-search

### DIFF
--- a/pixelflow-search/src/nnue/factored.rs
+++ b/pixelflow-search/src/nnue/factored.rs
@@ -1013,17 +1013,22 @@ impl EdgeAccumulator {
             // Classify this node's variance if analysis is available
             if let Some(va) = variance_analysis {
                 let v = va.get(egraph, canonical);
-                if v.is_const() {
-                    n_const += 1;
-                } else if v.is_x_invariant() && !v.depends_on_y() {
-                    // Frame-uniform: depends only on Z/W (no X, no Y)
-                    n_frame += 1;
-                } else if v.is_x_invariant() {
-                    // Scanline-uniform: depends on Y (but not X)
-                    n_scanline += 1;
-                } else {
-                    // Pixel-varying: depends on X
-                    n_pixel += 1;
+                match (v.is_const(), v.is_x_invariant(), v.depends_on_y()) {
+                    (true, _, _) => {
+                        n_const += 1;
+                    }
+                    (false, true, false) => {
+                        // Frame-uniform: depends only on Z/W (no X, no Y)
+                        n_frame += 1;
+                    }
+                    (false, true, true) => {
+                        // Scanline-uniform: depends on Y (but not X)
+                        n_scanline += 1;
+                    }
+                    (false, false, _) => {
+                        // Pixel-varying: depends on X
+                        n_pixel += 1;
+                    }
                 }
             }
 


### PR DESCRIPTION
Scope:
- `pixelflow-search/src/nnue/factored.rs`

Fixes:
- Replaced `else if` chain relying on multiple boolean flags with idiomatic `match` expression grouping the booleans into a tuple, conforming to `STYLE.md`.

Unresolved Issues:
- None

Verification:
- Ran `cargo check -p pixelflow-search` and `cargo test -p pixelflow-search`.

---
*PR created automatically by Jules for task [13147140755441080380](https://jules.google.com/task/13147140755441080380) started by @jppittman*