### PR TITLE
Fix bench_scanline_jit compile errors: missing imports, not missing code

### DIFF
--- a/pixelflow-pipeline/src/bin/bench_scanline_jit.rs
+++ b/pixelflow-pipeline/src/bin/bench_scanline_jit.rs
@@ -2,13 +2,14 @@
 //!
 //! cargo run --release -p pixelflow-pipeline --features training --bin bench_scanline_jit
 
-use pixelflow_pipeline::jit_bench::benchmark_jit_arena;
+use pixelflow_pipeline::jit_bench::{benchmark_jit_arena, nanos_now};
 use pixelflow_pipeline::training::factored::parse_kernel_code_arena;
 
-#[cfg(target_os = "macos")]
-unsafe extern "C" {
-    fn mach_absolute_time() -> u64;
-}
+#[cfg(target_arch = "aarch64")]
+use pixelflow_ir::ScanlineJitManifold;
+#[cfg(target_arch = "aarch64")]
+use pixelflow_ir::backend::emit::compile_arena_dag_scanline;
+
 fn main() {
     // Load psychedelic expressions from file
     let content = std::fs::read_to_string("pixelflow-pipeline/data/psychedelic_full.jsonl")

--- a/pixelflow-pipeline/src/jit_bench.rs
+++ b/pixelflow-pipeline/src/jit_bench.rs
@@ -170,13 +170,13 @@ unsafe extern "C" {
 }
 
 #[cfg(target_os = "macos")]
-fn nanos_now() -> u64 {
+pub fn nanos_now() -> u64 {
     // On Apple Silicon, mach_absolute_time() ticks == nanoseconds (timebase 1:1).
     unsafe { mach_absolute_time() }
 }
 
 #[cfg(target_os = "linux")]
-fn nanos_now() -> u64 {
+pub fn nanos_now() -> u64 {
     let mut ts = libc::timespec {
         tv_sec: 0,
         tv_nsec: 0,
@@ -188,7 +188,7 @@ fn nanos_now() -> u64 {
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "linux")))]
-fn nanos_now() -> u64 {
+pub fn nanos_now() -> u64 {
     use std::time::Instant;
     static EPOCH: std::sync::OnceLock<Instant> = std::sync::OnceLock::new();
     let epoch = EPOCH.get_or_init(Instant::now);


### PR DESCRIPTION
compile_arena_dag_scanline and ScanlineJitManifold already exist and are pub in pixelflow-ir; the binary just never imported them. jit_bench's nanos_now was private to its module, so a sibling src/bin binary (a separate compilation unit) couldn't reach it. Made nanos_now pub and reused it instead of the dead half-written mach_absolute_time extern block that was already sitting unused in bench_scanline_jit.rs.