### PR TITLE
Test quality control: close mutation-testing gaps, enforce public-API-only tests

### DIFF
--- a/core-term/src/term/emulator/input_handler.rs
+++ b/core-term/src/term/emulator/input_handler.rs
@@ -206,13 +206,15 @@ mod tests {
     #[test]
     fn paste_text_action_bracketed_on() {
         let mut emu = create_test_emu_for_input();
-        // Enable bracketed paste mode via public API (CSI ? 2004 h)
-        // This ensures we test the mode setting logic and state representation contract
-        // rather than modifying internal fields directly.
-        // TODO: Refactor to use the true public API (message passing via interpret_input) and
-        // consider restricting handle_set_mode visibility to pub(super) or private if feasible.
-        use crate::term::modes::{Mode, ModeAction};
-        emu.handle_set_mode(Mode::DecPrivate(2004), ModeAction::Enable);
+        // Enable bracketed paste mode the way a real client would: send the
+        // ANSI escape sequence (CSI ? 2004 h) through the same public
+        // interpret_input entry point the PTY reader uses, rather than
+        // calling the private mode handler directly.
+        use crate::ansi::commands::{AnsiCommand, CsiCommand};
+        use crate::term::EmulatorInput;
+        emu.interpret_input(EmulatorInput::Ansi(AnsiCommand::Csi(
+            CsiCommand::SetModePrivate(2004),
+        )));
 
         let text_to_paste = "Hello\nWorld".to_string();
         let action = UserInputAction::PasteText(text_to_paste.clone());
@@ -225,8 +227,10 @@ mod tests {
 
     #[test]
     fn paste_text_action_bracketed_off() {
+        // Bracketed paste mode is off by default (no CSI ? 2004 h was sent);
+        // the behavior asserted below - an unwrapped paste - is itself the
+        // proof of that, rather than reading internal mode state directly.
         let mut emu = create_test_emu_for_input();
-        assert!(!emu.dec_modes.bracketed_paste_mode);
 
         let text_to_paste = "Hello\nWorld".to_string();
         let action = UserInputAction::PasteText(text_to_paste.clone());

--- a/pixelflow-ml/src/graphics.rs
+++ b/pixelflow-ml/src/graphics.rs
@@ -298,9 +298,16 @@ mod tests {
 
     #[test]
     fn elu_feature_positive() {
+        // x >= 0: ELU(x) + 1 = max(0, x) + exp(min(0, x)) = x + exp(0) = x + 1.
         let f = EluFeature;
-        let result = f.apply(Field::from(0.0));
-        let _ = result;
+        assert_field_approx_eq(f.apply(Field::from(2.0)), 3.0);
+    }
+
+    #[test]
+    fn elu_feature_negative() {
+        // x < 0: ELU(x) + 1 = max(0, x) + exp(min(0, x)) = 0 + exp(x).
+        let f = EluFeature;
+        assert_field_approx_eq(f.apply(Field::from(-1.0)), core::f32::consts::E.recip());
     }
 
     #[test]
@@ -332,6 +339,42 @@ mod tests {
         let mut output = [0.0f32; 3];
         attn.query(&key_sh, &mut output);
         assert!(output[0] > 0.5);
+    }
+
+    #[test]
+    fn harmonic_attention_accumulate_computes_outer_product() {
+        let mut attn: HarmonicAttention<9> = HarmonicAttention::new(1);
+        let mut coeffs = [0.0f32; 9];
+        coeffs[0] = 2.0;
+        let key_sh = Sh2 { coeffs };
+
+        attn.accumulate(&key_sh, &[3.0]);
+
+        // coeffs[j] += key_sh.coeffs[j] * v, not + or /.
+        assert_eq!(attn.accumulated[0].coeffs[0], 6.0);
+        // denominator.coeffs[j] += key_sh.coeffs[j], not -= or *=.
+        assert_eq!(attn.denominator.coeffs[0], 2.0);
+    }
+
+    #[test]
+    fn harmonic_attention_accumulate_ignores_values_past_value_dim() {
+        let mut attn: HarmonicAttention<9> = HarmonicAttention::new(1);
+        let key_sh = Sh2 { coeffs: [1.0; 9] };
+
+        // value has more entries than the attention layer has value slots for;
+        // the extra entry must be skipped, not indexed out of bounds.
+        attn.accumulate(&key_sh, &[1.0, 2.0]);
+    }
+
+    #[test]
+    fn harmonic_attention_query_ignores_output_slots_past_value_dim() {
+        let attn: HarmonicAttention<9> = HarmonicAttention::new(1);
+        let query_sh = Sh2 { coeffs: [1.0; 9] };
+        let mut output = [0.0f32; 2];
+
+        // output has more slots than the attention layer accumulated values for;
+        // the extra slot must be skipped, not indexed out of bounds.
+        attn.query(&query_sh, &mut output);
     }
 
     #[test]
@@ -371,20 +414,23 @@ mod tests {
 
     #[test]
     fn sh_feature_map_matches_closed_form_sh_basis() {
-        // Unnormalized direction (1, 2, 2), |v| = 3 -> normalized (1/3, 2/3, 2/3).
+        // Unnormalized direction (1, 3, 4), |v| = sqrt(26) -> normalized
+        // (0.196116, 0.588348, 0.784465). Components are deliberately distinct
+        // and avoid 0 and 2 (where n*n and n+n coincide), so every multiply in
+        // the basis computation is distinguishable from a same-position add.
         // Expected values are the real SH basis Y_lm evaluated at that direction,
         // using the same SH_NORM constants as pixelflow-core's spherical.rs.
-        let result = ShFeatureMap::<9>::project(Field::from(1.0), Field::from(2.0), Field::from(2.0));
+        let result = ShFeatureMap::<9>::project(Field::from(1.0), Field::from(3.0), Field::from(4.0));
 
         assert_field_approx_eq(result[0], 0.282_095);
-        assert_field_approx_eq(result[1], 0.325_735);
-        assert_field_approx_eq(result[2], 0.325_735);
-        assert_field_approx_eq(result[3], 0.162_867);
-        assert_field_approx_eq(result[4], 0.121_394);
-        assert_field_approx_eq(result[5], 0.485_577);
-        assert_field_approx_eq(result[6], 0.105_131);
-        assert_field_approx_eq(result[7], 0.242_789);
-        assert_field_approx_eq(result[8], -0.182_091);
+        assert_field_approx_eq(result[1], 0.287_469);
+        assert_field_approx_eq(result[2], 0.383_291);
+        assert_field_approx_eq(result[3], 0.095_823);
+        assert_field_approx_eq(result[4], 0.063_032);
+        assert_field_approx_eq(result[5], 0.504_253);
+        assert_field_approx_eq(result[6], 0.266_870);
+        assert_field_approx_eq(result[7], 0.168_084);
+        assert_field_approx_eq(result[8], -0.168_084);
     }
 
     #[test]

--- a/pixelflow-ml/src/graphics.rs
+++ b/pixelflow-ml/src/graphics.rs
@@ -349,6 +349,19 @@ mod tests {
         }
     }
 
+    /// Asserts that a Field is approximately equal to a float value across all lanes.
+    ///
+    /// Mirrors the helper in `pixelflow-core/tests/unit_tests.rs`: uses only the
+    /// public `Field` API (`Sub`, `abs`, `lt`, `all`), never raw lane access.
+    fn assert_field_approx_eq(field: Field, expected: f32) {
+        let diff = (field - Field::from(expected)).abs();
+        let is_small = diff.lt(Field::from(1e-2)).constant();
+        assert!(
+            is_small.all(),
+            "expected ~{expected}, field differed by more than 1e-2"
+        );
+    }
+
     #[test]
     fn sh_feature_map_projects_direction() {
         let result =
@@ -357,10 +370,60 @@ mod tests {
     }
 
     #[test]
+    fn sh_feature_map_matches_closed_form_sh_basis() {
+        // Unnormalized direction (1, 2, 2), |v| = 3 -> normalized (1/3, 2/3, 2/3).
+        // Expected values are the real SH basis Y_lm evaluated at that direction,
+        // using the same SH_NORM constants as pixelflow-core's spherical.rs.
+        let result = ShFeatureMap::<9>::project(Field::from(1.0), Field::from(2.0), Field::from(2.0));
+
+        assert_field_approx_eq(result[0], 0.282_095);
+        assert_field_approx_eq(result[1], 0.325_735);
+        assert_field_approx_eq(result[2], 0.325_735);
+        assert_field_approx_eq(result[3], 0.162_867);
+        assert_field_approx_eq(result[4], 0.121_394);
+        assert_field_approx_eq(result[5], 0.485_577);
+        assert_field_approx_eq(result[6], 0.105_131);
+        assert_field_approx_eq(result[7], 0.242_789);
+        assert_field_approx_eq(result[8], -0.182_091);
+    }
+
+    #[test]
+    fn sh_feature_map_normalizes_unit_z_direction() {
+        // Direction along +z should light up only the m=0 harmonics (l=0, l=1 m=0,
+        // l=2 m=0) and leave every basis function that depends on nx or ny at zero.
+        let result =
+            ShFeatureMap::<9>::project(Field::from(0.0), Field::from(0.0), Field::from(5.0));
+
+        assert_field_approx_eq(result[0], 0.282_095);
+        assert_field_approx_eq(result[1], 0.0);
+        assert_field_approx_eq(result[2], 0.488_602_5);
+        assert_field_approx_eq(result[3], 0.0);
+        assert_field_approx_eq(result[4], 0.0);
+        assert_field_approx_eq(result[5], 0.0);
+        assert_field_approx_eq(result[6], 0.630_783);
+        assert_field_approx_eq(result[7], 0.0);
+        assert_field_approx_eq(result[8], 0.0);
+    }
+
+    #[test]
     fn linear_attention_new() {
         let attn = LinearAttention::new(EluFeature, 4, 3);
         assert_eq!(attn.feature_dim, 4);
         assert_eq!(attn.value_dim, 3);
+        assert!(attn.kv_state.iter().all(|&v| v == 0.0));
+        assert!(attn.k_state.iter().all(|&v| v == 0.0));
+    }
+
+    #[test]
+    fn linear_attention_reset_clears_accumulated_state() {
+        let mut attn = LinearAttention::new(EluFeature, 2, 3);
+        attn.kv_state.fill(7.0);
+        attn.k_state.fill(3.0);
+
+        attn.reset();
+
+        assert!(attn.kv_state.iter().all(|&v| v == 0.0));
+        assert!(attn.k_state.iter().all(|&v| v == 0.0));
     }
 
     #[test]

--- a/pixelflow-runtime/src/testing/mod.rs
+++ b/pixelflow-runtime/src/testing/mod.rs
@@ -1,3 +1,3 @@
 pub mod mock_engine;
 
-pub use mock_engine::MockEngine;
+pub use mock_engine::{MockEngine, ReceivedMessage};

--- a/pixelflow-runtime/tests/macos_integration_tests.rs
+++ b/pixelflow-runtime/tests/macos_integration_tests.rs
@@ -1,62 +1,23 @@
 #[cfg(target_os = "macos")]
 mod tests {
-    use actor_scheduler::{Actor, ActorStatus, HandlerError, HandlerResult, SystemStatus};
-    use pixelflow_runtime::api::private::{create_engine_actor, EngineControl, EngineData};
-    use pixelflow_runtime::api::public::{AppManagement, WindowDescriptor};
-    use pixelflow_runtime::display::messages::{DisplayControl, DisplayMgmt};
+    use actor_scheduler::SystemStatus;
+    use pixelflow_runtime::api::private::EngineData;
+    use pixelflow_runtime::api::public::WindowDescriptor;
+    use pixelflow_runtime::display::messages::{DisplayControl, DisplayEvent, DisplayMgmt};
     use pixelflow_runtime::display::ops::PlatformOps;
     use pixelflow_runtime::platform::macos::MetalOps;
-    use std::sync::{Arc, Mutex};
+    use pixelflow_runtime::testing::{MockEngine, ReceivedMessage};
     use std::thread;
     use std::time::Duration;
-
-    // A mock Engine actor to capture events
-    struct MockEngine {
-        pub captured_events: Arc<Mutex<Vec<pixelflow_runtime::display::messages::DisplayEvent>>>,
-    }
-
-    impl MockEngine {
-        fn new(
-            captured_events: Arc<Mutex<Vec<pixelflow_runtime::display::messages::DisplayEvent>>>,
-        ) -> Self {
-            Self { captured_events }
-        }
-    }
-
-    // Use generics as required by the Actor trait definition
-    impl Actor<EngineData, EngineControl, AppManagement> for MockEngine {
-        fn handle_data(&mut self, msg: EngineData) -> HandlerResult {
-            if let EngineData::FromDriver(evt) = msg {
-                self.captured_events.lock().unwrap().push(evt);
-            }
-            Ok(())
-        }
-
-        fn handle_control(&mut self, _msg: EngineControl) -> HandlerResult {
-            Ok(())
-        }
-        fn handle_management(&mut self, _msg: AppManagement) -> HandlerResult {
-            Ok(())
-        }
-        fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
-            Ok(ActorStatus::Idle)
-        }
-    }
 
     #[test]
     #[ignore = "Requires UI interaction or window server"]
     fn metal_ops_lifecycle() {
-        let events = Arc::new(Mutex::new(Vec::new()));
-        let events_clone = events.clone();
-
-        // 1. Create Engine Actor (Scheduler + Handle)
-        let (handle, mut scheduler) = create_engine_actor(None);
-
-        // 2. Spawn Scheduler in background
-        thread::spawn(move || {
-            let mut mock_engine = MockEngine::new(events_clone);
-            scheduler.run(&mut mock_engine);
-        });
+        // The crate's sanctioned test double already runs an actor that
+        // records every message sent to it and hands out a producer handle -
+        // no need to hand-roll another Actor impl against api::private types.
+        let mut mock_engine = MockEngine::new();
+        let handle = mock_engine.take_handle();
 
         // 3. Instantiate MetalOps
         let mut ops = MetalOps::new(handle).expect("Failed to create MetalOps");
@@ -79,20 +40,22 @@ mod tests {
         thread::sleep(Duration::from_millis(100));
 
         // 6. Verify Window Creation Event within MockEngine
-        let captured = events.lock().unwrap();
-        let found_window_id = captured.iter().find_map(|e| {
-            if let pixelflow_runtime::display::messages::DisplayEvent::WindowCreated { window } = e
-            {
-                Some(window.id)
-            } else {
-                None
-            }
+        let captured = mock_engine.messages();
+        let found_window_id = captured.iter().find_map(|msg| {
+            let ReceivedMessage::Data(EngineData::FromDriver(DisplayEvent::WindowCreated {
+                window,
+            })) = msg
+            else {
+                return None;
+            };
+            Some(window.id)
         });
         assert!(
             found_window_id.is_some(),
             "Expected WindowCreated event, found: {:?}",
             *captured
         );
+        drop(captured);
 
         // 7. Update Window Title
         let win_id = found_window_id.unwrap();

--- a/pixelflow-runtime/tests/vsync_actor_tests.rs
+++ b/pixelflow-runtime/tests/vsync_actor_tests.rs
@@ -496,12 +496,11 @@ fn set_config_auto_starts_actor() {
     let self_handle = builder.add_producer();
     let mut rx = builder.build();
 
-    // We need a dummy engine handle for SetConfig - create but won't be used
-    let (engine_handle, _) = actor_scheduler::ActorScheduler::<
-        pixelflow_runtime::api::private::EngineData,
-        pixelflow_runtime::api::private::EngineControl,
-        pixelflow_runtime::api::public::AppManagement,
-    >::new(10, 100);
+    // We need a dummy engine handle for SetConfig - create but won't be used.
+    // Use the crate's sanctioned test double rather than reaching into
+    // api::private to hand-assemble an ActorScheduler directly.
+    let mut mock_engine = pixelflow_runtime::testing::MockEngine::new();
+    let engine_handle = mock_engine.take_handle();
 
     let handle = thread::spawn(move || {
         let mut actor = MockVsyncActor::new(log_clone);


### PR DESCRIPTION
## Summary

Recurring test-quality-control pass: run `cargo mutants` across workspace crates and
strengthen tests that don't actually catch behavior changes, plus a static audit for
tests that violate `docs/STYLE.md`'s "Test Public API" rule (unit tests should exercise
the public/exported API against its documented contract, not internal implementation
details).

### Mutation testing: pixelflow-ml (now fully mutation-clean)

`cargo mutants -p pixelflow-ml` started at 62/75 (then 10/75 after a first pass) mutants
surviving. Root cause: `ShFeatureMap<9>::project`'s only test asserted `result.len() ==
9`, `EluFeature::apply` had no value assertion, and `HarmonicAttention::accumulate`/
`query`/`LinearAttention::reset` had no coverage of their bounds guards or state
mutation at all. Fixed by:

- Value-level assertions against the closed-form real SH basis (reusing `SH_NORM` from
  `pixelflow-core::combinators::spherical`), with a direction chosen so no component is
  0 or 2 (where `n*n` and `n+n` coincide, hiding multiply-vs-add mutants).
- Exact-value assertions on `EluFeature::apply`'s two branches.
- Bounds-guard tests for `accumulate`/`query` (out-of-range slices that would index out
  of bounds under a `<` → `<=` mutant).
- An outer-product test with inputs where each of the four arithmetic mutants on the
  accumulate path produces a distinguishable wrong answer.
- A `reset` test that dirties state and checks it clears.

All assertions go through `Field`'s public comparison API only (`Sub`, `abs`, `lt`,
`constant`, `all`) per pixelflow-core's raw-op ban. **Result: 74/74 viable mutants
caught** (1 unviable, excluded).

### Public-API test-style audit

Ran a workspace-wide audit for tests reaching past a crate's public boundary. Result:
pixelflow-core, pixelflow-ir, pixelflow-search, and actor-scheduler are clean (prior
cleanup passes held); pixelflow-compiler's white-box tests are correctly exempt (proc-
macro crate, no public surface besides the macros). Found and fixed 4 real violations,
all in core-term/pixelflow-runtime:

- **core-term**: `paste_text_action_bracketed_on` called the `pub(super)`
  `handle_set_mode` directly instead of driving the mode change through the real public
  input path — now sends `CSI ? 2004 h` through `TerminalEmulator::interpret_input`, as
  a pre-existing TODO in the test already asked for. `paste_text_action_bracketed_off`
  dropped a redundant direct read of the `pub(super)` `dec_modes` field (the behavioral
  assertion that follows already proves the mode defaults off).
- **pixelflow-runtime**: two tests (`macos_integration_tests.rs`,
  `vsync_actor_tests.rs::set_config_auto_starts_actor`) reached into
  `api::private::{create_engine_actor, EngineData, EngineControl}` to hand-roll engine
  actor plumbing the crate already ships a sanctioned test double for
  (`pixelflow_runtime::testing::MockEngine`). Both now use
  `MockEngine::new().take_handle()` / `.messages()` instead.

### Follow-ups noted, not fixed this pass

- **actor-scheduler-macros** (`actor_impl!`, `troupe!`): `cargo mutants` finds 40/44
  mutants surviving, but the crate has zero tests today and genuinely can't unit-test
  its `proc_macro::TokenStream` logic — `proc_macro` APIs panic when called outside an
  active macro invocation (confirmed directly: `TokenStream::from_str` panics in a
  `#[test]`). Closing this gap needs either a `proc-macro2`-based internal refactor (the
  crate deliberately has zero deps today — "No external dependencies - only proc_macro
  from std") or integration tests via a dev-dependency cycle on `actor-scheduler`
  (Cargo supports this, but it's a real dependency-graph change). Flagging for a
  deliberate decision rather than making it unilaterally in a test-quality pass.
- Two minor/judgment-call items from the audit (not violations): `pixelflow-search`'s
  `Provenance` tests constructing `EClassId` directly (same-file white-box test on the
  type's own bookkeeping, acceptable), and a `pixelflow-runtime` test importing
  `WindowId` via `api::private` instead of the crate-root re-export (functionally
  identical, just an odd path).
- Full-workspace mutation testing isn't tractable in one pass (pixelflow-core alone has
  ~4000 mutants; pixelflow-ir ~3700). Remaining unaudited: pixelflow-core, pixelflow-ir,
  pixelflow-search, pixelflow-runtime (mutation testing, as opposed to the style audit
  above, which did cover them), pixelflow-compiler, pixelflow-pipeline. Working these
  crate-by-crate across runs, same pattern as the prior mutation-testing passes on
  actor-scheduler and core-term/pixelflow-graphics (see git log).

## Test plan

- [x] `cargo test -p pixelflow-ml` passes; `cargo mutants -p pixelflow-ml` confirms
      74/74 viable mutants caught
- [x] `cargo test -p core-term input_handler` passes (bracketed-paste fix)
- [x] `cargo test -p pixelflow-runtime --test vsync_actor_tests` passes (MockEngine fix)
- [x] `cargo check --workspace --tests` passes
- [ ] `macos_integration_tests.rs` is `cfg(target_os = "macos")`-gated and could not be
      compiled/run on this Linux dev machine; verified by careful manual type-checking
      against `pixelflow_runtime::testing::MockEngine`'s actual signatures instead
