### PR TITLE
Fix JIT log2 accuracy and value-head gradient check flakiness

### DIFF
--- a/pixelflow-ir/src/backend/emit/lowering.rs
+++ b/pixelflow-ir/src/backend/emit/lowering.rs
@@ -538,10 +538,18 @@ fn expand_exp2(arena: &mut ExprArena, x: ExprId) -> ExprId {
 
 /// `log2(x)` as a primitive subgraph (x > 0).
 ///
-/// `log2(x) = e + log2(m)` where `e` is the unbiased exponent and `m ∈ [1,2)` is
-/// the mantissa. Extract `e` by shifting the exponent field down; rebuild `m` by
-/// masking the mantissa bits and OR-ing in exponent bias 127 (= 1.0). Then a
-/// degree-4 polynomial for `log2(m)` on `[1,2)`.
+/// Cephes `log2f` algorithm. `log2(x) = e + log2(m)` where `e` is the unbiased
+/// exponent and `m ∈ [1,2)` is the mantissa. Extract `e` by shifting the
+/// exponent field down; rebuild `m` by masking the mantissa bits and OR-ing in
+/// exponent bias 127 (= 1.0). When `m ≥ √2`, halve `m` and bump `e` so the
+/// polynomial argument `t = m − 1` stays in `[√2/2 − 1, √2 − 1]` — a degree-4
+/// polynomial on the full `[1,2)` peaks at ~0.1 absolute error near `m → 2`.
+/// Then `ln(1+t) = t − t²/2 + t³·P(t)` (degree-8 minimax `P`), scaled to base 2
+/// via the split constant `log2 e = 1 + LOG2EA` to avoid the rounding from one
+/// full-width multiply. Accurate to ~1 ulp over the reduced range.
+///
+/// Uses `Select` on a `Ge` mask for the range reduction, so (like the other
+/// bit-manipulating expansions) this is value-path only.
 fn expand_log2(arena: &mut ExprArena, x: ExprId) -> ExprId {
     // Reinterpret x's bits as int (free) and extract exponent: e = (bits >> 23) - 127.
     // Shift amount read by value -> plain 23.0.
@@ -557,19 +565,55 @@ fn expand_log2(arena: &mut ExprArena, x: ExprId) -> ExprId {
     let mant = arena.push_binary(OpKind::BitAnd, x, mant_mask);
     let m = arena.push_binary(OpKind::BitOr, mant, one_bits);
 
-    // log2(m) on [1,2): polynomial in (m - 1).
+    // Range-reduce: if m ≥ √2 { m /= 2; e += 1 } so t = m − 1 ∈ [−0.293, 0.414].
+    let sqrt2 = arena.push_const(core::f32::consts::SQRT_2);
+    let reduce = arena.push_binary(OpKind::Ge, m, sqrt2);
+    let half = arena.push_const(0.5);
+    let m_halved = arena.push_binary(OpKind::Mul, m, half);
+    let m = arena.push_ternary(OpKind::Select, reduce, m_halved, m);
     let one = arena.push_const(1.0);
+    let e_bumped = arena.push_binary(OpKind::Add, e, one);
+    let e = arena.push_ternary(OpKind::Select, reduce, e_bumped, e);
+
     let t = arena.push_binary(OpKind::Sub, m, one);
-    let c1 = arena.push_const(core::f32::consts::LOG2_E);
-    let c2 = arena.push_const(-0.721_347_5);
-    let c3 = arena.push_const(0.479_924_46);
-    let c4 = arena.push_const(-0.298_768_3);
-    let p = horner_step(arena, c4, t, c3);
+
+    // P(t): Cephes lnf/log2f degree-8 minimax numerator for
+    // (ln(1+t) − t + t²/2) / t³ on the reduced range.
+    let c8 = arena.push_const(7.037_683_6e-2);
+    let c7 = arena.push_const(-1.151_461e-1);
+    let c6 = arena.push_const(1.167_699_9e-1);
+    let c5 = arena.push_const(-1.242_014_1e-1);
+    let c4 = arena.push_const(1.424_932_3e-1);
+    let c3 = arena.push_const(-1.666_805_8e-1);
+    let c2 = arena.push_const(2.000_071_5e-1);
+    let c1 = arena.push_const(-2.499_999_4e-1);
+    let c0 = arena.push_const(3.333_333_1e-1);
+    let p = horner_step(arena, c8, t, c7);
+    let p = horner_step(arena, p, t, c6);
+    let p = horner_step(arena, p, t, c5);
+    let p = horner_step(arena, p, t, c4);
+    let p = horner_step(arena, p, t, c3);
     let p = horner_step(arena, p, t, c2);
     let p = horner_step(arena, p, t, c1);
-    let log2_m = arena.push_binary(OpKind::Mul, p, t);
+    let p = horner_step(arena, p, t, c0);
 
-    arena.push_binary(OpKind::Add, e, log2_m)
+    // y = t³·P(t) − t²/2, so ln(1+t) = t + y.
+    let t2 = arena.push_binary(OpKind::Mul, t, t);
+    let t3 = arena.push_binary(OpKind::Mul, t2, t);
+    let t3p = arena.push_binary(OpKind::Mul, t3, p);
+    let half_t2 = arena.push_binary(OpKind::Mul, t2, half);
+    let y = arena.push_binary(OpKind::Sub, t3p, half_t2);
+
+    // log2(m) = (t + y)·log2(e), with log2(e) split as 1 + LOG2EA and the
+    // pieces summed smallest-first (Cephes ordering) to keep full precision:
+    // e + t + y + y·LOG2EA + t·LOG2EA.
+    let log2ea = arena.push_const(0.442_695_04); // log2(e) − 1
+    let y_ea = arena.push_binary(OpKind::Mul, y, log2ea);
+    let t_ea = arena.push_binary(OpKind::Mul, t, log2ea);
+    let z = arena.push_binary(OpKind::Add, y_ea, t_ea);
+    let z = arena.push_binary(OpKind::Add, z, y);
+    let z = arena.push_binary(OpKind::Add, z, t);
+    arena.push_binary(OpKind::Add, z, e)
 }
 
 /// `sin(x)` as a primitive subgraph (Chebyshev, matching the runtime path).

--- a/pixelflow-pipeline/src/training/factored.rs
+++ b/pixelflow-pipeline/src/training/factored.rs
@@ -679,7 +679,6 @@ mod tests {
                     .unwrap_or_else(|| panic!("eval_ternary failed for {op:?}"))
             }
             ExprNode::Nary(kind, _, _) => panic!("Nary in eval_arena_scalar: {kind:?}"),
-            ExprNode::Buffer(_) => panic!("Buffer node not supported in scalar eval"),
         }
     }
 

--- a/pixelflow-pipeline/src/training/unified_backward.rs
+++ b/pixelflow-pipeline/src/training/unified_backward.rs
@@ -1632,25 +1632,42 @@ mod tests {
         }
 
         // expr_proj_w (value path)
+        //
+        // This block uses a larger step than the rest of the test. The forward
+        // pass is f32, so the central-difference numerator carries a constant
+        // absolute roundoff noise of ~ulp(loss)/(2*eps) (~1.5e-4 at eps=1e-3),
+        // which swamps small true gradients (~1.7e-4 for expr_proj_w[32][12])
+        // and made this assertion flaky (rel_err 0.086 in June 2026, 0.101 in
+        // July 2026; the June "fix" loosened the threshold instead of fixing
+        // the step size). With a frozen ReLU pattern the loss is exactly
+        // quadratic in any single weight, so the central difference has zero
+        // truncation error and a larger eps strictly improves the
+        // signal-to-roundoff ratio, provided no ReLU flips sign. An
+        // expr_proj_w perturbation only reaches the value-MLP ReLUs, and none
+        // flip at eps=1e-2 for this net/input (verified; unlike trunk_b,
+        // where eps=1e-2 does cross a kink, so the global eps stays 1e-3).
+        // Measured rel_err on the once-failing parameter:
+        // 0.38 @ eps=1e-4, 0.10 @ 1e-3, 0.005 @ 3e-3, 0.001 @ 1e-2.
+        let proj_eps = 1e-2f32;
         for j in [0, 32, 63] {
             for k in [0, 12, 23] {
                 let mut net_p = net.clone();
-                net_p.expr_proj_w[j][k] += eps;
+                net_p.expr_proj_w[j][k] += proj_eps;
                 let loss_plus =
                     value_loss(&net_p, &acc, &gacc, &rule_embed, target_cost, value_coeff);
 
                 let mut net_m = net.clone();
-                net_m.expr_proj_w[j][k] -= eps;
+                net_m.expr_proj_w[j][k] -= proj_eps;
                 let loss_minus =
                     value_loss(&net_m, &acc, &gacc, &rule_embed, target_cost, value_coeff);
 
-                let num_grad = (loss_plus - loss_minus) / (2.0 * eps as f64);
+                let num_grad = (loss_plus - loss_minus) / (2.0 * proj_eps as f64);
                 let (a, n, err) = check_gradient(grads.d_expr_proj_w[j][k], num_grad);
                 if err > max_err {
                     max_err = err;
                 }
                 assert!(
-                    err < 0.1,
+                    err < 0.05,
                     "expr_proj_w[{j}][{k}] (value): analytical={a:.8}, numerical={n:.8}, rel_err={err:.6}"
                 );
                 checked += 1;


### PR DESCRIPTION
## Summary

Fixes the three pre-existing lib test failures in `pixelflow-pipeline` (training feature):
`seed_42_t1_initial_jit_matches_scalar`, `seed_42_t1_final_jit_matches_scalar`, and
`numerical_gradient_check_value`.

## JIT log2 was genuinely inaccurate (the two seed_42 failures)

A per-subtree scalar-vs-JIT diagnostic localized the divergence to `Log2`: `expand_log2`
in `pixelflow-ir/src/backend/emit/lowering.rs` approximated `log2(m)` over the full
mantissa range `[1,2)` with a degree-4 **Taylor** polynomial in `(m−1)`, whose absolute
error peaks at ~0.1 near `m → 2` (at t=1 it evaluates to 0.9025 instead of 1.0). The
seed_42 expression hits mantissas 1.52 and 1.61 — mid-range, error ~7.7e-3 — which then
amplifies through `exp` and a second `log2` into the observed 3.7e-3 final divergence.
The seed_24042 tests only passed by luck (their log arguments have mantissas near 1.03,
where Taylor is accurate).

**Fix:** the standard Cephes `log2f` algorithm — reduce the mantissa to `[√2/2, √2)`
(halve m / bump e via a `Ge`+`Select` pair; the expansion already used bit-manipulation
primitives, so it was value-path-only before this change too), evaluate
`ln(1+t) = t − t²/2 + t³·P(t)` with the degree-8 minimax `P`, and scale to base 2 with
the split constant `log2 e = 1 + 0.44269504`. Result: `log2(0.201)` is now bit-exact vs
libm, and the failing expressions agree with scalar eval to **7e-6** (tolerance 1e-3).
`ln`/`log10` and pow-via-log chains share this expansion and improve with it.

## Gradient check was flaky methodology, not a backprop bug

The analytical gradient for `expr_proj_w` is **correct**. The central difference at
eps=1e-3 on an f32 forward pass has a roundoff noise floor of ~1.5e-4 — the same
magnitude as the smallest checked gradient (1.7e-4). Decisive evidence: the numerical
estimate converges **toward** the analytical value as eps grows (rel_err 0.38 @ 1e-4,
0.10 @ 1e-3, 0.001 @ 1e-2); a real backprop bug converges to the wrong value as h→0.
With the ReLU pattern frozen the loss is exactly quadratic in any single weight, so
larger eps has zero truncation cost provided no kink flips (verified none flip for this
block at 1e-2, unlike `trunk_b`, which keeps the global eps=1e-3).

**Fix:** block-local eps=1e-2 for the `expr_proj_w` differences, and the threshold is
**restored to 0.05** — a June 2026 CI-fix commit (`ce1f5cee`) had loosened it to 0.1 to
paper over this same noise, and it predictably failed again at 0.101. The test is now
tighter than before and passes with ~15x margin.

## Also fixed in passing

- Removed a dead duplicate `ExprNode::Buffer` match arm in factored.rs test helpers
  (`unreachable_patterns` warning).

(A `bench_scanline_jit.rs` bitrot fix was originally part of this branch, but main
landed an equivalent fix independently; it dropped out in the rebase.)

## Verification

- `cargo test --release -p pixelflow-pipeline --features training --lib`: 32 passed
- `cargo test --release -p pixelflow-ir`: 104 passed
- `cargo test --workspace --features pixelflow-pipeline/training`: all suites green

## Reviewer notes

- The log2 change affects every JIT consumer on both aarch64 and x86-64 (the expansion
  is shared lowering); only aarch64 was runtime-tested here since the deep seed_42
  kernels exceed the x86-64 spill-free register budget by design.
- `expand_exp2`'s coefficients are also Taylor rather than minimax (rel error ~2e-5 —
  harmless today, but the same class of issue if precision demands tighten). Left as-is
  to keep this change scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
