### PR TITLE
Refactor: [actor-scheduler] Simplify DrainStatus control flow using match tuple

### DIFF
--- a/actor-scheduler/src/sharded.rs
+++ b/actor-scheduler/src/sharded.rs
@@ -133,23 +133,10 @@ impl<T> ShardedInbox<T> {
         // Rotate starting shard for next drain
         self.round_robin = (self.round_robin + 1) % n;
 
-        if all_disconnected {
-            Ok(DrainStatus::Disconnected)
-        } else if total >= limit || !all_empty {
-            // We either hit the limit, or we had per-shard caps that stopped early
-            if total >= limit {
-                Ok(DrainStatus::More)
-            } else if all_empty {
-                Ok(DrainStatus::Empty)
-            } else {
-                // Some shards may have more, but we haven't proven it
-                // Re-check: did any shard actually hit its per-shard limit?
-                // If total < limit, we only stopped because of per-shard caps.
-                // That means there might be more in those shards.
-                Ok(DrainStatus::More)
-            }
-        } else {
-            Ok(DrainStatus::Empty)
+        match (all_disconnected, total >= limit, all_empty) {
+            (true, _, _) => Ok(DrainStatus::Disconnected),
+            (false, false, true) => Ok(DrainStatus::Empty),
+            _ => Ok(DrainStatus::More),
         }
     }
 


### PR DESCRIPTION
Scope: `actor-scheduler/src/sharded.rs`
Fixes: Addressed a stylistic violation of the "Prefer `match` over `else if`" and "Avoid Deep Nesting" guidelines defined in `docs/STYLE.md`. Replaced a deeply nested boolean `if / else if` block with a cleaner pattern-matched tuple `match (all_disconnected, total >= limit, all_empty)`.
Unresolved Issues: None.
Verification: `cargo check -p actor-scheduler` and `cargo test -p actor-scheduler` pass successfully.

---
*PR created automatically by Jules for task [17628953410371268759](https://jules.google.com/task/17628953410371268759) started by @jppittman*