### PR TITLE
Refactor build_expr arguments in tests to adhere to STYLE.md

### DIFF
--- a/pixelflow-search/src/math/pict_rewrite_tests.rs
+++ b/pixelflow-search/src/math/pict_rewrite_tests.rs
@@ -217,18 +217,22 @@ fn build_shape(a: &mut ExprArena, shape: usize, konst: f32) -> ExprId {
     }
 }
 
-fn build_expr(
-    a: &mut ExprArena,
+struct ExprParams {
     outer: OpKind,
     wrapper: Option<OpKind>,
     left: usize,
     right: usize,
     konst: f32,
+}
+
+fn build_expr(
+    a: &mut ExprArena,
+    params: &ExprParams,
 ) -> ExprId {
-    let l = build_shape(a, left, konst);
-    let r = build_shape(a, right, konst);
-    let inner = a.push_binary(outer, l, r);
-    match wrapper {
+    let l = build_shape(a, params.left, params.konst);
+    let r = build_shape(a, params.right, params.konst);
+    let inner = a.push_binary(params.outer, l, r);
+    match params.wrapper {
         None => inner,
         Some(op) => a.push_unary(op, inner),
     }
@@ -303,13 +307,16 @@ fn pict_rewrite_rules_preserve_semantics() {
     let mut changed = 0usize; // how many cases the optimizer actually rewrote
 
     for row in &rows {
-        let outer = OUTER_OPS[row[0]];
-        let wrapper = UNARY_WRAPPERS[row[1]];
-        let (left, right) = (row[2], row[3]);
-        let konst = CONSTS[row[4]];
+        let params = ExprParams {
+            outer: OUTER_OPS[row[0]],
+            wrapper: UNARY_WRAPPERS[row[1]],
+            left: row[2],
+            right: row[3],
+            konst: CONSTS[row[4]],
+        };
 
         let mut arena = ExprArena::new();
-        let root = build_expr(&mut arena, outer, wrapper, left, right, konst);
+        let root = build_expr(&mut arena, &params);
         let orig_str = arena.display(root).to_string();
 
         // Optimize the way the compiler does: build e-graph, saturate once,


### PR DESCRIPTION
**Scope**
- Modified `pixelflow-search/src/math/pict_rewrite_tests.rs`

**Fixes**
- Grouped 5 related arguments in the `build_expr` function into an `ExprParams` struct, adhering to the "Argument Management" guidelines in `STYLE.md` that functions should take fewer than 4 arguments.

**Unresolved Issues**
- None

**Verification**
- Passed `cargo check -p pixelflow-search --tests`
- Passed `cargo test -p pixelflow-search`

---
*PR created automatically by Jules for task [4726539779648683506](https://jules.google.com/task/4726539779648683506) started by @jppittman*