### PR TITLE
Fix 41.67x under-scaling in bench timers (mach_absolute_time timebase)

### DIFF
--- a/docs/NNUE_TRAINING_RECIPE.md
+++ b/docs/NNUE_TRAINING_RECIPE.md
@@ -175,7 +175,12 @@ Training happens in a separate loop at the trajectory level, not in the per-step
 ### Benchmark Methodology
 - `eval100!` macro: 100 function calls fully unrolled, zero loop counter overhead
 - 20 timed samples, take median
-- `mach_absolute_time()` on macOS (1ns resolution on Apple Silicon)
+- `mach_absolute_time()` on macOS — **correction (2026-07-20): NOT 1:1 with
+  nanoseconds on native Apple Silicon.** The timebase is 125/3 (1 tick =
+  41.67ns; 1:1 only held on Intel Macs / under Rosetta). The shared harness
+  timer (`pixelflow-pipeline/src/jit_bench.rs::nanos_now`) now converts via
+  `mach_timebase_info`. Every absolute-ns figure below that predates this fix
+  is under-scaled 41.67x; see docs/results/2026-07-20-jit-compile-cost.md.
 - `benchmark_jit` divides by INNER_ITERS to return per-eval nanoseconds
 
 The loop counter bias (~0.3ns/iter) was corrupting the additive cost model — small expressions appeared proportionally more expensive. Full unrolling eliminates this.
@@ -187,6 +192,12 @@ Causal Decision Transformer with 3 layers, 4 attention heads, 128-dim. The `/ste
 Op weights match ShaderToy shader analysis: 36% mul, 18% add, 14% sub, 6% div, with moderate abs/sin/cos/clamp and rare exotic ops. Default depth 8, leaf probability 0.2.
 
 ## Results
+
+> **⚠ Correction (2026-07-20)**: the absolute ns figures below predate the
+> `nanos_now` timebase fix and are under-scaled 41.67x on native Apple
+> Silicon (e.g. "0.420ns/eval" was really ~17.5ns/eval). Ratios (speedups,
+> cross-channel CSE factor) are unaffected. See
+> docs/results/2026-07-20-jit-compile-cost.md.
 
 - **Synthetic expressions**: 95%+ achieve >1x speedup, median 1.05x
 - **Psychedelic shader (3-channel)**:

--- a/docs/results/2026-07-08-extraction-3way.md
+++ b/docs/results/2026-07-08-extraction-3way.md
@@ -1,5 +1,17 @@
 # Extraction 3-way bench: NNUE vs static latency prior vs no-swap (2026-07-08)
 
+> **⚠ Correction (2026-07-20): absolute ns columns under-scaled 41.67x.**
+> The harness timer (`pixelflow-pipeline/src/jit_bench.rs::nanos_now`) reported
+> raw `mach_absolute_time()` ticks as nanoseconds, but on native Apple Silicon
+> the timebase is 125/3 (one tick = 41.67ns; 1:1 holds only on Intel Macs and
+> under Rosetta). Every **`ns NNUE` / `ns static` / `ns no-swap`** figure below
+> is therefore 41.67x smaller than the true wall-clock time (e.g. swirl's
+> "0.290ns" is really ~12.1ns). Because the scale factor is uniform, **all
+> ratios, geomeans, orderings, and the Phase 2 gate verdict are unaffected**.
+> The `extract μs` columns were measured with `std::time::Instant` and were
+> always correct. See docs/results/2026-07-20-jit-compile-cost.md, "Timer
+> correction" section, for the fix and empirical verification.
+
 Phase 2 gate of `docs/plans/2026-07-07-guided-saturation-redesign.md` — the
 deferred February 3-way experiment (HCE vs Judge vs Guided), redone with the
 freshly retrained Judge and no HCE (deleted in the April squash; NNUE vs the
@@ -10,7 +22,9 @@ Reproduce: `cargo run --release -p pixelflow-pipeline --features training --bin 
 ## Setup
 
 - **Machine**: Apple M2 Max (Apple Silicon MacBook), aarch64, NEON JIT ABI.
-  `mach_absolute_time()` timing (1 tick = 1 ns on this hardware).
+  `mach_absolute_time()` timing (1 tick = 1 ns on this hardware). *[Correction
+  2026-07-20: this assumption was wrong — the timebase on this machine is
+  125/3, so 1 tick = 41.67ns. See the correction note at the top.]*
 - **Judge weights**: `pixelflow-pipeline/data/expr_nnue_trid.bin` (138,120
   bytes, TRID format), loaded via `ExprNnue::from_bytes` — the same loader
   verified by `pixelflow-pipeline/tests/judge_weights_load.rs`.

--- a/pixelflow-pipeline/src/jit_bench.rs
+++ b/pixelflow-pipeline/src/jit_bench.rs
@@ -165,14 +165,36 @@ impl fmt::Display for BenchError {
 // Platform-specific high-resolution timing.
 
 #[cfg(target_os = "macos")]
+#[repr(C)]
+struct MachTimebaseInfo {
+    numer: u32,
+    denom: u32,
+}
+
+#[cfg(target_os = "macos")]
 unsafe extern "C" {
     fn mach_absolute_time() -> u64;
+    fn mach_timebase_info(info: *mut MachTimebaseInfo) -> libc::c_int;
 }
 
 #[cfg(target_os = "macos")]
 fn nanos_now() -> u64 {
-    // On Apple Silicon, mach_absolute_time() ticks == nanoseconds (timebase 1:1).
-    unsafe { mach_absolute_time() }
+    // mach_absolute_time() ticks are NOT nanoseconds on native Apple Silicon:
+    // the timebase is 125/3 (one tick = 41.67ns; 1:1 only holds on Intel Macs
+    // and under Rosetta). Convert via mach_timebase_info, queried once.
+    // Verified empirically 2026-07-20: a 100ms sleep measured 2.47M raw ticks.
+    static TIMEBASE: std::sync::OnceLock<(u32, u32)> = std::sync::OnceLock::new();
+    let (numer, denom) = *TIMEBASE.get_or_init(|| {
+        let mut info = MachTimebaseInfo { numer: 0, denom: 0 };
+        let rc = unsafe { mach_timebase_info(&mut info) };
+        assert_eq!(rc, 0, "mach_timebase_info failed with {}", rc);
+        assert_ne!(info.denom, 0, "mach_timebase_info returned denom=0");
+        (info.numer, info.denom)
+    });
+    let ticks = unsafe { mach_absolute_time() };
+    // u128 intermediate: ticks * numer overflows u64 after ~50 days of uptime
+    // at timebase 125/3.
+    ((ticks as u128 * numer as u128) / denom as u128) as u64
 }
 
 #[cfg(target_os = "linux")]

--- a/pixelflow-runtime/examples/bench_psychedelic.rs
+++ b/pixelflow-runtime/examples/bench_psychedelic.rs
@@ -6,14 +6,37 @@ use pixelflow_compiler::{kernel, kernel_jit, kernel_raw};
 use pixelflow_core::{Field, Manifold, PARALLELISM};
 
 #[cfg(target_os = "macos")]
+#[repr(C)]
+struct MachTimebaseInfo {
+    numer: u32,
+    denom: u32,
+}
+
+#[cfg(target_os = "macos")]
 unsafe extern "C" {
     fn mach_absolute_time() -> u64;
+    fn mach_timebase_info(info: *mut MachTimebaseInfo) -> i32;
 }
 
 fn nanos_now() -> u64 {
     #[cfg(target_os = "macos")]
-    unsafe {
-        mach_absolute_time()
+    {
+        // mach_absolute_time() ticks are NOT nanoseconds on native Apple
+        // Silicon: the timebase is 125/3 (one tick = 41.67ns; 1:1 only holds
+        // on Intel Macs and under Rosetta). Convert via mach_timebase_info,
+        // queried once. See pixelflow-pipeline/src/jit_bench.rs::nanos_now
+        // and docs/results/2026-07-20-jit-compile-cost.md for the same fix
+        // applied to the shared JIT bench harness.
+        static TIMEBASE: std::sync::OnceLock<(u32, u32)> = std::sync::OnceLock::new();
+        let (numer, denom) = *TIMEBASE.get_or_init(|| {
+            let mut info = MachTimebaseInfo { numer: 0, denom: 0 };
+            let rc = unsafe { mach_timebase_info(&mut info) };
+            assert_eq!(rc, 0, "mach_timebase_info failed with {}", rc);
+            assert_ne!(info.denom, 0, "mach_timebase_info returned denom=0");
+            (info.numer, info.denom)
+        });
+        let ticks = unsafe { mach_absolute_time() };
+        ((ticks as u128 * numer as u128) / denom as u128) as u64
     }
     #[cfg(not(target_os = "macos"))]
     {


### PR DESCRIPTION
## What changed

`nanos_now()` in the shared JIT bench harness ([pixelflow-pipeline/src/jit_bench.rs](../blob/claude/funny-mirzakhani-6f9fc1/pixelflow-pipeline/src/jit_bench.rs)) and the `bench_psychedelic` example returned raw `mach_absolute_time()` ticks as nanoseconds. That 1:1 assumption holds on Intel Macs and under Rosetta, but **not on native Apple Silicon**, where the timebase is 125/3 — one tick = 41.67ns. Both timers now convert via `mach_timebase_info` (queried once through a `OnceLock`, with a `u128` intermediate so `ticks * numer` can't overflow after ~50 days of uptime, and hard asserts on the syscall per the no-silent-failures rule).

Docs quoting pre-fix absolute numbers now carry correction banners:
- `docs/results/2026-07-08-extraction-3way.md` — the `ns NNUE / ns static / ns no-swap` columns are under-scaled 41.67x. **Ratios, geomeans, and the Phase 2 gate verdict (NNUE loses to the static latency prior) are unaffected** — the scale factor is uniform. The `extract μs` columns used `std::time::Instant` and were always correct.
- `docs/NNUE_TRAINING_RECIPE.md` — benchmark-methodology section corrected, results section annotated (e.g. "0.420ns/eval" was really ~17.5ns/eval).

## Why

Every nanosecond figure the harness produced on Apple Silicon — bench corpus labels, extraction-head training targets, recorded benchmark docs — was 41.67x smaller than reality. Verified empirically: `mach_timebase_info` returns `numer=125, denom=3`, and a 100ms sleep measures ~2.47M raw ticks.

## Downstream recalibration (done, artifacts gitignored)

- Regenerated the bench corpus (`gen_bench_corpus`, 360k expressions) and retrained the extraction head (`bootstrap_extraction_head`, 150k samples) with the corrected timer. Targets now in true ns (median ~48ns vs the ~1.15ns the old timer would have reported); converged to RMSE 0.14 in log-ns.
- Audited all other consumers: the corpus binary format stores no ns labels (expressions only), `CostModel::latency_prior()` is cycle-based, and no persisted episode/trajectory data predates the fix.

## Notes for reviewers

- The `nanos_now` hunk is byte-identical to the uncommitted fix in the primary checkout's working tree (from the 2026-07-20 jit-compile-cost session), so it will merge/rebase cleanly against that in-flight work. The correction banners reference `docs/results/2026-07-20-jit-compile-cost.md`, which lands with that work.
- `bench_scanline_jit.rs` also has a raw-tick timer but is pre-existing dead code — it doesn't compile on `main` (references `compile_arena_dag_scanline` / `ScanlineJitManifold`, which no longer exist). Being handled in a separate task rather than folded in here.
- Pre-existing, unrelated: `training::factored::tests::seed_42_t1_{initial,final}_jit_matches_scalar` fail identically with and without this change (scalar/JIT tolerance 0.0037 > 0.001 on an atan2/pow chain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)