### PR TITLE
Fix bench_scanline_jit.rs compile break blocking pixelflow-pipeline tests

### DIFF
--- a/pixelflow-pipeline/src/bin/bench_extraction_3way.rs
+++ b/pixelflow-pipeline/src/bin/bench_extraction_3way.rs
@@ -413,9 +413,8 @@ fn main() {
     eprintln!("=== Extraction 3-way bench: NNUE vs STATIC vs NO-SWAP ===");
     eprintln!("Loading Judge weights from {NNUE_WEIGHTS_PATH}");
 
-    let weights_bytes = std::fs::read(NNUE_WEIGHTS_PATH).unwrap_or_else(|e| {
-        panic!("failed to read Judge weights at {NNUE_WEIGHTS_PATH}: {e}")
-    });
+    let weights_bytes = std::fs::read(NNUE_WEIGHTS_PATH)
+        .unwrap_or_else(|e| panic!("failed to read Judge weights at {NNUE_WEIGHTS_PATH}: {e}"));
     let nnue = ExprNnue::from_bytes(&weights_bytes).unwrap_or_else(|e| {
         panic!(
             "ExprNnue::from_bytes rejected {NNUE_WEIGHTS_PATH}: {e}. \
@@ -468,7 +467,15 @@ fn main() {
     println!("\n=== RESULTS ===\n");
     println!(
         "{:<14} {:>6} {:>10} {:>10} {:>10} {:>9} {:>9} {:>8} {:>8}",
-        "kernel", "nodes", "ns_nnue", "ns_static", "ns_noswap", "nnue/stc", "stc/nosw", "ex_nnue", "ex_stc"
+        "kernel",
+        "nodes",
+        "ns_nnue",
+        "ns_static",
+        "ns_noswap",
+        "nnue/stc",
+        "stc/nosw",
+        "ex_nnue",
+        "ex_stc"
     );
     println!("{}", "-".repeat(14 + 6 + 10 * 3 + 9 * 2 + 8 * 2 + 16));
 
@@ -494,28 +501,51 @@ fn main() {
             fmt_opt(r.ns_nnue),
             fmt_opt(r.ns_static),
             r.ns_noswap,
-            ratio_ns.map(|v| format!("{v:.3}")).unwrap_or_else(|| "-".into()),
-            ratio_sn.map(|v| format!("{v:.3}")).unwrap_or_else(|| "-".into()),
+            ratio_ns
+                .map(|v| format!("{v:.3}"))
+                .unwrap_or_else(|| "-".into()),
+            ratio_sn
+                .map(|v| format!("{v:.3}"))
+                .unwrap_or_else(|| "-".into()),
             r.extract_us_nnue,
             r.extract_us_static,
         );
     };
 
     for r in &named_results {
-        print_row(r, &mut all_nnue_static_ratios, &mut all_static_noswap_ratios);
+        print_row(
+            r,
+            &mut all_nnue_static_ratios,
+            &mut all_static_noswap_ratios,
+        );
     }
 
     println!("{}", "-".repeat(14 + 6 + 10 * 3 + 9 * 2 + 8 * 2 + 16));
 
     // Synthetic aggregate row (geomean ns per policy across the synthetic set).
     let syn_nnue_ns: Vec<f64> = synthetic_results.iter().filter_map(|r| r.ns_nnue).collect();
-    let syn_static_ns: Vec<f64> = synthetic_results.iter().filter_map(|r| r.ns_static).collect();
+    let syn_static_ns: Vec<f64> = synthetic_results
+        .iter()
+        .filter_map(|r| r.ns_static)
+        .collect();
     let syn_noswap_ns: Vec<f64> = synthetic_results.iter().map(|r| r.ns_noswap).collect();
-    let syn_extract_nnue: Vec<f64> = synthetic_results.iter().map(|r| r.extract_us_nnue).collect();
-    let syn_extract_static: Vec<f64> = synthetic_results.iter().map(|r| r.extract_us_static).collect();
+    let syn_extract_nnue: Vec<f64> = synthetic_results
+        .iter()
+        .map(|r| r.extract_us_nnue)
+        .collect();
+    let syn_extract_static: Vec<f64> = synthetic_results
+        .iter()
+        .map(|r| r.extract_us_static)
+        .collect();
 
-    let syn_nnue_fail = synthetic_results.iter().filter(|r| r.nnue_fail.is_some()).count();
-    let syn_static_fail = synthetic_results.iter().filter(|r| r.static_fail.is_some()).count();
+    let syn_nnue_fail = synthetic_results
+        .iter()
+        .filter(|r| r.nnue_fail.is_some())
+        .count();
+    let syn_static_fail = synthetic_results
+        .iter()
+        .filter(|r| r.static_fail.is_some())
+        .count();
 
     for r in &synthetic_results {
         let ratio_ns = match r.ns_nnue {
@@ -560,8 +590,14 @@ fn main() {
         geomean_static_noswap,
     );
 
-    let named_nnue_fail = named_results.iter().filter(|r| r.nnue_fail.is_some()).count();
-    let named_static_fail = named_results.iter().filter(|r| r.static_fail.is_some()).count();
+    let named_nnue_fail = named_results
+        .iter()
+        .filter(|r| r.nnue_fail.is_some())
+        .count();
+    let named_static_fail = named_results
+        .iter()
+        .filter(|r| r.static_fail.is_some())
+        .count();
     println!(
         "\nNamed-kernel failures: nnue={named_nnue_fail}/{}, static={named_static_fail}/{}",
         named_results.len(),

--- a/pixelflow-pipeline/src/bin/bench_scanline_jit.rs
+++ b/pixelflow-pipeline/src/bin/bench_scanline_jit.rs
@@ -5,10 +5,6 @@
 use pixelflow_pipeline::jit_bench::benchmark_jit_arena;
 use pixelflow_pipeline::training::factored::parse_kernel_code_arena;
 
-#[cfg(target_os = "macos")]
-unsafe extern "C" {
-    fn mach_absolute_time() -> u64;
-}
 fn main() {
     // Load psychedelic expressions from file
     let content = std::fs::read_to_string("pixelflow-pipeline/data/psychedelic_full.jsonl")
@@ -31,6 +27,9 @@ fn main() {
     #[cfg(target_arch = "aarch64")]
     {
         use core::arch::aarch64::*;
+        use pixelflow_ir::ScanlineJitManifold;
+        use pixelflow_ir::backend::emit::compile_arena_dag_scanline;
+        use std::time::Instant;
 
         let scanline_result =
             compile_arena_dag_scanline(&arena, root).expect("scanline compile failed");
@@ -61,11 +60,11 @@ fn main() {
         let samples = 50;
         let mut times = vec![0u64; samples];
         for t in &mut times {
-            let start = nanos_now();
+            let start = Instant::now();
             unsafe {
                 scanline_jit.eval_scanline(&xs, y, z, w, &mut outputs);
             }
-            *t = nanos_now() - start;
+            *t = start.elapsed().as_nanos() as u64;
         }
         times.sort();
         let scanline_ns = times[samples / 2] as f64 / width as f64;

--- a/pixelflow-pipeline/src/training/episodes.rs
+++ b/pixelflow-pipeline/src/training/episodes.rs
@@ -226,7 +226,9 @@ pub fn run_episode(
     } else {
         0.0
     };
-    eprintln!("[REWRITE] {seed_name}: {speedup:.2}x ({initial_cost_ns:.1}ns -> {final_cost_ns:.1}ns)");
+    eprintln!(
+        "[REWRITE] {seed_name}: {speedup:.2}x ({initial_cost_ns:.1}ns -> {final_cost_ns:.1}ns)"
+    );
 
     Some(Episode {
         episode_id,
@@ -326,8 +328,15 @@ mod tests {
         let root = arena.push_binary(OpKind::Add, mul, x); // (x * 1.0) + x
 
         let model = ExprNnue::new();
-        let episode = run_episode(&arena, root, "smoke_seed", &model, 10, "smoke_0".to_string())
-            .expect("episode should complete for a small, well-defined seed expression");
+        let episode = run_episode(
+            &arena,
+            root,
+            "smoke_seed",
+            &model,
+            10,
+            "smoke_0".to_string(),
+        )
+        .expect("episode should complete for a small, well-defined seed expression");
 
         assert!(
             episode.initial_cost_ns.is_finite() && episode.initial_cost_ns >= 0.0,
@@ -339,8 +348,14 @@ mod tests {
             "final_cost_ns should be a finite non-negative measurement, got {}",
             episode.final_cost_ns
         );
-        assert!(episode.node_budget >= 50, "node_budget should respect the floor");
-        assert!(episode.epoch_budget >= 10, "epoch_budget should respect the floor");
+        assert!(
+            episode.node_budget >= 50,
+            "node_budget should respect the floor"
+        );
+        assert!(
+            episode.epoch_budget >= 10,
+            "epoch_budget should respect the floor"
+        );
     }
 
     #[test]

--- a/pixelflow-pipeline/tests/judge_weights_load.rs
+++ b/pixelflow-pipeline/tests/judge_weights_load.rs
@@ -29,8 +29,8 @@ fn judge_weights_round_trip_via_trid() {
         .save(&path)
         .unwrap_or_else(|e| panic!("ExprNnue::save failed for {}: {e}", path.display()));
 
-    let bytes = std::fs::read(&path)
-        .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
+    let bytes =
+        std::fs::read(&path).unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
     let _ = std::fs::remove_file(&path);
 
     // The magic must be TRID (not a stale TRIC/TRIB), and the loader must accept it.


### PR DESCRIPTION
## Summary
- `bench_scanline_jit.rs` referenced `compile_arena_dag_scanline`, `ScanlineJitManifold`, and `nanos_now` without importing/qualifying them, a break introduced by lint-cleanup commit 60d13cdb. Since `cargo test -p pixelflow-pipeline --features training` compiles all bins, this silently blocked the whole crate's test build.
- Restored the `pixelflow_ir` scanline compile imports and replaced the deleted `nanos_now` (which silently returned 0 on non-macOS) with `std::time::Instant`, matching the sibling `bench_hoisted_scanline.rs`.
- Applied `cargo fmt` to pre-existing drift in `bench_extraction_3way.rs`, `training/episodes.rs`, and `tests/judge_weights_load.rs` (formatting only, no logic changes).

## Test plan
- [x] `cargo check -p pixelflow-pipeline --features training --all-targets` passes
- [x] `cargo test -p pixelflow-pipeline --features training` now runs (was previously blocked from compiling); 30/32 lib tests pass — the 2 remaining failures (`seed_42_t1_*_jit_matches_scalar`) are a pre-existing scalar/JIT numeric tolerance mismatch, confirmed present on the untouched tree and unrelated to this fix (tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)