### PR TITLE
Fix input wedge: drain queued events and coalesce wake tokens

### DIFF
--- a/actor-scheduler/src/lib.rs
+++ b/actor-scheduler/src/lib.rs
@@ -1262,6 +1262,44 @@ mod tests {
         );
     }
 
+    // Regression: with a data burst limit of 0, the scheduler must neither
+    // spin forever (drain(0) reporting More every cycle) nor exit early by
+    // misreporting the lane as Disconnected and dropping queued messages.
+    // The drain clamps its budget to 1, so it makes progress and terminates.
+    #[test]
+    fn zero_data_burst_limit_processes_messages_and_exits() {
+        let (tx, mut rx) = ActorScheduler::<String, String, String>::new(0, 10);
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let log_clone = log.clone();
+
+        let scheduler = thread::spawn(move || {
+            let mut handler = TestHandler { log: log_clone };
+            rx.run(&mut handler);
+        });
+
+        tx.send(Message::Data("a".to_string())).unwrap();
+        tx.send(Message::Data("b".to_string())).unwrap();
+        drop(tx);
+
+        // Bounded join: the scheduler must exit once all handles are gone.
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while !scheduler.is_finished() && std::time::Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            scheduler.is_finished(),
+            "scheduler must terminate with a zero data burst limit"
+        );
+        scheduler.join().unwrap();
+
+        let log = log.lock().unwrap();
+        assert!(
+            log.contains(&"Data: a".to_string()) && log.contains(&"Data: b".to_string()),
+            "queued messages must not be dropped on exit; got {:?}",
+            *log
+        );
+    }
+
     #[test]
     fn verify_data_lane_backpressure_contract() {
         let (tx, mut rx) = ActorScheduler::new(2, 1);

--- a/actor-scheduler/src/lib.rs
+++ b/actor-scheduler/src/lib.rs
@@ -934,8 +934,10 @@ impl<D, C, M> ActorScheduler<D, C, M> {
         A: Actor<D, C, M>,
     {
         // Drain Control → Mgmt → Control → Data
-        // Control budget is split evenly between the two control runs to prevent double priority
-        let half_control = self.control_burst_limit / 2;
+        // Control budget is split evenly between the two control runs to prevent double priority.
+        // Floor at 1: integer halving would otherwise zero the budget when the
+        // limit is 1, and a zero-budget drain can never make progress.
+        let half_control = (self.control_burst_limit / 2).max(1);
 
         let control1 = self
             .rx_control
@@ -1213,6 +1215,51 @@ mod tests {
         fn park(&mut self, _hint: SystemStatus) -> Result<ActorStatus, HandlerError> {
             Ok(ActorStatus::Idle)
         }
+    }
+
+    // Regression: control_burst_limit of 1 used to halve to a zero drain
+    // budget (1 / 2 == 0), so the control lane could never make progress —
+    // and a zero-limit drain misreported the lane as Disconnected.
+    #[test]
+    fn control_lane_progresses_with_burst_limit_one() {
+        let params = SchedulerParams {
+            control_mgmt_buffer_size: 1,
+            control_burst_multiplier: 1, // control_burst_limit == 1
+            ..SchedulerParams::DEFAULT
+        };
+        assert_eq!(params.control_burst_limit(), 1);
+
+        let (tx, mut rx) = ActorScheduler::<String, String, String>::new_with_params(4, 4, params);
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let log_clone = log.clone();
+
+        let scheduler = thread::spawn(move || {
+            let mut handler = TestHandler { log: log_clone };
+            rx.run(&mut handler);
+        });
+
+        tx.send(Message::Control("ping".to_string())).unwrap();
+
+        // Must be observed BEFORE shutdown: shutdown-time draining would mask
+        // a broken steady-state control path.
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        let processed = loop {
+            if log.lock().unwrap().contains(&"Ctrl: ping".to_string()) {
+                break true;
+            }
+            if std::time::Instant::now() >= deadline {
+                break false;
+            }
+            thread::sleep(Duration::from_millis(5));
+        };
+
+        tx.send(Message::Shutdown).unwrap();
+        scheduler.join().unwrap();
+
+        assert!(
+            processed,
+            "control message was never processed with control_burst_limit == 1"
+        );
     }
 
     #[test]

--- a/actor-scheduler/src/sharded.rs
+++ b/actor-scheduler/src/sharded.rs
@@ -107,8 +107,14 @@ impl<T> ShardedInbox<T> {
 
             loop {
                 if total >= limit || shard_count >= per_shard {
-                    // Hit per-shard or total limit — there might be more
+                    // Hit per-shard or total limit — there might be more.
+                    // This shard was NOT observed disconnected: we stopped
+                    // before polling it (again), so it must not count toward
+                    // all_disconnected. Otherwise a drain that exhausts its
+                    // limit early (or a limit of 0) reports Disconnected with
+                    // live producers, and the scheduler shuts the actor down.
                     all_empty = false;
+                    all_disconnected = false;
                     break;
                 }
 
@@ -301,6 +307,37 @@ mod tests {
         });
 
         assert!(result.is_err());
+    }
+
+    // Regression: a drain that never polls a shard (limit exhausted before the
+    // first try_recv — the degenerate case being limit == 0) must not report
+    // Disconnected. all_disconnected was vacuously true because no shard was
+    // observed, and the scheduler treats Disconnected-on-all-lanes as "actor
+    // is done", silently shutting it down with live producers.
+    #[test]
+    fn zero_limit_drain_does_not_report_disconnected() {
+        let mut builder = InboxBuilder::new(8);
+        let tx = builder.add_producer();
+        let mut inbox = builder.build();
+
+        tx.try_send(42u32).unwrap();
+
+        let status = inbox.drain(0, |_msg: u32| Ok(())).unwrap();
+        assert_ne!(
+            status,
+            DrainStatus::Disconnected,
+            "no shard was polled — reporting Disconnected is unsound"
+        );
+
+        // The queued message must still be deliverable afterwards.
+        let mut got = Vec::new();
+        inbox
+            .drain(10, |msg| {
+                got.push(msg);
+                Ok(())
+            })
+            .unwrap();
+        assert_eq!(got, vec![42]);
     }
 
     #[test]

--- a/actor-scheduler/src/sharded.rs
+++ b/actor-scheduler/src/sharded.rs
@@ -84,6 +84,12 @@ impl<T> ShardedInbox<T> {
     /// `per_shard` messages (limit / num_shards, minimum 1), then we
     /// rotate the starting shard for fairness.
     ///
+    /// A `limit` of 0 is clamped to 1: every drain must be able to make
+    /// progress. The scheduler's exit condition (all lanes observed
+    /// disconnected) and its wake loop (`More` means come back) both rely
+    /// on shards actually being polled — a zero-budget drain can prove
+    /// neither, so it would either strand queued messages or spin forever.
+    ///
     /// Returns:
     /// - `Ok(DrainStatus::Empty)` — all shards empty
     /// - `Ok(DrainStatus::More)` — hit limit, more messages may exist
@@ -94,6 +100,7 @@ impl<T> ShardedInbox<T> {
         limit: usize,
         mut handler: impl FnMut(T) -> HandlerResult,
     ) -> Result<DrainStatus, crate::HandlerError> {
+        let limit = limit.max(1);
         let n = self.shards.len();
         let per_shard = (limit / n).max(1);
         let mut total = 0usize;
@@ -309,35 +316,39 @@ mod tests {
         assert!(result.is_err());
     }
 
-    // Regression: a drain that never polls a shard (limit exhausted before the
-    // first try_recv — the degenerate case being limit == 0) must not report
-    // Disconnected. all_disconnected was vacuously true because no shard was
-    // observed, and the scheduler treats Disconnected-on-all-lanes as "actor
-    // is done", silently shutting it down with live producers.
+    // Regression: a zero-budget drain used to skip every shard while leaving
+    // all_disconnected vacuously true, reporting Disconnected with live
+    // producers — and the scheduler treats Disconnected-on-all-lanes as
+    // "actor is done", silently dropping queued messages. The limit is now
+    // clamped to 1 so a drain always makes progress and only reports what it
+    // actually observed.
     #[test]
-    fn zero_limit_drain_does_not_report_disconnected() {
+    fn zero_limit_drain_makes_progress_and_reports_honestly() {
         let mut builder = InboxBuilder::new(8);
         let tx = builder.add_producer();
         let mut inbox = builder.build();
 
         tx.try_send(42u32).unwrap();
 
-        let status = inbox.drain(0, |_msg: u32| Ok(())).unwrap();
-        assert_ne!(
-            status,
-            DrainStatus::Disconnected,
-            "no shard was polled — reporting Disconnected is unsound"
-        );
-
-        // The queued message must still be deliverable afterwards.
         let mut got = Vec::new();
-        inbox
-            .drain(10, |msg| {
+        let status = inbox
+            .drain(0, |msg: u32| {
                 got.push(msg);
                 Ok(())
             })
             .unwrap();
-        assert_eq!(got, vec![42]);
+        assert_ne!(
+            status,
+            DrainStatus::Disconnected,
+            "producer is alive — reporting Disconnected is unsound"
+        );
+        assert_eq!(got, vec![42], "clamped drain should deliver the message");
+
+        // Once the producer drops and the queue is empty, Disconnected is the
+        // honest answer even at limit 0.
+        drop(tx);
+        let status = inbox.drain(0, |_msg: u32| Ok(())).unwrap();
+        assert_eq!(status, DrainStatus::Disconnected);
     }
 
     #[test]

--- a/core-term/src/terminal_app.rs
+++ b/core-term/src/terminal_app.rs
@@ -161,7 +161,10 @@ impl TerminalApp {
     fn resize_pty(&self, cols: u16, rows: u16) {
         if let Err(e) = self
             .pty_writer
-            .send(Message::Control(WriterControl::Resize(Resize { cols, rows })))
+            .send(Message::Control(WriterControl::Resize(Resize {
+                cols,
+                rows,
+            })))
         {
             log::warn!("Failed to send PTY resize command: {}", e);
         }
@@ -980,6 +983,187 @@ mod tests {
                 rows: 50
             }],
             "PTY resize command should match new dimensions"
+        );
+    }
+
+    /// Engine double that discards every message, so the app's frame sends
+    /// never block. Runs on its own thread like the real engine actor.
+    struct EngineDiscard;
+
+    impl
+        Actor<
+            pixelflow_runtime::api::private::EngineData,
+            pixelflow_runtime::api::private::EngineControl,
+            pixelflow_runtime::api::public::AppManagement,
+        > for EngineDiscard
+    {
+        fn handle_data(
+            &mut self,
+            _msg: pixelflow_runtime::api::private::EngineData,
+        ) -> HandlerResult {
+            Ok(())
+        }
+        fn handle_control(
+            &mut self,
+            _msg: pixelflow_runtime::api::private::EngineControl,
+        ) -> HandlerResult {
+            Ok(())
+        }
+        fn handle_management(
+            &mut self,
+            _msg: pixelflow_runtime::api::public::AppManagement,
+        ) -> HandlerResult {
+            Ok(())
+        }
+        fn park(&mut self, _hint: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            Ok(ActorStatus::Idle)
+        }
+    }
+
+    /// End-to-end regression for "can't Ctrl-C out of `yes`": real PTY troupe,
+    /// real TerminalApp actor on a real scheduler, production-shaped producer
+    /// set and burst limits. Floods the pipeline with `yes` output, then
+    /// injects the exact KeyDown the X11 mapper produces for Ctrl+C and
+    /// asserts the child dies (i.e. 0x03 reached the PTY line discipline).
+    #[test]
+    fn ctrl_c_interrupts_yes_flood() {
+        use crate::io::event_monitor_actor::PtyTroupe;
+        use crate::io::pty::{NixPty, PtyChannel, PtyConfig};
+        use std::time::{Duration, Instant};
+
+        let font_path = find_font_path();
+        if !font_path.exists()
+            || std::fs::metadata(&font_path)
+                .map(|m| m.len() < 1000)
+                .unwrap_or(true)
+        {
+            eprintln!(
+                "Test skipped: usable font not found at {}",
+                font_path.display()
+            );
+            return;
+        }
+
+        let pty = NixPty::spawn_with_config(&PtyConfig {
+            command_executable: "/bin/sh",
+            args: &["-c", "yes"],
+            initial_cols: 80,
+            initial_rows: 24,
+        })
+        .expect("spawn pty running yes");
+        let child = pty.child_pid();
+
+        let mut troupe = PtyTroupe::new(pty).expect("pty troupe");
+        let pty_writer = troupe.writer_handle();
+
+        // Engine double on its own thread (real engine drains fast; so does this).
+        let mut engine_builder = actor_scheduler::ActorBuilder::<
+            pixelflow_runtime::api::private::EngineData,
+            pixelflow_runtime::api::private::EngineControl,
+            pixelflow_runtime::api::public::AppManagement,
+        >::new(1024, None);
+        let engine_tx = engine_builder.add_producer();
+        let mut engine_rx = engine_builder.build();
+        let engine_thread = std::thread::spawn(move || {
+            engine_rx.run(&mut EngineDiscard);
+        });
+
+        // App channels mirror spawn_terminal_app: 4 producers, data burst 10.
+        let mut builder =
+            ActorBuilder::<TerminalData, EngineEventControl, EngineEventManagement>::new(128, None);
+        let key_tx = builder.add_producer(); // stands in for the engine adapter
+        let parser_handle = builder.add_producer();
+        let reader_handle = builder.add_producer();
+        let keepalive = builder.add_producer();
+        let mut app_rx = builder.build_with_burst(10, actor_scheduler::ShutdownMode::default());
+
+        let mut app = TerminalApp::new_registered(TerminalAppParamsRegistered {
+            emulator: TerminalEmulator::new(80, 24),
+            pty_writer,
+            config: Config::default(),
+            engine_tx: EngineHandle::new_for_test(engine_tx),
+        });
+        let app_thread = std::thread::spawn(move || {
+            app_rx.run(&mut app);
+        });
+
+        let troupe_handle = troupe
+            .spawn(
+                Box::new(TerminalAppSender::new(parser_handle)),
+                Box::new(TerminalAppSender::new(reader_handle)),
+            )
+            .expect("spawn pty troupe");
+
+        // Engine-adapter stand-in on its own thread (the handle is single-owner):
+        // hammers the adapter shard with RequestFrame at ~155Hz so the app is
+        // doing full-grid send_frame work, then injects Ctrl+C after 2s of
+        // flood WHILE the frame pressure keeps running — just like production,
+        // where vsync doesn't pause because a key was pressed.
+        //
+        // The KeyDown is exactly what platform/linux/events.rs reports for
+        // Ctrl+C: XLookupString applies the control translation, so text and
+        // symbol are both ETX.
+        let stop_vsync = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let vsync_stop = stop_vsync.clone();
+        let adapter_thread = std::thread::spawn(move || {
+            use pixelflow_runtime::api::public::EngineEventData;
+            let interval = Duration::from_micros(6450);
+            let key_at = Instant::now() + Duration::from_secs(2);
+            let mut key_sent = false;
+            while !vsync_stop.load(std::sync::atomic::Ordering::Relaxed) {
+                let now = Instant::now();
+                key_tx
+                    .send(Message::Data(TerminalData::Engine(
+                        EngineEventData::RequestFrame {
+                            timestamp: now,
+                            target_timestamp: now + interval,
+                            refresh_interval: interval,
+                        },
+                    )))
+                    .expect("send RequestFrame");
+                if !key_sent && Instant::now() >= key_at {
+                    key_tx
+                        .send(Message::Management(EngineEventManagement::KeyDown {
+                            key: pixelflow_runtime::input::KeySymbol::Char('\u{3}'),
+                            mods: pixelflow_runtime::input::Modifiers::CONTROL,
+                            text: Some("\u{3}".to_string()),
+                        }))
+                        .expect("send ctrl-c keydown");
+                    key_sent = true;
+                }
+                std::thread::sleep(interval);
+            }
+        });
+
+        // The line discipline should SIGINT the foreground job promptly.
+        // (Key is injected ~2s in; allow generous slack on loaded CI.)
+        let deadline = Instant::now() + Duration::from_secs(15);
+        let mut dead = false;
+        while Instant::now() < deadline {
+            use nix::sys::wait::{waitpid, WaitPidFlag, WaitStatus};
+            match waitpid(child, Some(WaitPidFlag::WNOHANG)) {
+                Ok(WaitStatus::StillAlive) => std::thread::sleep(Duration::from_millis(50)),
+                _ => {
+                    dead = true;
+                    break;
+                }
+            }
+        }
+
+        // Cleanup regardless of outcome so a failure doesn't leak `yes`.
+        if !dead {
+            let _killed = nix::sys::signal::kill(child, nix::sys::signal::Signal::SIGKILL);
+        }
+        stop_vsync.store(true, std::sync::atomic::Ordering::Relaxed);
+        adapter_thread.join().expect("adapter thread");
+        drop(troupe_handle); // shuts down reader/parser/writer, joins troupe thread
+        drop(keepalive);
+        app_thread.join().expect("app thread");
+        engine_thread.join().expect("engine thread");
+
+        assert!(
+            dead,
+            "Ctrl+C did not interrupt `yes` within 10s — input path is wedged"
         );
     }
 

--- a/pixelflow-runtime/src/platform/macos/platform.rs
+++ b/pixelflow-runtime/src/platform/macos/platform.rs
@@ -183,7 +183,13 @@ impl PlatformOps for MetalOps {
         // Logic for event loop interaction
         // The CocoaWaker posts an NSEvent when messages arrive, so distantFuture is safe.
         unsafe {
-            let until_date = match status {
+            // Only the FIRST wait may block (when the scheduler says Idle).
+            // Everything already queued is then drained without blocking:
+            // a park pass must empty the NSEvent queue, or wake events pile
+            // up ahead of real input and a KeyDown can sit behind an
+            // unbounded backlog (the "can't Ctrl-C out of `yes`" wedge).
+            // This mirrors LinuxOps::park's `while XPending > 0` drain.
+            let first_until_date: sys::Id = match status {
                 SystemStatus::Idle => {
                     // Block until an event arrives (waker will post NSEvent when messages come)
                     let cls = sys::class(b"NSDate\0");
@@ -194,6 +200,10 @@ impl PlatformOps for MetalOps {
                     let cls = sys::class(b"NSDate\0");
                     sys::send(cls, sys::sel(b"distantPast\0"))
                 }
+            };
+            let distant_past: sys::Id = {
+                let cls = sys::class(b"NSDate\0");
+                sys::send(cls, sys::sel(b"distantPast\0"))
             };
 
             let mode = cocoa::make_nsstring("kCFRunLoopDefaultMode");
@@ -217,24 +227,34 @@ impl PlatformOps for MetalOps {
                 }
             }
 
-            // Use wrapper for next_event
-            let event = self.app.next_event(
-                u64::MAX,
-                until_date,
-                mode,
-                true, // dequeue
-            );
+            let mut until_date = first_until_date;
+            let mut processed_any = false;
 
-            // Release mode string
-            sys::send::<()>(mode, sys::sel(b"release\0"));
+            loop {
+                let event = self.app.next_event(
+                    u64::MAX,
+                    until_date,
+                    mode,
+                    true, // dequeue
+                );
+                // Subsequent iterations never block.
+                until_date = distant_past;
 
-            if !event.is_null() {
+                if event.is_null() {
+                    break;
+                }
+                processed_any = true;
+
                 let ty = event.type_();
                 match ty {
-                    event_type::APP_KIT_DEFINED
-                    | event_type::SYSTEM_DEFINED
-                    | event_type::APPLICATION_DEFINED => {
-                        log::trace!("MetalOps: Received Internal/WakeUp event");
+                    event_type::APPLICATION_DEFINED => {
+                        // A CocoaWaker wake token was just dequeued; allow the
+                        // next wake() to post a fresh one.
+                        crate::platform::waker::consume_wake_token();
+                        log::trace!("MetalOps: Received WakeUp event");
+                    }
+                    event_type::APP_KIT_DEFINED | event_type::SYSTEM_DEFINED => {
+                        log::trace!("MetalOps: Received internal AppKit/system event");
                     }
                     _ => {
                         let ns_win = event.window();
@@ -267,9 +287,19 @@ impl PlatformOps for MetalOps {
                     self.app.send_event(event);
                 }
             }
+
+            // Release mode string
+            sys::send::<()>(mode, sys::sel(b"release\0"));
+
+            // Busy after real work so the scheduler re-drains its lanes before
+            // blocking on the doorbell (a dequeued wake event usually means
+            // messages are waiting).
+            Ok(if processed_any {
+                ActorStatus::Busy
+            } else {
+                ActorStatus::Idle
+            })
         }
-        // Always return Idle since we block inside next_event when needed
-        Ok(ActorStatus::Idle)
     }
 }
 

--- a/pixelflow-runtime/src/platform/waker.rs
+++ b/pixelflow-runtime/src/platform/waker.rs
@@ -26,6 +26,14 @@ impl EventLoopWaker for NoOpWaker {
 
 #[cfg(use_cocoa_display)]
 pub use cocoa_waker::CocoaWaker;
+#[cfg(use_cocoa_display)]
+pub(crate) use cocoa_waker::consume_wake_token;
+
+/// No-op fallback: the macOS platform module compiles whenever
+/// `target_os = "macos"`, even with a non-Cocoa display driver selected
+/// (e.g. headless), where no CocoaWaker exists to coalesce.
+#[cfg(all(target_os = "macos", not(use_cocoa_display)))]
+pub(crate) fn consume_wake_token() {}
 
 #[cfg(use_x11_display)]
 pub use x11_waker::X11Waker;
@@ -152,11 +160,32 @@ mod cocoa_waker {
     use super::super::macos::sys::{self, Id, BOOL, NO};
     use super::*;
     use std::ptr;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    /// True while a wake NSEvent is sitting in the NSApp queue, not yet
+    /// dequeued by the platform pump. NSApp is process-global, so this is too.
+    ///
+    /// Without this token, every `ActorHandle::send()` to the driver posts a
+    /// fresh NSEvent. The doorbell coalesces bursts (bounded at 1), but the
+    /// NSEvent queue does not — under heavy data flow (e.g. a `yes` flood)
+    /// stale wake events accumulate faster than the pump dequeues them, and
+    /// real input events (a Ctrl-C KeyDown) are FIFO-queued behind thousands
+    /// of them. One outstanding wake event is all a wakeup needs.
+    static WAKE_EVENT_QUEUED: AtomicBool = AtomicBool::new(false);
+
+    /// Called by the macOS platform pump when it dequeues an
+    /// application-defined event: the queued token is spent, so the next
+    /// `wake()` must post again.
+    pub(crate) fn consume_wake_token() {
+        WAKE_EVENT_QUEUED.store(false, Ordering::SeqCst);
+    }
 
     /// macOS implementation of EventLoopWaker using NSEvent posting.
     ///
     /// Posts a dummy NSEventTypeApplicationDefined event to NSApplication's
     /// event queue, which wakes the runloop from [NSApp nextEventMatchingMask...].
+    /// Posts are coalesced: while one wake event is already queued, `wake()`
+    /// is a single atomic op and no Objective-C call.
     #[derive(Clone)]
     pub struct CocoaWaker;
 
@@ -174,6 +203,10 @@ mod cocoa_waker {
 
     impl EventLoopWaker for CocoaWaker {
         fn wake(&self) -> Result<(), RuntimeError> {
+            // Coalesce: a wake event is already queued, the pump will see it.
+            if WAKE_EVENT_QUEUED.swap(true, Ordering::SeqCst) {
+                return Ok(());
+            }
             unsafe {
                 log::trace!("CocoaWaker: Waking up NSApp");
                 let app = NSApplication::shared();
@@ -213,6 +246,11 @@ mod cocoa_waker {
                 if !event.is_null() {
                     let sel_post = sys::sel(b"postEvent:atStart:\0");
                     sys::send_2::<(), Id, BOOL>(app.0, sel_post, event, NO);
+                } else {
+                    // Post failed: release the token or every future wake()
+                    // would be suppressed and the pump could sleep forever.
+                    WAKE_EVENT_QUEUED.store(false, Ordering::SeqCst);
+                    log::warn!("CocoaWaker: failed to construct wake NSEvent");
                 }
             }
             Ok(())


### PR DESCRIPTION
## Summary

Fixes a critical bug where Ctrl-C could not interrupt long-running processes (e.g., `yes`) due to wake events accumulating in the platform event queue faster than they were dequeued, causing real input events to be FIFO-queued behind thousands of stale wake tokens.

The fix involves three coordinated changes:

1. **macOS platform pump**: Drain all queued events in a loop instead of processing one per park cycle, with subsequent iterations using `distantPast` to avoid blocking. Return `Busy` when events were processed so the scheduler re-drains lanes before blocking on the doorbell.

2. **CocoaWaker coalescing**: Track whether a wake NSEvent is already queued using an atomic flag. `wake()` becomes a single atomic operation when a token is already pending, preventing unbounded NSEvent accumulation under heavy data flow.

3. **Actor scheduler fixes**: 
   - Fix control lane starvation when `control_burst_limit == 1` (integer halving to 0 prevented progress)
   - Fix `ShardedInbox::drain()` reporting `Disconnected` when limit is exhausted before polling any shard (zero-limit case)

## Key Changes

- **pixelflow-runtime/src/platform/macos/platform.rs**
  - Changed `MetalOps::park()` to loop over `next_event()` calls, draining the NSEvent queue completely
  - First iteration blocks (respecting `SystemStatus::Idle`), subsequent iterations use `distantPast` for non-blocking drain
  - Return `ActorStatus::Busy` when events were processed to trigger scheduler re-drain before blocking
  - Properly consume wake tokens via `crate::platform::waker::consume_wake_token()`

- **pixelflow-runtime/src/platform/waker.rs**
  - Added `WAKE_EVENT_QUEUED` atomic flag to track queued wake NSEvents
  - Implemented `consume_wake_token()` to mark a dequeued wake event
  - Modified `CocoaWaker::wake()` to coalesce: returns early if a token is already queued
  - Added fallback no-op `consume_wake_token()` for non-Cocoa macOS builds

- **actor-scheduler/src/lib.rs**
  - Fixed control lane drain budget: `(control_burst_limit / 2).max(1)` ensures minimum budget of 1

- **actor-scheduler/src/sharded.rs**
  - Fixed `ShardedInbox::drain()` to not report `Disconnected` when limit exhausted before polling any shard
  - Set `all_disconnected = false` when breaking early due to limit

- **core-term/src/terminal_app.rs**
  - Added end-to-end regression test `ctrl_c_interrupts_yes_flood()` that spawns a real PTY running `yes`, floods it with frame requests, injects Ctrl-C after 2s, and verifies the child process dies

## Implementation Details

The root cause was a feedback loop: under heavy data flow (e.g., `yes` output), the engine adapter posts frame requests faster than the macOS pump dequeues wake events. Each `ActorHandle::send()` to the driver posted a fresh NSEvent, so the queue grew unbounded. Real input events (KeyDown for Ctrl-C) were FIFO-queued behind thousands of stale wake tokens, making the input path appear wedged.

The fix mirrors the Linux platform's `while XPending > 0` drain pattern: process all available events in one park cycle, then return `Busy` to let the scheduler re-drain message lanes before blocking again. Wake event coalescing ensures only one NSEvent sits in the queue at a time, regardless of send() call frequency.

The scheduler fixes are defensive: they prevent zero-budget drains and false `Disconnected` reports that could silently shut down actors with live producers.

https://claude.ai/code/session_01YMuAPhQP4Hys8usoT9doDd