### PR TITLE
Refactor: Fix if-let anti-pattern in tests

### DIFF
--- a/core-term/src/ansi/pict_sgr_tests.rs
+++ b/core-term/src/ansi/pict_sgr_tests.rs
@@ -104,10 +104,11 @@ fn build_case(factors: &[Vec<Level>], row: &[usize]) -> (Vec<u8>, Vec<Attribute>
     let mut expected: Vec<Attribute> = Vec::new();
     for (factor, &level_idx) in factors.iter().zip(row) {
         let level = &factor[level_idx];
-        if let Some(frag) = level.fragment {
-            fragments.push(frag);
-            expected.extend_from_slice(&level.expected);
-        }
+        let Some(frag) = level.fragment else {
+            continue;
+        };
+        fragments.push(frag);
+        expected.extend_from_slice(&level.expected);
     }
 
     let mut seq = b"\x1b[".to_vec();

--- a/core-term/src/ansi/tests.rs
+++ b/core-term/src/ansi/tests.rs
@@ -2099,22 +2099,21 @@ mod mutation_tests {
         // SGR with 16 parameters: 1;2;0;0;... (14 zeros)
         // All 16 must be collected and processed.
         let cmds = process_bytes(b"\x1b[1;2;0;0;0;0;0;0;0;0;0;0;0;0;0;0m");
-        if let Some(AnsiCommand::Csi(CsiCommand::SetGraphicsRendition(attrs))) = cmds.first() {
-            // Checking len kills mutations that reduce MAX_PARAMS below 16.
-            assert_eq!(attrs.len(), 16, "all 16 params must be retained");
-            assert_eq!(
-                attrs[0],
-                Attribute::Bold,
-                "first of 16 params should be Bold"
-            );
-            assert_eq!(
-                attrs[1],
-                Attribute::Faint,
-                "second of 16 params should be Faint"
-            );
-        } else {
+        let Some(AnsiCommand::Csi(CsiCommand::SetGraphicsRendition(attrs))) = cmds.first() else {
             panic!("expected SetGraphicsRendition, got {:?}", cmds);
-        }
+        };
+        // Checking len kills mutations that reduce MAX_PARAMS below 16.
+        assert_eq!(attrs.len(), 16, "all 16 params must be retained");
+        assert_eq!(
+            attrs[0],
+            Attribute::Bold,
+            "first of 16 params should be Bold"
+        );
+        assert_eq!(
+            attrs[1],
+            Attribute::Faint,
+            "second of 16 params should be Faint"
+        );
     }
 
     #[test]
@@ -2123,16 +2122,15 @@ mod mutation_tests {
         // We send: ESC [ 0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;7m
         //          that's 16 zeros + 1 extra -> the 7 (Reverse) is the 17th and dropped.
         let cmds = process_bytes(b"\x1b[0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;7m");
-        if let Some(AnsiCommand::Csi(CsiCommand::SetGraphicsRendition(attrs))) = cmds.first() {
-            // Every kept attribute should be Reset (0); Reverse (7) must NOT appear.
-            assert!(
-                !attrs.contains(&Attribute::Reverse),
-                "17th param (Reverse) should have been dropped; got attrs: {:?}",
-                attrs
-            );
-        } else {
+        let Some(AnsiCommand::Csi(CsiCommand::SetGraphicsRendition(attrs))) = cmds.first() else {
             panic!("expected SetGraphicsRendition, got {:?}", cmds);
-        }
+        };
+        // Every kept attribute should be Reset (0); Reverse (7) must NOT appear.
+        assert!(
+            !attrs.contains(&Attribute::Reverse),
+            "17th param (Reverse) should have been dropped; got attrs: {:?}",
+            attrs
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -2279,14 +2277,10 @@ mod mutation_tests {
         let cmds = process_bytes(b"\x1b[99999A");
         // Should produce CursorUp with some value (saturated), not panic
         assert_eq!(cmds.len(), 1, "should produce exactly one command");
-        assert!(
-            matches!(cmds[0], AnsiCommand::Csi(CsiCommand::CursorUp(_))),
-            "should still produce CursorUp; got {:?}",
-            cmds
-        );
-        if let AnsiCommand::Csi(CsiCommand::CursorUp(n)) = cmds[0] {
-            assert_eq!(n, u16::MAX, "overflow must saturate to u16::MAX, got {}", n);
-        }
+        let AnsiCommand::Csi(CsiCommand::CursorUp(n)) = cmds[0] else {
+            panic!("should still produce CursorUp; got {:?}", cmds);
+        };
+        assert_eq!(n, u16::MAX, "overflow must saturate to u16::MAX, got {}", n);
     }
 
     // -----------------------------------------------------------------------

--- a/core-term/src/io/pty_tests.rs
+++ b/core-term/src/io/pty_tests.rs
@@ -361,18 +361,18 @@ fn pty_spawn_invalid_command() {
             // We verify that the error is indeed related to the command not being found.
             // If it's wrapped in anyhow, we check the root cause.
             let root_cause = e.root_cause();
-            if let Some(io_err) = root_cause.downcast_ref::<std::io::Error>() {
-                assert_eq!(
-                    io_err.kind(),
-                    std::io::ErrorKind::NotFound,
-                    "Expected NotFound error, got {:?}",
-                    io_err.kind()
-                );
-            } else {
+            let Some(io_err) = root_cause.downcast_ref::<std::io::Error>() else {
                 log::warn!(
                     "Could not downcast error to std::io::Error to verify ErrorKind::NotFound, but an error occurred as expected."
                 );
-            }
+                return;
+            };
+            assert_eq!(
+                io_err.kind(),
+                std::io::ErrorKind::NotFound,
+                "Expected NotFound error, got {:?}",
+                io_err.kind()
+            );
         }
     }
 }

--- a/core-term/src/term/core_tests.rs
+++ b/core-term/src/term/core_tests.rs
@@ -172,20 +172,23 @@ fn assert_screen_state(
         }
     }
 
-    if let Some((r_expected, c_expected)) = expected_cursor_pos {
-        let cursor_state = snapshot.cursor_state.as_ref().unwrap_or_else(|| {
-            panic!(
-                "Expected cursor to be visible, but cursor_state is None. Expected pos: ({},{})",
-                r_expected, c_expected
+    match expected_cursor_pos {
+        Some((r_expected, c_expected)) => {
+            let cursor_state = snapshot.cursor_state.as_ref().unwrap_or_else(|| {
+                    panic!(
+                        "Expected cursor to be visible, but cursor_state is None. Expected pos: ({},{})",
+                        r_expected, c_expected
+                    );
+                });
+            assert_eq!(cursor_state.y, r_expected, "Cursor row mismatch");
+            assert_eq!(cursor_state.x, c_expected, "Cursor col mismatch");
+        }
+        None => {
+            assert!(
+                snapshot.cursor_state.is_none(),
+                "Expected cursor to be hidden, but cursor_state is Some"
             );
-        });
-        assert_eq!(cursor_state.y, r_expected, "Cursor row mismatch");
-        assert_eq!(cursor_state.x, c_expected, "Cursor col mismatch");
-    } else {
-        assert!(
-            snapshot.cursor_state.is_none(),
-            "Expected cursor to be hidden, but cursor_state is Some"
-        );
+        }
     }
 }
 
@@ -512,13 +515,10 @@ fn it_should_print_ascii_over_wide_char_that_straddles_line_end_after_wrap() {
     );
 
     let glyph_at_0_0 = get_glyph_from_snapshot(&s4, 0, 0).unwrap();
-    assert!(
-        matches!(glyph_at_0_0, Glyph::WidePrimary(_)),
-        "Expected WidePrimary at (0,0)"
-    );
-    if let Glyph::WidePrimary(cell) = glyph_at_0_0 {
-        assert_eq!(cell.c, '世');
-    }
+    let Glyph::WidePrimary(cell) = glyph_at_0_0 else {
+        panic!("Expected WidePrimary at (0,0)");
+    };
+    assert_eq!(cell.c, '世');
 
     let glyph_at_0_1 = get_glyph_from_snapshot(&s4, 0, 1).unwrap();
     match glyph_at_0_1 {

--- a/core-term/src/term/tests.rs
+++ b/core-term/src/term/tests.rs
@@ -205,20 +205,23 @@ fn assert_screen_state(
         }
     }
 
-    if let Some((r_expected, c_expected)) = expected_cursor_pos {
-        let cursor_state = snapshot.cursor_state.as_ref().unwrap_or_else(|| {
-            panic!(
-                "Expected cursor to be visible, but cursor_state is None. Expected pos: ({},{})",
-                r_expected, c_expected
+    match expected_cursor_pos {
+        Some((r_expected, c_expected)) => {
+            let cursor_state = snapshot.cursor_state.as_ref().unwrap_or_else(|| {
+                    panic!(
+                        "Expected cursor to be visible, but cursor_state is None. Expected pos: ({},{})",
+                        r_expected, c_expected
+                    );
+                });
+            assert_eq!(cursor_state.y, r_expected, "Cursor row mismatch");
+            assert_eq!(cursor_state.x, c_expected, "Cursor col mismatch");
+        }
+        None => {
+            assert!(
+                snapshot.cursor_state.is_none(),
+                "Expected cursor to be hidden, but cursor_state is Some"
             );
-        });
-        assert_eq!(cursor_state.y, r_expected, "Cursor row mismatch");
-        assert_eq!(cursor_state.x, c_expected, "Cursor col mismatch");
-    } else {
-        assert!(
-            snapshot.cursor_state.is_none(),
-            "Expected cursor to be hidden, but cursor_state is Some"
-        );
+        }
     }
 }
 

--- a/pixelflow-graphics/tests/optimization_fuzz.rs
+++ b/pixelflow-graphics/tests/optimization_fuzz.rs
@@ -41,17 +41,19 @@ fn field_val(f: Field) -> f32 {
     // Use the Debug representation to extract value
     let debug = format!("{:?}", f);
     // Parse "Field(F32x16([1.0, 1.0, ...]))" or similar
-    if let Some(start) = debug.find('[') {
-        if let Some(end) = debug.find(',') {
-            if let Ok(v) = debug[start + 1..end].trim().parse::<f32>() {
-                return v;
-            }
+    let Some(start) = debug.find('[') else {
+        panic!("Failed to parse Field value from: {}", debug);
+    };
+
+    if let Some(end) = debug.find(',') {
+        if let Ok(v) = debug[start + 1..end].trim().parse::<f32>() {
+            return v;
         }
-        // Single value case
-        if let Some(end) = debug.find(']') {
-            if let Ok(v) = debug[start + 1..end].trim().parse::<f32>() {
-                return v;
-            }
+    }
+    // Single value case
+    if let Some(end) = debug.find(']') {
+        if let Ok(v) = debug[start + 1..end].trim().parse::<f32>() {
+            return v;
         }
     }
     panic!("Failed to parse Field value from: {}", debug);


### PR DESCRIPTION
Scope:
- `pixelflow-graphics/tests/optimization_fuzz.rs`
- `core-term/src/io/pty_tests.rs`
- `core-term/src/ansi/tests.rs`
- `core-term/src/term/core_tests.rs`
- `core-term/src/term/tests.rs`
- `core-term/src/ansi/pict_sgr_tests.rs`

Fixes:
- Replaced nested `if let` blocks with modern `let ... else` or `match` guard clauses in test files to follow STYLE.md guidelines for reducing nesting and avoiding the arrow anti-pattern.
- Restored original logging context when refactoring error handling in `pty_tests.rs`.

Unresolved Issues:
- None.

Verification:
- Passed `cargo check` and `cargo test` on `pixelflow-graphics` and `core-term` to ensure testing semantics remain unchanged.

---
*PR created automatically by Jules for task [6547610691310287164](https://jules.google.com/task/6547610691310287164) started by @jppittman*