### PR TITLE
macOS: exit on last window close + native-DPI (Retina) rendering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,8 +109,8 @@ cargo test --workspace            # All tests
 cargo test -p pixelflow-core      # Single crate
 cargo bench -p pixelflow-core     # Benchmarks
 cargo run --release -p core-term  # Run terminal directly
-cargo xtask bundle-run            # macOS bundled app
-cargo xtask bundle-run --features profiling  # Flamegraph on exit
+cargo bundle-run            # macOS bundled app
+cargo bundle-run --features profiling  # Flamegraph on exit
 ```
 
 ### Build Profiles
@@ -198,7 +198,7 @@ handle.send(Message::Data(MyDataMsg))?;           // Lowest (backpressure)
 
 ### macOS
 - Cocoa MUST run on main thread
-- `cargo xtask bundle-run` creates `CoreTerm.app`
+- `cargo bundle-run` creates `CoreTerm.app`
 - PTY I/O: kqueue-based on dedicated thread
 
 ### Linux

--- a/core-term/src/terminal_app.rs
+++ b/core-term/src/terminal_app.rs
@@ -530,11 +530,12 @@ impl Actor<TerminalData, EngineEventControl, EngineEventManagement> for Terminal
                     .expect("Failed to shutdown PTY writer on CloseRequested");
             }
             EngineEventControl::ScaleChanged { id, scale } => {
-                unimplemented!(
-                    "ScaleChanged: id={}, scale={} - need to adjust font sizes and redraw",
-                    id.0,
-                    scale
-                );
+                // Rendering is resolution-independent: the frame buffer is
+                // sized from the window's content bounds (points) and cell
+                // metrics come from config, so a backing-scale change needs no
+                // font adjustment — just a redraw on the new display.
+                log::info!("[TERM] Scale changed: id={}, scale={}", id.0, scale);
+                self.send_frame();
             }
         }
         Ok(())

--- a/core-term/src/terminal_app.rs
+++ b/core-term/src/terminal_app.rs
@@ -133,6 +133,10 @@ pub struct TerminalApp {
     /// Currently pressed mouse button, tracked for motion reporting.
     /// Set on MouseClick, cleared on MouseRelease.
     pressed_mouse_button: Option<pixelflow_runtime::input::MouseButton>,
+    /// Device pixels per point of the current display (backing scale).
+    /// The scene stays in point space; this is only a density hint for the
+    /// glyph cache so bakes match the platform's sample lattice.
+    density: f32,
 }
 
 /// Parameters for constructing a TerminalApp.
@@ -248,10 +252,11 @@ impl TerminalApp {
 
         let loaded_font = Arc::new(LoadedFont::new(source).expect("Failed to parse font"));
 
-        // Create glyph cache and pre-warm with ASCII
+        // Create glyph cache and pre-warm with ASCII. Density 1.0 until the
+        // platform reports the real backing scale via WindowCreated.
         let cell_height = params.config.appearance.cell_height_px as f32;
         let mut glyph_cache = GlyphCache::with_capacity(128);
-        glyph_cache.warm_ascii(&loaded_font.font(), cell_height);
+        glyph_cache.warm_ascii(&loaded_font.font(), cell_height, 1.0);
 
         Self {
             emulator: params.emulator,
@@ -261,7 +266,25 @@ impl TerminalApp {
             loaded_font,
             glyph_cache,
             pressed_mouse_button: None,
+            density: 1.0,
         }
+    }
+
+    /// Adopt a new display density (device pixels per point), re-baking the
+    /// warm glyph set so cached lattices match the platform's sample grid.
+    fn set_density(&mut self, scale: f64) {
+        assert!(
+            scale.is_finite() && scale > 0.0,
+            "invalid display scale: {scale}"
+        );
+        let density = scale as f32;
+        if density == self.density {
+            return;
+        }
+        self.density = density;
+        let cell_height = self.config.appearance.cell_height_px as f32;
+        self.glyph_cache
+            .warm_ascii(&self.loaded_font.font(), cell_height, density);
     }
 
     /// Build a render manifold from the current terminal state.
@@ -343,7 +366,7 @@ impl TerminalApp {
                 // Get cached glyph - glyph_scaled now accounts for descenders
                 if let Some(cached) =
                     self.glyph_cache
-                        .get(&self.loaded_font.font(), ch, cell_height)
+                        .get(&self.loaded_font.font(), ch, cell_height, self.density)
                 {
                     let (fg_r, fg_g, fg_b, fg_a) = fg_color.to_f32_rgba();
                     let (bg_r, bg_g, bg_b, bg_a) = cell_bg.to_f32_rgba();
@@ -482,12 +505,13 @@ impl Actor<TerminalData, EngineEventControl, EngineEventManagement> for Terminal
                 scale,
             } => {
                 log::info!(
-                    "[TERM] Window created: id={}, {}x{} pixels, scale={}",
+                    "[TERM] Window created: id={}, {}x{} points, scale={}",
                     id.0,
                     width_px,
                     height_px,
                     scale
                 );
+                self.set_density(scale);
 
                 // Window is now ready - send initial frame to start VSync loop
                 self.send_frame();
@@ -530,11 +554,11 @@ impl Actor<TerminalData, EngineEventControl, EngineEventManagement> for Terminal
                     .expect("Failed to shutdown PTY writer on CloseRequested");
             }
             EngineEventControl::ScaleChanged { id, scale } => {
-                // Rendering is resolution-independent: the frame buffer is
-                // sized from the window's content bounds (points) and cell
-                // metrics come from config, so a backing-scale change needs no
-                // font adjustment — just a redraw on the new display.
+                // The scene stays in point space (grid, cell metrics, mouse
+                // math are all unchanged); only the glyph cache cares, since
+                // its baked lattices must match the new sample density.
                 log::info!("[TERM] Scale changed: id={}, scale={}", id.0, scale);
+                self.set_density(scale);
                 self.send_frame();
             }
         }

--- a/core-term/src/terminal_app.rs
+++ b/core-term/src/terminal_app.rs
@@ -519,7 +519,15 @@ impl Actor<TerminalData, EngineEventControl, EngineEventManagement> for Terminal
                 self.send_frame();
             }
             EngineEventControl::CloseRequested => {
-                unimplemented!("CloseRequested handler - need to cleanup and shutdown");
+                // The engine is already running its shutdown cascade (vsync,
+                // rasterizer, driver, itself). Our job is local cleanup: stop
+                // the PTY writer so no further writes race the teardown. The
+                // PTY master closes when the process exits, which delivers
+                // SIGHUP to the child shell.
+                log::info!("[TERM] Close requested; shutting down PTY writer");
+                self.pty_writer
+                    .send(Message::Shutdown)
+                    .expect("Failed to shutdown PTY writer on CloseRequested");
             }
             EngineEventControl::ScaleChanged { id, scale } => {
                 unimplemented!(

--- a/pixelflow-graphics/benches/font_rendering.rs
+++ b/pixelflow-graphics/benches/font_rendering.rs
@@ -123,7 +123,7 @@ fn bench_pixelflow_with_caching(c: &mut Criterion) {
 
     group.bench_function("cached_HELLO", |b| {
         let mut cache = GlyphCache::new();
-        let cached = CachedText::new(&font, &mut cache, "HELLO", 20.0);
+        let cached = CachedText::new(&font, &mut cache, "HELLO", 20.0, 1.0);
         let colored = Grayscale(cached);
 
         b.iter(|| {
@@ -137,7 +137,7 @@ fn bench_pixelflow_with_caching(c: &mut Criterion) {
         b.iter(|| {
             let mut cache = GlyphCache::new();
             for ch in 'A'..='Z' {
-                black_box(CachedText::new(&font, &mut cache, &ch.to_string(), 16.0));
+                black_box(CachedText::new(&font, &mut cache, &ch.to_string(), 16.0, 1.0));
             }
         });
     });

--- a/pixelflow-graphics/src/fonts/cache.rs
+++ b/pixelflow-graphics/src/fonts/cache.rs
@@ -48,7 +48,7 @@
 //! let mut cache = GlyphCache::new();
 //!
 //! // Cache glyphs at specific sizes (happy path: fast)
-//! let cached = cache.get(&font, 'A', 16.0);
+//! let cached = cache.get(&font, 'A', 16.0, 1.0);
 //!
 //! // Arbitrary sizes still work (uncached: infinite resolution)
 //! let uncached = font.glyph_scaled('A', 17.3);
@@ -101,32 +101,52 @@ pub struct CachedGlyph {
     /// Bilinear sampler over the baked coverage lattice.
     /// Arc so cloning a cached glyph (once per cell per frame) is O(1).
     sampler: Arc<Bilinear<DiscreteManifold>>,
-    /// Baked width in pixels.
+    /// Point-space width (the baked lattice holds `width × density` texels).
     width: usize,
-    /// Baked height in pixels.
+    /// Point-space height (the baked lattice holds `height × density` texels).
     height: usize,
+    /// Sample density the lattice was baked at, in texels per point.
+    /// Queries stay in point space; `eval` contramaps by this factor.
+    density: f32,
+}
+
+/// Baked lattice extent in texels for a point-space size at a density.
+fn px_extent(size: usize, density: f32) -> usize {
+    (size as f32 * density).round() as usize
 }
 
 impl CachedGlyph {
     /// Create a cached glyph by collapsing a glyph manifold over a lattice.
     ///
-    /// The glyph's *antialiased* coverage is tabulated at `size × size`
-    /// resolution, at pixel centers (see the module docs for the coordinate
-    /// convention). The bake evaluates the glyph through [`Antialiased`], so
-    /// every texel stores a gradient-normalized crossing ramp value — the
-    /// bilinear read-back then interpolates already-smooth coverage.
+    /// The glyph's *antialiased* coverage is tabulated at
+    /// `(size × density)²` texels, at texel centers (see the module docs for
+    /// the coordinate convention). The bake evaluates the glyph through
+    /// [`Antialiased`], so every texel stores a gradient-normalized crossing
+    /// ramp value — the bilinear read-back then interpolates already-smooth
+    /// coverage.
+    ///
+    /// `density` is the sample density in texels per point (a display's
+    /// backing scale). The caller must supply a `glyph` whose outline is
+    /// scaled to `size × density` pixels, so the analytic curves are truly
+    /// sampled denser — not upscaled. The resulting manifold still takes
+    /// point-space coordinates and occupies `size × size` points.
     #[must_use]
-    pub fn new<L, Q>(glyph: &Glyph<L, Q>, size: usize) -> Self
+    pub fn new<L, Q>(glyph: &Glyph<L, Q>, size: usize, density: f32) -> Self
     where
         Glyph<L, Q>: Manifold<Jet2x4, Output = Field>,
     {
+        assert!(
+            density.is_finite() && density > 0.0,
+            "invalid bake density: {density}"
+        );
         // Antialiased coverage: seed Jet2 screen-space derivatives so each
-        // edge crossing bakes as a ~1px gradient-normalized ramp.
+        // edge crossing bakes as a ~1-texel gradient-normalized ramp.
         let coverage = Antialiased::new(glyph);
 
-        // Tabulate at pixel centers: texel (i, j) = coverage(i+0.5, j+0.5).
+        // Tabulate at texel centers: texel (i, j) = coverage(i+0.5, j+0.5).
+        let px = px_extent(size, density);
         let lattice = Lattice {
-            extent: [size as u32, size as u32, 1, 1],
+            extent: [px as u32, px as u32, 1, 1],
             origin: [TEXEL_CENTER, TEXEL_CENTER, 0.0, 0.0],
         };
         let baked = lattice.collapse(&coverage);
@@ -135,6 +155,7 @@ impl CachedGlyph {
             sampler: Arc::new(Bilinear::new(baked)),
             width: size,
             height: size,
+            density,
         }
     }
 
@@ -165,20 +186,23 @@ impl Manifold<Field4> for CachedGlyph {
 
     #[inline(always)]
     fn eval(&self, p: Field4) -> Field {
-        // Contramap into the sampler's integer texel grid: texel (i, j)
-        // holds coverage at pixel center (i + 0.5, j + 0.5), so shift the
-        // query by -0.5 before bilinear interpolation.
+        // Contramap the point-space query into the sampler's texel grid:
+        // point p lands on baked pixel p·density, and texel (i, j) holds
+        // coverage at pixel center (i + 0.5, j + 0.5), so the composed
+        // embedding is p·density − 0.5. At integer densities this maps a
+        // density-matched sample grid exactly onto texel centers, so the
+        // bilinear read degenerates to lossless lookup.
         let sampled = At {
             inner: &*self.sampler,
-            x: X - TEXEL_CENTER,
-            y: Y - TEXEL_CENTER,
+            x: X * self.density - TEXEL_CENTER,
+            y: Y * self.density - TEXEL_CENTER,
             z: Z,
             w: W,
         };
-        // Bound to the baked extent: `DiscreteManifold` clamps out-of-range
-        // indices to the edge texel, which would smear nonzero boundary
-        // coverage (e.g. a descender reaching the em-box bottom) to infinity.
-        // Outside the bake there is no data — coverage is zero.
+        // Bound to the point-space extent: `DiscreteManifold` clamps
+        // out-of-range indices to the edge texel, which would smear nonzero
+        // boundary coverage (e.g. a descender reaching the em-box bottom) to
+        // infinity. Outside the bake there is no data — coverage is zero.
         let in_bounds = X.ge(0.0) & X.le(self.width as f32) & Y.ge(0.0) & Y.le(self.height as f32);
         Select {
             cond: in_bounds,
@@ -203,11 +227,29 @@ fn size_bucket(size: f32) -> usize {
     bucket.max(8)
 }
 
+/// Quantization granularity for density buckets: eighth-of-a-texel steps.
+const DENSITY_STEPS: f32 = 8.0;
+
+/// Density bucket for cache keys.
+///
+/// Quantizes texels-per-point to eighth steps (1.0, 1.125, …, 2.0, …) so a
+/// bake and its key always agree, and a 16pt glyph on a 2x display never
+/// collides with a 32pt glyph on a 1x display — same texel count, different
+/// point-space geometry.
+fn density_bucket(density: f32) -> u16 {
+    assert!(
+        density.is_finite() && density > 0.0,
+        "invalid glyph density: {density}"
+    );
+    ((density * DENSITY_STEPS).round() as u16).max(1)
+}
+
 /// Key for cached glyphs.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 struct CacheKey {
     codepoint: u32,
     size_bucket: usize,
+    density_q: u16,
 }
 
 /// A cache of baked glyphs.
@@ -249,33 +291,39 @@ impl GlyphCache {
 
     /// Get or create a cached glyph.
     ///
-    /// If the glyph at this size bucket is already cached, returns it.
-    /// Otherwise, bakes the glyph and caches it.
-    pub fn get(&mut self, font: &Font, ch: char, size: f32) -> Option<CachedGlyph> {
+    /// If the glyph at this (size bucket, density bucket) is already cached,
+    /// returns it. Otherwise bakes the glyph at `size × density` texels and
+    /// caches it. `density` is texels per point (a display's backing scale);
+    /// the returned glyph takes point-space coordinates regardless.
+    pub fn get(&mut self, font: &Font, ch: char, size: f32, density: f32) -> Option<CachedGlyph> {
         let bucket = size_bucket(size);
+        let density_q = density_bucket(density);
         let key = CacheKey {
             codepoint: ch as u32,
             size_bucket: bucket,
+            density_q,
         };
 
         if let Some(cached) = self.entries.get(&key) {
             return Some(cached.clone());
         }
 
-        // Bake the glyph at the bucket size
-        let glyph = font.glyph_scaled(ch, bucket as f32)?;
-        let cached = CachedGlyph::new(&glyph, bucket);
+        // Bake at the quantized density so the key and the lattice agree.
+        let density = density_q as f32 / DENSITY_STEPS;
+        let px = px_extent(bucket, density);
+        let glyph = font.glyph_scaled(ch, px as f32)?;
+        let cached = CachedGlyph::new(&glyph, bucket, density);
         self.entries.insert(key, cached.clone());
         Some(cached)
     }
 
-    /// Check if a glyph is cached at this size.
+    /// Check if a glyph is cached at this size and density.
     #[must_use]
-    pub fn contains(&self, ch: char, size: f32) -> bool {
-        let bucket = size_bucket(size);
+    pub fn contains(&self, ch: char, size: f32, density: f32) -> bool {
         let key = CacheKey {
             codepoint: ch as u32,
-            size_bucket: bucket,
+            size_bucket: size_bucket(size),
+            density_q: density_bucket(density),
         };
         self.entries.contains_key(&key)
     }
@@ -283,15 +331,21 @@ impl GlyphCache {
     /// Pre-warm the cache with common characters.
     ///
     /// Call this at startup to avoid cache misses during rendering.
-    pub fn warm(&mut self, font: &Font, chars: impl IntoIterator<Item = char>, size: f32) {
+    pub fn warm(
+        &mut self,
+        font: &Font,
+        chars: impl IntoIterator<Item = char>,
+        size: f32,
+        density: f32,
+    ) {
         for ch in chars {
-            self.get(font, ch, size);
+            self.get(font, ch, size, density);
         }
     }
 
     /// Pre-warm with ASCII printable characters.
-    pub fn warm_ascii(&mut self, font: &Font, size: f32) {
-        self.warm(font, ' '..='~', size);
+    pub fn warm_ascii(&mut self, font: &Font, size: f32, density: f32) {
+        self.warm(font, ' '..='~', size, density);
     }
 
     /// Clear all cached entries.
@@ -316,7 +370,10 @@ impl GlyphCache {
     pub fn memory_usage(&self) -> usize {
         self.entries
             .values()
-            .map(|g| g.width * g.height * 4) // f32 per texel
+            .map(|g| {
+                let tex = g.coverage();
+                tex.width() * tex.height() * 4 // f32 per texel
+            })
             .sum()
     }
 }
@@ -340,9 +397,9 @@ impl Default for GlyphCache {
 ///
 /// ```ignore
 /// let mut cache = GlyphCache::new();
-/// cache.warm_ascii(&font, 16.0);
+/// cache.warm_ascii(&font, 16.0, 1.0);
 ///
-/// let text = CachedText::new(&font, &mut cache, "Hello", 16.0);
+/// let text = CachedText::new(&font, &mut cache, "Hello", 16.0, 1.0);
 /// execute(&Lift(text), buffer, shape);
 /// ```
 #[derive(Clone)]
@@ -354,8 +411,9 @@ pub struct CachedText {
 impl CachedText {
     /// Create cached text from a string.
     ///
-    /// Glyphs are retrieved from the cache (or baked on-demand).
-    pub fn new(font: &Font, cache: &mut GlyphCache, text: &str, size: f32) -> Self {
+    /// Glyphs are retrieved from the cache (or baked on-demand) at the given
+    /// sample density (texels per point); layout stays in point space.
+    pub fn new(font: &Font, cache: &mut GlyphCache, text: &str, size: f32, density: f32) -> Self {
         let mut glyphs = Vec::with_capacity(text.len());
         let mut cursor_x = 0.0f32;
         let mut prev_id = None;
@@ -376,7 +434,7 @@ impl CachedText {
             }
 
             // Get cached glyph
-            if let Some(cached) = cache.get(font, ch, size) {
+            if let Some(cached) = cache.get(font, ch, size, density) {
                 // Scale and translate to cursor position
                 // The cached glyph is at bucket size, so we need to scale it
                 let transform = [scale, 0.0, 0.0, scale, cursor_x, 0.0];
@@ -460,24 +518,24 @@ mod tests {
 
         // 9.0 and 12.0 both round up into the 12px bucket, so caching one
         // makes the cache report the other as already cached.
-        cache.get(&font, 'A', 9.0);
+        cache.get(&font, 'A', 9.0, 1.0);
         assert_eq!(cache.len(), 1);
         assert!(
-            cache.contains('A', 12.0),
+            cache.contains('A', 12.0, 1.0),
             "9.0 and 12.0 should share the 12px bucket"
         );
 
         // 13.0 rounds up to the next bucket (16px), so it must not collide
         // with the 12px bucket.
         assert!(
-            !cache.contains('A', 13.0),
+            !cache.contains('A', 13.0, 1.0),
             "13.0 should land in a different bucket than 12.0"
         );
 
         // Sizes at or below the minimum clamp to the 8px bucket.
-        cache.get(&font, 'B', 1.0);
+        cache.get(&font, 'B', 1.0, 1.0);
         assert!(
-            cache.contains('B', 8.0),
+            cache.contains('B', 8.0, 1.0),
             "sub-minimum sizes should clamp to the 8px bucket"
         );
     }
@@ -486,7 +544,7 @@ mod tests {
     fn cached_glyph_creation() {
         let font = Font::parse(FONT_DATA).unwrap();
         let glyph = font.glyph_scaled('A', 32.0).unwrap();
-        let cached = CachedGlyph::new(&glyph, 32);
+        let cached = CachedGlyph::new(&glyph, 32, 1.0);
 
         assert_eq!(cached.width(), 32);
         assert_eq!(cached.height(), 32);
@@ -496,7 +554,7 @@ mod tests {
     fn baked_coverage_dimensions_range_and_ink() {
         let font = Font::parse(FONT_DATA).unwrap();
         let glyph = font.glyph_scaled('A', 32.0).unwrap();
-        let cached = CachedGlyph::new(&glyph, 32);
+        let cached = CachedGlyph::new(&glyph, 32, 1.0);
 
         let coverage = cached.coverage();
         assert_eq!(coverage.width(), 32);
@@ -528,7 +586,7 @@ mod tests {
         let font = Font::parse(FONT_DATA).unwrap();
         let glyph = font.glyph_scaled('A', 32.0).unwrap();
         let smooth = Antialiased::new(&glyph);
-        let cached = CachedGlyph::new(&glyph, 32);
+        let cached = CachedGlyph::new(&glyph, 32, 1.0);
 
         for &(i, j) in &[(4usize, 4usize), (10, 16), (16, 8), (16, 20), (24, 28)] {
             let (x, y) = (i as f32 + 0.5, j as f32 + 0.5);
@@ -563,7 +621,7 @@ mod tests {
 
         // Cached glyph sampled at pixel centers through the full
         // bake -> bilinear -> half-pixel-shift chain.
-        let cached = CachedGlyph::new(&glyph, size);
+        let cached = CachedGlyph::new(&glyph, size, 1.0);
         let resampled = Lattice {
             extent: [size as u32, size as u32, 1, 1],
             origin: [0.5, 0.5, 0.0, 0.0],
@@ -584,7 +642,7 @@ mod tests {
         // ~0.25 (texels are in [0,1]); nearest-neighbor jumps by up to 1.0.
         let font = Font::parse(FONT_DATA).unwrap();
         let glyph = font.glyph_scaled('A', 32.0).unwrap();
-        let cached = CachedGlyph::new(&glyph, 32);
+        let cached = CachedGlyph::new(&glyph, 32, 1.0);
 
         let step = 0.25;
         for &y in &[8.5f32, 16.5, 24.5] {
@@ -609,17 +667,17 @@ mod tests {
         let mut cache = GlyphCache::new();
 
         // First access should cache
-        let cached = cache.get(&font, 'A', 16.0);
+        let cached = cache.get(&font, 'A', 16.0, 1.0);
         assert!(cached.is_some());
         assert_eq!(cache.len(), 1);
 
         // Second access should hit cache
-        let cached2 = cache.get(&font, 'A', 16.0);
+        let cached2 = cache.get(&font, 'A', 16.0, 1.0);
         assert!(cached2.is_some());
         assert_eq!(cache.len(), 1);
 
         // Different size should create new entry
-        let cached3 = cache.get(&font, 'A', 32.0);
+        let cached3 = cache.get(&font, 'A', 32.0, 1.0);
         assert!(cached3.is_some());
         assert_eq!(cache.len(), 2);
     }
@@ -629,15 +687,15 @@ mod tests {
         let font = Font::parse(FONT_DATA).unwrap();
         let mut cache = GlyphCache::new();
 
-        cache.warm_ascii(&font, 16.0);
+        cache.warm_ascii(&font, 16.0, 1.0);
 
         // ASCII printable is 95 characters
         assert_eq!(cache.len(), 95);
 
         // All should be cached now
-        assert!(cache.contains('A', 16.0));
-        assert!(cache.contains('z', 16.0));
-        assert!(cache.contains(' ', 16.0));
+        assert!(cache.contains('A', 16.0, 1.0));
+        assert!(cache.contains('z', 16.0, 1.0));
+        assert!(cache.contains(' ', 16.0, 1.0));
     }
 
     #[test]
@@ -646,7 +704,7 @@ mod tests {
 
         let font = Font::parse(FONT_DATA).unwrap();
         let glyph = font.glyph_scaled('A', 32.0).unwrap();
-        let cached = CachedGlyph::new(&glyph, 32);
+        let cached = CachedGlyph::new(&glyph, 32, 1.0);
 
         // Evaluate coverage at multiple coordinates - should not panic
         for x in [2.0, 8.0, 16.0, 24.0] {
@@ -668,7 +726,7 @@ mod tests {
         let font = Font::parse(FONT_DATA).unwrap();
         let mut cache = GlyphCache::new();
 
-        let text = CachedText::new(&font, &mut cache, "Hello", 16.0);
+        let text = CachedText::new(&font, &mut cache, "Hello", 16.0, 1.0);
 
         // Should have cached glyphs for H, e, l, o (l appears twice)
         assert_eq!(cache.len(), 4);
@@ -691,9 +749,101 @@ mod tests {
         let font = Font::parse(FONT_DATA).unwrap();
         let mut cache = GlyphCache::new();
 
-        cache.get(&font, 'A', 16.0); // 16x16 = 256 texels * 4 bytes = 1024
-        cache.get(&font, 'B', 16.0); // Another 1024
+        cache.get(&font, 'A', 16.0, 1.0); // 16x16 = 256 texels * 4 bytes = 1024
+        cache.get(&font, 'B', 16.0, 1.0); // Another 1024
 
         assert_eq!(cache.memory_usage(), 2048);
+    }
+
+    #[test]
+    fn density_preserves_point_geometry() {
+        // A denser bake must not change where the glyph lives in point space:
+        // same reported extent, same out-of-bounds masking, and roughly the
+        // same coverage at matching point coordinates.
+        let font = Font::parse(FONT_DATA).unwrap();
+        let mut cache = GlyphCache::new();
+
+        let d1 = cache.get(&font, 'A', 16.0, 1.0).unwrap();
+        let d2 = cache.get(&font, 'A', 16.0, 2.0).unwrap();
+
+        assert_eq!(d1.width(), 16);
+        assert_eq!(d2.width(), 16, "density must not change point-space width");
+        assert_eq!(d2.height(), 16);
+        assert_eq!(d2.coverage().width(), 32, "density 2 must bake 2x texels");
+
+        // Outside the point-space extent both are transparent.
+        assert_eq!(sample(&d1, 17.0, 8.0), 0.0);
+        assert_eq!(sample(&d2, 17.0, 8.0), 0.0);
+
+        // Ink sits in the same place: centers of mass over the same
+        // point-space grid agree to well under a point.
+        let grid = |g: &CachedGlyph| {
+            Lattice {
+                extent: [16, 16, 1, 1],
+                origin: [0.5, 0.5, 0.0, 0.0],
+            }
+            .collapse(g)
+        };
+        let (x1, y1) = center_of_mass(grid(&d1).buffer(), 16);
+        let (x2, y2) = center_of_mass(grid(&d2).buffer(), 16);
+        assert!(
+            (x1 - x2).abs() < 0.25 && (y1 - y2).abs() < 0.25,
+            "density moved the glyph: d1 ({x1}, {y1}) vs d2 ({x2}, {y2})"
+        );
+    }
+
+    #[test]
+    fn density_two_resamples_sharper_edges() {
+        // The whole point of density: a 2x bake must re-sample the analytic
+        // outline, not upscale the 1x lattice. The AA crossing ramp is ~1
+        // texel wide, so in point space it is ~1 point at density 1 but only
+        // ~0.5 points at density 2 — scanning a stem edge at sub-point steps
+        // must find a strictly narrower transition zone.
+        let font = Font::parse(FONT_DATA).unwrap();
+        let mut cache = GlyphCache::new();
+        let d1 = cache.get(&font, 'l', 16.0, 1.0).unwrap();
+        let d2 = cache.get(&font, 'l', 16.0, 2.0).unwrap();
+
+        let transition_samples = |g: &CachedGlyph| {
+            let mut count = 0usize;
+            let mut x = 0.0f32;
+            while x <= 16.0 {
+                let v = sample(g, x, 8.0);
+                if v > 0.1 && v < 0.9 {
+                    count += 1;
+                }
+                x += 0.0625;
+            }
+            count
+        };
+
+        let t1 = transition_samples(&d1);
+        let t2 = transition_samples(&d2);
+        assert!(t1 > 0, "density-1 scan found no edge transition to compare");
+        assert!(
+            t2 < t1,
+            "density 2 did not sharpen edges: {t2} transition samples vs {t1} at density 1 \
+             (denser bake is interpolating, not re-sampling)"
+        );
+    }
+
+    #[test]
+    fn cache_key_distinguishes_density_from_size() {
+        // 16pt @ 2x and 32pt @ 1x bake the same texel count but are different
+        // glyphs (different point-space extent) — they must not collide.
+        let font = Font::parse(FONT_DATA).unwrap();
+        let mut cache = GlyphCache::new();
+
+        let hidpi = cache.get(&font, 'A', 16.0, 2.0).unwrap();
+        let large = cache.get(&font, 'A', 32.0, 1.0).unwrap();
+
+        assert_eq!(cache.len(), 2, "16pt@2x collided with 32pt@1x");
+        assert_eq!(hidpi.width(), 16);
+        assert_eq!(large.width(), 32);
+
+        // Densities quantize to eighth steps: 2.0 and 2.04 share a bucket,
+        // 2.0 and 2.1 do not.
+        assert!(cache.contains('A', 16.0, 2.04));
+        assert!(!cache.contains('A', 16.0, 2.1));
     }
 }

--- a/pixelflow-graphics/src/fonts/mod.rs
+++ b/pixelflow-graphics/src/fonts/mod.rs
@@ -86,9 +86,9 @@
 //!
 //! let font = Font::parse(font_data).unwrap();
 //! let mut cache = GlyphCache::new();
-//! cache.warm_ascii(&font, 16.0);
+//! cache.warm_ascii(&font, 16.0, 1.0);
 //!
-//! let text = CachedText::new(&font, &mut cache, "Hello, World!", 16.0);
+//! let text = CachedText::new(&font, &mut cache, "Hello, World!", 16.0, 1.0);
 //! ```
 //!
 //! Both produce **coverage** manifolds (`Output = Field`, values in

--- a/pixelflow-graphics/src/lib.rs
+++ b/pixelflow-graphics/src/lib.rs
@@ -102,7 +102,7 @@
 //! use pixelflow_graphics::GlyphCache;
 //!
 //! let mut cache = GlyphCache::new();
-//! let glyph = cache.get(&font, 'A', size)?;
+//! let glyph = cache.get(&font, 'A', size, 1.0)?;
 //! ```
 //!
 //! ### Text Layout and Rendering

--- a/pixelflow-ir/src/backend/emit/lowering.rs
+++ b/pixelflow-ir/src/backend/emit/lowering.rs
@@ -587,7 +587,7 @@ fn expand_log2(arena: &mut ExprArena, x: ExprId) -> ExprId {
     let c3 = arena.push_const(-1.666_805_8e-1);
     let c2 = arena.push_const(2.000_071_5e-1);
     let c1 = arena.push_const(-2.499_999_4e-1);
-    let c0 = arena.push_const(3.333_333_1e-1);
+    let c0 = arena.push_const(3.333_333e-1);
     let p = horner_step(arena, c8, t, c7);
     let p = horner_step(arena, p, t, c6);
     let p = horner_step(arena, p, t, c5);

--- a/pixelflow-runtime/src/engine_troupe.rs
+++ b/pixelflow-runtime/src/engine_troupe.rs
@@ -19,7 +19,7 @@ use actor_scheduler::{
     Actor, ActorHandle, ActorStatus, ActorTypes, HandlerError, HandlerResult, Message,
     SystemStatus, TroupeActor,
 };
-use pixelflow_core::{Discrete, Manifold};
+use pixelflow_core::{At, Discrete, Manifold, W, X, Y, Z};
 use pixelflow_graphics::render::rasterizer::{
     RasterizerActor, RasterizerHandle, RenderRequest, RenderResponse,
 };
@@ -429,6 +429,32 @@ impl EngineHandler {
             scale,
             stale: false,
         });
+
+        // The scene is authored in point space; the frame is the platform's
+        // sample lattice and may be denser (device pixels on HiDPI displays).
+        // The lattice embedding is the measured ratio points/pixels per axis —
+        // identity when the platform samples 1:1 (X11, non-Retina macOS).
+        // Contramapping here keeps the app scale-agnostic: platform = dimap.
+        assert!(
+            frame.width > 0 && frame.height > 0,
+            "cannot render into an empty frame ({}x{})",
+            frame.width,
+            frame.height
+        );
+        let point_per_px_x = width_px as f32 / frame.width as f32;
+        let point_per_px_y = height_px as f32 / frame.height as f32;
+        let manifold: Arc<dyn Manifold<Output = Discrete> + Send + Sync> =
+            if point_per_px_x == 1.0 && point_per_px_y == 1.0 {
+                manifold
+            } else {
+                Arc::new(At {
+                    inner: manifold,
+                    x: X * point_per_px_x,
+                    y: Y * point_per_px_y,
+                    z: Z,
+                    w: W,
+                })
+            };
 
         // Build render request (no response_tx - rasterizer uses registered channel)
         let request = RenderRequest { manifold, frame };

--- a/pixelflow-runtime/src/platform/macos/platform.rs
+++ b/pixelflow-runtime/src/platform/macos/platform.rs
@@ -139,6 +139,9 @@ impl PlatformOps for MetalOps {
                         let width = win.current_width;
                         let height = win.current_height;
                         let scale = win.scale_factor();
+                        // Frame is device-pixel sized (the sample lattice);
+                        // width_px/height_px stay in points for layout/input.
+                        let (px_w, px_h) = win.pixel_size();
 
                         // Generate window ID from pointer (like Linux does)
                         let id = WindowId(ptr as u64);
@@ -149,7 +152,7 @@ impl PlatformOps for MetalOps {
                         // Create Window with initial frame buffer
                         let window = Window {
                             id,
-                            frame: Frame::<PlatformPixel>::new(width, height),
+                            frame: Frame::<PlatformPixel>::new(px_w, px_h),
                             width_px: width,
                             height_px: height,
                             scale,
@@ -212,9 +215,11 @@ impl PlatformOps for MetalOps {
             for (id, mac_window) in self.windows.iter_mut() {
                 if let Some((width, height)) = mac_window.poll_resize() {
                     // Create new Window with resized frame buffer
+                    // (device pixels; width_px/height_px are points)
+                    let (px_w, px_h) = mac_window.pixel_size();
                     let window = Window {
                         id: *id,
-                        frame: Frame::<PlatformPixel>::new(width, height),
+                        frame: Frame::<PlatformPixel>::new(px_w, px_h),
                         width_px: width,
                         height_px: height,
                         scale: mac_window.scale_factor(),
@@ -311,12 +316,35 @@ impl PlatformOps for MetalOps {
             // Report backing-scale changes (window dragged to a display with
             // different DPI). Drained after closes: a window that closed this
             // pass is already out of window_map, so its scale event is dropped.
+            //
+            // A scale change keeps the point-space bounds but changes the
+            // sample lattice, so the circulating frame has the wrong pixel
+            // density. Emit Resized with a fresh pixel-sized frame (the engine
+            // marks any in-flight render stale and swaps buffers), then
+            // ScaleChanged so the app can re-bake density-keyed resources.
             for (ptr, scale) in crate::platform::macos::window::drain_scale_changes() {
-                if let Some(id) = self.window_map.get(&ptr) {
+                if let Some(id) = self.window_map.get(&ptr).copied() {
+                    let win = self
+                        .windows
+                        .get(&id)
+                        .expect("window_map entry without a matching window");
+                    let (px_w, px_h) = win.pixel_size();
+                    let window = Window {
+                        id,
+                        frame: Frame::<PlatformPixel>::new(px_w, px_h),
+                        width_px: win.current_width,
+                        height_px: win.current_height,
+                        scale,
+                    };
                     processed_any = true;
                     self.event_tx
                         .send(Message::Data(EngineData::FromDriver(
-                            DisplayEvent::ScaleChanged { id: *id, scale },
+                            DisplayEvent::Resized { window },
+                        )))
+                        .expect("Failed to send Resized (scale change) to engine");
+                    self.event_tx
+                        .send(Message::Data(EngineData::FromDriver(
+                            DisplayEvent::ScaleChanged { id, scale },
                         )))
                         .expect("Failed to send ScaleChanged to engine");
                 }

--- a/pixelflow-runtime/src/platform/macos/platform.rs
+++ b/pixelflow-runtime/src/platform/macos/platform.rs
@@ -308,6 +308,20 @@ impl PlatformOps for MetalOps {
                 }
             }
 
+            // Report backing-scale changes (window dragged to a display with
+            // different DPI). Drained after closes: a window that closed this
+            // pass is already out of window_map, so its scale event is dropped.
+            for (ptr, scale) in crate::platform::macos::window::drain_scale_changes() {
+                if let Some(id) = self.window_map.get(&ptr) {
+                    processed_any = true;
+                    self.event_tx
+                        .send(Message::Data(EngineData::FromDriver(
+                            DisplayEvent::ScaleChanged { id: *id, scale },
+                        )))
+                        .expect("Failed to send ScaleChanged to engine");
+                }
+            }
+
             // Busy after real work so the scheduler re-drains its lanes before
             // blocking on the doorbell (a dequeued wake event usually means
             // messages are waiting).

--- a/pixelflow-runtime/src/platform/macos/platform.rs
+++ b/pixelflow-runtime/src/platform/macos/platform.rs
@@ -291,6 +291,23 @@ impl PlatformOps for MetalOps {
             // Release mode string
             sys::send::<()>(mode, sys::sel(b"release\0"));
 
+            // Report windows the user closed during event routing (the click
+            // on the close button runs windowWillClose: synchronously inside
+            // sendEvent: above). CloseRequested triggers the engine's full
+            // shutdown cascade — without this the process outlives its last
+            // window as an invisible zombie.
+            for ptr in crate::platform::macos::window::drain_closed_windows() {
+                if let Some(id) = self.window_map.remove(&ptr) {
+                    self.windows.remove(&id);
+                    processed_any = true;
+                    self.event_tx
+                        .send(Message::Data(EngineData::FromDriver(
+                            DisplayEvent::CloseRequested { id },
+                        )))
+                        .expect("Failed to send CloseRequested to engine");
+                }
+            }
+
             // Busy after real work so the scheduler re-drains its lanes before
             // blocking on the doorbell (a dequeued wake event usually means
             // messages are waiting).

--- a/pixelflow-runtime/src/platform/macos/sys.rs
+++ b/pixelflow-runtime/src/platform/macos/sys.rs
@@ -85,6 +85,10 @@ extern "C" {
     pub fn objc_getClass(name: *const u8) -> Class;
     pub fn sel_registerName(name: *const u8) -> Sel;
     pub fn objc_msgSend(self_: Id, op: Sel, ...) -> Id;
+    pub fn objc_allocateClassPair(superclass: Class, name: *const u8, extra_bytes: usize)
+        -> Class;
+    pub fn objc_registerClassPair(cls: Class);
+    pub fn class_addMethod(cls: Class, name: Sel, imp: *const c_void, types: *const u8) -> BOOL;
 }
 
 // --- Inline Helpers ---

--- a/pixelflow-runtime/src/platform/macos/window.rs
+++ b/pixelflow-runtime/src/platform/macos/window.rs
@@ -1,13 +1,66 @@
 use crate::api::public::WindowDescriptor;
 use crate::error::RuntimeError;
 use crate::platform::macos::cocoa::{NSPoint, NSRect, NSSize, NSView, NSWindow};
-use crate::platform::macos::sys::{self, Id, BOOL, YES};
+use crate::platform::macos::sys::{self, Id, BOOL, NO, YES};
 use std::ffi::c_void;
+use std::sync::{Mutex, OnceLock};
+
+/// NSWindow pointers whose delegate received `windowWillClose:` and which the
+/// platform pump has not yet reported to the engine. AppKit invokes the
+/// delegate synchronously on the main thread while the pump routes the click
+/// through `sendEvent:`; the pump drains this queue at the end of the same
+/// park pass and emits `DisplayEvent::CloseRequested`.
+static CLOSED_WINDOWS: Mutex<Vec<usize>> = Mutex::new(Vec::new());
+
+/// Take all windows closed since the last drain.
+pub(crate) fn drain_closed_windows() -> Vec<usize> {
+    std::mem::take(
+        &mut *CLOSED_WINDOWS
+            .lock()
+            .expect("closed-window queue poisoned"),
+    )
+}
+
+extern "C" fn window_will_close(_this: sys::Id, _cmd: sys::Sel, notification: sys::Id) {
+    unsafe {
+        let window: sys::Id = sys::send(notification, sys::sel(b"object\0"));
+        CLOSED_WINDOWS
+            .lock()
+            .expect("closed-window queue poisoned")
+            .push(window as usize);
+    }
+}
+
+/// The Objective-C delegate class, registered once per process.
+fn delegate_class() -> sys::Class {
+    static CLASS: OnceLock<usize> = OnceLock::new();
+    *CLASS.get_or_init(|| unsafe {
+        let superclass = sys::class(b"NSObject\0");
+        let cls = sys::objc_allocateClassPair(superclass, b"PixelflowWindowDelegate\0".as_ptr(), 0);
+        assert!(
+            !cls.is_null(),
+            "failed to allocate PixelflowWindowDelegate class"
+        );
+        let added = sys::class_addMethod(
+            cls,
+            sys::sel(b"windowWillClose:\0"),
+            window_will_close as *const c_void,
+            // v@:@ — returns void, takes (self, _cmd, notification)
+            b"v@:@\0".as_ptr(),
+        );
+        assert!(added == YES, "failed to add windowWillClose: method");
+        sys::objc_registerClassPair(cls);
+        cls as usize
+    }) as sys::Class
+}
 
 pub struct MacWindow {
     pub(crate) window: NSWindow,
     pub(crate) view: NSView,
     pub(crate) layer: Id, // CAMetalLayer
+    /// Retained delegate instance; NSWindow's `delegate` property is weak.
+    #[allow(dead_code)]
+    delegate: Id,
     pub(crate) current_width: u32,
     pub(crate) current_height: u32,
 }
@@ -26,6 +79,22 @@ impl MacWindow {
 
         let window = NSWindow::alloc().init_with_content_rect(rect, style_mask, backing, false);
         window.set_title(&desc.title);
+
+        // We keep messaging this pointer (poll_resize, present) until the pump
+        // reports the close to the engine, so the window must outlive `close`.
+        // AppKit's default for titled windows is releasedWhenClosed = YES.
+        let delegate = unsafe {
+            sys::send_1::<(), BOOL>(window.0, sys::sel(b"setReleasedWhenClosed:\0"), NO);
+
+            let cls = delegate_class();
+            let instance: Id = sys::send(sys::send(cls, sys::sel(b"alloc\0")), sys::sel(b"init\0"));
+            assert!(
+                !instance.is_null(),
+                "failed to instantiate PixelflowWindowDelegate"
+            );
+            sys::send_1::<(), Id>(window.0, sys::sel(b"setDelegate:\0"), instance);
+            instance
+        };
 
         let view = NSView::alloc().init_with_frame(rect);
 
@@ -75,6 +144,7 @@ impl MacWindow {
             window,
             view,
             layer,
+            delegate,
             current_width: desc.width,
             current_height: desc.height,
         })

--- a/pixelflow-runtime/src/platform/macos/window.rs
+++ b/pixelflow-runtime/src/platform/macos/window.rs
@@ -218,6 +218,20 @@ impl MacWindow {
         }
     }
 
+    /// Frame-buffer size in device pixels: content bounds (points) × backing
+    /// scale. This is the sample lattice the scene is rasterized onto; the
+    /// `Window`'s `width_px`/`height_px` stay in points for layout and input.
+    pub fn pixel_size(&self) -> (u32, u32) {
+        let scale = self.scale_factor();
+        assert!(
+            scale.is_finite() && scale > 0.0,
+            "invalid backingScaleFactor: {scale}"
+        );
+        let w = (self.current_width as f64 * scale).round() as u32;
+        let h = (self.current_height as f64 * scale).round() as u32;
+        (w, h)
+    }
+
     pub fn set_cursor(&mut self, icon: crate::api::public::CursorIcon) {
         use crate::api::public::CursorIcon;
         unsafe {

--- a/pixelflow-runtime/src/platform/macos/window.rs
+++ b/pixelflow-runtime/src/platform/macos/window.rs
@@ -21,6 +21,20 @@ pub(crate) fn drain_closed_windows() -> Vec<usize> {
     )
 }
 
+/// (NSWindow pointer, new backingScaleFactor) pairs reported by
+/// `windowDidChangeBackingProperties:` and not yet drained by the pump.
+/// Fires when a window moves between displays with different DPI.
+static SCALE_CHANGES: Mutex<Vec<(usize, f64)>> = Mutex::new(Vec::new());
+
+/// Take all backing-scale changes since the last drain.
+pub(crate) fn drain_scale_changes() -> Vec<(usize, f64)> {
+    std::mem::take(
+        &mut *SCALE_CHANGES
+            .lock()
+            .expect("scale-change queue poisoned"),
+    )
+}
+
 extern "C" fn window_will_close(_this: sys::Id, _cmd: sys::Sel, notification: sys::Id) {
     unsafe {
         let window: sys::Id = sys::send(notification, sys::sel(b"object\0"));
@@ -28,6 +42,21 @@ extern "C" fn window_will_close(_this: sys::Id, _cmd: sys::Sel, notification: sy
             .lock()
             .expect("closed-window queue poisoned")
             .push(window as usize);
+    }
+}
+
+extern "C" fn window_did_change_backing_properties(
+    _this: sys::Id,
+    _cmd: sys::Sel,
+    notification: sys::Id,
+) {
+    unsafe {
+        let window: sys::Id = sys::send(notification, sys::sel(b"object\0"));
+        let scale: f64 = sys::send(window, sys::sel(b"backingScaleFactor\0"));
+        SCALE_CHANGES
+            .lock()
+            .expect("scale-change queue poisoned")
+            .push((window as usize, scale));
     }
 }
 
@@ -49,6 +78,16 @@ fn delegate_class() -> sys::Class {
             b"v@:@\0".as_ptr(),
         );
         assert!(added == YES, "failed to add windowWillClose: method");
+        let added = sys::class_addMethod(
+            cls,
+            sys::sel(b"windowDidChangeBackingProperties:\0"),
+            window_did_change_backing_properties as *const c_void,
+            b"v@:@\0".as_ptr(),
+        );
+        assert!(
+            added == YES,
+            "failed to add windowDidChangeBackingProperties: method"
+        );
         sys::objc_registerClassPair(cls);
         cls as usize
     }) as sys::Class


### PR DESCRIPTION
## What

Two related macOS fixes and one architectural feature, developed in one session:

1. **App now exits when the last window closes** (71b08ff7). Nothing translated an NSWindow close into `DisplayEvent::CloseRequested`, so closing the window left a windowless zombie process — and relaunching the .app appeared to do nothing because LaunchServices just activated the zombie (the "app won't open" bug). A runtime-registered `NSWindowDelegate` (`PixelflowWindowDelegate`) now records `windowWillClose:` into a queue the platform pump drains, emitting `CloseRequested` into the engine's existing shutdown cascade. Also fixes a latent use-after-free: windows now set `releasedWhenClosed:NO` since `poll_resize`/`present` keep messaging the pointer after close.

2. **Backing-scale changes are wired end to end** (bbf0c1bf). `DisplayEvent::ScaleChanged` existed but no driver emitted it, and the app handler was `unimplemented!()` (an abort waiting to fire). The delegate now implements `windowDidChangeBackingProperties:`; the pump reallocates the circulating frame (synthetic `Resized`) and notifies the app.

3. **Native-DPI rendering** (08412f91). Frames are now allocated at device-pixel resolution (`contentView bounds × backingScaleFactor`) while the scene stays entirely in point space:
   - The engine contramaps the scene manifold by the **measured** points/pixels ratio per axis (`At { X·r, Y·r }`) before rasterization. Deliberately not `Window.scale`: X11 carries `Xft.dpi/96` with 1:1 frames, so scale semantics differ per platform; the measured ratio is identity on X11 automatically.
   - `Window.width_px`/`height_px` intentionally stay in points — emulator grid math and mouse hit-testing depend on it; only `frame` is pixel-sized.
   - The glyph cache is density-keyed (eighth-step quantization): bakes tabulate the analytic outline at `size × density` texels, and `CachedGlyph::eval` maps point `p → p·density − 0.5`, which is texel-exact at integer densities (lossless lookup). `get`/`warm`/`warm_ascii`/`CachedText::new` take an explicit density; 16pt@2x cannot collide with 32pt@1x.

## Why

Retina rendering previously drew at 1x and let Metal bilinearly upscale — visibly blurry text. The conceptual framing (platform = profunctor: contravariant lattice embedding in, covariant present out; scene never learns about DPI) kept the app-side diff minimal: core-term only threads an opaque density hint to the glyph cache.

## Verification

- Real Cocoa, 2x display: rasterizer logs went from `800x384` to `1600x768` frames for the same window; before/after window captures show visibly crisper glyphs at identical physical size.
- Launch → close cycle exits the process cleanly (verified with synthetic clicks); the bundled app (`cargo bundle-run`) opens and quits correctly.
- New tests prove the density-2 bake **re-samples the analytic outline** (strictly sharper edge ramp than density-1, i.e. not interpolation), preserves point-space geometry, and keys separately from size.
- At density 1.0 behavior is unchanged; `cargo test --workspace` passes.

## Reviewer notes

- Delegate callbacks are context-free `extern "C"` fns; they communicate with the pump via module-private static `Mutex<Vec<_>>` queues. NSApp is process-global and there is exactly one pump, so this is sound, but the purer alternative is a context ivar on the delegate instance.
- `Window.width_px` being points is a pre-existing misnomer this PR leans into rather than fixes; renaming is a follow-up.
- Also includes a CLAUDE.md fix: the bundling alias is `cargo bundle-run`, not `cargo xtask bundle-run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)