### PR TITLE
Font AA via autodiff crossing ramps, lattice glyph cache, and kernel! optimizer fixes

### DIFF
--- a/docs/plans/2026-07-20-kernel-unification.md
+++ b/docs/plans/2026-07-20-kernel-unification.md
@@ -1,0 +1,93 @@
+# One Kernel Language: Retiring the Combinator Emitter
+
+**Date:** 2026-07-20
+**Status:** Plan of record
+**Supersedes:** the dual-backend framing of the 2025-02-21 kernel-jit-feature-parity plan (whose param-baking scope is done).
+
+## North star
+
+We don't want two languages. There is one kernel language with one pipeline:
+
+```
+parse → sema → e-graph → ExprArena → backend emit
+```
+
+The proc-macro and the runtime compiler are the *same pipeline* run at different
+times with different e-graph budgets:
+
+- **AOT (`kernel!`):** parse/sema/e-graph run at macro-expansion time with a
+  generous saturation budget; the macro emits tokens reconstructing the
+  *pre-optimized arena*; machine code is emitted once at load time (kernels are
+  constructed at load time — existing project law).
+- **Runtime (fused roots, dynamic composition, param re-folding):** same
+  pipeline with a bounded e-graph budget. The guided-saturation / rule-masking
+  research (docs/plans/2026-07-07-guided-saturation-redesign.md) is the budget
+  policy for this tier.
+
+**The combinator emitter (`pixelflow-compiler/src/codegen/`, ZST Let/Var trees)
+is the part that goes away.** It is not the long-term fallback. It keeps working
+until the parity suite + font goldens prove arena coverage, then it is deleted.
+`kernel!` and `kernel_jit!` converge into one macro surface.
+
+## What replaces the combinator emitter's roles
+
+| Role today | Replacement |
+|---|---|
+| Jet2/Jet3 domain evaluation (font AA, 3D normals) | `Dwrt` symbolic differentiation lowered in pixelflow-ir; derivatives are ordinary expressions compiled by the same backend. NOT the deleted emit-time jet mode (bd47aa7c) — that was an architectural trap. |
+| Portable / reference semantics (SSE2, WASM, scalar — no JIT emitters) | The IR interpreter (`pixelflow-ir/src/eval.rs`). Same arena, same semantics, slow. WASM may later get its own arena emitter. |
+| Composition (`.at()`, `Sum`, named structs, manifold params) | IR-carrying kernels: every kernel exposes its arena fragment; composition is arena splicing (contramap = Var substitution, Sum = chained Add). |
+| Opaque Rust manifolds (DiscreteManifold, dynamic BSP, CachedGlyph) | Enter the IR as bound buffers / ctx-pointer calls (the existing Gather pattern), not as expressions. The `Manifold` trait survives as the composition substrate. |
+
+Numerics are defined once: the JIT's near-libm behavior is canonical. The
+combinator backend's inaccurate `sin` (0.5116 vs 0.8415 at x=1; see
+pixelflow-compiler/tests/jit_parity.rs header) is a parity bug in the
+to-be-retired backend, tracked until that backend dies.
+
+## Phases
+
+- **P0 — ground truth** *(in flight)*: JIT compile-cost bench
+  (docs/results/2026-07-20-jit-compile-cost.md) settles load-time compile
+  budgets; golden coverage-lattice fixtures for the warm-ASCII font set are the
+  visual regression guard for every backend switch.
+- **P0.5 — e-graph type stability** *(in flight)*: extraction must be
+  type-stable across the V/DX/DY projection boundary and must not share
+  non-Copy manifold-param subexpressions. Prerequisite for fonts on `kernel!`;
+  the defect class itself dies with the emitter, but fonts run on the emitter
+  until parity lands.
+- **P2 — `lower_dwrt` in pixelflow-ir**: symbolic-differentiation lowering pass
+  (peer of `expand_gather`/`expand_reduce`); ir_bridge maps V/DX/DY/DZ →
+  `Dwrt` nodes; the codegen panic at a surviving `Dwrt` becomes an unreachable
+  precondition. Errors loudly on unsupported ops. Acceptance: font-shaped
+  coverage expressions JIT-compile and match combinator-over-Jet2 within
+  tolerance.
+- **P3 — routing scaffolding**: `kernel!` routes eligible bodies through the
+  arena backend behind a cargo feature; parity suite runs both ways. This is
+  transition scaffolding, not an end-state decision — default flips when the
+  parity suite says so.
+- **P4 — IR-carrying kernels + arena splicing**: `HasIr`-style fragment
+  accessor emitted by the macro; splice/substitute APIs on `ExprArena`. This is
+  what shrinks `is_jit_eligible`'s ineligible set toward zero (named structs,
+  manifold params, composition).
+- **P5 — JIT at the root**: glyph bake through the fused arena
+  (`CachedGlyph::new`), then `Lattice::collapse` JIT fast path → frame as one
+  bound kernel (M4 in docs/designs/KERNELS_AND_LATTICES.md). Interpreter/
+  combinator path remains the fallback until goldens pass.
+- **P6 — deprecate and delete** the combinator emitter once P2–P5 cover the
+  surface (parity suite + goldens green on arena-only).
+
+**Demoted:** native multi-domain stamping in `kernel!` (`Field | Jet2 -> Field`
+syntax). It would invest in the dying emitter; the fonts' `macro_rules!`
+stamping is acceptable transitional scaffolding. Revisit only if the transition
+drags.
+
+## Constraints and non-goals
+
+- No per-leaf JIT-at-construction for the thousands of curve-kernel instances:
+  compile cost is µs-scale (see P0 results), leaves are bake-time-only, and
+  P4/P5 fuse at roots instead.
+- A general jet-in/jet-out ABI is not needed: consumers seed screen-space at
+  the root (`Antialiased`), so derivative kernels are single-output Field
+  kernels containing `Dwrt`. Deferred indefinitely.
+- Suckless: pixelflow-ir gets no pixelflow-search dependency; the runtime
+  `lower_dwrt` pass is ir-local, while the e-graph `ChainRule` remains the
+  compile-time optimizer of the same algebra.

--- a/docs/results/2026-07-20-jit-compile-cost.md
+++ b/docs/results/2026-07-20-jit-compile-cost.md
@@ -1,0 +1,81 @@
+# JIT compile cost: gate G0 for per-kernel JIT (2026-07-20)
+
+Phase 0 of the kernel-unification plan: measure how long `compile_arena_dag`
+(`pixelflow-ir/src/backend/emit/mod.rs`) takes for expression arenas of ~8, 32,
+128, and 512 nodes, distinguishing fresh executable-memory allocation per
+compile from a reused code buffer. Gate G0: if the amortized cost exceeds
+~1µs/kernel, per-leaf JIT is formally dead.
+
+Reproduce: `cargo run --release -p pixelflow-pipeline --features training --bin bench_jit_compile_cost`
+
+## Timer correction (affects all prior harness numbers)
+
+While validating these results, the shared harness timer
+(`pixelflow-pipeline/src/jit_bench.rs::nanos_now`) was found to return raw
+`mach_absolute_time()` ticks under the assumption that ticks == nanoseconds.
+That is true on Intel Macs and under Rosetta, but **not on native Apple
+Silicon**, where the timebase is 125/3 — one tick = 41.67ns. Verified
+empirically on this machine: `mach_timebase_info` returns `numer=125,
+denom=3`, and a 100ms sleep measures 2.47M raw ticks. `nanos_now` now converts
+ticks to true nanoseconds via `mach_timebase_info` (queried once).
+
+Consequence: every nanosecond figure previously produced by this harness on
+Apple Silicon (bench corpus labels, the 2026-07-08 extraction-3way absolute
+ns columns, extraction-head training targets) is **under-scaled by 41.67x**.
+Ratios and orderings are unaffected (uniform scale factor); absolute values
+are not. Without this fix, the fresh-path number below would have read
+"~119ns per compile" and G0 would have (wrongly) passed.
+
+## Setup
+
+- **Machine**: Apple M2 Max, macOS 26.5.2, aarch64 (NEON JIT ABI, 16KB pages).
+  rustc 1.92.0, `--release` (opt-level=3, no LTO).
+- **Timing**: corrected `nanos_now` (see above); 101 timed compiles per cell,
+  16 warmup compiles, median reported. Two independent runs agreed within ~2%.
+- **Arenas**: deterministic, exactly-sized, built by `build_kernel_arena` in
+  `pixelflow-pipeline/src/bin/bench_jit_compile_cost.rs`: a circle-SDF core
+  (`(x-0.5)² + (y-0.5)²` via `mul_add`) extended by a cycling op mix of
+  `mul`/`add`/`sub`/`sqrt`/`mul_add`/`max` and `Lt`-guarded `select` — the
+  font/shader-kernel shape. All nodes reachable from the root. Ops stay in the
+  directly-emittable set (no transcendentals/gather/reduce), so the lowering
+  passes are identity fast-paths and both paths below compile identical work.
+- **(a) fresh** — `compile_arena_dag`: each compile mmaps a new
+  `ExecutableCode` region, mprotects it to RX, invalidates icache, and
+  munmaps on drop. mmap and munmap are both inside the timed window.
+- **(b) reused** — `CompileWorkspace::compile_arena`
+  (`pixelflow-ir/src/backend/emit/mod.rs`): the `CodeBuffer` (MAP_JIT) is
+  mmap'd once; each compile pays `pthread_jit_write_protect_np` toggles +
+  `sys_icache_invalidate` instead of mmap/munmap, and reuses pre-sized
+  scratch vectors for the schedule.
+
+## Results
+
+| nodes | code bytes | fresh ns/compile | reused ns/compile | reused ns/node |
+|---:|---:|---:|---:|---:|
+| 8   | 40    | 4,959     | 5,042     | 630 |
+| 32  | 160   | 12,250    | 11,958    | 374 |
+| 128 | 628   | 83,500    | 82,917    | 648 |
+| 512 | 2,504 | 1,142,792 | 1,127,375 | 2,202 |
+
+Observations:
+
+- **Buffer reuse buys almost nothing** (±2%, within run-to-run noise). On this
+  macOS version the mmap/munmap pair is far cheaper than the ~10-20µs
+  documented in `executable.rs:143-152`; codegen itself dominates at every
+  size. The amortizable syscall overhead the CodeBuffer was designed to
+  eliminate is not where the time goes.
+- **Scaling is superlinear past ~128 nodes**: ~374-650 ns/node up to 128
+  nodes, 2,200 ns/node at 512 (1.14ms total). The schedule/regalloc/emit
+  pipeline, not executable-memory management, is the cost center.
+
+## Conclusion vs gate G0
+
+**Per-leaf JIT fails G0 decisively.** The amortized (reused-buffer) cost of
+compiling even the smallest, 8-node leaf-shaped kernel is ~4.8-5.0µs — about
+5x over the ~1µs/kernel threshold — and the floor is set by codegen, not by
+executable-memory allocation, so no allocation-pooling scheme can rescue it.
+At ~5-12µs per small kernel, JIT compilation is only viable for kernels that
+are compiled once and evaluated many thousands of times (its current batch
+use), not per-leaf. Any path to per-leaf viability would require a
+fundamentally cheaper emitter (e.g. template/copy-and-patch codegen), not
+buffer reuse.

--- a/pixelflow-compiler/src/annotate.rs
+++ b/pixelflow-compiler/src/annotate.rs
@@ -21,9 +21,10 @@
 //! its Var index (stored in [`LiteralExpr::var_index`]).
 
 use crate::ast::{
-    BinaryExpr, BlockExpr, CallExpr, Expr, LetStmt, LiteralExpr, MethodCallExpr, Stmt, TupleExpr,
-    UnaryExpr,
+    BinaryExpr, BinaryOp, BlockExpr, CallExpr, Expr, LetStmt, LiteralExpr, MethodCallExpr, Stmt,
+    TupleExpr, UnaryExpr,
 };
+use std::collections::HashMap;
 use syn::Lit;
 
 /// Context threaded through the annotation pass.
@@ -40,11 +41,36 @@ impl AnnotationCtx {
     }
 }
 
+/// Which type "space" a literal lives in.
+///
+/// Kernel bodies that use the derivative projections `V`/`DX`/`DY`/`DZ` mix
+/// two spaces: **domain space** (values of the kernel's scalar/domain type,
+/// e.g. `Jet2`) and **projected space** (`Field` values produced by the
+/// projections). The projections are the boundary: domain-space in,
+/// Field-space out.
+///
+/// Literals are polymorphic at the source level, but codegen must pick a
+/// concrete type: domain-space literals are lifted to the kernel's scalar
+/// type (via the `A0` context array), while projected-space literals must
+/// evaluate to `Field` — otherwise e-graph rewrites that introduce fresh
+/// literals into Field-space math (e.g. `a/b + c -> mul_add(a, 1/b, c)`)
+/// emit ill-typed `Jet2 op Field` expressions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LiteralSpace {
+    /// Lifted to the kernel's domain scalar type (the default).
+    Domain,
+    /// Field-space: the literal participates in post-`V`/`DX`/`DY` math and
+    /// is emitted re-projected (`V(CtxVar...)`) so it evaluates to `Field`.
+    Projected,
+}
+
 /// Collected literal for Let binding generation.
 #[derive(Debug, Clone)]
 pub struct CollectedLiteral {
     pub index: usize,
     pub lit: Lit,
+    /// The inferred type space this literal must be emitted in.
+    pub space: LiteralSpace,
 }
 
 /// Annotate an expression tree, resolving literal Var indices in place.
@@ -54,7 +80,294 @@ pub struct CollectedLiteral {
 pub fn annotate(expr: &Expr, ctx: AnnotationCtx) -> (Expr, AnnotationCtx, Vec<CollectedLiteral>) {
     let mut literals = Vec::new();
     let (annotated, final_ctx) = annotate_expr(expr, ctx, &mut literals);
+
+    // Infer each literal's type space from the annotated tree (literals now
+    // carry their collection index) and record it for codegen.
+    let spaces = infer_literal_spaces(&annotated, literals.len());
+    for lit in &mut literals {
+        lit.space = spaces[lit.index];
+    }
+
     (annotated, final_ctx, literals)
+}
+
+// ============================================================================
+// Literal Space Inference
+// ============================================================================
+
+/// Internal lattice for bottom-up space resolution.
+///
+/// `Unknown` means "not constrained by any leaf yet" (literals, opaque calls,
+/// parameters). `Domain` and `Projected` correspond to [`LiteralSpace`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Space {
+    Unknown,
+    Domain,
+    Projected,
+}
+
+/// Join two operand spaces at a type-homogeneous operator.
+///
+/// `Unknown` is the identity. A `Domain`/`Projected` mix would already be
+/// ill-typed in the source (there are no mixed `Jet op Field` operators), so
+/// the choice is arbitrary — the generated code fails to compile loudly
+/// either way. `Projected` wins so a fresh literal at least stays with the
+/// Field-space operand that most likely constrained the rewrite.
+fn join(a: Space, b: Space) -> Space {
+    match (a, b) {
+        (Space::Unknown, s) | (s, Space::Unknown) => s,
+        (Space::Projected, _) | (_, Space::Projected) => Space::Projected,
+        (Space::Domain, Space::Domain) => Space::Domain,
+    }
+}
+
+/// Is this call one of the derivative projections (domain-space in,
+/// Field-space out)?
+fn is_projection(func: &str) -> bool {
+    matches!(func, "V" | "DX" | "DY" | "DZ" | "DXX" | "DXY" | "DYY")
+}
+
+/// Infer the [`LiteralSpace`] for every collected literal in an annotated
+/// expression.
+///
+/// Bottom-up pass: leaves with known space (coordinates → `Domain`,
+/// `V`/`DX`/`DY`/`DZ` projections → `Projected`, locals → the space of their
+/// init) propagate through type-homogeneous operators. Wherever an operator
+/// resolves to a known space, that space is pushed down onto any literals in
+/// its still-unresolved operands. Literals never constrained by a
+/// Field-space sibling default to `Domain` — exactly the pre-existing
+/// behavior, so kernels without projections are unaffected.
+fn infer_literal_spaces(expr: &Expr, literal_count: usize) -> Vec<LiteralSpace> {
+    let mut inference = SpaceInference {
+        spaces: vec![None; literal_count],
+        locals: HashMap::new(),
+    };
+    inference.resolve(expr);
+    inference
+        .spaces
+        .into_iter()
+        .map(|s| s.unwrap_or(LiteralSpace::Domain))
+        .collect()
+}
+
+struct SpaceInference {
+    /// Per-collection-index space assignment (None = still unconstrained).
+    spaces: Vec<Option<LiteralSpace>>,
+    /// Space of each let-bound local, keyed by name.
+    locals: HashMap<String, Space>,
+}
+
+impl SpaceInference {
+    /// Resolve the space of `expr`, assigning spaces to literals wherever an
+    /// operator join produces a known space.
+    fn resolve(&mut self, expr: &Expr) -> Space {
+        match expr {
+            Expr::Literal(_) => Space::Unknown,
+
+            Expr::Ident(ident) => {
+                let name = ident.name.to_string();
+                match name.as_str() {
+                    // Coordinate variables evaluate to the domain scalar type.
+                    "X" | "Y" | "Z" | "W" => Space::Domain,
+                    // Locals carry the space of their init expression.
+                    // Anything else (scalar params, manifold params) is
+                    // unconstraining: scalar params are domain-lifted, but
+                    // `Unknown` + the `Domain` default yields the same
+                    // emission, without guessing about manifold outputs.
+                    _ => self.locals.get(&name).copied().unwrap_or(Space::Unknown),
+                }
+            }
+
+            Expr::Call(call) => {
+                let func = call.func.to_string();
+                // Resolve args for their internal literals either way.
+                for arg in &call.args {
+                    self.resolve(arg);
+                }
+                if is_projection(&func) {
+                    // Projection boundary: argument is domain-space (its
+                    // literals keep the Domain default), result is Field.
+                    Space::Projected
+                } else {
+                    Space::Unknown
+                }
+            }
+
+            Expr::Binary(binary) => {
+                let l = self.resolve(&binary.lhs);
+                let r = self.resolve(&binary.rhs);
+                let joined = join(l, r);
+                if joined != Space::Unknown {
+                    self.force(&binary.lhs, joined);
+                    self.force(&binary.rhs, joined);
+                }
+                match binary.op {
+                    BinaryOp::Add
+                    | BinaryOp::Sub
+                    | BinaryOp::Mul
+                    | BinaryOp::Div
+                    | BinaryOp::Rem => joined,
+                    // Comparisons and mask combinators constrain their
+                    // operands (joined above) but produce a mask, which does
+                    // not carry either value space outward.
+                    BinaryOp::Lt
+                    | BinaryOp::Le
+                    | BinaryOp::Gt
+                    | BinaryOp::Ge
+                    | BinaryOp::Eq
+                    | BinaryOp::Ne
+                    | BinaryOp::BitAnd
+                    | BinaryOp::BitOr => Space::Unknown,
+                }
+            }
+
+            Expr::Unary(unary) => self.resolve(&unary.operand),
+
+            Expr::MethodCall(call) => {
+                let method = call.method.to_string();
+                match method.as_str() {
+                    // `.clone()` preserves the receiver's space.
+                    "clone" => self.resolve(&call.receiver),
+
+                    // `select(mask, a, b)`: the mask is an independent
+                    // island; the value space is the join of the branches.
+                    "select" => {
+                        self.resolve(&call.receiver);
+                        let mut joined = Space::Unknown;
+                        for arg in &call.args {
+                            joined = join(joined, self.resolve(arg));
+                        }
+                        if joined != Space::Unknown {
+                            for arg in &call.args {
+                                self.force(arg, joined);
+                            }
+                        }
+                        joined
+                    }
+
+                    // `.at()` re-maps the domain; coordinates keep their own
+                    // spaces and the output is the inner manifold's, which we
+                    // cannot see. Resolve children, propagate nothing.
+                    "at" => {
+                        self.resolve(&call.receiver);
+                        for arg in &call.args {
+                            self.resolve(arg);
+                        }
+                        Space::Unknown
+                    }
+
+                    // Comparison methods: operands share a space, output is
+                    // a mask.
+                    "lt" | "le" | "gt" | "ge" | "eq" | "ne" => {
+                        self.join_and_force(call);
+                        Space::Unknown
+                    }
+
+                    // Everything else (sqrt, abs, min, max, mul_add, clamp,
+                    // trig, ...) is type-homogeneous: receiver, args, and
+                    // output all share one space.
+                    _ => self.join_and_force(call),
+                }
+            }
+
+            Expr::Paren(inner) => self.resolve(inner),
+
+            Expr::Block(block) => {
+                for stmt in &block.stmts {
+                    match stmt {
+                        Stmt::Let(let_stmt) => {
+                            let space = self.resolve(&let_stmt.init);
+                            self.locals.insert(let_stmt.name.to_string(), space);
+                        }
+                        Stmt::Expr(e) => {
+                            self.resolve(e);
+                        }
+                    }
+                }
+                match &block.expr {
+                    Some(e) => self.resolve(e),
+                    None => Space::Unknown,
+                }
+            }
+
+            Expr::Tuple(tuple) => {
+                for elem in &tuple.elems {
+                    self.resolve(elem);
+                }
+                Space::Unknown
+            }
+
+            Expr::Verbatim(_) => Space::Unknown,
+        }
+    }
+
+    /// Join receiver + args of a type-homogeneous method call and force the
+    /// joined space onto unresolved operands.
+    fn join_and_force(&mut self, call: &MethodCallExpr) -> Space {
+        let mut joined = self.resolve(&call.receiver);
+        for arg in &call.args {
+            joined = join(joined, self.resolve(arg));
+        }
+        if joined != Space::Unknown {
+            self.force(&call.receiver, joined);
+            for arg in &call.args {
+                self.force(arg, joined);
+            }
+        }
+        joined
+    }
+
+    /// Push a resolved space down into `expr`, assigning it to any literal
+    /// that is not yet constrained. Recursion stays within type-homogeneous
+    /// structure: it does not cross projection calls (`V(...)` internals are
+    /// domain-space), `.at()` coordinate lists, opaque calls, or blocks
+    /// (locals were resolved in order already). Assignments are first-wins,
+    /// so literals already fixed by an inner join are untouched.
+    fn force(&mut self, expr: &Expr, space: Space) {
+        let assign = match space {
+            Space::Domain => LiteralSpace::Domain,
+            Space::Projected => LiteralSpace::Projected,
+            Space::Unknown => return,
+        };
+        match expr {
+            Expr::Literal(lit) => {
+                if let Some(idx) = lit.var_index {
+                    if let Some(slot) = self.spaces.get_mut(idx) {
+                        if slot.is_none() {
+                            *slot = Some(assign);
+                        }
+                    }
+                }
+            }
+            Expr::Binary(binary) => {
+                self.force(&binary.lhs, space);
+                self.force(&binary.rhs, space);
+            }
+            Expr::Unary(unary) => self.force(&unary.operand, space),
+            Expr::Paren(inner) => self.force(inner, space),
+            Expr::Tuple(tuple) => {
+                for elem in &tuple.elems {
+                    self.force(elem, space);
+                }
+            }
+            Expr::MethodCall(call) => match call.method.to_string().as_str() {
+                "at" => {}
+                "select" => {
+                    for arg in &call.args {
+                        self.force(arg, space);
+                    }
+                }
+                _ => {
+                    self.force(&call.receiver, space);
+                    for arg in &call.args {
+                        self.force(arg, space);
+                    }
+                }
+            },
+            // Boundaries: projections/opaque calls, idents, blocks, verbatim.
+            Expr::Call(_) | Expr::Ident(_) | Expr::Block(_) | Expr::Verbatim(_) => {}
+        }
+    }
 }
 
 fn annotate_expr(
@@ -79,6 +392,9 @@ fn annotate_expr(
             literals.push(CollectedLiteral {
                 index: collection_index,
                 lit: lit_expr.lit.clone(),
+                // Refined by space inference in `annotate` once the whole
+                // tree is annotated.
+                space: LiteralSpace::Domain,
             });
             let new_ctx = AnnotationCtx {
                 next_literal: ctx.next_literal + 1,

--- a/pixelflow-compiler/src/codegen/emitter.rs
+++ b/pixelflow-compiler/src/codegen/emitter.rs
@@ -121,6 +121,125 @@ fn find_derivative_params_inner(
     }
 }
 
+/// Collect locals whose bound value (transitively) involves a manifold param.
+///
+/// Such locals are bound to non-Copy values — tap expressions like
+/// `tex.at(...)` capture `&self.tex`, and only fully-ZST expression trees are
+/// Copy. The e-graph optimizer is free to extract a form that references such
+/// a local more than once, so every use must clone instead of move (the clone
+/// copies coordinate ZSTs plus a reference — free).
+///
+/// Walks blocks in statement order so taint propagates through chains of
+/// lets (`let c = tex.at(...); let s = c + ...;` taints both `c` and `s`).
+fn find_manifold_tainted_locals(
+    expr: &Expr,
+    symbols: &crate::symbol::SymbolTable,
+) -> HashSet<String> {
+    let mut tainted = HashSet::new();
+    collect_tainted_locals(expr, symbols, &mut tainted);
+    tainted
+}
+
+fn collect_tainted_locals(
+    expr: &Expr,
+    symbols: &crate::symbol::SymbolTable,
+    tainted: &mut HashSet<String>,
+) {
+    match expr {
+        Expr::Block(block) => {
+            for stmt in &block.stmts {
+                match stmt {
+                    Stmt::Let(let_stmt) => {
+                        // Nested blocks inside the init may bind their own locals.
+                        collect_tainted_locals(&let_stmt.init, symbols, tainted);
+                        if expr_touches_manifold(&let_stmt.init, symbols, tainted) {
+                            tainted.insert(let_stmt.name.to_string());
+                        }
+                    }
+                    Stmt::Expr(e) => collect_tainted_locals(e, symbols, tainted),
+                }
+            }
+            if let Some(e) = &block.expr {
+                collect_tainted_locals(e, symbols, tainted);
+            }
+        }
+        Expr::Binary(b) => {
+            collect_tainted_locals(&b.lhs, symbols, tainted);
+            collect_tainted_locals(&b.rhs, symbols, tainted);
+        }
+        Expr::Unary(u) => collect_tainted_locals(&u.operand, symbols, tainted),
+        Expr::Paren(p) => collect_tainted_locals(p, symbols, tainted),
+        Expr::MethodCall(c) => {
+            collect_tainted_locals(&c.receiver, symbols, tainted);
+            for arg in &c.args {
+                collect_tainted_locals(arg, symbols, tainted);
+            }
+        }
+        Expr::Call(c) => {
+            for arg in &c.args {
+                collect_tainted_locals(arg, symbols, tainted);
+            }
+        }
+        Expr::Tuple(t) => {
+            for elem in &t.elems {
+                collect_tainted_locals(elem, symbols, tainted);
+            }
+        }
+        Expr::Ident(_) | Expr::Literal(_) | Expr::Verbatim(_) => {}
+    }
+}
+
+/// Does this expression reference a manifold param or an already-tainted
+/// local anywhere?
+fn expr_touches_manifold(
+    expr: &Expr,
+    symbols: &crate::symbol::SymbolTable,
+    tainted: &HashSet<String>,
+) -> bool {
+    match expr {
+        Expr::Ident(ident) => {
+            let name = ident.name.to_string();
+            if tainted.contains(&name) {
+                return true;
+            }
+            matches!(
+                symbols.lookup(&name).map(|s| &s.kind),
+                Some(SymbolKind::ManifoldParam)
+            )
+        }
+        Expr::Binary(b) => {
+            expr_touches_manifold(&b.lhs, symbols, tainted)
+                || expr_touches_manifold(&b.rhs, symbols, tainted)
+        }
+        Expr::Unary(u) => expr_touches_manifold(&u.operand, symbols, tainted),
+        Expr::Paren(p) => expr_touches_manifold(p, symbols, tainted),
+        Expr::MethodCall(c) => {
+            expr_touches_manifold(&c.receiver, symbols, tainted)
+                || c.args
+                    .iter()
+                    .any(|a| expr_touches_manifold(a, symbols, tainted))
+        }
+        Expr::Call(c) => c
+            .args
+            .iter()
+            .any(|a| expr_touches_manifold(a, symbols, tainted)),
+        Expr::Tuple(t) => t
+            .elems
+            .iter()
+            .any(|e| expr_touches_manifold(e, symbols, tainted)),
+        Expr::Block(b) => {
+            b.stmts.iter().any(|s| match s {
+                Stmt::Let(l) => expr_touches_manifold(&l.init, symbols, tainted),
+                Stmt::Expr(e) => expr_touches_manifold(e, symbols, tainted),
+            }) || b
+                .expr
+                .as_ref()
+                .is_some_and(|e| expr_touches_manifold(e, symbols, tainted))
+        }
+        Expr::Literal(_) | Expr::Verbatim(_) => false,
+    }
+}
+
 fn find_at_manifold_params_inner(
     expr: &Expr,
     symbols: &crate::symbol::SymbolTable,
@@ -196,6 +315,9 @@ pub struct CodeEmitter<'a> {
     manifold_indices: HashMap<String, usize>,
     /// Collected literals from annotation pass (for Let bindings in Jet mode).
     collected_literals: Vec<crate::annotate::CollectedLiteral>,
+    /// Locals whose bound value involves a manifold param (non-Copy);
+    /// every reference to these is emitted as a clone, never a move.
+    manifold_locals: HashSet<String>,
 }
 
 impl<'a> CodeEmitter<'a> {
@@ -231,11 +353,16 @@ impl<'a> CodeEmitter<'a> {
             manifold_indices.insert(param.name.to_string(), i);
         }
 
+        // The body here is post-optimization, so this also covers optimizer-
+        // introduced `__N` bindings whose value chains back to a manifold param.
+        let manifold_locals = find_manifold_tainted_locals(&analyzed.def.body, &analyzed.symbols);
+
         CodeEmitter {
             analyzed,
             param_indices,
             manifold_indices,
             collected_literals: Vec::new(),
+            manifold_locals,
         }
     }
 
@@ -789,6 +916,15 @@ impl<'a> CodeEmitter<'a> {
                 let name = &ident_expr.name;
                 let name_str = name.to_string();
 
+                // Locals bound to manifold-tapping expressions (user lets or
+                // optimizer-introduced `__N` bindings) are non-Copy: the
+                // extracted form may reference them more than once, so every
+                // use clones. UFCS keeps this valid for not-yet-inferred
+                // types; for ZST expression values the clone is free.
+                if self.manifold_locals.contains(&name_str) {
+                    return quote! { ::core::clone::Clone::clone(&#name) };
+                }
+
                 match self.analyzed.symbols.lookup(&name_str) {
                     Some(symbol) => match symbol.kind {
                         SymbolKind::Intrinsic => {
@@ -851,7 +987,31 @@ impl<'a> CodeEmitter<'a> {
                 if let Some(var_idx) = lit.var_index {
                     // Literals go at indices in the context array
                     // Use array-based indexing: CtxVar::<A0, INDEX>::new()
-                    quote! { CtxVar::<A0, #var_idx>::new() }
+                    let collected = self
+                        .collected_literals
+                        .iter()
+                        .find(|c| c.index == var_idx)
+                        .unwrap_or_else(|| {
+                            panic!(
+                                "literal with var_index {var_idx} was never collected \
+                                 by the annotation pass — annotation and emission are \
+                                 out of sync"
+                            )
+                        });
+                    match collected.space {
+                        // Domain-space: the A0 entry already has the domain
+                        // scalar type; reference it directly.
+                        crate::annotate::LiteralSpace::Domain => {
+                            quote! { CtxVar::<A0, #var_idx>::new() }
+                        }
+                        // Field-space (post-V/DX/DY math): re-project the
+                        // domain-lifted A0 entry back to Field, exactly like
+                        // user-written `V(literal)`. Keeps the tree ZST while
+                        // making optimizer-introduced literals type-stable.
+                        crate::annotate::LiteralSpace::Projected => {
+                            quote! { V(CtxVar::<A0, #var_idx>::new()) }
+                        }
+                    }
                 } else {
                     // Fallback: no var_index assigned (shouldn't happen after annotation)
                     // Emit as Field::from

--- a/pixelflow-compiler/src/optimize.rs
+++ b/pixelflow-compiler/src/optimize.rs
@@ -101,9 +101,7 @@ impl Extraction<'_> {
 
 fn get_extraction() -> Extraction<'static> {
     match std::env::var("PIXELFLOW_NNUE_WEIGHTS") {
-        Ok(path) => {
-            Extraction::Nnue(OPTIMIZATION_MODEL.get_or_init(|| load_opt_in_weights(&path)))
-        }
+        Ok(path) => Extraction::Nnue(OPTIMIZATION_MODEL.get_or_init(|| load_opt_in_weights(&path))),
         Err(_) => Extraction::Static(Box::new(CostModel::latency_prior())),
     }
 }
@@ -1048,7 +1046,14 @@ impl EGraphContext {
 
             // Only bind shared classes that aren't the root
             // (the root becomes the final expression, not a binding)
-            if dag.is_shared(canonical) && canonical != dag.root {
+            //
+            // Leaves (Var/Const) are never bound — they re-materialize at each
+            // use instead. Binding them is at best a no-op and at worst wrong:
+            // a `let __0 = ident;` moves non-Copy values (manifold-tapping
+            // locals), and a shared literal must be re-emitted per use so each
+            // occurrence gets its own type-space assignment (a constant can
+            // legitimately appear in both domain-space and Field-space math).
+            if dag.is_shared(canonical) && canonical != dag.root && !self.is_leaf(canonical, dag) {
                 let var_name = format!("__{}", binding_idx);
 
                 // Build the AST for this e-class
@@ -1080,6 +1085,19 @@ impl EGraphContext {
                 expr: Some(Box::new(root_expr)),
                 span,
             })
+        }
+    }
+
+    /// Is the extraction choice for this e-class a leaf (Var or Const)?
+    ///
+    /// Leaves are re-materialized at each use site rather than let-bound; see
+    /// the comment in [`Self::dag_to_expr`].
+    fn is_leaf(&self, canonical: EClassId, dag: &ExtractedDAG) -> bool {
+        match dag.best_node_idx(canonical) {
+            Some(node_idx) => !matches!(self.egraph.nodes(canonical)[node_idx], ENode::Op { .. }),
+            // No recorded choice: eclass_to_expr will fail loudly if this
+            // class is actually reachable; don't bind it here.
+            None => true,
         }
     }
 

--- a/pixelflow-compiler/tests/optimizer_type_stability.rs
+++ b/pixelflow-compiler/tests/optimizer_type_stability.rs
@@ -1,0 +1,190 @@
+//! Compile-and-evaluate tests for e-graph optimization type-stability.
+//!
+//! Two historical defects forced font/bilinear kernels onto `kernel_raw!`:
+//!
+//! 1. **Type instability across the V/DX/DY projection boundary**: kernel
+//!    bodies mixing domain-space math (e.g. `Jet2`) with Field-space math
+//!    (post-`V`/`DX`/`DY` projection) were rewritten by the e-graph into forms
+//!    with fresh literals (e.g. `a/b + c -> mul_add(a, 1/b, c)`); codegen
+//!    lifted those literals to the kernel's domain scalar type, producing
+//!    ill-typed `Jet2 op Field` expressions.
+//!
+//! 2. **Extraction reused non-Copy subexpressions**: a kernel with a manifold
+//!    param tapped via `.at()` is not Copy (taps capture `&self.param`), but
+//!    extraction could emit a form that binds a tap once and uses it twice,
+//!    failing E0382.
+//!
+//! These tests assert both shapes now compile under the optimizing `kernel!`
+//! macro and evaluate identically to the unoptimized `kernel_raw!` form.
+
+use pixelflow_compiler::{kernel, kernel_raw};
+use pixelflow_core::jet::Jet2;
+use pixelflow_core::{DiscreteManifold, Field, Manifold};
+
+/// Extract the first lane from a Field as f32.
+fn field_extract(f: Field) -> f32 {
+    unsafe { core::mem::transmute_copy(&f) }
+}
+
+// ============================================================================
+// Defect 1: V/DX/DY projection boundary (gradient-normalized coverage ramp)
+// ============================================================================
+
+/// The line-crossing coverage ramp from the font renderer, stamped per
+/// evaluation domain. This is exactly the shape that used to extract to
+/// ill-typed code: `V(d) / (grad + V(min_grad)) + V(0.5)` invites the
+/// `a/b + c -> mul_add(a, recip(b), c)` rewrite, whose fresh `1.0` literal
+/// must stay in Field space (the ramp is Field math after projection).
+macro_rules! ramp_kernel {
+    ($n:ty) => {
+        kernel!(|x0: f32, y0: f32, dx_over_dy: f32, min_grad: f32| -> $n {
+            let d = X - ((Y - y0) * dx_over_dy + x0);
+            let grad = (DX(d.clone()) * DX(d.clone()) + DY(d.clone()) * DY(d.clone())).sqrt();
+            (V(d) / (grad + V(min_grad)) + V(0.5))
+                .max(V(0.0))
+                .min(V(1.0))
+        })
+    };
+}
+
+macro_rules! ramp_kernel_raw {
+    ($n:ty) => {
+        kernel_raw!(|x0: f32, y0: f32, dx_over_dy: f32, min_grad: f32| -> $n {
+            let d = X - ((Y - y0) * dx_over_dy + x0);
+            let grad = (DX(d.clone()) * DX(d.clone()) + DY(d.clone()) * DY(d.clone())).sqrt();
+            (V(d) / (grad + V(min_grad)) + V(0.5))
+                .max(V(0.0))
+                .min(V(1.0))
+        })
+    };
+}
+
+#[test]
+fn ramp_kernel_field_domain_matches_raw() {
+    let opt = ramp_kernel!(Field)(2.0, 0.5, 0.25, 1e-3);
+    let raw = ramp_kernel_raw!(Field)(2.0, 0.5, 0.25, 1e-3);
+
+    for &(x, y) in &[(0.0, 0.0), (2.5, 1.0), (1.9, 0.3), (-4.0, 7.5)] {
+        let p = (
+            Field::from(x),
+            Field::from(y),
+            Field::from(0.0_f32),
+            Field::from(0.0_f32),
+        );
+        let got = field_extract(opt.eval(p));
+        let want = field_extract(raw.eval(p));
+        assert!(
+            (got - want).abs() < 1e-5,
+            "Field domain mismatch at ({x}, {y}): kernel! gave {got}, kernel_raw! gave {want}"
+        );
+    }
+}
+
+#[test]
+fn ramp_kernel_jet2_domain_matches_raw() {
+    let opt = ramp_kernel!(Jet2)(2.0, 0.5, 0.25, 1e-3);
+    let raw = ramp_kernel_raw!(Jet2)(2.0, 0.5, 0.25, 1e-3);
+
+    for &(x, y) in &[(0.0, 0.0), (2.5, 1.0), (1.9, 0.3), (-4.0, 7.5)] {
+        let p = (
+            Jet2::x(Field::from(x)),
+            Jet2::y(Field::from(y)),
+            Jet2::constant(Field::from(0.0_f32)),
+            Jet2::constant(Field::from(0.0_f32)),
+        );
+        let got = field_extract(opt.eval(p));
+        let want = field_extract(raw.eval(p));
+        assert!(
+            (got - want).abs() < 1e-5,
+            "Jet2 domain mismatch at ({x}, {y}): kernel! gave {got}, kernel_raw! gave {want}"
+        );
+    }
+
+    // Sanity: over Jet2 the ramp is gradient-normalized, so a point one pixel
+    // inside the crossing must have coverage strictly between hard 0/1 only
+    // near the edge; far away it saturates. Check saturation far inside.
+    let far_inside = (
+        Jet2::x(Field::from(100.0_f32)),
+        Jet2::y(Field::from(0.0_f32)),
+        Jet2::constant(Field::from(0.0_f32)),
+        Jet2::constant(Field::from(0.0_f32)),
+    );
+    let v = field_extract(opt.eval(far_inside));
+    assert!(
+        (v - 1.0).abs() < 1e-6,
+        "coverage must saturate to 1 far inside the crossing, got {v}"
+    );
+}
+
+// ============================================================================
+// Defect 2: non-Copy manifold-param taps shared by extraction
+// ============================================================================
+
+// The 4-tap bilinear kernel shape: `tex` taps are non-Copy (they capture
+// `&self.tex`), and the optimizer is free to rewrite the weighted sum into a
+// form that references a tap more than once. That must compile (clone/borrow
+// legally), not fail E0382.
+kernel!(pub struct BilerpShape = |tex: kernel| Field -> Field {
+    let x0 = X.floor();
+    let y0 = Y.floor();
+    let fx = X - x0;
+    let fy = Y - y0;
+
+    let c00 = tex.at(x0, y0, Z, W);
+    let c10 = tex.at(x0 + 1.0, y0, Z, W);
+    let c01 = tex.at(x0, y0 + 1.0, Z, W);
+    let c11 = tex.at(x0 + 1.0, y0 + 1.0, Z, W);
+
+    c00 * ((1.0 - fx) * (1.0 - fy))
+        + c10 * (fx * (1.0 - fy))
+        + c01 * ((1.0 - fx) * fy)
+        + c11 * (fx * fy)
+});
+
+fn sample<M>(m: &M, x: f32, y: f32) -> f32
+where
+    M: Manifold<(Field, Field, Field, Field), Output = Field>,
+{
+    field_extract(m.eval((
+        Field::from(x),
+        Field::from(y),
+        Field::from(0.0_f32),
+        Field::from(0.0_f32),
+    )))
+}
+
+#[test]
+fn bilerp_shape_constant_field_is_identity() {
+    let tex = DiscreteManifold::new(vec![0.75; 9], 3, 3);
+    let bilerp = BilerpShape::new(tex);
+
+    for &(x, y) in &[(0.0, 0.0), (0.5, 0.5), (1.25, 0.75), (1.9, 1.1)] {
+        let v = sample(&bilerp, x, y);
+        assert!(
+            (v - 0.75).abs() < 1e-6,
+            "constant field not reproduced at ({x}, {y}): got {v}"
+        );
+    }
+}
+
+#[test]
+fn bilerp_shape_linear_gradient_reproduced() {
+    // f(x, y) = x + 2y sampled at integer coords, 4x4. Bilinear interpolation
+    // of an affine function is exact everywhere.
+    let mut buf = Vec::with_capacity(16);
+    for y in 0..4 {
+        for x in 0..4 {
+            buf.push(x as f32 + 2.0 * y as f32);
+        }
+    }
+    let bilerp = BilerpShape::new(DiscreteManifold::new(buf, 4, 4));
+
+    for &(x, y) in &[(0.5, 0.5), (1.25, 2.75), (0.1, 0.9), (2.5, 1.0)] {
+        let expect = x + 2.0 * y;
+        let v = sample(&bilerp, x, y);
+        assert!(
+            (v - expect).abs() < 1e-5,
+            "gradient not reproduced at ({x}, {y}): got {v}, want {expect}"
+        );
+    }
+}

--- a/pixelflow-graphics/benches/font_rendering.rs
+++ b/pixelflow-graphics/benches/font_rendering.rs
@@ -4,6 +4,7 @@
 
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use pixelflow_graphics::fonts::{text, CachedText, Font, GlyphCache};
+use pixelflow_graphics::render::aa::aa;
 use pixelflow_graphics::render::color::{Grayscale, Rgba8};
 use pixelflow_graphics::render::frame::Frame;
 use pixelflow_graphics::render::rasterizer::rasterize;
@@ -43,6 +44,31 @@ fn bench_pixelflow_text_sizes(c: &mut Criterion) {
 
         group.bench_with_input(BenchmarkId::from_parameter(length), &length, |b, _| {
             let glyph = text(&font, &text_str, 16.0);
+            let colored = Grayscale(glyph);
+            let width = (length as u32) * 15;
+            let mut frame = Frame::<Rgba8>::new(width, 24);
+
+            b.iter(|| {
+                rasterize(black_box(&colored), black_box(&mut frame), 1);
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_pixelflow_aa_text(c: &mut Criterion) {
+    // Antialiased uncached path: same pipeline as `text`, evaluated over Jet2
+    // coordinates (gradient-normalized crossing ramps). Measures the cost of
+    // Jet2 autodiff evaluation relative to the hard Field path above.
+    let mut group = c.benchmark_group("pixelflow_aa_text");
+    let font = Font::parse(FONT_DATA).unwrap();
+
+    for length in [5, 10, 26, 50] {
+        let text_str: String = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".chars().take(length).collect();
+
+        group.bench_with_input(BenchmarkId::from_parameter(length), &length, |b, _| {
+            let glyph = aa(text(&font, &text_str, 16.0));
             let colored = Grayscale(glyph);
             let width = (length as u32) * 15;
             let mut frame = Frame::<Rgba8>::new(width, 24);
@@ -182,6 +208,7 @@ criterion_group!(
     pixelflow_benches,
     bench_pixelflow_single_char,
     bench_pixelflow_text_sizes,
+    bench_pixelflow_aa_text,
     bench_pixelflow_threading,
     bench_pixelflow_with_caching,
 );

--- a/pixelflow-graphics/src/fonts/cache.rs
+++ b/pixelflow-graphics/src/fonts/cache.rs
@@ -1,15 +1,20 @@
 //! # Font Caching
 //!
-//! Glyph caching via the Baked combinator.
+//! Glyph caching via lattice collapse + bilinear sampling.
 //!
 //! ## Categorical Semantics
 //!
 //! Caching is a **morphism between evaluation strategies**:
 //! - `Glyph` evaluates mathematically (winding numbers, infinite resolution)
-//! - `CachedGlyph` evaluates from texture memory (SIMD gather, fixed resolution)
+//! - `CachedGlyph` evaluates from a baked lattice (SIMD gather, fixed resolution)
 //!
 //! Both implement `Manifold`, preserving composition. The cache is a functor
-//! that transforms evaluation strategy while maintaining the algebraic interface.
+//! that transforms evaluation strategy while maintaining the algebraic
+//! interface. The bake evaluates the glyph through [`Antialiased`] (`Jet2`
+//! autodiff coordinates, gradient-normalized crossing ramps) and tabulates
+//! the result via `Lattice::collapse`; the read-back is `DiscreteManifold`
+//! (index) smoothed by the [`Bilinear`] combinator. Texels therefore store
+//! *antialiased* coverage — no post-hoc filtering of hard 0/1 samples.
 //!
 //! ```text
 //!            cache_at(size)
@@ -19,6 +24,20 @@
 //!       ▼                        ▼
 //!     coverage                 coverage
 //! ```
+//!
+//! ## Coordinate convention (half-pixel)
+//!
+//! The rasterizer samples pixel *centers*: output pixel `(i, j)` is the
+//! manifold evaluated at `(i + 0.5, j + 0.5)` (see `render/rasterizer`).
+//! The bake follows the same convention: texel `(i, j)` of the coverage
+//! lattice stores the glyph's coverage at continuous coordinate
+//! `(i + 0.5, j + 0.5)` (the lattice origin is `(0.5, 0.5)`).
+//! `CachedGlyph::eval` shifts incoming coordinates by −0.5 into
+//! [`Bilinear`]'s integer texel grid, so a query at a pixel center returns
+//! the stored texel exactly — the cached glyph reproduces the analytical
+//! antialiased glyph (`Antialiased::new(glyph)`) at pixel centers with no
+//! half-pixel shift and no extra blur at the baked size, while fractional
+//! positions interpolate smoothly.
 //!
 //! ## Usage
 //!
@@ -35,29 +54,42 @@
 //! let uncached = font.glyph_scaled('A', 17.3);
 //! ```
 
-use crate::render::color::Pixel;
-use crate::render::frame::Frame;
-use crate::render::rasterizer::execute;
-use crate::Rgba8;
-use pixelflow_core::{Field, Manifold, ManifoldCompat, Texture};
+use crate::render::aa::Antialiased;
+use crate::render::bilinear::Bilinear;
+use pixelflow_core::jet::Jet2;
+use pixelflow_core::{
+    At, DiscreteManifold, Field, Lattice, Manifold, ManifoldCompat, ManifoldExt, Select, W, X, Y, Z,
+};
 use std::collections::HashMap;
 use std::sync::Arc;
 
 /// The standard 4D Field domain type.
 type Field4 = (Field, Field, Field, Field);
 
+/// The 4D Jet2 domain type (2D autodiff seeded in screen space).
+type Jet2x4 = (Jet2, Jet2, Jet2, Jet2);
+
 use super::ttf::{affine, Affine, Font, Glyph, Sum};
-use crate::Grayscale;
+
+/// Offset of a texel's sampling point from its integer index.
+///
+/// Texel `(i, j)` stores coverage at continuous coordinate
+/// `(i + TEXEL_CENTER, j + TEXEL_CENTER)`, matching the rasterizer's
+/// pixel-center convention. The bake adds this offset (lattice origin);
+/// `CachedGlyph::eval` subtracts it before bilinear sampling.
+const TEXEL_CENTER: f32 = 0.5;
 
 // ═══════════════════════════════════════════════════════════════════════════
 // CachedGlyph: The Morphism
 // ═══════════════════════════════════════════════════════════════════════════
 
-/// A glyph cached to texture memory.
+/// A glyph baked to a coverage lattice.
 ///
 /// This is the output of the caching morphism: a glyph that evaluates from
-/// memory rather than computing winding numbers. The texture stores coverage
-/// values (0.0 to 1.0), enabling SIMD gather for parallel sampling.
+/// memory rather than computing winding numbers. The lattice stores f32
+/// *antialiased* coverage values (0.0 to 1.0) — baked through [`Antialiased`],
+/// no u8 quantization roundtrip — sampled back via SIMD gather with bilinear
+/// interpolation.
 ///
 /// # Resolution
 ///
@@ -66,8 +98,9 @@ use crate::Grayscale;
 /// The cache uses size buckets (multiples of 4) to balance memory with reuse.
 #[derive(Clone)]
 pub struct CachedGlyph {
-    /// Coverage texture (single channel, 0.0-1.0).
-    coverage: Arc<Texture>,
+    /// Bilinear sampler over the baked coverage lattice.
+    /// Arc so cloning a cached glyph (once per cell per frame) is O(1).
+    sampler: Arc<Bilinear<DiscreteManifold>>,
     /// Baked width in pixels.
     width: usize,
     /// Baked height in pixels.
@@ -75,33 +108,31 @@ pub struct CachedGlyph {
 }
 
 impl CachedGlyph {
-    /// Create a cached glyph by baking a glyph manifold.
+    /// Create a cached glyph by collapsing a glyph manifold over a lattice.
     ///
-    /// The glyph is rasterized at `size × size` resolution.
+    /// The glyph's *antialiased* coverage is tabulated at `size × size`
+    /// resolution, at pixel centers (see the module docs for the coordinate
+    /// convention). The bake evaluates the glyph through [`Antialiased`], so
+    /// every texel stores a gradient-normalized crossing ramp value — the
+    /// bilinear read-back then interpolates already-smooth coverage.
     #[must_use]
     pub fn new<L, Q>(glyph: &Glyph<L, Q>, size: usize) -> Self
     where
-        L: Manifold<Field4, Output = Field>,
-        Q: Manifold<Field4, Output = Field>,
-        Glyph<L, Q>: Clone,
+        Glyph<L, Q>: Manifold<Jet2x4, Output = Field>,
     {
-        // Rasterize glyph to RGBA frame using Grayscale (coverage → grayscale)
-        let lifted = Grayscale(glyph.clone());
-        let mut frame = Frame::<Rgba8>::new(size as u32, size as u32);
-        execute(&lifted, &mut frame);
+        // Antialiased coverage: seed Jet2 screen-space derivatives so each
+        // edge crossing bakes as a ~1px gradient-normalized ramp.
+        let coverage = Antialiased::new(glyph);
 
-        // Extract coverage from red channel (Lift produces uniform gray)
-        let mut data = Vec::with_capacity(size * size);
-        for pixel in &frame.data {
-            let packed = pixel.to_u32();
-            let r = (packed & 0xFF) as f32 / 255.0;
-            data.push(r);
-        }
-
-        let coverage = Texture::new(data, size, size);
+        // Tabulate at pixel centers: texel (i, j) = coverage(i+0.5, j+0.5).
+        let lattice = Lattice {
+            extent: [size as u32, size as u32, 1, 1],
+            origin: [TEXEL_CENTER, TEXEL_CENTER, 0.0, 0.0],
+        };
+        let baked = lattice.collapse(&coverage);
 
         Self {
-            coverage: Arc::new(coverage),
+            sampler: Arc::new(Bilinear::new(baked)),
             width: size,
             height: size,
         }
@@ -120,6 +151,13 @@ impl CachedGlyph {
     pub fn height(&self) -> usize {
         self.height
     }
+
+    /// The baked coverage lattice (row-major f32 in `[0, 1]`).
+    #[inline]
+    #[must_use]
+    pub fn coverage(&self) -> &DiscreteManifold {
+        &self.sampler.tex
+    }
 }
 
 impl Manifold<Field4> for CachedGlyph {
@@ -127,9 +165,27 @@ impl Manifold<Field4> for CachedGlyph {
 
     #[inline(always)]
     fn eval(&self, p: Field4) -> Field {
-        let (x, y, z, w) = p;
-        // Sample coverage from texture (SIMD gather)
-        self.coverage.eval_raw(x, y, z, w)
+        // Contramap into the sampler's integer texel grid: texel (i, j)
+        // holds coverage at pixel center (i + 0.5, j + 0.5), so shift the
+        // query by -0.5 before bilinear interpolation.
+        let sampled = At {
+            inner: &*self.sampler,
+            x: X - TEXEL_CENTER,
+            y: Y - TEXEL_CENTER,
+            z: Z,
+            w: W,
+        };
+        // Bound to the baked extent: `DiscreteManifold` clamps out-of-range
+        // indices to the edge texel, which would smear nonzero boundary
+        // coverage (e.g. a descender reaching the em-box bottom) to infinity.
+        // Outside the bake there is no data — coverage is zero.
+        let in_bounds = X.ge(0.0) & X.le(self.width as f32) & Y.ge(0.0) & Y.le(self.height as f32);
+        Select {
+            cond: in_bounds,
+            if_true: sampled,
+            if_false: 0.0f32,
+        }
+        .eval(p)
     }
 }
 
@@ -260,7 +316,7 @@ impl GlyphCache {
     pub fn memory_usage(&self) -> usize {
         self.entries
             .values()
-            .map(|g| g.width * g.height * 4) // f32 per pixel
+            .map(|g| g.width * g.height * 4) // f32 per texel
             .sum()
     }
 }
@@ -370,6 +426,33 @@ mod tests {
     // tests run without `git lfs pull`. NotoSansMono is an LFS pointer.
     const FONT_DATA: &[u8] = include_bytes!("../../assets/DejaVuSansMono-Fallback.ttf");
 
+    /// Evaluate a coverage manifold at a single point via public lattice API.
+    fn sample<M>(m: &M, x: f32, y: f32) -> f32
+    where
+        M: Manifold<Field4, Output = Field>,
+    {
+        Lattice::point(x, y, 0.0, 0.0).collapse(m).into_buffer()[0]
+    }
+
+    /// Center of mass of a row-major coverage grid.
+    ///
+    /// Panics if the grid has no ink: a blank glyph makes position
+    /// comparisons meaningless, and silently passing would hide it.
+    fn center_of_mass(buf: &[f32], width: usize) -> (f32, f32) {
+        let mut total = 0.0f64;
+        let mut mx = 0.0f64;
+        let mut my = 0.0f64;
+        for (idx, &v) in buf.iter().enumerate() {
+            let x = (idx % width) as f64;
+            let y = (idx / width) as f64;
+            total += v as f64;
+            mx += v as f64 * x;
+            my += v as f64 * y;
+        }
+        assert!(total > 0.0, "center_of_mass on a blank coverage grid");
+        ((mx / total) as f32, (my / total) as f32)
+    }
+
     #[test]
     fn verify_size_bucket() {
         assert_eq!(size_bucket(8.0), 8);
@@ -388,6 +471,117 @@ mod tests {
 
         assert_eq!(cached.width(), 32);
         assert_eq!(cached.height(), 32);
+    }
+
+    #[test]
+    fn baked_coverage_dimensions_range_and_ink() {
+        let font = Font::parse(FONT_DATA).unwrap();
+        let glyph = font.glyph_scaled('A', 32.0).unwrap();
+        let cached = CachedGlyph::new(&glyph, 32);
+
+        let coverage = cached.coverage();
+        assert_eq!(coverage.width(), 32);
+        assert_eq!(coverage.height(), 32);
+
+        let buf = coverage.buffer();
+        assert_eq!(buf.len(), 32 * 32);
+
+        let mut ink = 0.0f32;
+        for (i, &v) in buf.iter().enumerate() {
+            assert!(
+                (0.0..=1.0).contains(&v),
+                "coverage out of [0,1] at texel {i}: {v}"
+            );
+            ink += v;
+        }
+        // 'A' at 32px must put real ink in the interior.
+        assert!(
+            ink > 10.0,
+            "glyph 'A' baked with almost no ink: sum = {ink}"
+        );
+    }
+
+    #[test]
+    fn cached_glyph_matches_analytical_at_pixel_centers() {
+        // At pixel centers the bilinear weights vanish, so the cached glyph
+        // must reproduce the analytical *antialiased* glyph exactly (up to
+        // f32 noise) — the bake stores Antialiased coverage.
+        let font = Font::parse(FONT_DATA).unwrap();
+        let glyph = font.glyph_scaled('A', 32.0).unwrap();
+        let smooth = Antialiased::new(&glyph);
+        let cached = CachedGlyph::new(&glyph, 32);
+
+        for &(i, j) in &[(4usize, 4usize), (10, 16), (16, 8), (16, 20), (24, 28)] {
+            let (x, y) = (i as f32 + 0.5, j as f32 + 0.5);
+            let direct = sample(&smooth, x, y);
+            let baked = sample(&cached, x, y);
+            assert!(
+                (direct - baked).abs() < 1e-5,
+                "cached glyph diverges from analytical AA at pixel center ({x}, {y}): \
+                 direct {direct}, baked {baked}"
+            );
+        }
+    }
+
+    #[test]
+    fn no_half_pixel_shift_center_of_mass() {
+        // Regression: the baked glyph must sit at the same position as the
+        // analytical glyph rasterized directly at pixel centers. A half-pixel
+        // convention error here shows up as a ~0.5px center-of-mass shift.
+        let size = 32usize;
+        let font = Font::parse(FONT_DATA).unwrap();
+        let glyph = font.glyph_scaled('A', size as f32).unwrap();
+
+        // Direct analytical AA tabulation at pixel centers (the rasterizer's
+        // sampling convention, without the u8 quantization of the old path).
+        // Antialiased to match what the bake stores.
+        let direct = Lattice {
+            extent: [size as u32, size as u32, 1, 1],
+            origin: [0.5, 0.5, 0.0, 0.0],
+        }
+        .collapse(&Antialiased::new(&glyph));
+        let (dx, dy) = center_of_mass(direct.buffer(), size);
+
+        // Cached glyph sampled at pixel centers through the full
+        // bake -> bilinear -> half-pixel-shift chain.
+        let cached = CachedGlyph::new(&glyph, size);
+        let resampled = Lattice {
+            extent: [size as u32, size as u32, 1, 1],
+            origin: [0.5, 0.5, 0.0, 0.0],
+        }
+        .collapse(&cached);
+        let (cx, cy) = center_of_mass(resampled.buffer(), size);
+
+        assert!(
+            (dx - cx).abs() < 0.05 && (dy - cy).abs() < 0.05,
+            "center of mass shifted: direct ({dx}, {dy}) vs cached ({cx}, {cy})"
+        );
+    }
+
+    #[test]
+    fn cached_glyph_interpolates_smoothly() {
+        // Sampling at sub-texel steps must ramp, not jump: with bilinear
+        // filtering a quarter-pixel step can change coverage by at most
+        // ~0.25 (texels are in [0,1]); nearest-neighbor jumps by up to 1.0.
+        let font = Font::parse(FONT_DATA).unwrap();
+        let glyph = font.glyph_scaled('A', 32.0).unwrap();
+        let cached = CachedGlyph::new(&glyph, 32);
+
+        let step = 0.25;
+        for &y in &[8.5f32, 16.5, 24.5] {
+            let mut prev = sample(&cached, 1.0, y);
+            let mut x = 1.0 + step;
+            while x <= 31.0 {
+                let v = sample(&cached, x, y);
+                let jump = (v - prev).abs();
+                assert!(
+                    jump < 0.3,
+                    "hard jump {jump} at ({x}, {y}): nearest-neighbor artifact"
+                );
+                prev = v;
+                x += step;
+            }
+        }
     }
 
     #[test]
@@ -478,7 +672,7 @@ mod tests {
         let font = Font::parse(FONT_DATA).unwrap();
         let mut cache = GlyphCache::new();
 
-        cache.get(&font, 'A', 16.0); // 16x16 = 256 pixels * 4 bytes = 1024
+        cache.get(&font, 'A', 16.0); // 16x16 = 256 texels * 4 bytes = 1024
         cache.get(&font, 'B', 16.0); // Another 1024
 
         assert_eq!(cache.memory_usage(), 2048);

--- a/pixelflow-graphics/src/fonts/mod.rs
+++ b/pixelflow-graphics/src/fonts/mod.rs
@@ -1,175 +1,105 @@
 //! # Font Rendering Pipeline
 //!
-//! Bridges vector font formats (TTF/OTF) to rasterized glyphs as manifolds.
+//! Bridges vector font formats (TTF) to glyph coverage manifolds.
 //!
 //! ## Architecture: Four Layers
 //!
 //! ```text
-//! Application Layer (CachedText)
+//! Text Layer (text(), CachedText)
 //!      ↓
-//!      │  High-level text rendering with layout and caching
+//!      │  Layout: kerning, advances; Sum of positioned glyphs
 //!      │
-//! Rasterization Layer (GlyphCache)
+//! Cache Layer (GlyphCache, CachedGlyph)
 //!      ↓
-//!      │  Lazy glyph caching per size
+//!      │  Lattice-collapsed f32 AA coverage + bilinear read-back
 //!      │
 //! Font Layer (Font, Glyph)
 //!      ↓
-//!      │  TTF/OTF parsing and glyph decomposition
+//!      │  TTF parsing; glyphs as analytical curve manifolds
 //!      │
-//! Loading Layer (FontSource, LoadedFont)
+//! Loading Layer (loader: DataSource, EmbeddedSource, MmapSource, LoadedFont)
 //!      ↓
 //! In-Memory Font Data
 //! ```
 //!
-//! ## Layer 1: Font Loading (`loader` module)
+//! ## Coverage semantics: hard over `Field`, antialiased over `Jet2`
 //!
-//! The entry point for font data. Supports multiple sources:
+//! The whole analytical pipeline (`AnalyticalLine`/`AnalyticalQuad` crossing
+//! kernels, `Geometry` winding accumulation, affine transforms, `Glyph`,
+//! `Translate`, `Sum`) is generic over the evaluation domain:
 //!
-//! ### FontSource Variants
+//! - Over **`Field`** coordinates, derivatives are zero and every edge
+//!   crossing degenerates to a hard 0/1 step — the classic aliased
+//!   winding-number test.
+//! - Over **`Jet2`** coordinates (2D dual numbers), each crossing computes a
+//!   gradient-normalized ramp `clamp(d / (‖∇d‖ + ε) + 0.5, 0, 1)` that is
+//!   ~1 *screen* pixel wide at any glyph scale — the chain rule carries
+//!   ‖∇d‖ through every coordinate transform.
 //!
-//! - **Embedded**: Fonts baked into the binary (no I/O)
-//! - **Filesystem**: Load from disk at runtime
-//! - **Memory-mapped**: Zero-copy file access via mmap
+//! [`crate::render::aa::Antialiased`] (or the [`crate::render::aa::aa`]
+//! function) is the bridge: it wraps a domain-generic coverage manifold and
+//! seeds `Jet2` derivatives in screen space, exposing an antialiased
+//! `Manifold<(Field, Field, Field, Field), Output = Field>`.
 //!
 //! ```ignore
-//! use pixelflow_graphics::fonts::{Font, FontSource};
+//! use pixelflow_graphics::fonts::{text, Font};
+//! use pixelflow_graphics::render::aa::aa;
 //!
-//! // Load embedded font (fast, no I/O)
-//! let font = Font::from_source(FontSource::Embedded)?;
-//!
-//! // Load from file (slower, but flexible)
-//! let font = Font::from_source(FontSource::Filesystem {
-//!     path: "/path/to/font.ttf".into(),
-//! })?;
+//! let font = Font::parse(font_data).unwrap();
+//! let hard = text(&font, "Hello", 16.0);   // aliased coverage
+//! let smooth = aa(text(&font, "Hello", 16.0)); // antialiased coverage
 //! ```
+//!
+//! ## Layer 1: Font Loading (`loader` module)
+//!
+//! Font bytes come from a [`FontSource`]: [`DataSource`] (owned bytes),
+//! [`EmbeddedSource`] (bytes baked into the binary), or [`MmapSource`]
+//! (zero-copy memory-mapped file). [`LoadedFont`] owns the source and
+//! lends out parsed [`Font`] views.
 //!
 //! ## Layer 2: Glyph Decomposition (`ttf` module)
 //!
-//! Parses TTF/OTF files and decomposes glyphs into curves.
+//! [`Font::parse`] reads the TTF tables (cmap, glyf, loca, hmtx, kern).
+//! [`Font::glyph_scaled`] compiles a character's outline into a
+//! [`Glyph`]: lines and quadratic Béziers as analytical crossing kernels,
+//! composed with bounds checks and affine transforms. Metrics come from
+//! `advance`/`kern` and their `*_by_id`/`*_scaled` variants.
 //!
-//! ### Glyph Structure
+//! ## Layer 3: Glyph Caching (`cache` module)
 //!
-//! Each glyph contains:
-//! - **Contours**: Outlines composed of quadratic Bézier curves (TrueType) or cubic Bézier curves (PostScript)
-//! - **Metrics**: Advance width, bounding box, bearing
-//! - **Rasterization state**: Hints and grid-fitting instructions (optional)
-//!
-//! ### Font Trait
-//!
-//! ```ignore
-//! pub trait Font {
-//!     fn glyph(&self, codepoint: char) -> Option<Glyph>;
-//!     fn glyph_metrics(&self, codepoint: char) -> Option<Metrics>;
-//!     fn baseline_offset(&self) -> i32;
-//! }
-//! ```
-//!
-//! The `Font` trait provides:
-//! - **Glyph lookup**: Get the vector outline for a character
-//! - **Metrics**: Advance width and bounding box
-//! - **Baseline**: Vertical offset for proper alignment
-//!
-//! ## Layer 3: Glyph Rasterization (`cache` module)
-//!
-//! Glyphs are expensive to rasterize (curves → pixels). The cache stores rasterized glyphs per size.
-//!
-//! ### GlyphCache
-//!
-//! Stores a 2D grid of rasterized glyphs, keyed by character and size.
-//!
-//! ```ignore
-//! use pixelflow_graphics::GlyphCache;
-//!
-//! let cache = GlyphCache::new();
-//! let rasterized = cache.get_or_rasterize('A', &font, 16)?;
-//! // Returns: height_px, width_px, pixels
-//! ```
-//!
-//! ### Caching Strategy
-//!
-//! - **Lazy**: Glyphs are rasterized on first use
-//! - **Per-size**: Each font size gets its own cache (common for terminals)
-//! - **Exponential growth**: Cache grows as needed; never shrinks
-//! - **Memory-efficient**: Typical terminal use (ANSI colors + 100 glyphs) uses ~1MB per size
+//! Analytical evaluation walks every curve per sample. `GlyphCache` bakes
+//! glyphs once per (character, size bucket): `CachedGlyph::new` evaluates
+//! the glyph through `Antialiased` and collapses it over a `Lattice` into a
+//! `DiscreteManifold` of f32 coverage sampled at pixel centers. Read-back
+//! goes through the [`crate::render::bilinear::Bilinear`] combinator, so
+//! fractional positions interpolate the baked AA coverage smoothly. See the
+//! `cache` module docs for the half-pixel coordinate convention.
 //!
 //! ## Layer 4: Text Layout (`text` module and `CachedText`)
 //!
-//! Combines font, cache, and manifold composition for high-level text rendering.
-//!
-//! ### CachedText
-//!
-//! The primary interface for rendering text. It:
-//! - **Caches glyphs**: Via internal `GlyphCache`
-//! - **Composes manifolds**: Each glyph position gets a manifold that samples the cache
-//! - **Handles layout**: Advance widths, kerning (if available), baseline alignment
+//! [`text()`](text::text) lays out a string as a `Sum` of translated
+//! analytical glyphs (kerning-free advance layout). [`CachedText::new`]
+//! does the same over cached glyphs, with kerning:
 //!
 //! ```ignore
-//! use pixelflow_graphics::CachedText;
+//! use pixelflow_graphics::fonts::{CachedText, Font, GlyphCache};
 //!
-//! let text = CachedText::new(
-//!     "Hello, World!",
-//!     &font,
-//!     size,
-//!     foreground_color,
-//!     background_color,
-//! )?;
+//! let font = Font::parse(font_data).unwrap();
+//! let mut cache = GlyphCache::new();
+//! cache.warm_ascii(&font, 16.0);
 //!
-//! // Text is now a Manifold<Output = Discrete> (a color manifold)
-//! // Can be rendered directly or composed with other manifolds
+//! let text = CachedText::new(&font, &mut cache, "Hello, World!", 16.0);
 //! ```
 //!
-//! ## Rendering Pipeline
-//!
-//! Typical usage flow:
-//!
-//! 1. **Load font** (once): `Font::from_source(FontSource::...)?`
-//! 2. **Create text manifold** (per string): `CachedText::new(text, &font, ...)?`
-//! 3. **Render** (every frame): `execute(&text_manifold, &mut framebuffer, shape)`
-//!
-//! The glyph cache is shared across all `CachedText` instances using the same font and size,
-//! so repeated text doesn't re-rasterize glyphs.
-//!
-//! ## Integration with Colors
-//!
-//! `CachedText` produces manifolds with `Output = Discrete` (RGBA pixels), so they compose
-//! seamlessly with color manifolds and other effects:
-//!
-//! ```ignore
-//! use pixelflow_graphics::{CachedText, ColorCube};
-//! use pixelflow_core::combinators::At;
-//!
-//! let text = CachedText::new(...)?;
-//! let background = At { inner: ColorCube, x: 0.2, y: 0.2, z: 0.2, w: 1.0 };  // Dark gray
-//!
-//! // Compose: text over background
-//! let scene = text.select(background);  // TextOn{text, background}
-//! ```
-//!
-//! ## Performance Characteristics
-//!
-//! | Operation | Time | Cache Status |
-//! |-----------|------|--------------|
-//! | Load font | ~1-10ms | Single per app |
-//! | First render (new size) | ~10-50ms per unique char | Cache miss |
-//! | Second render (same size) | ~0.1ms per pixel | Cache hit (SIMD) |
-//!
-//! For a 1080p terminal with ~20 unique characters per frame, rasterization is negligible (<1% of frame time).
-//!
-//! ## Memory Layout: Glyphs as Manifolds
-//!
-//! A `CachedText` manifold doesn't store pixel data directly. Instead:
-//! 1. It stores the glyph cache (shared across all text instances)
-//! 2. At evaluation time, it samples the cache at the requested coordinates
-//! 3. The compiler fuses this sampling into the main SIMD loop
-//!
-//! Result: No intermediate framebuffer, no memory copies. Text is rasterized directly into the final output.
+//! Both produce **coverage** manifolds (`Output = Field`, values in
+//! `[0, 1]`), not colors. Map coverage to pixels with
+//! `render::color::Grayscale`, or blend foreground/background per channel
+//! the way `core-term`'s cell renderer does.
 //!
 //! ## Supported Formats
 //!
-//! - **TTF** (TrueType): Quadratic Bézier curves
-//! - **OTF** (OpenType): Cubic Bézier curves (via subsetting)
-//! - **Variable fonts**: Supported if font has variation axes
+//! - **TTF** (TrueType): quadratic Bézier outlines, cmap formats 4 and 12,
+//!   horizontal kerning (kern format 0).
 //!
 pub mod cache;
 pub mod loader;

--- a/pixelflow-graphics/src/fonts/ttf.rs
+++ b/pixelflow-graphics/src/fonts/ttf.rs
@@ -1,20 +1,25 @@
 //! pixelflow-graphics/src/fonts/ttf.rs
 //!
-//! Pure Manifold TTF Parser with Analytical Loop-Blinn Rendering.
+//! Pure Manifold TTF Parser with analytical ray-crossing rendering.
 //!
-//! Glyphs use analytical curves with coverage-based antialiasing.
-//! All derivatives are precomputed polynomials - no Jets needed!
+//! The whole glyph pipeline (curves, geometry, affine transforms, glyphs) is
+//! generic over the evaluation domain:
+//!
+//! - Evaluated over `Field` coordinates, crossings are hard 0/1 steps
+//!   (the classic aliased winding test).
+//! - Evaluated over `Jet2` coordinates (see [`crate::render::aa::Antialiased`]),
+//!   each crossing becomes a gradient-normalized ramp ~1 screen pixel wide:
+//!   the derivatives chain through every affine transform, so antialiasing is
+//!   scale-invariant.
 
 use crate::shapes::{square, Bounded};
 use pixelflow_compiler::kernel;
-use pixelflow_core::{At, Field, Manifold, ManifoldCompat, ManifoldExt, W, Z};
+use pixelflow_core::jet::Jet2;
+use pixelflow_core::{At, Field, Manifold, ManifoldExt, W, Z};
 use std::sync::Arc;
 
 // Import analytical curve kernels
 use super::ttf_curve_analytical::{AnalyticalLine, AnalyticalQuad};
-
-/// The standard 4D Field domain type.
-type Field4 = (Field, Field, Field, Field);
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Type Aliases for Concrete Kernel Types
@@ -30,12 +35,54 @@ pub type QuadKernel = AnalyticalQuad;
 // Combinators
 // ═══════════════════════════════════════════════════════════════════════════
 
-// Affine coordinate transform kernel.
-// Computes: (X - tx) * a + (Y - ty) * b
-kernel!(
-    pub struct AffineTransform = |tx: f32, a: f32, ty: f32, b: f32|
-    (X - tx) * a + (Y - ty) * b
-);
+/// Affine coordinate transform kernel.
+///
+/// Computes: (X - tx) * a + (Y - ty) * b
+///
+/// Domain-generic: over `Jet2` the output carries the transform's Jacobian,
+/// which is what makes the crossing ramp scale-invariant in screen space.
+#[derive(Clone, Copy, Debug)]
+pub struct AffineTransform {
+    /// X translation (applied before the linear part).
+    pub tx: f32,
+    /// First row coefficient for X.
+    pub a: f32,
+    /// Y translation (applied before the linear part).
+    pub ty: f32,
+    /// First row coefficient for Y.
+    pub b: f32,
+}
+
+impl AffineTransform {
+    /// Create a new affine coordinate expression.
+    #[inline(always)]
+    #[must_use]
+    pub fn new(tx: f32, a: f32, ty: f32, b: f32) -> Self {
+        Self { tx, a, ty, b }
+    }
+}
+
+// One kernel body, stamped per evaluation domain: `kernel!` lifts scalar
+// params to a single concrete domain type chosen at expansion time, so a
+// named kernel struct cannot be polymorphic over the domain.
+macro_rules! impl_affine_transform_manifold {
+    ($n:ty) => {
+        impl Manifold<($n, $n, $n, $n)> for AffineTransform {
+            type Output = $n;
+
+            #[inline(always)]
+            fn eval(&self, p: ($n, $n, $n, $n)) -> $n {
+                let k = kernel!(|tx: f32, a: f32, ty: f32, b: f32| -> $n {
+                    (X - tx) * a + (Y - ty) * b
+                });
+                k(self.tx, self.a, self.ty, self.b).eval(p)
+            }
+        }
+    };
+}
+
+impl_affine_transform_manifold!(Field);
+impl_affine_transform_manifold!(Jet2);
 
 /// Affine transform combinator type alias.
 ///
@@ -70,20 +117,25 @@ pub fn affine<M>(inner: M, [a, b, c, d, tx, ty]: [f32; 6]) -> Affine<M> {
 #[derive(Clone, Debug)]
 pub struct Sum<M>(pub Arc<[M]>);
 
-impl<M: Manifold<Field4, Output = Field>> Manifold<Field4> for Sum<M> {
+// Domain-generic: the summands produce Field coverage in every domain, so the
+// accumulation itself is plain Field math.
+impl<P, M> Manifold<P> for Sum<M>
+where
+    P: Copy + Send + Sync,
+    M: Manifold<P, Output = Field>,
+{
     type Output = Field;
 
     #[inline(always)]
-    fn eval(&self, p: Field4) -> Field {
-        let (x, y, z, w) = p;
+    fn eval(&self, p: P) -> Field {
         if self.0.len() == 1 {
-            return self.0[0].eval_raw(x, y, z, w);
+            return self.0[0].eval(p);
         }
         // Build sum AST and evaluate - each iteration builds Add node, then evals
         let zero = Field::from(0.0);
         self.0.iter().fold(zero, |acc, m| {
-            let val = m.eval_raw(x, y, z, w);
-            (acc + val).eval_raw(zero, zero, zero, zero)
+            let val = m.eval(p);
+            (acc + val).eval(p)
         })
     }
 }
@@ -131,25 +183,31 @@ impl<K> Line<K> {
     }
 }
 
-// ─── Field Implementation (Winding Number Coverage) ────────────────────────
+// ─── Winding Number Coverage (generic over the evaluation domain) ──────────
 
-impl<K: Manifold<Field4, Output = Field>> Manifold<Field4> for Line<K> {
+impl<P, K> Manifold<P> for Line<K>
+where
+    P: Copy + Send + Sync,
+    K: Manifold<P, Output = Field>,
+{
     type Output = Field;
 
     #[inline(always)]
-    fn eval(&self, p: Field4) -> Field {
-        let (x, y, z, w) = p;
-        self.kernel.eval_raw(x, y, z, w)
+    fn eval(&self, p: P) -> Field {
+        self.kernel.eval(p)
     }
 }
 
-impl<K: Manifold<Field4, Output = Field>> Manifold<Field4> for Quad<K> {
+impl<P, K> Manifold<P> for Quad<K>
+where
+    P: Copy + Send + Sync,
+    K: Manifold<P, Output = Field>,
+{
     type Output = Field;
 
     #[inline(always)]
-    fn eval(&self, p: Field4) -> Field {
-        let (x, y, z, w) = p;
-        self.kernel.eval_raw(x, y, z, w)
+    fn eval(&self, p: P) -> Field {
+        self.kernel.eval(p)
     }
 }
 
@@ -164,49 +222,49 @@ pub struct Geometry<L, Q> {
     pub quads: Arc<[Q]>,
 }
 
-impl<L: Manifold<Field4, Output = Field>, Q: Manifold<Field4, Output = Field>> Manifold<Field4>
-    for Geometry<L, Q>
+// Domain-generic: segments produce Field coverage in every domain (the
+// crossing ramp projects derivatives away), so winding accumulation and the
+// non-zero fill rule are plain Field math.
+impl<P, L, Q> Manifold<P> for Geometry<L, Q>
+where
+    P: Copy + Send + Sync,
+    L: Manifold<P, Output = Field>,
+    Q: Manifold<P, Output = Field>,
 {
     type Output = Field;
 
     #[inline(always)]
-    fn eval(&self, p: Field4) -> Field {
-        let (x, y, z, w) = p;
+    fn eval(&self, p: P) -> Field {
         let fzero = Field::from(0.0);
 
         // Accumulate line and quad contributions into a single composite value.
         // Note: Field + Field produces Add<Field, Field> (a manifold), so we must
-        // evaluate to get back a scalar. This pattern is more efficient than the
-        // old code because we defer the final evaluation until after combining
-        // all contributions, rather than collapsing after each addition.
+        // evaluate to get back a scalar.
         let total = self
             .lines
             .iter()
-            .map(|l| l.eval_raw(x, y, z, w))
-            .chain(self.quads.iter().map(|q| q.eval_raw(x, y, z, w)))
+            .map(|l| l.eval(p))
+            .chain(self.quads.iter().map(|q| q.eval(p)))
             .fold(fzero, |acc, contrib| {
                 // Compose: acc + contrib produces Add<Field, Field>
                 // Evaluate the sum to collapse back to Field
-                (acc + contrib).eval_raw(fzero, fzero, fzero, fzero)
+                (acc + contrib).eval(p)
             });
 
         // Apply non-zero winding rule: |winding| becomes coverage (clamped to [0, 1])
-        total
-            .abs()
-            .min(Field::from(1.0))
-            .eval_raw(fzero, fzero, fzero, fzero)
+        total.abs().min(Field::from(1.0)).eval(p)
     }
 }
 
 /// A simple glyph: segments in unit space, bounded, then transformed.
 ///
 /// The composition is: Affine<Select<UnitSquare, Geometry, 0.0>>
-/// - Geometry: Optimized Sum of Lines and Quads (produces smooth 0.0-1.0 coverage)
+/// - Geometry: Optimized Sum of Lines and Quads
 /// - Select (via square): Bounds check with short-circuit
 /// - Affine: Restores to font coordinate space
 ///
-/// Note: Lines and Quads now produce analytically anti-aliased coverage directly,
-/// so Threshold is no longer needed.
+/// Coverage is hard 0/1 over `Field` coordinates; antialiased when the same
+/// pipeline is evaluated over `Jet2` coordinates (via `Antialiased`).
 pub type SimpleGlyph<L, Q> = Affine<Bounded<Geometry<L, Q>>>;
 
 /// A compound glyph: sum of transformed child glyphs.
@@ -233,57 +291,56 @@ impl<L, Q> core::fmt::Debug for Glyph<L, Q> {
     }
 }
 
-// Glyph evaluation - concrete impls because Line/Quad/Segment have
-// different implementations for Field (hard) vs Jet2 (anti-aliased).
+// Glyph evaluation - one body, stamped per evaluation domain (Field: hard
+// coverage, Jet2: antialiased). Concrete impls rather than a single generic
+// one because the inner `Select` (bounds check) only has per-domain Manifold
+// impls, and the compound arm recurses into `Glyph` itself, which a generic
+// impl could not express without a cyclic where-clause.
+macro_rules! impl_glyph_manifold {
+    ($n:ty) => {
+        impl<L, Q> Manifold<($n, $n, $n, $n)> for Glyph<L, Q>
+        where
+            L: Manifold<($n, $n, $n, $n), Output = Field>,
+            Q: Manifold<($n, $n, $n, $n), Output = Field>,
+        {
+            type Output = Field;
 
-impl<L, Q> Manifold<Field4> for Glyph<L, Q>
-where
-    L: ManifoldCompat<Field, Output = Field>,
-    Q: ManifoldCompat<Field, Output = Field>,
-{
-    type Output = Field;
-
-    #[inline(always)]
-    fn eval(&self, p: Field4) -> Field {
-        let (x, y, z, w) = p;
-        match self {
-            Self::Empty => Field::from(0.0),
-            Self::Simple(g) => {
-                // Inline the Affine<Bounded<Geometry>> evaluation
-                // The affine transform has been stored as At<AffineTransform, AffineTransform, Z, W, Select<..., Geometry, f32>>
-                // We need to evaluate the coordinate expressions and then call the inner manifold
-
-                // For SimpleGlyph, the structure is:
-                // At<trans_x, trans_y, Z, W, Select<UnitSquare, Geometry, 0.0>>
-                //
-                // We evaluate trans_x and trans_y at (x, y, z, w), then pass to inner
-                let tx = g.x.eval(p); // transformed x
-                let ty = g.y.eval(p); // transformed y
-                let tz = g.z.eval(p); // z (passthrough)
-                let tw = g.w.eval(p); // w (passthrough)
-
-                // Now evaluate the inner Select<UnitSquare, Geometry, 0.0>
-                g.inner.eval((tx, ty, tz, tw))
-            }
-            Self::Compound(sum) => {
-                // Compound glyphs are Sum<Affine<Glyph>>
-                // We need to evaluate each child and sum the results
-                let mut acc = Field::from(0.0);
-                for child in sum.0.iter() {
-                    // Each child is Affine<Glyph<L, Q>>
-                    // Inline the At evaluation
-                    let tx = child.x.eval(p);
-                    let ty = child.y.eval(p);
-                    let tz = child.z.eval(p);
-                    let tw = child.w.eval(p);
-                    let child_val = child.inner.eval((tx, ty, tz, tw));
-                    acc = (acc + child_val).at(x, y, z, w).collapse();
+            #[inline(always)]
+            fn eval(&self, p: ($n, $n, $n, $n)) -> Field {
+                match self {
+                    Self::Empty => Field::from(0.0),
+                    Self::Simple(g) => {
+                        // Inline the Affine<Bounded<Geometry>> evaluation:
+                        // evaluate the coordinate expressions, then the inner
+                        // Select<UnitSquare, Geometry, 0.0>.
+                        let tx = g.x.eval(p); // transformed x
+                        let ty = g.y.eval(p); // transformed y
+                        let tz = g.z.eval(p); // z (passthrough)
+                        let tw = g.w.eval(p); // w (passthrough)
+                        g.inner.eval((tx, ty, tz, tw))
+                    }
+                    Self::Compound(sum) => {
+                        // Compound glyphs are Sum<Affine<Glyph>>: evaluate each
+                        // child through its affine transform and sum.
+                        let mut acc = Field::from(0.0);
+                        for child in sum.0.iter() {
+                            let tx = child.x.eval(p);
+                            let ty = child.y.eval(p);
+                            let tz = child.z.eval(p);
+                            let tw = child.w.eval(p);
+                            let child_val = child.inner.eval((tx, ty, tz, tw));
+                            acc = (acc + child_val).eval(p);
+                        }
+                        acc
+                    }
                 }
-                acc
             }
         }
-    }
+    };
 }
+
+impl_glyph_manifold!(Field);
+impl_glyph_manifold!(Jet2);
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Reader

--- a/pixelflow-graphics/src/fonts/ttf_curve_analytical.rs
+++ b/pixelflow-graphics/src/fonts/ttf_curve_analytical.rs
@@ -6,46 +6,88 @@
 //! For lines: direct x-intersection with the horizontal scanline.
 //! For quadratics: analytical root-finding (quadratic formula).
 //!
-//! The winding number is a pure integer ±1 per crossing. Coverage is a
-//! hard step (0 or 1), not a smooth ramp. Geometry::eval applies
-//! abs().min(1.0) to convert winding to inside/outside coverage.
+//! Each crossing contributes a **gradient-normalized ramp** instead of a hard
+//! step. With `d = X - x_intersection` computed in the evaluation domain, the
+//! per-crossing coverage is:
+//!
+//! ```text
+//! coverage = clamp(d / (‖∇d‖ + ε) + 0.5, 0, 1)
+//! ```
+//!
+//! The same kernel body serves both evaluation domains:
+//!
+//! - **`Field`** (no derivative tracking): `‖∇d‖ = 0`, so `d / ε` saturates the
+//!   clamp and the ramp degenerates to the classic hard 0/1 step.
+//! - **`Jet2`** (autodiff): `∇d` chains through every enclosing coordinate
+//!   transform (affine scale/flip, translation), so the ramp is exactly one
+//!   *screen* pixel wide regardless of glyph scale. This is the antialiased
+//!   path; see [`crate::render::aa::Antialiased`] for the seeding combinator.
+//!
+//! `Geometry::eval` applies `abs().min(1.0)` to convert the summed winding
+//! contributions to inside/outside coverage.
 
-// The AnalyticalLine kernel's generated builder takes one argument per
-// segment coefficient; the macro cannot forward an `#[allow]` to it.
-#![allow(clippy::too_many_arguments)]
 use pixelflow_compiler::kernel;
+use pixelflow_core::jet::Jet2;
 use pixelflow_core::{Field, Manifold};
 
-type Field4 = (Field, Field, Field, Field);
+/// Gradient floor for the crossing ramp. In the `Field` domain the gradient is
+/// identically zero, so `d / MIN_GRADIENT` saturates the clamp and reproduces
+/// the hard step. In the `Jet2` domain real gradients are ~1, so this floor
+/// only guards against division by zero at degenerate tangencies.
+const MIN_GRADIENT: f32 = 1e-3;
+
+/// Discriminant floor for the quadratic solver. `Jet2::sqrt` is implemented
+/// via `rsqrt`, which is infinite at zero (`0 * inf = NaN`). Clamping the
+/// discriminant to a tiny positive value keeps values and derivatives finite
+/// at the curve's Y-extremum (tangent point); the resulting root perturbation
+/// is ~1e-6 font units. The `disc >= 0` gate still rejects non-intersections.
+const MIN_DISC: f32 = 1e-12;
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Line Segment (Ray-Crossing Winding)
 // ═══════════════════════════════════════════════════════════════════════════
 
-// Line segment with precomputed ray-crossing coefficients.
-//
-// Winding number contribution via horizontal ray intersection:
-// 1. Check if Y is within the segment's vertical extent
-// 2. Compute x_intersection where the segment crosses y = Y
-// 3. Step: 1 if X >= x_intersection (ray crosses to the left of X), else 0
-// 4. Multiply by winding direction (±1)
-kernel!(
-    pub struct AnalyticalLine = |x0: f32, y0: f32, dx_over_dy: f32,
-                                  dir: f32, y_min: f32, y_max: f32| {
-        // Early rejection: only contributes when Y is in segment's vertical range
-        let in_y = (Y >= y_min) & (Y < y_max);
-
-        // X-coordinate where line segment crosses the horizontal scanline at Y
-        let x_int = (Y - y0) * dx_over_dy + x0;
-
-        // Step: 1.0 if X >= x_int (crossing is to the left of or at X)
-        let crossed = (X >= x_int).select(1.0, 0.0);
-
-        in_y.select(crossed * dir, 0.0)
-    }
-);
+/// Line segment with precomputed ray-crossing coefficients.
+///
+/// Winding number contribution via horizontal ray intersection:
+/// 1. Check if Y is within the segment's vertical extent
+/// 2. Compute x_intersection where the segment crosses y = Y
+/// 3. Gradient-normalized ramp on `d = X - x_intersection`
+/// 4. Multiply by winding direction (±1)
+#[derive(Clone, Copy, Debug)]
+pub struct AnalyticalLine {
+    /// X coordinate of the segment start.
+    pub x0: f32,
+    /// Y coordinate of the segment start.
+    pub y0: f32,
+    /// Segment slope as dx/dy (the segment is never horizontal).
+    pub dx_over_dy: f32,
+    /// Winding direction: -1 for upward segments, +1 for downward.
+    pub dir: f32,
+    /// Lower Y bound of the segment.
+    pub y_min: f32,
+    /// Upper Y bound of the segment.
+    pub y_max: f32,
+}
 
 impl AnalyticalLine {
+    /// Create from precomputed coefficients.
+    // One argument per segment coefficient; grouping them would just mirror
+    // the struct itself. Prefer `from_points` for construction from geometry.
+    #[allow(clippy::too_many_arguments)]
+    #[inline(always)]
+    #[must_use]
+    pub fn new(x0: f32, y0: f32, dx_over_dy: f32, dir: f32, y_min: f32, y_max: f32) -> Self {
+        Self {
+            x0,
+            y0,
+            dx_over_dy,
+            dir,
+            y_min,
+            y_max,
+        }
+    }
+
     /// Create from two endpoints. Returns None for horizontal/degenerate lines.
     #[must_use]
     pub fn from_points([x0, y0]: [f32; 2], [x1, y1]: [f32; 2]) -> Option<Self> {
@@ -65,8 +107,72 @@ impl AnalyticalLine {
     }
 }
 
+// One kernel body, stamped per evaluation domain. The `kernel!` macro lifts
+// scalar params and literals to a single concrete domain type chosen at
+// expansion time (`-> $n`), so a named kernel struct cannot be polymorphic
+// over the domain; the macro_rules wrapper keeps a single source of truth.
+//
+// Inside the body, `V`/`DX`/`DY` project a domain-valued subexpression to its
+// `Field` value/derivative components, so the coverage ramp is Field math in
+// every domain. `V(literal)` re-projects a domain-lifted constant back to
+// `Field` for use in that ramp. The optimizer is type-space aware across the
+// projection boundary: fresh literals introduced by rewrites (e.g.
+// `a/b + c -> mul_add(a, 1/b, c)`) are emitted in the space of the math they
+// join, so the extracted form stays well-typed in every domain.
+macro_rules! impl_analytical_line_manifold {
+    ($n:ty) => {
+        impl Manifold<($n, $n, $n, $n)> for AnalyticalLine {
+            type Output = Field;
+
+            #[inline(always)]
+            fn eval(&self, p: ($n, $n, $n, $n)) -> Field {
+                let k = kernel!(|x0: f32,
+                                 y0: f32,
+                                 dx_over_dy: f32,
+                                 dir: f32,
+                                 y_min: f32,
+                                 y_max: f32,
+                                 min_grad: f32|
+                 -> $n {
+                    // Early rejection: only contributes when Y is in the
+                    // segment's vertical range. Masks carry no derivatives.
+                    let in_y = (Y >= y_min) & (Y < y_max);
+
+                    // Signed crossing distance in the evaluation domain. Over
+                    // Jet2 its derivatives chain through every enclosing
+                    // coordinate transform.
+                    let d = X - ((Y - y0) * dx_over_dy + x0);
+
+                    // Gradient-normalized ramp: hard step over Field
+                    // (zero gradient), ~1 screen pixel wide over Jet2.
+                    let grad =
+                        (DX(d.clone()) * DX(d.clone()) + DY(d.clone()) * DY(d.clone())).sqrt();
+                    let coverage = (V(d) / (grad + V(min_grad)) + V(0.5))
+                        .max(V(0.0))
+                        .min(V(1.0));
+
+                    in_y.select(coverage * V(dir), V(0.0))
+                });
+                k(
+                    self.x0,
+                    self.y0,
+                    self.dx_over_dy,
+                    self.dir,
+                    self.y_min,
+                    self.y_max,
+                    MIN_GRADIENT,
+                )
+                .eval(p)
+            }
+        }
+    };
+}
+
+impl_analytical_line_manifold!(Field);
+impl_analytical_line_manifold!(Jet2);
+
 // ═══════════════════════════════════════════════════════════════════════════
-// Quadratic Bezier (Analytical Root-Finding with Gradient AA)
+// Quadratic Bezier (Analytical Root-Finding with Gradient Ramp)
 // ═══════════════════════════════════════════════════════════════════════════
 
 /// Quadratic Bezier with precomputed analytical ray-crossing coefficients.
@@ -76,7 +182,8 @@ impl AnalyticalLine {
 ///   y(t) = ay*t^2 + by*t + cy
 ///
 /// To find intersections with y = Y, solve: ay*t^2 + by*t + (cy - Y) = 0
-/// For each valid root t in [0,1], compute x(t) and gradient-based coverage.
+/// For each valid root t in [0,1], compute x(t) and gradient-normalized
+/// crossing coverage (hard step over `Field`, antialiased over `Jet2`).
 #[derive(Clone)]
 pub struct AnalyticalQuad {
     // Parametric coefficients: x(t) = ax*t^2 + bx*t + cx
@@ -130,86 +237,133 @@ impl AnalyticalQuad {
     }
 }
 
-impl Manifold<Field4> for AnalyticalQuad {
-    type Output = Field;
+// One kernel body per case (degenerate line / true quadratic), stamped per
+// evaluation domain — see the note on `impl_analytical_line_manifold`.
+macro_rules! impl_analytical_quad_manifold {
+    ($n:ty) => {
+        impl Manifold<($n, $n, $n, $n)> for AnalyticalQuad {
+            type Output = Field;
 
-    #[inline(always)]
-    fn eval(&self, p: Field4) -> Field {
-        if self.is_linear {
-            // Degenerate: quadratic is a line. Solve by*t + (cy - Y) = 0
-            let k = kernel!(|ax: f32, bx: f32, cx: f32, by: f32, cy: f32| {
-                let t = (Y - cy) / by;
-                let in_t = t.clone().ge(0.0) & t.clone().le(1.0);
+            #[inline(always)]
+            fn eval(&self, p: ($n, $n, $n, $n)) -> Field {
+                if self.is_linear {
+                    // Degenerate: quadratic is a line. Solve by*t + (cy - Y) = 0
+                    let k = kernel!(|ax: f32,
+                                     bx: f32,
+                                     cx: f32,
+                                     by: f32,
+                                     cy: f32,
+                                     dir: f32,
+                                     min_grad: f32|
+                     -> $n {
+                        let t = (Y - cy) / by;
+                        let in_t = t.clone().ge(0.0) & t.clone().le(1.0);
 
-                // x-coordinate at intersection
-                let x_int = t.clone() * t.clone() * ax + t.clone() * bx + cx;
+                        // Signed crossing distance at the intersection.
+                        let d = X - (t.clone() * t.clone() * ax + t * bx + cx);
 
-                // Step: 1.0 if crossing is to the left of or at X
-                let crossed = (X >= x_int).select(1.0, 0.0);
+                        // Gradient-normalized ramp (hard over Field).
+                        let grad =
+                            (DX(d.clone()) * DX(d.clone()) + DY(d.clone()) * DY(d.clone())).sqrt();
+                        let coverage = (V(d) / (grad + V(min_grad)) + V(0.5))
+                            .max(V(0.0))
+                            .min(V(1.0));
 
-                let dir = if by > 0.0 { -1.0 } else { 1.0 };
-                in_t.select(crossed * dir, 0.0)
-            });
-            return k(self.ax, self.bx, self.cx, self.by, self.cy).eval(p);
+                        in_t.select(coverage * V(dir), V(0.0))
+                    });
+                    let dir = if self.by > 0.0 { -1.0 } else { 1.0 };
+                    return k(
+                        self.ax,
+                        self.bx,
+                        self.cx,
+                        self.by,
+                        self.cy,
+                        dir,
+                        MIN_GRADIENT,
+                    )
+                    .eval(p);
+                }
+
+                // True quadratic: solve ay*t^2 + by*t + (cy - Y) = 0
+                // discriminant = by^2 - 4*ay*(cy - Y) = disc_const + disc_slope*Y
+                let k = kernel!(|ax: f32,
+                                 bx: f32,
+                                 cx: f32,
+                                 ay: f32,
+                                 by: f32,
+                                 inv_2a: f32,
+                                 neg_b_2a: f32,
+                                 disc_const: f32,
+                                 disc_slope: f32,
+                                 min_grad: f32,
+                                 min_disc: f32|
+                 -> $n {
+                    let disc = Y * disc_slope + disc_const;
+                    // max(min_disc) keeps sqrt finite (value AND derivative) at
+                    // the tangent point; disc >= 0 below still gates validity.
+                    let sqrt_disc = disc.clone().max(min_disc).sqrt();
+
+                    // Two roots: t = (-by +/- sqrt(disc)) / (2*ay)
+                    let t_plus = sqrt_disc.clone() * inv_2a + neg_b_2a;
+                    let t_minus = sqrt_disc * -inv_2a + neg_b_2a;
+
+                    // Signed crossing distances at the intersection points.
+                    let d_plus =
+                        X - (t_plus.clone() * t_plus.clone() * ax + t_plus.clone() * bx + cx);
+                    let d_minus =
+                        X - (t_minus.clone() * t_minus.clone() * ax + t_minus.clone() * bx + cx);
+
+                    // Tangent dy/dt at each root for winding direction
+                    let dy_plus = t_plus.clone() * (ay * 2.0) + by;
+                    let dy_minus = t_minus.clone() * (ay * 2.0) + by;
+
+                    // Gradient-normalized ramps (hard over Field).
+                    let grad_plus = (DX(d_plus.clone()) * DX(d_plus.clone())
+                        + DY(d_plus.clone()) * DY(d_plus.clone()))
+                    .sqrt();
+                    let cov_plus = (V(d_plus) / (grad_plus + V(min_grad)) + V(0.5))
+                        .max(V(0.0))
+                        .min(V(1.0));
+                    let grad_minus = (DX(d_minus.clone()) * DX(d_minus.clone())
+                        + DY(d_minus.clone()) * DY(d_minus.clone()))
+                    .sqrt();
+                    let cov_minus = (V(d_minus) / (grad_minus + V(min_grad)) + V(0.5))
+                        .max(V(0.0))
+                        .min(V(1.0));
+
+                    // Validity: only count roots with t in [0, 1]
+                    let valid_plus = t_plus.clone().ge(0.0) & t_plus.le(1.0);
+                    let valid_minus = t_minus.clone().ge(0.0) & t_minus.le(1.0);
+
+                    // Winding sign from tangent direction
+                    let sign_plus = dy_plus.gt(0.0).select(V(-1.0), V(1.0));
+                    let sign_minus = dy_minus.gt(0.0).select(V(-1.0), V(1.0));
+
+                    // Combine: valid roots contribute signed coverage,
+                    // masked by the (unclamped) discriminant.
+                    let contrib_plus = valid_plus.select(cov_plus * sign_plus, V(0.0));
+                    let contrib_minus = valid_minus.select(cov_minus * sign_minus, V(0.0));
+                    disc.ge(0.0).select(contrib_plus + contrib_minus, V(0.0))
+                });
+
+                k(
+                    self.ax,
+                    self.bx,
+                    self.cx,
+                    self.ay,
+                    self.by,
+                    self.inv_2ay,
+                    self.neg_b_2a,
+                    self.disc_const,
+                    self.disc_slope,
+                    MIN_GRADIENT,
+                    MIN_DISC,
+                )
+                .eval(p)
+            }
         }
-
-        // True quadratic: solve ay*t^2 + by*t + (cy - Y) = 0
-        // discriminant = by^2 - 4*ay*(cy - Y) = disc_const + disc_slope*Y
-        let k = kernel!(|ax: f32,
-                         bx: f32,
-                         cx: f32,
-                         ay: f32,
-                         by: f32,
-                         inv_2a: f32,
-                         neg_b_2a: f32,
-                         disc_const: f32,
-                         disc_slope: f32| {
-            let disc = Y * disc_slope + disc_const;
-            let sqrt_disc = disc.max(0.0).sqrt();
-
-            // Two roots: t = (-by +/- sqrt(disc)) / (2*ay)
-            let t_plus = sqrt_disc.clone() * inv_2a.clone() + neg_b_2a.clone();
-            let t_minus = sqrt_disc * -inv_2a + neg_b_2a;
-
-            // X-coordinates at intersection points
-            let x_plus = t_plus.clone() * t_plus.clone() * ax.clone()
-                + t_plus.clone() * bx.clone()
-                + cx.clone();
-            let x_minus = t_minus.clone() * t_minus.clone() * ax + t_minus.clone() * bx + cx;
-
-            // Tangent dy/dt at each root for winding direction
-            let dy_plus = t_plus.clone() * (2.0 * ay.clone()) + by.clone();
-            let dy_minus = t_minus.clone() * (2.0 * ay) + by;
-
-            // Step: 1.0 if crossing is to the left of or at X
-            let crossed_plus = (X >= x_plus).select(1.0, 0.0);
-            let crossed_minus = (X >= x_minus).select(1.0, 0.0);
-
-            // Validity: only count roots with t in [0, 1]
-            let valid_plus = t_plus.clone().ge(0.0) & t_plus.clone().le(1.0);
-            let valid_minus = t_minus.clone().ge(0.0) & t_minus.clone().le(1.0);
-
-            // Winding sign from tangent direction
-            let sign_plus = dy_plus.gt(0.0).select(-1.0, 1.0);
-            let sign_minus = dy_minus.gt(0.0).select(-1.0, 1.0);
-
-            // Combine: valid roots contribute signed step, masked by discriminant
-            let contrib_plus = valid_plus.select(crossed_plus * sign_plus, 0.0);
-            let contrib_minus = valid_minus.select(crossed_minus * sign_minus, 0.0);
-            disc.ge(0.0).select(contrib_plus + contrib_minus, 0.0)
-        });
-
-        k(
-            self.ax,
-            self.bx,
-            self.cx,
-            self.ay,
-            self.by,
-            self.inv_2ay,
-            self.neg_b_2a,
-            self.disc_const,
-            self.disc_slope,
-        )
-        .eval(p)
-    }
+    };
 }
+
+impl_analytical_quad_manifold!(Field);
+impl_analytical_quad_manifold!(Jet2);

--- a/pixelflow-graphics/src/lib.rs
+++ b/pixelflow-graphics/src/lib.rs
@@ -82,30 +82,33 @@
 //!
 //! ## Tier 2: Fonts
 //!
-//! Font rendering bridges vector glyphs (TTF/OTF) to pixels. Typically used in terminals for character rendering.
+//! Font rendering bridges vector glyphs (TTF) to coverage manifolds. Typically used in terminals for character rendering.
 //!
 //! ### Font Loading
-//! Fonts are loaded from multiple sources (embedded, filesystem, or memory-mapped):
+//! Fonts are parsed from bytes; the `fonts::loader` module provides sources
+//! (owned, embedded, or memory-mapped) via `LoadedFont`:
 //!
 //! ```ignore
-//! use pixelflow_graphics::fonts::{Font, FontSource, LoadedFont};
+//! use pixelflow_graphics::fonts::Font;
 //!
-//! // Load from memory
-//! let font = Font::from_source(FontSource::Embedded)?;
+//! let font = Font::parse(font_bytes)?;
 //! ```
 //!
 //! ### Glyph Caching
-//! Glyphs are **lazily cached** per size. A `GlyphCache` stores rasterized glyphs to avoid redundant computation.
+//! Glyphs are **lazily cached** per size bucket. A `GlyphCache` bakes each
+//! glyph's antialiased coverage to an f32 lattice (read back bilinearly):
 //!
 //! ```ignore
 //! use pixelflow_graphics::GlyphCache;
 //!
-//! let cache = GlyphCache::new();
-//! let glyph = cache.get_or_rasterize('A', font, size)?;
+//! let mut cache = GlyphCache::new();
+//! let glyph = cache.get(&font, 'A', size)?;
 //! ```
 //!
 //! ### Text Layout and Rendering
-//! `CachedText` combines font, cache, layout, and rendering into a single manifold.
+//! `fonts::text()` lays out uncached analytical text (wrap with `render::aa::aa`
+//! for antialiasing); `CachedText` composes cached glyphs with kerning.
+//! See the `fonts` module docs for the full pipeline.
 //!
 //! ## Tier 3: Materialization (Manifold → Pixels)
 //!

--- a/pixelflow-graphics/src/render/aa.rs
+++ b/pixelflow-graphics/src/render/aa.rs
@@ -1,65 +1,85 @@
-//! Automatic antialiasing using gradient-based coverage.
+//! Antialiasing via automatic differentiation.
 //!
-//! Uses Jet2 automatic differentiation to compute exact pixel coverage.
-//! The gradient tells us how fast the SDF changes per pixel, giving us
-//! the exact coverage without any smoothstep hacks.
+//! [`Antialiased`] evaluates a domain-generic coverage manifold over `Jet2`
+//! coordinates seeded in screen space. Inside the font pipeline each edge
+//! crossing computes a gradient-normalized ramp
+//! `clamp(d / (‖∇d‖ + ε) + 0.5, 0, 1)`; with the derivatives seeded here, the
+//! chain rule propagates ‖∇d‖ through every coordinate transform, so the ramp
+//! is ~1 *screen* pixel wide at any glyph scale.
+//!
+//! The same manifold evaluated directly over `Field` coordinates (i.e. without
+//! this wrapper) has zero derivatives everywhere, and the ramp degenerates to
+//! the classic hard 0/1 step. `glyph` = hard, `Antialiased::new(glyph)` (or
+//! `aa(glyph)`) = antialiased. No smoothstep — the gradient IS the
+//! antialiasing.
+//!
+//! Two consumers:
+//! - **Uncached text**: `aa(text(&font, s, size))` evaluates the analytical
+//!   pipeline with AA every sample.
+//! - **The glyph cache**: `fonts::cache::CachedGlyph::new` bakes through
+//!   `Antialiased` once per (glyph, size bucket), collapsing the AA coverage
+//!   to an f32 lattice that is then bilinearly indexed at render time.
+//!
+//! Hand-written combinator (not a `kernel!`): it changes the evaluation domain
+//! (`Field` in, `Jet2` inside), which the kernel macro cannot express; this is
+//! the same shape as `pixelflow_core::WithGradient`, but collapsing to a
+//! `Field` coverage output instead of exposing the jet.
 
 use pixelflow_core::jet::Jet2;
-use pixelflow_core::{Computational, Field, Manifold, ManifoldCompat, ManifoldExt};
+use pixelflow_core::{Field, Manifold};
 
 /// The standard 4D Field domain type.
 type Field4 = (Field, Field, Field, Field);
 
-const MIN_GRADIENT: f32 = 0.001;
+/// The 4D Jet2 domain type (2D autodiff seeded in screen space).
+type Jet2x4 = (Jet2, Jet2, Jet2, Jet2);
 
-/// Computes antialiased coverage using gradient information from Jet2.
+/// Antialiased coverage: evaluates the inner manifold over `Jet2` coordinates.
 ///
-/// Generic over input coordinate types - works with any manifold that returns Jet2:
-/// - `sdf / grad_mag` gives distance in pixels to the edge
-/// - Coverage is linear: 0.5 at edge, 1.0 at +0.5px inside, 0.0 at -0.5px outside
+/// Seeds `∂/∂x` and `∂/∂y` at the screen-space sample position; `z`/`w` are
+/// constants. The inner manifold must be generic over the evaluation domain
+/// and produce `Field` coverage (the whole glyph pipeline is).
 ///
-/// No smoothstep. The gradient IS the antialiasing.
-pub fn aa_coverage<C, M>(manifold: M) -> AACoverage<M, C>
-where
-    M: ManifoldCompat<C, Output = Jet2> + Send + Sync,
-    C: Computational + From<Field> + Send + Sync + 'static,
-{
-    AACoverage {
-        manifold,
-        _phantom: std::marker::PhantomData,
+/// # Example
+///
+/// ```ignore
+/// let glyph = font.glyph_scaled('g', 16.0).unwrap(); // hard coverage
+/// let smooth = Antialiased::new(glyph);              // antialiased coverage
+/// ```
+#[derive(Clone, Debug)]
+pub struct Antialiased<M> {
+    /// The coverage manifold to evaluate with autodiff coordinates.
+    pub inner: M,
+}
+
+impl<M> Antialiased<M> {
+    /// Wrap a coverage manifold for antialiased evaluation.
+    #[inline(always)]
+    pub fn new(inner: M) -> Self {
+        Self { inner }
     }
 }
 
-/// Antialiased coverage manifold using gradients from Jet2.
-#[derive(Clone, Debug)]
-pub struct AACoverage<M, C = Field> {
-    pub manifold: M,
-    _phantom: std::marker::PhantomData<C>,
+/// Wrap a coverage manifold for antialiased evaluation (function form).
+#[inline(always)]
+pub fn aa<M>(inner: M) -> Antialiased<M>
+where
+    M: Manifold<Jet2x4, Output = Field>,
+{
+    Antialiased::new(inner)
 }
 
-impl<C, M> Manifold<Field4> for AACoverage<M, C>
+impl<M> Manifold<Field4> for Antialiased<M>
 where
-    M: ManifoldCompat<C, Output = Jet2> + Send + Sync,
-    C: Computational + From<Field> + Send + Sync + 'static,
+    M: Manifold<Jet2x4, Output = Field>,
 {
     type Output = Field;
 
+    #[inline(always)]
     fn eval(&self, p: Field4) -> Field {
         let (x, y, z, w) = p;
-        // Convert Field coordinates to the manifold's coordinate type and evaluate
-        let result = self
-            .manifold
-            .eval_raw(C::from(x), C::from(y), C::from(z), C::from(w));
-
-        // Gradient magnitude = how many SDF units per pixel
-        let grad_mag = (result.dx * result.dx + result.dy * result.dy).sqrt();
-
-        // Distance to edge in pixels = sdf / grad_mag
-        // Coverage: 0.5 at edge, +0.5 adds 1.0, -0.5 subtracts 1.0
-        // Linear ramp over 1 pixel centered on edge
-        let coverage = result.val / (grad_mag + Field::from(MIN_GRADIENT)) + Field::from(0.5);
-
-        // Clamp to [0, 1] - collapse AST to Field
-        coverage.max(0.0f32).min(1.0f32).at(x, y, z, w).collapse()
+        // Seed screen-space derivatives: ∂x/∂x = 1, ∂y/∂y = 1.
+        self.inner
+            .eval((Jet2::x(x), Jet2::y(y), Jet2::constant(z), Jet2::constant(w)))
     }
 }

--- a/pixelflow-graphics/src/render/bilinear.rs
+++ b/pixelflow-graphics/src/render/bilinear.rs
@@ -1,0 +1,150 @@
+//! Bilinear interpolation combinator.
+//!
+//! [`Bilinear`] is the smooth companion to `DiscreteManifold`'s
+//! nearest-neighbor indexing: where the discrete manifold snaps a continuous
+//! coordinate to the containing lattice cell, `Bilinear` samples the four
+//! surrounding integer-grid points and blends them with the fractional
+//! coordinate weights.
+//!
+//! # Coordinate convention
+//!
+//! `Bilinear` works in **integer-grid space**: the wrapped manifold is
+//! sampled at integer (x, y) coordinates. A query at `(i + fx, j + fy)` with
+//! `fx, fy ∈ [0, 1)` blends the samples at `(i, j)`, `(i+1, j)`, `(i, j+1)`,
+//! and `(i+1, j+1)`. Consequences:
+//!
+//! - At exact integer coordinates the wrapped manifold's value is returned
+//!   untouched (the fractional weights are zero).
+//! - A manifold that is affine in x and y is reproduced exactly everywhere.
+//! - No half-pixel convention is baked in here. Callers that store samples
+//!   at texel *centers* (the rasterizer's `i + 0.5` convention) must shift
+//!   coordinates by −0.5 before sampling — see `fonts::cache::CachedGlyph`.
+//!
+//! Z and W pass through unchanged; interpolation is 2D over X/Y only.
+
+use pixelflow_compiler::kernel;
+use pixelflow_core::Field;
+
+// The 4-tap bilinear kernel. `tex` is a manifold parameter: any
+// `Manifold<Field4, Output = Field>` (e.g. `DiscreteManifold`) can be wrapped.
+// The taps are lazy `.at()` re-evaluations of the wrapped manifold at offset
+// integer coordinates. Tap expressions capture `&self.tex` and are not Copy;
+// the optimizer's extracted form may reference a tap more than once, which
+// codegen handles by cloning tap-bound locals at each use.
+kernel!(pub struct Bilinear = |tex: kernel| Field -> Field {
+    let x0 = X.floor();
+    let y0 = Y.floor();
+    let fx = X - x0;
+    let fy = Y - y0;
+
+    let c00 = tex.at(x0, y0, Z, W);
+    let c10 = tex.at(x0 + 1.0, y0, Z, W);
+    let c01 = tex.at(x0, y0 + 1.0, Z, W);
+    let c11 = tex.at(x0 + 1.0, y0 + 1.0, Z, W);
+
+    c00 * ((1.0 - fx) * (1.0 - fy))
+        + c10 * (fx * (1.0 - fy))
+        + c01 * ((1.0 - fx) * fy)
+        + c11 * (fx * fy)
+});
+
+#[cfg(test)]
+mod tests {
+    use super::Bilinear;
+    use pixelflow_core::{DiscreteManifold, Lattice, Manifold};
+
+    /// Evaluate a manifold at a single point through public lattice API.
+    fn sample<M>(m: &M, x: f32, y: f32) -> f32
+    where
+        M: Manifold<
+            (
+                pixelflow_core::Field,
+                pixelflow_core::Field,
+                pixelflow_core::Field,
+                pixelflow_core::Field,
+            ),
+            Output = pixelflow_core::Field,
+        >,
+    {
+        Lattice::point(x, y, 0.0, 0.0).collapse(m).into_buffer()[0]
+    }
+
+    #[test]
+    fn constant_field_is_identity() {
+        // A 3x3 constant grid: bilinear must return the constant everywhere.
+        let tex = DiscreteManifold::new(vec![0.75; 9], 3, 3);
+        let bilerp = Bilinear::new(tex);
+
+        for &(x, y) in &[(0.0, 0.0), (0.5, 0.5), (1.25, 0.75), (1.9, 1.1)] {
+            let v = sample(&bilerp, x, y);
+            assert!(
+                (v - 0.75).abs() < 1e-6,
+                "constant field not reproduced at ({x}, {y}): got {v}"
+            );
+        }
+    }
+
+    #[test]
+    fn linear_gradient_reproduced_exactly() {
+        // Buffer holding f(x, y) = x + 2y sampled at integer coords, 4x4.
+        let mut buf = Vec::with_capacity(16);
+        for y in 0..4 {
+            for x in 0..4 {
+                buf.push(x as f32 + 2.0 * y as f32);
+            }
+        }
+        let bilerp = Bilinear::new(DiscreteManifold::new(buf, 4, 4));
+
+        // Bilinear interpolation of an affine function is exact.
+        for &(x, y) in &[(0.5, 0.5), (1.25, 2.75), (0.1, 0.9), (2.5, 1.0)] {
+            let expect = x + 2.0 * y;
+            let v = sample(&bilerp, x, y);
+            assert!(
+                (v - expect).abs() < 1e-5,
+                "gradient not reproduced at ({x}, {y}): got {v}, want {expect}"
+            );
+        }
+    }
+
+    #[test]
+    fn exact_at_grid_points_blended_between() {
+        // 2x2 checker: (0,0)=0, (1,0)=1, (0,1)=1, (1,1)=0.
+        let tex = DiscreteManifold::new(vec![0.0, 1.0, 1.0, 0.0], 2, 2);
+        let bilerp = Bilinear::new(tex);
+
+        // At integer grid points: exact stored values, no smoothing.
+        assert!((sample(&bilerp, 0.0, 0.0) - 0.0).abs() < 1e-6);
+        assert!((sample(&bilerp, 1.0, 0.0) - 1.0).abs() < 1e-6);
+        assert!((sample(&bilerp, 0.0, 1.0) - 1.0).abs() < 1e-6);
+        assert!((sample(&bilerp, 1.0, 1.0) - 0.0).abs() < 1e-6);
+
+        // Midpoint of an edge: average of its two endpoints.
+        assert!((sample(&bilerp, 0.5, 0.0) - 0.5).abs() < 1e-6);
+        // Cell center: average of all four corners.
+        assert!((sample(&bilerp, 0.5, 0.5) - 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn no_nearest_jumps_across_cell_boundaries() {
+        // Step buffer: left column 0, right column 1. Nearest-neighbor would
+        // jump 0 -> 1 crossing x = 1; bilinear must ramp smoothly.
+        let tex = DiscreteManifold::new(vec![0.0, 0.0, 1.0, 0.0, 0.0, 1.0], 3, 2);
+        let bilerp = Bilinear::new(tex);
+
+        let step = 0.125;
+        let mut prev = sample(&bilerp, 0.0, 0.5);
+        let mut x = step;
+        while x <= 2.0 {
+            let v = sample(&bilerp, x, 0.5);
+            let jump = (v - prev).abs();
+            assert!(
+                jump < 0.25,
+                "non-smooth jump {jump} at x = {x} (bilinear should ramp, not step)"
+            );
+            prev = v;
+            x += step;
+        }
+        // And the ramp actually reaches the step's top value.
+        assert!((sample(&bilerp, 2.0, 0.5) - 1.0).abs() < 1e-6);
+    }
+}

--- a/pixelflow-graphics/src/render/mod.rs
+++ b/pixelflow-graphics/src/render/mod.rs
@@ -1,4 +1,5 @@
 pub mod aa;
+pub mod bilinear;
 pub mod color;
 pub mod frame;
 pub mod pixel;
@@ -9,7 +10,7 @@ mod pict; // PICT-style pairwise covering-array generator (POC)
 #[cfg(test)]
 mod pict_color_tests; // Pairwise color/pixel testing built on `pict`
 
-pub use aa::aa_coverage;
+pub use aa::{aa, Antialiased};
 pub use color::{
     AttrFlags, Bgra8, BgraColorCube, CocoaPixel, Color, ColorCube, ColorManifold, Grayscale,
     NamedColor, Rgba8, RgbaColorCube, WebPixel, X11Pixel,

--- a/pixelflow-graphics/src/render/pict.rs
+++ b/pixelflow-graphics/src/render/pict.rs
@@ -88,7 +88,10 @@ pub fn pairwise(level_counts: &[usize]) -> Vec<Vec<usize>> {
             row[f] = Some(best_level);
         }
 
-        let row: Vec<usize> = row.into_iter().map(|v| v.expect("row fully assigned")).collect();
+        let row: Vec<usize> = row
+            .into_iter()
+            .map(|v| v.expect("row fully assigned"))
+            .collect();
 
         // Mark every pair this row realizes as covered.
         for i in 0..n {

--- a/pixelflow-graphics/src/render/pict_color_tests.rs
+++ b/pixelflow-graphics/src/render/pict_color_tests.rs
@@ -60,20 +60,31 @@ fn pict_pixel_packing_algebra() {
     };
 
     for row in &rows {
-        let (r, g, b, a) = (LEVELS[row[0]], LEVELS[row[1]], LEVELS[row[2]], LEVELS[row[3]]);
+        let (r, g, b, a) = (
+            LEVELS[row[0]],
+            LEVELS[row[1]],
+            LEVELS[row[2]],
+            LEVELS[row[3]],
+        );
 
         // Rgba8 construction and accessors round-trip.
         let rgba = Rgba8::new(r, g, b, a);
         check(
             (rgba.r(), rgba.g(), rgba.b(), rgba.a()) == (r, g, b, a),
-            format!("Rgba8::new accessors: ({r},{g},{b},{a}) -> {:?}", (rgba.r(), rgba.g(), rgba.b(), rgba.a())),
+            format!(
+                "Rgba8::new accessors: ({r},{g},{b},{a}) -> {:?}",
+                (rgba.r(), rgba.g(), rgba.b(), rgba.a())
+            ),
         );
 
         // Bgra8 stores the same logical channels (note the (b,g,r,a) arg order).
         let bgra = Bgra8::new(b, g, r, a);
         check(
             (bgra.r(), bgra.g(), bgra.b(), bgra.a()) == (r, g, b, a),
-            format!("Bgra8::new accessors: logical ({r},{g},{b},{a}) -> {:?}", (bgra.r(), bgra.g(), bgra.b(), bgra.a())),
+            format!(
+                "Bgra8::new accessors: logical ({r},{g},{b},{a}) -> {:?}",
+                (bgra.r(), bgra.g(), bgra.b(), bgra.a())
+            ),
         );
 
         // Rgba8 <-> Bgra8 preserves logical channels and is involutive.

--- a/pixelflow-graphics/src/shapes.rs
+++ b/pixelflow-graphics/src/shapes.rs
@@ -196,7 +196,6 @@ mod tests {
         tex.data()[0]
     }
 
-
     #[test]
     fn composition_works() {
         // circle inside square

--- a/pixelflow-graphics/src/transform.rs
+++ b/pixelflow-graphics/src/transform.rs
@@ -2,6 +2,8 @@
 //!
 //! Provides composable coordinate warping using the `At` combinator.
 
+use pixelflow_compiler::kernel;
+use pixelflow_core::jet::Jet2;
 use pixelflow_core::ops::{Div, Sub};
 use pixelflow_core::{At, Field, Manifold, W, X, Y, Z};
 
@@ -112,25 +114,38 @@ where
     }
 }
 
-impl<M> Manifold<Field4> for Translate<M>
-where
-    M: Manifold<Field4, Output = Field>,
-{
-    type Output = Field;
+// Translate is domain-generic (one kernel body per domain, see the note in
+// fonts/ttf_curve_analytical.rs): raw `f32` coordinate offsets always evaluate
+// to `Field`, so `X - offset` would be ill-typed over `Jet2`; the kernel lifts
+// the offset into the evaluation domain instead.
+macro_rules! impl_translate_manifold {
+    ($n:ty) => {
+        impl<M> Manifold<($n, $n, $n, $n)> for Translate<M>
+        where
+            M: Manifold<($n, $n, $n, $n), Output = Field>,
+        {
+            type Output = Field;
 
-    #[inline(always)]
-    fn eval(&self, p: Field4) -> Field {
-        // Create At combinator with coordinate expressions
-        let at = At {
-            inner: &self.manifold,
-            x: X - self.offset[0],
-            y: Y - self.offset[1],
-            z: Z,
-            w: W,
-        };
-        at.eval(p)
-    }
+            #[inline(always)]
+            fn eval(&self, p: ($n, $n, $n, $n)) -> Field {
+                let shift_x = kernel!(|d: f32| -> $n { X - d });
+                let shift_y = kernel!(|d: f32| -> $n { Y - d });
+                // Create At combinator with coordinate expressions
+                let at = At {
+                    inner: &self.manifold,
+                    x: shift_x(self.offset[0]),
+                    y: shift_y(self.offset[1]),
+                    z: Z,
+                    w: W,
+                };
+                at.eval(p)
+            }
+        }
+    };
 }
+
+impl_translate_manifold!(Field);
+impl_translate_manifold!(Jet2);
 
 #[cfg(test)]
 mod tests {

--- a/pixelflow-graphics/tests/font_antialiasing.rs
+++ b/pixelflow-graphics/tests/font_antialiasing.rs
@@ -1,0 +1,322 @@
+//! Tests for gradient-normalized crossing-ramp antialiasing in the font path.
+//!
+//! The glyph pipeline is generic over the evaluation domain:
+//! - `Field` coordinates → hard 0/1 coverage (legacy behavior).
+//! - `Jet2` coordinates (via `Antialiased`) → a coverage ramp exactly
+//!   ~1 screen pixel wide, at any glyph scale (autodiff chain rule).
+
+use pixelflow_core::combinators::{At, Texture};
+use pixelflow_core::{Field, Manifold};
+use pixelflow_graphics::fonts::ttf::{
+    make_line, make_quad, Geometry, Line, LineKernel, Quad, QuadKernel,
+};
+use pixelflow_graphics::fonts::Font;
+use pixelflow_graphics::render::aa::Antialiased;
+use std::sync::Arc;
+
+const FONT_BYTES: &[u8] = include_bytes!("../assets/DejaVuSansMono-Fallback.ttf");
+
+type Field4 = (Field, Field, Field, Field);
+
+/// Evaluate a scalar coverage manifold at a single point.
+fn sample<M: Manifold<Field4, Output = Field>>(m: &M, x: f32, y: f32) -> f32 {
+    let bound = At {
+        inner: m,
+        x,
+        y,
+        z: 0.0f32,
+        w: 0.0f32,
+    };
+    let tex = Texture::from_manifold(&bound, 1, 1);
+    tex.data()[0]
+}
+
+/// A square from (100,100) to (500,500) built from line segments.
+///
+/// Horizontal edges contribute nothing to the winding number, so `make_line`
+/// rejects them; the inside test is determined by the two vertical edges.
+fn square_geometry() -> Geometry<Line<LineKernel>, Quad<QuadKernel>> {
+    let lines: Vec<Line<LineKernel>> = [
+        make_line([[100.0, 100.0], [500.0, 100.0]]),
+        make_line([[500.0, 100.0], [500.0, 500.0]]),
+        make_line([[500.0, 500.0], [100.0, 500.0]]),
+        make_line([[100.0, 500.0], [100.0, 100.0]]),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+    Geometry {
+        lines: Arc::from(lines),
+        quads: Arc::from(Vec::<Quad<QuadKernel>>::new()),
+    }
+}
+
+/// A dome: quadratic from (0,0) up to the control point (50,100) and back to
+/// (100,0), closed by the (rejected, horizontal) chord. The curve's
+/// Y-extremum — the tangent point of the horizontal scanline — is at (50, 50).
+fn dome_geometry() -> Geometry<Line<LineKernel>, Quad<QuadKernel>> {
+    let quad = make_quad([[0.0, 0.0], [50.0, 100.0], [100.0, 0.0]]);
+    Geometry {
+        lines: Arc::from(Vec::<Line<LineKernel>>::new()),
+        quads: Arc::from(vec![quad]),
+    }
+}
+
+// =============================================================================
+// Hard degeneration: Field-domain evaluation is still a binary step
+// =============================================================================
+
+#[test]
+fn hard_coverage_is_binary() {
+    let geo = square_geometry();
+
+    // Interior and exterior points.
+    assert_eq!(sample(&geo, 300.0, 300.0), 1.0, "interior must be 1");
+    assert_eq!(sample(&geo, 50.0, 300.0), 0.0, "exterior must be 0");
+    assert_eq!(sample(&geo, 600.0, 300.0), 0.0, "exterior must be 0");
+
+    // Scan across the left edge: every sample is 0 or 1, and the step happens
+    // at the edge. (The ramp denominator ε = 1e-3 makes the transition band
+    // half a *milli*-pixel wide, so any sample off the exact edge is binary;
+    // the 0.05 offset keeps the scan off the measure-zero d = 0 point, where
+    // coverage is 0.5 by construction.)
+    let mut prev = 0.0f32;
+    for i in 0..80 {
+        let x = 96.05 + i as f32 * 0.1;
+        let c = sample(&geo, x, 300.0);
+        assert!(
+            !(1e-3..=1.0 - 1e-3).contains(&c),
+            "hard coverage must be binary, got {c} at x={x}"
+        );
+        assert!(c >= prev - 1e-3, "hard step must be monotonic at x={x}");
+        prev = c;
+    }
+    assert_eq!(sample(&geo, 99.9, 300.0), 0.0);
+    assert_eq!(sample(&geo, 100.1, 300.0), 1.0);
+}
+
+#[test]
+fn hard_glyph_still_works_for_existing_consumers() {
+    let font = Font::parse(FONT_BYTES).unwrap();
+    let glyph = font.glyph_scaled('H', 32.0).unwrap();
+
+    // Glyph: Manifold<Field4, Output = Field> keeps working unchanged.
+    let mut inside = 0;
+    for j in 0..32 {
+        for i in 0..32 {
+            let c = sample(&glyph, i as f32 + 0.5, j as f32 + 0.5);
+            assert!(c.is_finite(), "hard glyph coverage NaN/inf at ({i},{j})");
+            if c > 0.5 {
+                inside += 1;
+            }
+        }
+    }
+    assert!(inside > 50, "'H' at 32px should cover many pixels");
+}
+
+// =============================================================================
+// AA behavior: monotonic ~1px ramp across a straight edge
+// =============================================================================
+
+#[test]
+fn aa_ramp_across_straight_edge() {
+    let geo = square_geometry();
+    let smooth = Antialiased::new(&geo);
+
+    // Far from the edge, AA matches hard coverage.
+    assert!(sample(&smooth, 98.0, 300.0) < 0.01, "far outside must be 0");
+    assert!(sample(&smooth, 102.0, 300.0) > 0.99, "far inside must be 1");
+
+    // On the edge, coverage is one half.
+    let mid = sample(&smooth, 100.0, 300.0);
+    assert!(
+        (mid - 0.5).abs() < 0.05,
+        "coverage on the edge should be ~0.5, got {mid}"
+    );
+
+    // Across the edge: monotonic, with genuinely intermediate values confined
+    // to ~1px around the edge.
+    let step = 0.125f32;
+    let mut prev = -1.0f32;
+    let mut intermediate = 0;
+    for i in 0..33 {
+        let x = 98.0 + i as f32 * step;
+        let c = sample(&smooth, x, 300.0);
+        assert!(c >= prev - 1e-4, "AA ramp must be monotonic at x={x}");
+        prev = c;
+        if c > 0.05 && c < 0.95 {
+            intermediate += 1;
+            assert!(
+                (x - 100.0).abs() <= 0.75,
+                "intermediate coverage {c} outside the 1px band at x={x}"
+            );
+        }
+    }
+    assert!(
+        intermediate >= 3,
+        "expected several intermediate samples across the edge, got {intermediate}"
+    );
+}
+
+// =============================================================================
+// Scale invariance: the ramp is ~1 *screen* pixel wide at any em size
+// =============================================================================
+
+/// Measure the width (in screen pixels) of the first left-to-right coverage
+/// ramp on the given scanline, by scanning at 1/16px resolution and measuring
+/// the contiguous run of intermediate values around the 0.5 crossing.
+fn first_ramp_width<M: Manifold<Field4, Output = Field>>(m: &M, y: f32, x_max: f32) -> f32 {
+    const STEP: f32 = 1.0 / 16.0;
+    let n = (x_max / STEP) as usize;
+    let cov: Vec<f32> = (0..n).map(|i| sample(m, i as f32 * STEP, y)).collect();
+
+    // First 0.5 crossing.
+    let crossing = cov
+        .windows(2)
+        .position(|w| w[0] < 0.5 && w[1] >= 0.5)
+        .expect("no coverage edge found on scanline");
+
+    // Contiguous run of intermediate samples containing the crossing.
+    let is_mid = |c: f32| c > 0.02 && c < 0.98;
+    let mut lo = crossing;
+    while lo > 0 && is_mid(cov[lo]) {
+        lo -= 1;
+    }
+    let mut hi = crossing + 1;
+    while hi < n - 1 && is_mid(cov[hi]) {
+        hi += 1;
+    }
+    (hi - lo - 1) as f32 * STEP
+}
+
+#[test]
+fn ramp_width_is_one_screen_pixel_at_any_scale() {
+    let font = Font::parse(FONT_BYTES).unwrap();
+
+    let mut widths = Vec::new();
+    for size in [16.0f32, 64.0f32] {
+        let glyph = font.glyph_scaled('H', size).unwrap();
+        let smooth = Antialiased::new(glyph);
+        let w = first_ramp_width(&smooth, size * 0.5, size);
+        assert!(
+            (0.4..=1.6).contains(&w),
+            "ramp width should be ~1 screen px at {size}px em, got {w}"
+        );
+        widths.push(w);
+    }
+
+    // The autodiff chain-rule payoff: 4x the glyph scale, same screen ramp.
+    let diff = (widths[0] - widths[1]).abs();
+    assert!(
+        diff <= 0.5,
+        "ramp width must not scale with em size: 16px -> {}, 64px -> {}",
+        widths[0],
+        widths[1]
+    );
+}
+
+// =============================================================================
+// AA agrees with hard coverage away from edges
+// =============================================================================
+
+#[test]
+fn aa_matches_hard_far_from_edges() {
+    let font = Font::parse(FONT_BYTES).unwrap();
+    let size = 32.0f32;
+    let glyph = font.glyph_scaled('H', size).unwrap();
+    let smooth = Antialiased::new(&glyph);
+
+    let n = size as usize;
+    // hard[j][i] at pixel centers.
+    let hard: Vec<Vec<f32>> = (0..n)
+        .map(|j| {
+            (0..n)
+                .map(|i| sample(&glyph, i as f32 + 0.5, j as f32 + 0.5))
+                .collect()
+        })
+        .collect();
+
+    for j in 1..n - 1 {
+        for i in 1..n - 1 {
+            // Only compare where the whole 3x3 pixel neighborhood agrees —
+            // i.e. at least one pixel away from any edge.
+            let neighborhood = (-1i32..=1)
+                .flat_map(|dj| (-1i32..=1).map(move |di| (di, dj)))
+                .map(|(di, dj)| hard[(j as i32 + dj) as usize][(i as i32 + di) as usize]);
+            let (mut all_in, mut all_out) = (true, true);
+            for h in neighborhood {
+                all_in &= h > 0.5;
+                all_out &= h <= 0.5;
+            }
+            let c = sample(&smooth, i as f32 + 0.5, j as f32 + 0.5);
+            if all_in {
+                assert!(c > 0.9, "AA {c} disagrees with hard interior at ({i},{j})");
+            }
+            if all_out {
+                assert!(c < 0.1, "AA {c} disagrees with hard exterior at ({i},{j})");
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Quadratics: finite coverage everywhere, including the tangent point
+// =============================================================================
+
+#[test]
+fn quad_tangent_point_is_finite() {
+    let geo = dome_geometry();
+    let smooth = Antialiased::new(&geo);
+
+    // Dense grid over the dome, including the exact Y-extremum row (y = 50,
+    // where the quadratic discriminant is 0) and the tangent point (50, 50).
+    for j in 0..=120 {
+        let y = j as f32 * 0.5;
+        for i in 0..=100 {
+            let x = i as f32;
+            for (name, c) in [("hard", sample(&geo, x, y)), ("aa", sample(&smooth, x, y))] {
+                assert!(
+                    c.is_finite(),
+                    "{name} coverage not finite at ({x},{y}): {c}"
+                );
+                assert!(
+                    (-1e-3..=1.0 + 1e-3).contains(&c),
+                    "{name} coverage out of range at ({x},{y}): {c}"
+                );
+            }
+        }
+    }
+
+    // Sanity: the dome interior is actually covered.
+    assert!(sample(&geo, 50.0, 25.0) > 0.99);
+    assert!(sample(&smooth, 50.0, 25.0) > 0.99);
+}
+
+#[test]
+fn quad_heavy_glyph_is_finite_everywhere() {
+    let font = Font::parse(FONT_BYTES).unwrap();
+    let size = 32.0f32;
+    let glyph = font.glyph_scaled('O', size).unwrap();
+    let smooth = Antialiased::new(&glyph);
+
+    let mut covered = 0;
+    for j in 0..=(size as usize * 2) {
+        let y = j as f32 * 0.5;
+        for i in 0..=(size as usize * 2) {
+            let x = i as f32 * 0.5;
+            let c = sample(&smooth, x, y);
+            assert!(
+                c.is_finite(),
+                "'O' AA coverage not finite at ({x},{y}): {c}"
+            );
+            assert!(
+                (-1e-3..=1.0 + 1e-3).contains(&c),
+                "'O' AA coverage out of range at ({x},{y}): {c}"
+            );
+            if c > 0.5 {
+                covered += 1;
+            }
+        }
+    }
+    assert!(covered > 50, "'O' at 32px should cover many samples");
+}

--- a/pixelflow-pipeline/Cargo.toml
+++ b/pixelflow-pipeline/Cargo.toml
@@ -65,3 +65,8 @@ required-features = ["training"]
 name = "bench_extraction_3way"
 path = "src/bin/bench_extraction_3way.rs"
 required-features = ["training"]
+
+[[bin]]
+name = "bench_jit_compile_cost"
+path = "src/bin/bench_jit_compile_cost.rs"
+required-features = ["training"]

--- a/pixelflow-pipeline/src/bin/bench_jit_compile_cost.rs
+++ b/pixelflow-pipeline/src/bin/bench_jit_compile_cost.rs
@@ -1,0 +1,173 @@
+//! JIT compile-cost benchmark (kernel-unification Phase 0, gate G0).
+//!
+//! Measures how long `compile_arena_dag` takes for expression arenas of
+//! ~8, 32, 128, and 512 nodes, distinguishing:
+//!
+//! - **fresh**: every compile mmaps a new executable region and munmaps it on
+//!   drop (`ExecutableCode` lifecycle — what a naive per-kernel JIT pays).
+//! - **reused**: compiles into a persistent `CompileWorkspace` code buffer,
+//!   paying `pthread_jit_write_protect_np` toggles + icache invalidation
+//!   instead of mmap/munmap (the amortizable steady state).
+//!
+//! Gate G0: if the amortized (reused) cost exceeds ~1µs/kernel, per-leaf JIT
+//! is formally dead.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --release -p pixelflow-pipeline --features training \
+//!     --bin bench_jit_compile_cost
+//! ```
+//!
+//! Results are recorded in `docs/results/2026-07-20-jit-compile-cost.md`.
+
+use pixelflow_ir::{ExprArena, ExprId, OpKind};
+use pixelflow_pipeline::jit_bench::benchmark_compile_fresh;
+#[cfg(target_arch = "aarch64")]
+use pixelflow_pipeline::jit_bench::benchmark_compile_reused;
+
+/// Arena sizes to measure (exact node counts, all reachable from the root).
+const ARENA_SIZES: &[usize] = &[8, 32, 128, 512];
+
+/// G0 threshold: amortized compile cost above this kills per-leaf JIT.
+const G0_THRESHOLD_NS: f64 = 1_000.0;
+
+/// Build a deterministic arena of exactly `target_nodes` nodes with a
+/// font/shader-like op mix: arithmetic, `sqrt`, `mul_add`, `min`/`max`, and a
+/// comparison-guarded `select`, seeded from an SDF-style distance core.
+///
+/// Every appended op consumes the previous root as an operand, so all
+/// `target_nodes` nodes are reachable from the returned root. Ops stay within
+/// the directly-emittable set (no transcendentals, no gather/reduce) so the
+/// fresh path's lowering passes are identity fast-paths and the
+/// `CompileWorkspace` path — which skips lowering — compiles identical work.
+fn build_kernel_arena(target_nodes: usize) -> (ExprArena, ExprId) {
+    // The SDF seed below is 7 nodes; need at least one more op for a root.
+    assert!(
+        target_nodes >= 8,
+        "target_nodes must be >= 8, got {}",
+        target_nodes
+    );
+
+    let mut arena = ExprArena::new();
+    // Circle-SDF-style core: (x-0.5)^2 + (y-0.5)^2 via mul_add. 7 nodes.
+    let x = arena.push_var(0);
+    let y = arena.push_var(1);
+    let half = arena.push_const(0.5);
+    let dx = arena.push_binary(OpKind::Sub, x, half);
+    let dy = arena.push_binary(OpKind::Sub, y, half);
+    let dx2 = arena.push_binary(OpKind::Mul, dx, dx);
+    let mut cur = arena.push_ternary(OpKind::MulAdd, dy, dy, dx2);
+
+    let mut step = 0usize;
+    while arena.len() < target_nodes {
+        let remaining = target_nodes - arena.len();
+        cur = match step % 8 {
+            // Select costs 2 nodes (its Lt guard + the Select itself);
+            // when only 1 node of budget remains, fall through to `_`.
+            0 if remaining >= 2 => {
+                let inside = arena.push_binary(OpKind::Lt, cur, half);
+                arena.push_ternary(OpKind::Select, inside, dx2, cur)
+            }
+            1 => arena.push_unary(OpKind::Sqrt, cur),
+            2 => arena.push_binary(OpKind::Mul, cur, dx),
+            3 => arena.push_binary(OpKind::Add, cur, dy),
+            4 => arena.push_ternary(OpKind::MulAdd, cur, half, dx2),
+            5 => arena.push_binary(OpKind::Max, cur, dx),
+            6 => arena.push_binary(OpKind::Sub, cur, half),
+            _ => arena.push_binary(OpKind::Mul, cur, cur),
+        };
+        step += 1;
+    }
+
+    assert_eq!(
+        arena.len(),
+        target_nodes,
+        "builder produced {} nodes, wanted {}",
+        arena.len(),
+        target_nodes
+    );
+    (arena, cur)
+}
+
+fn main() {
+    println!("=== JIT compile cost (gate G0: amortized <= ~1us/kernel) ===");
+    println!(
+        "arch: {}, 101 timed compiles per cell, median reported\n",
+        std::env::consts::ARCH
+    );
+
+    #[cfg(target_arch = "aarch64")]
+    println!(
+        "{:>6}  {:>10}  {:>12}  {:>12}  {:>10}",
+        "nodes", "code B", "fresh ns", "reused ns", "ns/node"
+    );
+    #[cfg(not(target_arch = "aarch64"))]
+    println!(
+        "{:>6}  {:>10}  {:>12}  {:>10}",
+        "nodes", "code B", "fresh ns", "ns/node"
+    );
+
+    let mut worst_amortized_per_node = 0.0f64;
+    for &size in ARENA_SIZES {
+        let (arena, root) = build_kernel_arena(size);
+
+        let fresh = benchmark_compile_fresh(&arena, root)
+            .unwrap_or_else(|e| panic!("fresh compile bench failed at {} nodes: {}", size, e));
+
+        #[cfg(target_arch = "aarch64")]
+        {
+            let reused = benchmark_compile_reused(&arena, root)
+                .unwrap_or_else(|e| panic!("reused compile bench failed at {} nodes: {}", size, e));
+            let per_node = reused / size as f64;
+            worst_amortized_per_node = worst_amortized_per_node.max(per_node);
+            println!(
+                "{:>6}  {:>10}  {:>12.0}  {:>12.0}  {:>10.1}",
+                size, fresh.code_bytes, fresh.ns, reused, per_node
+            );
+        }
+        #[cfg(not(target_arch = "aarch64"))]
+        {
+            let per_node = fresh.ns / size as f64;
+            worst_amortized_per_node = worst_amortized_per_node.max(per_node);
+            println!(
+                "{:>6}  {:>10}  {:>12.0}  {:>10.1}",
+                size, fresh.code_bytes, fresh.ns, per_node
+            );
+        }
+    }
+
+    #[cfg(not(target_arch = "aarch64"))]
+    println!(
+        "\nNOTE: CompileWorkspace (reused code buffer) is aarch64-only; \
+         only the fresh mmap-per-compile path was measured on this arch."
+    );
+
+    // G0 is stated per-kernel; the smallest arena is the per-leaf shape, so
+    // judge the gate on the smallest size's amortized cost.
+    let (arena, root) = build_kernel_arena(ARENA_SIZES[0]);
+    #[cfg(target_arch = "aarch64")]
+    let leaf_ns = benchmark_compile_reused(&arena, root)
+        .unwrap_or_else(|e| panic!("G0 leaf measurement failed: {}", e));
+    #[cfg(not(target_arch = "aarch64"))]
+    let leaf_ns = benchmark_compile_fresh(&arena, root)
+        .unwrap_or_else(|e| panic!("G0 leaf measurement failed: {}", e))
+        .ns;
+
+    println!(
+        "\nG0: amortized cost for a {}-node leaf kernel = {:.0}ns ({}, threshold {:.0}ns) => {}",
+        ARENA_SIZES[0],
+        leaf_ns,
+        if cfg!(target_arch = "aarch64") {
+            "reused buffer"
+        } else {
+            "fresh mmap path"
+        },
+        G0_THRESHOLD_NS,
+        if leaf_ns > G0_THRESHOLD_NS {
+            "per-leaf JIT FAILS G0"
+        } else {
+            "per-leaf JIT passes G0"
+        }
+    );
+}

--- a/pixelflow-pipeline/src/jit_bench.rs
+++ b/pixelflow-pipeline/src/jit_bench.rs
@@ -165,14 +165,36 @@ impl fmt::Display for BenchError {
 // Platform-specific high-resolution timing.
 
 #[cfg(target_os = "macos")]
+#[repr(C)]
+struct MachTimebaseInfo {
+    numer: u32,
+    denom: u32,
+}
+
+#[cfg(target_os = "macos")]
 unsafe extern "C" {
     fn mach_absolute_time() -> u64;
+    fn mach_timebase_info(info: *mut MachTimebaseInfo) -> libc::c_int;
 }
 
 #[cfg(target_os = "macos")]
 fn nanos_now() -> u64 {
-    // On Apple Silicon, mach_absolute_time() ticks == nanoseconds (timebase 1:1).
-    unsafe { mach_absolute_time() }
+    // mach_absolute_time() ticks are NOT nanoseconds on native Apple Silicon:
+    // the timebase is 125/3 (one tick = 41.67ns; 1:1 only holds on Intel Macs
+    // and under Rosetta). Convert via mach_timebase_info, queried once.
+    // Verified empirically 2026-07-20: a 100ms sleep measured 2.47M raw ticks.
+    static TIMEBASE: std::sync::OnceLock<(u32, u32)> = std::sync::OnceLock::new();
+    let (numer, denom) = *TIMEBASE.get_or_init(|| {
+        let mut info = MachTimebaseInfo { numer: 0, denom: 0 };
+        let rc = unsafe { mach_timebase_info(&mut info) };
+        assert_eq!(rc, 0, "mach_timebase_info failed with {}", rc);
+        assert_ne!(info.denom, 0, "mach_timebase_info returned denom=0");
+        (info.numer, info.denom)
+    });
+    let ticks = unsafe { mach_absolute_time() };
+    // u128 intermediate: ticks * numer overflows u64 after ~50 days of uptime
+    // at timebase 125/3.
+    ((ticks as u128 * numer as u128) / denom as u128) as u64
 }
 
 #[cfg(target_os = "linux")]
@@ -369,6 +391,101 @@ pub fn benchmark_jit_arena_repeated(
 ) -> Result<BenchResult, BenchError> {
     let result = compile_arena_dag(arena, root).map_err(BenchError::CompileFailed)?;
     benchmark_exec_code(result.code, repeat_batches)
+}
+
+// =============================================================================
+// Compile-cost benchmarking (kernel-unification Phase 0, gate G0)
+// =============================================================================
+
+/// Timed compile samples per measurement. A single compile costs microseconds,
+/// far above the ~1ns timer resolution, so one compile per sample is enough;
+/// the median over many samples rejects OS scheduling jitter.
+const COMPILE_TIMED_RUNS: usize = 101;
+
+/// Warmup compiles before timing. Warms the allocator, icache, and (on the
+/// fresh path) the kernel's VM-map fast paths so the timed samples measure
+/// steady-state cost, not cold-start page faults.
+const COMPILE_WARMUP_ITERS: usize = 16;
+
+/// Code-buffer capacity for the reused-buffer path. 256KB is generous for
+/// expressions up to ~2000 nodes (`CompileWorkspace` docs say 64KB covers
+/// ~500 nodes).
+#[cfg(target_arch = "aarch64")]
+const REUSED_CODE_CAPACITY: usize = 256 * 1024;
+
+/// Result of a compile-cost measurement.
+pub struct CompileCostResult {
+    /// Median ns for one complete compile.
+    pub ns: f64,
+    /// Emitted machine-code size in bytes.
+    pub code_bytes: usize,
+}
+
+/// Median wall-clock cost of one `compile_arena_dag` call, fresh-allocation
+/// path: every compile mmaps a new executable region and munmaps it on drop.
+/// Both syscalls are inside the timed window — this is the full per-compile
+/// lifecycle a naive per-kernel JIT would pay.
+pub fn benchmark_compile_fresh(
+    arena: &ExprArena,
+    root: ExprId,
+) -> Result<CompileCostResult, BenchError> {
+    for _ in 0..COMPILE_WARMUP_ITERS {
+        let result = compile_arena_dag(arena, root).map_err(BenchError::CompileFailed)?;
+        std::hint::black_box(result.code.as_bytes().first());
+    }
+
+    let mut times = [0u64; COMPILE_TIMED_RUNS];
+    let mut code_bytes = 0usize;
+    for t in &mut times {
+        let start = nanos_now();
+        let result = compile_arena_dag(arena, root).map_err(BenchError::CompileFailed)?;
+        std::hint::black_box(result.code.as_bytes().first());
+        code_bytes = result.code.len();
+        drop(result); // munmap inside the timed window
+        *t = nanos_now() - start;
+    }
+
+    times.sort_unstable();
+    let median = times[COMPILE_TIMED_RUNS / 2] as f64;
+    validate_median(median).map(|ns| CompileCostResult { ns, code_bytes })
+}
+
+/// Median wall-clock cost of one compile into a reused
+/// [`CompileWorkspace`](pixelflow_ir::backend::emit::CompileWorkspace):
+/// the executable region is mmap'd once up front, and each compile pays only
+/// `pthread_jit_write_protect_np` toggles + icache invalidation (Apple
+/// Silicon) instead of mmap/munmap. This is the amortized cost gate G0 cares
+/// about. aarch64 only — `CompileWorkspace` has no x86-64 counterpart.
+///
+/// Returns median ns per compile. Note the workspace path skips the lowering
+/// passes (`expand_reduce`/`expand_gather`/`expand_transcendentals`), so the
+/// arena must contain only directly-emittable ops for the comparison against
+/// [`benchmark_compile_fresh`] to be apples-to-apples.
+#[cfg(target_arch = "aarch64")]
+pub fn benchmark_compile_reused(arena: &ExprArena, root: ExprId) -> Result<f64, BenchError> {
+    use pixelflow_ir::backend::emit::CompileWorkspace;
+
+    let mut ws = CompileWorkspace::new(REUSED_CODE_CAPACITY).map_err(BenchError::CompileFailed)?;
+
+    // SAFETY: the returned KernelFn is never called, and is discarded before
+    // the next compile_arena call overwrites the buffer.
+    for _ in 0..COMPILE_WARMUP_ITERS {
+        let func = unsafe { ws.compile_arena(arena, root) }.map_err(BenchError::CompileFailed)?;
+        std::hint::black_box(func);
+    }
+
+    let mut times = [0u64; COMPILE_TIMED_RUNS];
+    for t in &mut times {
+        let start = nanos_now();
+        // SAFETY: as above — pointer discarded, never called.
+        let func = unsafe { ws.compile_arena(arena, root) }.map_err(BenchError::CompileFailed)?;
+        std::hint::black_box(func);
+        *t = nanos_now() - start;
+    }
+
+    times.sort_unstable();
+    let median = times[COMPILE_TIMED_RUNS / 2] as f64;
+    validate_median(median)
 }
 
 /// Convert nanoseconds to log-nanoseconds (floored at 1e-3ns, capped at 1s).


### PR DESCRIPTION
## What changed

**Antialiasing as a domain lift.** Font coverage is now computed by gradient-normalized crossing ramps: each curve's hard step `(X >= x_int).select(1, 0)` became `clamp(d/(‖∇d‖+ε) + 0.5, 0, 1)`. Because `Field` implements `HasDerivatives` with zero derivatives, the same kernel body degenerates to the exact hard step over `Field` and produces analytic ~1-screen-pixel AA over `Jet2` — the chain rule carries `∇d` through the glyph's affine transforms, so ramp width is scale-invariant (asserted in tests at 16px vs 64px em). Public surface: `Antialiased` / `aa()` in `render/aa.rs`. The dead `AACoverage` module is deleted.

**Lattice-backed glyph cache.** `CachedGlyph` bakes via `Lattice::collapse` straight into an f32 `DiscreteManifold` (removing the old `Frame<Rgba8>` u8-quantization roundtrip) and samples through a new `Bilinear` combinator (kernel with a manifold-typed param, 4 lazy taps + lerp) instead of nearest-neighbor. Pixel-center conventions cancel exactly: at native size the cached glyph reproduces the analytical one bit-for-bit at pixel centers. Coverage is bounded to the baked extent (fixes edge-texel smearing of descenders). core-term consumes AA glyphs with **zero code changes**.

**`kernel!` optimizer fixes** (unblocked the fonts from `kernel_raw!`):
1. Literal-space inference across the `V`/`DX`/`DY` projection boundary — fresh literals minted by rewrites (e.g. FMA's `recip`) now emit in the correct type space instead of being lifted to the kernel's domain type and producing ill-typed `Jet2 op Field` code.
2. Clone-at-use for manifold-tainted locals + never let-binding leaf e-classes — fixes E0382 when extraction shares non-`Copy` `.at()` taps.
Both failure shapes are pinned in `pixelflow-compiler/tests/optimizer_type_stability.rs`.

**`lower_dwrt` — symbolic differentiation as an IR lowering pass (P2 of the unification plan).** `Dwrt` nodes are eliminated before scheduling by a fallible post-order rewrite (peer of `expand_gather`/`expand_reduce`); derivatives become ordinary expressions compiled by the same backend. Full rule set with Jet2's exact tie conventions (min/max/clamp/select); unsupported ops error loudly by name; nested `Dwrt` = second derivatives, memoized so DAGs stay DAGs. All six compile entries run it as a precondition (the "jet fallback not yet wired" panic is now an unreachable assert), `eval.rs` lowers identically so interpreter and JIT agree by construction, and `kernel_jit!` now accepts `V`/`DX`/`DY`/`DZ` (+ second-order accessors) end-to-end. Parity proof: the font-ramp coverage expression JIT-compiled via `Dwrt` matches pixelflow-core Jet2 forward-mode AD on a 30-point grid at 1e-5.

**Bench harness timer fix (affects recorded data).** `nanos_now()` in `jit_bench.rs` returned raw `mach_absolute_time()` ticks as nanoseconds — a 41.67× under-scale on Apple Silicon. Ratios in previously recorded results are unaffected; absolute ns figures (including extraction-head corpus labels) need recalibration (follow-up in flight). New `bench_jit_compile_cost` bin + `docs/results/2026-07-20-jit-compile-cost.md`: JIT compile floor is ~5 µs/kernel, codegen-dominated — per-leaf JIT is formally dead, root-fusion strategy locked in.

**Plan of record:** `docs/plans/2026-07-20-kernel-unification.md` — one kernel language; AOT = same pipeline as the JIT run at macro time with a bigger e-graph budget; combinator emitter deprecated-then-deleted; IR interpreter is the portable fallback.

## Why

Glyphs rendered aliased (hard 0/1 winding, nearest-neighbor cached sampling, stroke dropout at small sizes). The Jet2 autodiff machinery existed but was disconnected. This wires it in as one elegant combinator, moves the cache onto the new lattice machinery, and starts the kernel/JIT unification with measurements instead of guesses — including the first parity milestone (Dwrt lowering) proving derivatives compile through the same machinery as everything else.

## Numbers

- Uncached AA cost: 1.7–1.8× vs hard path (5–50 chars); terminal pays it only at bake time.
- `kernel!` vs `kernel_raw!` on the AA benches: parity within ±1% (memory-bound; extracted forms are structurally better — FMA fusion, Horner quad roots).

## Reviewer notes

- `ttf.rs`/`ttf_curve_analytical.rs`/`transform.rs` stamp impls over `{Field, Jet2}` via `macro_rules!` — transitional scaffolding until the arena path replaces per-domain impls (see plan doc, P1 demoted).
- The quad kernel guards the tangent-point singularity with `disc.max(1e-12)` before the rsqrt-based sqrt; NaN-freedom is tested on a dense grid including the exact `disc = 0` row.
- The e-graph `ChainRule` rule set still lacks min/max/select/clamp/pow/hypot/atan2/exp2/log2/log10 — residual `Dwrt` survivors fall through saturation and are picked up by runtime `lower_dwrt`, per the plan's division of labor. Aligning them is follow-up, not this PR.
- `cargo test --workspace` green (76 suites; includes 25 lower_dwrt tests + 3 Dwrt/Jet2 JIT-parity tests). Pre-existing failures in `--features training` (bench_scanline_jit bin, 3 training lib tests) are untouched by this PR and have follow-up tasks in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)