### PR TITLE
Fix flaky pty test: openpty(3) is not thread-safe on macOS

### DIFF
--- a/core-term/src/io/pty.rs
+++ b/core-term/src/io/pty.rs
@@ -21,6 +21,20 @@ const POSIX_SPAWN_SETSID: libc::c_int = 0x0400;
 #[cfg(not(target_os = "macos"))]
 use libc::POSIX_SPAWN_SETSID;
 
+/// Upholds [`NixPty::spawn_with_config`]'s single-threaded contract inside
+/// the test binary, where libtest runs the crate's PTY-spawning tests as
+/// parallel threads.
+///
+/// Test-only on purpose. Production honours the contract structurally —
+/// one PTY, spawned on the main thread — so shipping a lock for it would
+/// be machinery for a race that cannot occur. Every in-crate spawn site
+/// (`io::pty_tests`, `io::event_monitor_actor`, `terminal_app`) funnels
+/// through `spawn_with_config`, so gating it here covers them all; no
+/// integration test spawns a PTY, which is what makes `cfg(test)` a
+/// sufficient boundary.
+#[cfg(test)]
+static OPENPTY_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 /// Configuration for spawning a PTY.
 #[derive(Debug, Clone)]
 pub struct PtyConfig<'a> {
@@ -92,14 +106,34 @@ impl NixPty {
     ///   controlling terminal on both Linux and the BSDs
     /// - `dup2(0/1/2)` → file actions (`addopen` + `adddup2`)
     ///
+    /// # Threading
+    ///
+    /// **Call this from one thread.** It is not safe to call concurrently:
+    /// `openpty(3)` is not thread-safe on macOS, and racing calls fail
+    /// intermittently with a corrupted (negative) errno that surfaces as
+    /// `Errno::UnknownErrno` — 107 failures in 57,600 calls at 48 threads
+    /// on 12 cores, versus 0 when serialized. See
+    /// `docs/bugs/2026-07-21-openpty-not-thread-safe.md`.
+    ///
+    /// The terminal satisfies this structurally rather than by locking:
+    /// `main` spawns the single PTY before the troupe's threads exist and
+    /// hands it to `PtyTroupe::new`, which delivers it to the actors as a
+    /// `Bind` message. If a second PTY is ever needed (tabs, splits), give
+    /// spawning a single owner rather than making this function reentrant.
+    ///
     /// # Parameters
     /// * `config` - Configuration for the PTY and command.
     ///
     /// # Returns
     /// * A new `NixPty` instance in the parent process.
     pub fn spawn_with_config(config: &PtyConfig) -> Result<Self> {
-        let pty_results =
-            openpty(None, None).with_context(|| "Failed to open PTY (nix::pty::openpty call)")?;
+        let pty_results = {
+            #[cfg(test)]
+            let _guard = OPENPTY_TEST_LOCK.lock().expect(
+                "OPENPTY_TEST_LOCK poisoned: a prior openpty call panicked while holding it",
+            );
+            openpty(None, None).with_context(|| "Failed to open PTY (nix::pty::openpty call)")?
+        };
         let master_fd = pty_results.master;
         let slave_fd = pty_results.slave;
 

--- a/docs/bugs/2026-07-21-openpty-not-thread-safe.md
+++ b/docs/bugs/2026-07-21-openpty-not-thread-safe.md
@@ -1,0 +1,123 @@
+# `openpty(3)` is not thread-safe on macOS
+
+**Status:** fixed 2026-07-21 (single-threaded contract on
+`NixPty::spawn_with_config`, upheld in tests by `OPENPTY_TEST_LOCK` in
+`core-term/src/io/pty.rs`).
+**Impact:** intermittent PTY spawn failures in the **test suite** — a flaky
+`io::pty_tests::pty_child_gets_default_sigpipe` under `cargo test --workspace`.
+
+**Not a live production race.** Production opens exactly one PTY per run:
+`main.rs` calls `spawn_with_config` once, on the main thread, before the
+troupe's threads are spawned, then hands the `NixPty` to `PtyTroupe::new`
+and on to the actors via `Bind` messages. Every other call site is inside
+`#[cfg(test)]`. No multi-window/multi-PTY design exists. The hazard is real
+but only reachable from concurrent callers, which today means tests.
+
+Unrelated to [the fork/malloc deadlock](2026-07-15-pty-fork-malloc-deadlock.md),
+which was fixed by moving to `posix_spawn`. This is a second, independent PTY
+hazard in the same spawn path.
+
+## Symptom
+
+```
+thread 'io::pty_tests::pty_child_gets_default_sigpipe' panicked at
+core-term/src/io/pty_tests.rs:230:
+  Failed to spawn PTY: Failed to open PTY (nix::pty::openpty call)
+Caused by:
+    UnknownErrno: Unknown errno
+```
+
+Note *where* it fails: line 230 is the `spawn_with_config(...).expect(...)`,
+not the read-with-timeout on line 231. This is **not** a timeout — the test's
+5-second `READ_TIMEOUT` is never reached, and the SIGPIPE behaviour the test
+asserts is not implicated at all. `openpty` itself fails before a child is
+ever spawned.
+
+Reproduced under `cargo test --workspace` (1 failure in 15 runs); passes
+reliably alone or with `-p core-term --lib`, because the trigger is thread
+oversubscription across concurrently-running test binaries.
+
+## Measurement
+
+Standalone C harness, `openpty` in a loop across N threads on a 12-core
+machine, counting failures:
+
+| Mode | Threads | Runs | Total calls | Failures |
+|------|---------|------|-------------|----------|
+| unserialized | 8  | 3 | 9,600  | **0** |
+| unserialized | 48 | 3 | 57,600 | **107** |
+| serialized (mutex) | 48 | 3 | 57,600 | **0** |
+
+The race only appears once threads meaningfully oversubscribe the cores —
+which is exactly what `cargo test --workspace` does (many test binaries ×
+many threads each). At 8 threads on 12 cores it does not reproduce, which is
+why the flake looked load-dependent and mysterious.
+
+## Why the errno is `UnknownErrno`
+
+The failing calls report errno **-6** — a *negative* value, not a valid errno.
+`nix`'s `Errno::from_raw` has no arm for it and falls through to
+`_ => UnknownErrno`. So `UnknownErrno` here does **not** mean "errno was 0";
+it means libc handed back a corrupted value.
+
+This also rules out the plausible-but-wrong theories:
+
+- **Not pty exhaustion.** `kern.tty.ptmx_max` is 511; exhausting it fails
+  cleanly with `ENXIO` (6), a *valid* errno, and the machine had 5 ptys in use.
+- **Not fd exhaustion.** `ulimit -n` is 1048576.
+- **Not the fork/malloc deadlock.** That path is gone; spawn uses `posix_spawn`.
+- **Not a `posix_spawn` signal-attribute race.** `POSIX_SPAWN_SETSIGDEF` +
+  `POSIX_SPAWN_SETSIGMASK` are applied atomically per spawn, and the failure
+  happens before `posix_spawn` is reached.
+
+## Which internal call races is unconfirmed
+
+`ptsname(3)` is the obvious suspect — `man ptsname` states it "is not
+guaranteed to be reentrant or thread safe" (process-global static buffer),
+and BSD-derived `openpty` implementations call it internally, whereas glibc's
+was fixed to use `ptsname_r`.
+
+But that story does not fully fit: a corrupted replica pathname would make
+the subsequent `open()` fail with a *valid* errno (`ENOENT`/`ENXIO`), not -6.
+A negative errno looks more like an internal error-propagation path in
+libutil writing a negated return code. **The fix is justified by the
+measurement, not by the mechanism.**
+
+Note `nix::unistd::ttyname` (used later in `posix_spawn_child`) is *not* a
+second instance of this bug — it uses the reentrant `ttyname_r`.
+
+## Fix
+
+`spawn_with_config` documents a **single-threaded contract**, and production
+satisfies it structurally: one PTY, spawned on the main thread before the
+troupe's threads exist, handed to `PtyTroupe::new` and delivered to the
+actors as a `Bind` message. No production lock.
+
+The contract is upheld inside the test binary by a `#[cfg(test)]`
+`OPENPTY_TEST_LOCK`, because libtest runs the PTY-spawning tests as parallel
+threads. It is gated inside `spawn_with_config` rather than sprinkled across
+the tests: spawn sites live in four different test modules (`io::pty_tests`,
+`io::event_monitor_actor::{mod, writer}`, `terminal_app`), and a lock a new
+test can forget to take would let the flake back in silently. No integration
+test spawns a PTY, which is what makes `cfg(test)` a sufficient boundary — if
+one ever does, it falls outside this guard.
+
+Lock poisoning is `.expect()`-ed rather than recovered from: a panic inside
+that critical section means the PTY layer is in an unknown state, and per
+project policy it must fail loudly.
+
+Deliberately *not* done: widening the test's timeout or retrying the spawn.
+Both would have masked a genuine libc thread-safety bug behind a timing knob.
+
+### Considered and rejected
+
+- **A production `Mutex`.** Rejected: it is machinery for a race that cannot
+  occur today, and a `Mutex<()>` guarding no data enforces the invariant by
+  convention anyway.
+- **Owning PTY spawning in an actor** (the tidiest answer — an OS-level
+  operation with a single owner). Rejected for now as a layering problem:
+  the natural home is the engine, but `pixelflow-runtime` is deliberately
+  generic and a PTY is terminal-specific.
+
+If a second PTY is ever needed (tabs, splits), the fix is to give spawning a
+single owner — not to make `spawn_with_config` reentrant.


### PR DESCRIPTION
## What

`io::pty_tests::pty_child_gets_default_sigpipe` failed intermittently under `cargo test --workspace` while passing reliably when run alone. Root cause: **`openpty(3)` is not thread-safe on macOS**. It is not a timeout and not a SIGPIPE bug.

The tell is *where* it panics — [pty_tests.rs:230](../blob/claude/intelligent-benz-177dc4/core-term/src/io/pty_tests.rs#L230) is the `spawn_with_config(...).expect(...)` line, not the read-with-timeout on 231. The 5-second `READ_TIMEOUT` is never reached and the SIGPIPE behaviour the test asserts is never exercised: `openpty` fails before a child is ever spawned. The test was a canary, not the culprit.

## Evidence

Standalone C harness, `openpty` in a loop across N threads on a 12-core machine:

| Mode | Threads | Runs | Total calls | Failures |
|------|---------|------|-------------|----------|
| unserialized | 8  | 3 | 9,600  | **0** |
| unserialized | 48 | 3 | 57,600 | **107** |
| serialized | 48 | 3 | 57,600 | **0** |

It only reproduces once threads oversubscribe the cores — exactly what `cargo test --workspace` does with many test binaries running concurrently, and why it never showed up under `-p core-term`.

The failing calls return errno **-6**, a negative and therefore invalid errno. `nix` has no arm for it and falls through to `_ => UnknownErrno`, which is the signature observed in the wild. That detail also rules out the alternatives:

- **Not pty exhaustion** — `kern.tty.ptmx_max` is 511, exhausting it fails cleanly with a *valid* `ENXIO`, and only 5 were in use.
- **Not fd exhaustion** — `ulimit -n` is 1048576.
- **Not the [fork/malloc deadlock](../blob/main/docs/bugs/2026-07-15-pty-fork-malloc-deadlock.md)** — that path is gone; spawn uses `posix_spawn`.
- **Not a `posix_spawn` signal-attribute race** — the failure precedes `posix_spawn` entirely.

Which internal call races is **unconfirmed**. `ptsname(3)` is the obvious suspect (`man ptsname`: not guaranteed reentrant or thread safe), but a corrupted replica path would make `open()` fail with a *valid* errno, not -6. The fix is justified by the measurement, not the mechanism — the doc says so explicitly rather than asserting a tidy story.

## The fix — no production lock

Production opens **exactly one PTY per run**: `main` spawns it on the main thread *before* the troupe's threads exist, then hands it to `PtyTroupe::new`, which delivers it to the actors as a `Bind` message. Every other call site is inside `#[cfg(test)]`, and there is no multi-window/multi-PTY design. So there is no live production race, and `spawn_with_config` now documents that **single-threaded contract** instead of carrying a lock for a race that cannot occur.

The contract is upheld in the test binary by a `#[cfg(test)] OPENPTY_TEST_LOCK`. It is gated inside `spawn_with_config` rather than sprinkled across the tests, because spawn sites live in four different test modules (`io::pty_tests`, `io::event_monitor_actor::{mod, writer}`, `terminal_app`) and a lock a new test can forget to take would let the flake back in silently. No integration test spawns a PTY, which is what makes `cfg(test)` a sufficient boundary. Poisoning is `.expect()`-ed so it fails loudly, per the project's no-silent-failures rule.

Deliberately **not** done: widening the timeout or retrying the spawn. Either would mask a genuine libc thread-safety bug behind a timing knob.

## Reviewer notes

- **In a non-test build the guard compiles away entirely** — production behaviour is byte-for-byte unchanged.
- Considered and rejected, both recorded in the bug doc: a production `Mutex` (machinery for an impossible race, and `Mutex<()>` guards no data), and giving PTY spawning its own actor (the tidiest answer, but the natural home is the engine and `pixelflow-runtime` is deliberately generic while a PTY is terminal-specific).
- If a second PTY is ever needed for tabs or splits, the fix is to give spawning a single owner — not to make `spawn_with_config` reentrant. Noted in the rustdoc.
- `nix::unistd::ttyname` in the same spawn path is **not** a second instance of this bug; it already uses the reentrant `ttyname_r`.

## Verification

- 7 full `cargo test --workspace` runs, zero failures and zero panics across all 74 test-result lines each.
- Targeted `cargo test -p core-term --lib io::pty_tests` passes.
- `cargo build --workspace` clean, no unused-import warnings.
- Pre-existing and unrelated: 3 clippy errors in `pixelflow-runtime/src/platform/macos/cocoa.rs` (raw-pointer lint), a file this PR does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)