### PR TITLE
feat(actor-scheduler): host wake, ports! codegen, Credit, priority lanes

### DIFF
--- a/actor-scheduler-macros/src/lib.rs
+++ b/actor-scheduler-macros/src/lib.rs
@@ -745,11 +745,14 @@ fn render_ports(base: &str, ports: &[Port], self_port: Option<&Port>) -> TokenSt
     let sends = deliverable
         .iter()
         .map(|p| {
-            let f = match p.kind {
-                PortKind::Droppable => "send_port_droppable",
-                _ => "send_port",
+            let delivery = match p.kind {
+                PortKind::Droppable => "Droppable",
+                _ => "Blocking",
             };
-            format!("            ::actor_scheduler::mealy::{f}(&mut out.{0}, &self.{0}),", p.name)
+            format!(
+                "            ::actor_scheduler::mealy::send_port(&mut out.{0}, &self.{0}, ::actor_scheduler::mealy::Delivery::{delivery}),",
+                p.name
+            )
         })
         .collect::<Vec<_>>()
         .join("\n");

--- a/actor-scheduler-macros/src/lib.rs
+++ b/actor-scheduler-macros/src/lib.rs
@@ -552,3 +552,263 @@ pub fn troupe(input: TokenStream) -> TokenStream {
     .parse()
     .expect("failed to parse generated troupe code")
 }
+
+// ────────────────────────────────────────────────────────────────────────────
+// ports! — the output word and its wiring
+// ────────────────────────────────────────────────────────────────────────────
+
+/// How one output port is delivered.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum PortKind {
+    /// Parks the actor when the target is full. The default, and the only kind that
+    /// propagates backpressure.
+    Blocking,
+    /// Discards when the target is full. Cannot park, so it may close a cycle.
+    Droppable,
+    /// Addressed to the actor itself. Never reaches the wiring — the scheduler lifts it into
+    /// the continuation slot.
+    SelfPort,
+}
+
+/// One declared port: field name, message type, delivery.
+struct Port {
+    name: String,
+    ty: String,
+    kind: PortKind,
+}
+
+/// Parse `[drop]` / `[self]`, defaulting to a blocking port.
+fn parse_port_kind(group_str: &str, port: &str) -> PortKind {
+    let mut kind = PortKind::Blocking;
+    for part in group_str.split(',') {
+        match part.trim() {
+            "drop" => kind = PortKind::Droppable,
+            "self" => kind = PortKind::SelfPort,
+            "" => {}
+            other => panic!("unknown port attribute `{other}` on port `{port}` (expected `drop` or `self`)"),
+        }
+    }
+    kind
+}
+
+/// Generates an actor's output word and the wiring that delivers it.
+///
+/// A Mealy actor returns its output instead of sending it, so every actor needs two types
+/// that are pure boilerplate: an output word with one optional slot per downstream port, and
+/// a wiring that delivers each set port and **leaves blocked ones in place**. Writing them by
+/// hand is repetitive and quietly dangerous — a port omitted from `flush` is a message that
+/// vanishes with no error anywhere.
+///
+/// # Syntax
+///
+/// ```ignore
+/// ports! {
+///     App {
+///         engine: Render,        // blocking: parks the actor when full
+///         write: Echo [drop],    // droppable: discards when full, never parks
+///         again: u32 [self],     // continuation: goes to the slot, not the wiring
+///     }
+/// }
+/// ```
+///
+/// # Generates
+///
+/// - `pub struct AppOut` — one `Option<T>` per port, `#[derive(Default)]` for the silent
+///   transition.
+/// - `pub struct AppWiring` — one `SpscSender<T>` per *deliverable* port. A `[self]` port has
+///   no field here, because it never travels through the wiring.
+/// - `impl Wiring for AppWiring` — `flush` delivering each port by its kind and combining the
+///   outcomes, so a partial flush falls out: the ports that fit go now, the rest wait.
+/// - `impl AppOut::take_continuation` when a `[self]` port is declared, for the actor's
+///   `Transducer::take_continuation` to delegate to.
+///
+/// # Panics
+///
+/// At expansion time, on malformed syntax, an unknown port attribute, or more than one
+/// `[self]` port — the continuation slot holds exactly one message.
+#[proc_macro]
+pub fn ports(input: TokenStream) -> TokenStream {
+    let mut tokens = input.into_iter().peekable();
+
+    let base = match tokens.next() {
+        Some(TokenTree::Ident(id)) => id.to_string(),
+        other => panic!("ports!: expected an actor name, found {other:?}"),
+    };
+
+    let body = match tokens.next() {
+        Some(TokenTree::Group(g)) if g.delimiter() == Delimiter::Brace => g.stream(),
+        _ => panic!("ports!: expected `{{ ... }}` after `{base}`"),
+    };
+
+    let ports = parse_ports(body, &base);
+
+    let self_ports: Vec<&Port> = ports
+        .iter()
+        .filter(|p| p.kind == PortKind::SelfPort)
+        .collect();
+    assert!(
+        self_ports.len() <= 1,
+        "ports!: `{base}` declares {} `[self]` ports, but the continuation slot holds exactly one",
+        self_ports.len()
+    );
+
+    render_ports(&base, &ports, self_ports.first().copied())
+}
+
+/// Parse the `name: Type [attrs],` list inside the braces.
+fn parse_ports(body: TokenStream, base: &str) -> Vec<Port> {
+    let mut ports: Vec<Port> = Vec::new();
+    let mut tokens = body.into_iter().peekable();
+
+    while let Some(tok) = tokens.next() {
+        let name = match tok {
+            TokenTree::Ident(id) => id.to_string(),
+            TokenTree::Punct(_) => continue, // trailing / separating commas
+            other => panic!("ports! `{base}`: expected a port name, found {other:?}"),
+        };
+
+        match tokens.next() {
+            Some(TokenTree::Punct(p)) if p.as_char() == ':' => {}
+            _ => panic!("ports! `{base}`: expected `:` after port `{name}`"),
+        }
+
+        // The type runs until a comma or an attribute bracket, so generics pass through.
+        let mut ty_tokens = Vec::new();
+        loop {
+            match tokens.peek() {
+                Some(TokenTree::Punct(p)) if p.as_char() == ',' => break,
+                Some(TokenTree::Group(g)) if g.delimiter() == Delimiter::Bracket => break,
+                None => break,
+                Some(_) => {}
+            }
+            if let Some(tok) = tokens.next() {
+                ty_tokens.push(tok);
+            }
+        }
+        let ty = ty_tokens
+            .into_iter()
+            .map(|t| t.to_string())
+            .collect::<Vec<_>>()
+            .join("");
+        assert!(
+            !ty.is_empty(),
+            "ports! `{base}`: expected a type after `{name}:`"
+        );
+
+        let mut kind = PortKind::Blocking;
+        if let Some(TokenTree::Group(g)) = tokens.peek()
+            && g.delimiter() == Delimiter::Bracket
+        {
+            kind = parse_port_kind(&g.stream().to_string(), &name);
+            tokens.next();
+        }
+
+        ports.push(Port { name, ty, kind });
+    }
+
+    assert!(!ports.is_empty(), "ports! `{base}`: declares no ports");
+    ports
+}
+
+/// Emit the output word, the wiring, and their impls.
+fn render_ports(base: &str, ports: &[Port], self_port: Option<&Port>) -> TokenStream {
+    let out_name = format!("{base}Out");
+    let wiring_name = format!("{base}Wiring");
+
+    let out_fields = ports
+        .iter()
+        .map(|p| {
+            format!(
+                "    /// The `{}` port.\n    pub {}: ::core::option::Option<{}>,",
+                p.name, p.name, p.ty
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let deliverable: Vec<&Port> = ports
+        .iter()
+        .filter(|p| p.kind != PortKind::SelfPort)
+        .collect();
+
+    let wiring_fields = deliverable
+        .iter()
+        .map(|p| {
+            format!(
+                "    /// Target of the `{}` port.\n    pub {}: ::actor_scheduler::spsc::SpscSender<{}>,",
+                p.name, p.name, p.ty
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let sends = deliverable
+        .iter()
+        .map(|p| {
+            let f = match p.kind {
+                PortKind::Droppable => "send_port_droppable",
+                _ => "send_port",
+            };
+            format!("            ::actor_scheduler::mealy::{f}(&mut out.{0}, &self.{0}),", p.name)
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    // A continuation must have been lifted into the slot before the wiring runs. Assert it
+    // rather than silently delivering nowhere.
+    let self_guard = self_port.map_or_else(String::new, |p| {
+        format!(
+            "        debug_assert!(\n            out.{}.is_none(),\n            \"the `{}` port is a continuation and must not reach the wiring\"\n        );\n",
+            p.name, p.name
+        )
+    });
+
+    let continuation_impl = self_port.map_or_else(String::new, |p| {
+        format!(
+            r#"
+impl {out_name} {{
+    /// Take the `{port}` continuation, for `Transducer::take_continuation` to delegate to.
+    ///
+    /// The scheduler calls this before the wiring runs, so a self-addressed message never
+    /// touches a queue and can never block.
+    #[must_use]
+    pub fn take_continuation(&mut self) -> ::core::option::Option<{ty}> {{
+        self.{port}.take()
+    }}
+}}
+"#,
+            out_name = out_name,
+            port = p.name,
+            ty = p.ty
+        )
+    });
+
+    format!(
+        r#"
+/// Output word for `{base}`: one optional slot per port.
+///
+/// `Default` is the silent transition — every port unset.
+#[derive(Default)]
+pub struct {out_name} {{
+{out_fields}
+}}
+
+/// Where `{base}`'s output ports go.
+pub struct {wiring_name} {{
+{wiring_fields}
+}}
+
+impl ::actor_scheduler::mealy::Wiring for {wiring_name} {{
+    type Out = {out_name};
+
+    fn flush(&mut self, out: &mut {out_name}) -> ::actor_scheduler::mealy::Flush {{
+{self_guard}        ::actor_scheduler::mealy::all([
+{sends}
+        ])
+    }}
+}}
+{continuation_impl}"#,
+    )
+    .parse()
+    .expect("ports!: failed to parse generated code")
+}

--- a/actor-scheduler/Cargo.toml
+++ b/actor-scheduler/Cargo.toml
@@ -43,3 +43,7 @@ harness = false
 [[bench]]
 name = "bench_mealy"
 harness = false
+
+[[bench]]
+name = "bench_priority"
+harness = false

--- a/actor-scheduler/benches/bench_mealy.rs
+++ b/actor-scheduler/benches/bench_mealy.rs
@@ -12,7 +12,7 @@
 //! The second is the honest measure of the design: the dispatch delta is small either way,
 //! but the thread-hop that disappears is not.
 
-use actor_scheduler::mealy::{Flush, Node, Step, Transducer, Wiring, all, send_port};
+use actor_scheduler::mealy::{Delivery, Flush, Node, Step, Transducer, Wiring, all, send_port};
 use actor_scheduler::spsc::{SpscSender, spsc_channel};
 use actor_scheduler::{
     Actor, ActorScheduler, ActorStatus, HandlerError, HandlerResult, Message, SystemStatus,
@@ -87,8 +87,8 @@ impl Wiring for AppWiring {
     type Out = AppOut;
     fn flush(&mut self, out: &mut AppOut) -> Flush {
         all([
-            send_port(&mut out.engine, &self.engine),
-            send_port(&mut out.write, &self.write),
+            send_port(&mut out.engine, &self.engine, Delivery::Blocking),
+            send_port(&mut out.write, &self.write, Delivery::Blocking),
         ])
     }
 }
@@ -214,7 +214,7 @@ struct ForwardWiring {
 impl Wiring for ForwardWiring {
     type Out = Option<u8>;
     fn flush(&mut self, out: &mut Option<u8>) -> Flush {
-        send_port(out, &self.next)
+        send_port(out, &self.next, Delivery::Blocking)
     }
 }
 

--- a/actor-scheduler/benches/bench_mealy.rs
+++ b/actor-scheduler/benches/bench_mealy.rs
@@ -18,6 +18,7 @@ use actor_scheduler::{
     Actor, ActorScheduler, ActorStatus, HandlerError, HandlerResult, Message, SystemStatus,
 };
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use std::convert::Infallible;
 
 const MESSAGES: [usize; 3] = [1_000, 10_000, 100_000];
 
@@ -94,10 +95,12 @@ impl Wiring for AppWiring {
 }
 
 impl Transducer for SteppingActor {
-    type In = u8;
+    type Control = Infallible;
+    type Management = Infallible;
+    type Data = u8;
     type Out = AppOut;
 
-    fn step(&mut self, byte: u8) -> Result<AppOut, HandlerError> {
+    fn step_data(&mut self, byte: u8) -> Result<AppOut, HandlerError> {
         self.seen += 1;
         Ok(AppOut {
             engine: Some(Render(byte)),
@@ -219,10 +222,12 @@ impl Wiring for ForwardWiring {
 }
 
 impl Transducer for ForwardStep {
-    type In = u8;
+    type Control = Infallible;
+    type Management = Infallible;
+    type Data = u8;
     type Out = Option<u8>;
 
-    fn step(&mut self, byte: u8) -> Result<Option<u8>, HandlerError> {
+    fn step_data(&mut self, byte: u8) -> Result<Option<u8>, HandlerError> {
         self.seen += 1;
         Ok(Some(byte.wrapping_add(1)))
     }

--- a/actor-scheduler/benches/bench_priority.rs
+++ b/actor-scheduler/benches/bench_priority.rs
@@ -1,0 +1,172 @@
+//! Demo + benchmark for the priority lanes ported onto `Node`/`Transducer`.
+//!
+//! `bench_mealy.rs` only exercises the data lane — it cannot show the thing this port actually
+//! bought: that a green actor's data lane keeps making progress under a continuous control
+//! flood, at a bounded, predictable ratio, instead of starving until the flood stops.
+//!
+//! Each `bench_function` prints a human-readable before/after comparison once (outside the
+//! timed loop) and then lets criterion measure the same scenario for statistical confidence.
+
+use actor_scheduler::mealy::{Flush, Lanes, Node, Step, Transducer, Wiring};
+use actor_scheduler::spsc::spsc_channel;
+use actor_scheduler::{HandlerError, SchedulerParams};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+
+/// Counts messages by lane; no output ports, so `Out = ()` and `NoWiring` is a no-op.
+struct Counter {
+    control_seen: u64,
+    data_seen: u64,
+}
+
+struct NoWiring;
+impl Wiring for NoWiring {
+    type Out = ();
+    fn flush(&mut self, (): &mut ()) -> Flush {
+        Flush::Done
+    }
+}
+
+impl Transducer for Counter {
+    type Control = ();
+    type Management = ();
+    type Data = ();
+    type Out = ();
+
+    fn step_data(&mut self, (): ()) -> Result<(), HandlerError> {
+        self.data_seen += 1;
+        Ok(())
+    }
+
+    fn step_control(&mut self, (): ()) -> Result<(), HandlerError> {
+        self.control_seen += 1;
+        Ok(())
+    }
+}
+
+/// A control:data burst ratio realistic enough to make contention visible without requiring
+/// an unreasonable number of polls: two control turns per one data turn, per full cycle.
+fn contention_params() -> SchedulerParams {
+    SchedulerParams {
+        control_mgmt_buffer_size: 1,
+        control_burst_multiplier: 2, // control_burst_limit = 2, half = 1
+        management_burst_multiplier: 1,
+        default_data_burst_limit: 1,
+        ..SchedulerParams::DEFAULT
+    }
+}
+
+/// Poll until every data message queued up front has been delivered, feeding a fresh control
+/// message back in after each one is consumed — an unbounded flood, not a fixed backlog.
+/// Returns the number of polls it took.
+fn drain_data_under_control_flood(data_messages: u64) -> u64 {
+    let (tx_c, rx_c) = spsc_channel::<()>(8);
+    let (tx_m, rx_m) = spsc_channel::<()>(4);
+    let (tx_d, rx_d) = spsc_channel::<()>(1024);
+
+    for _ in 0..data_messages {
+        tx_d.try_send(()).unwrap();
+    }
+    // Prime the flood: as long as this stays topped up, control never runs dry.
+    for _ in 0..4 {
+        tx_c.try_send(()).unwrap();
+    }
+    drop(tx_m); // no management traffic in this demo
+
+    let mut node = Node::new_with_lanes(
+        Counter {
+            control_seen: 0,
+            data_seen: 0,
+        },
+        Lanes {
+            control: rx_c,
+            management: rx_m,
+            data: rx_d,
+        },
+        NoWiring,
+        contention_params(),
+    );
+
+    let mut polls = 0u64;
+    while node.actor().data_seen < data_messages {
+        // Keep the flood alive: whatever control took last poll, replace it. A real flooder
+        // (e.g. continuous vsync ticks) never runs out either. A full ring just means the
+        // flood is already saturated — nothing to do about that here.
+        if tx_c.try_send(()).is_err() {
+            // Receiver gone would be a bug in this demo (control is never dropped); a full
+            // ring is fine and expected.
+        }
+        assert_eq!(node.poll(), Step::Ran, "must always make progress, never park or idle");
+        polls += 1;
+        assert!(
+            polls < data_messages * 20,
+            "data should not need more than a small constant factor of polls"
+        );
+    }
+    polls
+}
+
+/// The same data volume with no control traffic at all — the baseline this demo compares
+/// against.
+fn drain_data_uncontended(data_messages: u64) -> u64 {
+    let (_tx_c, rx_c) = spsc_channel::<()>(4);
+    let (_tx_m, rx_m) = spsc_channel::<()>(4);
+    let (tx_d, rx_d) = spsc_channel::<()>(1024);
+
+    for _ in 0..data_messages {
+        tx_d.try_send(()).unwrap();
+    }
+
+    let mut node = Node::new_with_lanes(
+        Counter {
+            control_seen: 0,
+            data_seen: 0,
+        },
+        Lanes {
+            control: rx_c,
+            management: rx_m,
+            data: rx_d,
+        },
+        NoWiring,
+        contention_params(),
+    );
+
+    let mut polls = 0u64;
+    while node.actor().data_seen < data_messages {
+        assert_eq!(node.poll(), Step::Ran);
+        polls += 1;
+    }
+    polls
+}
+
+fn bench_data_under_control_flood(c: &mut Criterion) {
+    const DATA_MESSAGES: u64 = 1_000;
+
+    // Printed once, outside the timed loop: the human-readable comparison.
+    let uncontended_polls = drain_data_uncontended(DATA_MESSAGES);
+    let contended_polls = drain_data_under_control_flood(DATA_MESSAGES);
+    println!(
+        "\n[bench_priority] delivering {DATA_MESSAGES} data messages:\n\
+         \x20 no control traffic:        {uncontended_polls} polls ({:.2} polls/message)\n\
+         \x20 continuous control flood:  {contended_polls} polls ({:.2} polls/message)\n\
+         \x20 => every data message still arrived; the flood cost a bounded, predictable\n\
+         \x20    ~{:.1}x more polls per message, not starvation.\n",
+        uncontended_polls as f64 / DATA_MESSAGES as f64,
+        contended_polls as f64 / DATA_MESSAGES as f64,
+        contended_polls as f64 / uncontended_polls as f64,
+    );
+
+    let mut group = c.benchmark_group("priority");
+
+    group.bench_function("data_uncontended", |b| {
+        b.iter(|| black_box(drain_data_uncontended(black_box(DATA_MESSAGES))));
+    });
+
+    group.bench_function("data_under_control_flood", |b| {
+        b.iter(|| black_box(drain_data_under_control_flood(black_box(DATA_MESSAGES))));
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_data_under_control_flood);
+criterion_main!(benches);

--- a/actor-scheduler/src/host.rs
+++ b/actor-scheduler/src/host.rs
@@ -49,11 +49,13 @@ pub trait Green {
     fn poll(&mut self) -> Step;
 }
 
-impl<T, W, R> Green for Node<T, W, R>
+impl<T, W, RD, RC, RM> Green for Node<T, W, RD, RC, RM>
 where
     T: Transducer,
     W: Wiring<Out = T::Out>,
-    R: Inbox<Item = T::In>,
+    RD: Inbox<Item = T::Data>,
+    RC: Inbox<Item = T::Control>,
+    RM: Inbox<Item = T::Management>,
 {
     fn poll(&mut self) -> Step {
         Node::poll(self)
@@ -243,10 +245,12 @@ mod tests {
     }
 
     impl Transducer for Forward {
-        type In = u32;
+        type Control = Infallible;
+        type Management = Infallible;
+        type Data = u32;
         type Out = Option<u32>;
 
-        fn step(&mut self, n: u32) -> Result<Option<u32>, HandlerError> {
+        fn step_data(&mut self, n: u32) -> Result<Option<u32>, HandlerError> {
             self.seen += 1;
             Ok(Some(n + 1))
         }

--- a/actor-scheduler/src/host.rs
+++ b/actor-scheduler/src/host.rs
@@ -34,11 +34,11 @@
 //! by one stage.
 
 use std::convert::Infallible;
-use std::marker::PhantomData;
 
 use crate::lifecycle::Exit;
 use crate::mealy::{Inbox, Node, Step, Transducer, Wiring};
-use crate::{Actor, ActorStatus, HandlerError, HandlerResult, SystemStatus};
+use crate::spsc::{SpscReceiver, SpscSender, TrySendError, spsc_channel};
+use crate::{Actor, ActorStatus, HandlerError, HandlerResult, SystemStatus, Waker};
 
 /// A hosted green actor with its types erased, so one host can own a heterogeneous set.
 ///
@@ -62,30 +62,24 @@ where
 
 /// An OS-thread actor that owns green actors and runs them in its `park`.
 ///
-/// The host has no control or management messages of its own — those type parameters are
-/// [`Infallible`], so the compiler knows the handlers are unreachable and the `match msg {}`
-/// bodies below are total. Its data lane carries whatever the hosted actors are fed with:
-/// `handle_data` hands each inbound message to the `deliver` closure, which pushes it into
-/// the right green actor's inbox.
-pub struct Host<D, F> {
+/// A host has **no messages of its own**: all three lane types are [`Infallible`], so the
+/// compiler knows its handlers are unreachable and the `match msg {}` bodies below are total.
+/// Work reaches a hosted actor by being pushed straight into that actor's inbox with a
+/// [`GreenSender`], which then rings the host's doorbell. The host routes nothing; it hosts.
+///
+/// `Message::Shutdown` still stops it, because shutdown travels on the doorbell rather than a
+/// lane.
+#[derive(Default)]
+pub struct Host {
     nodes: Vec<Box<dyn Green>>,
-    deliver: F,
     exits: Vec<Exit>,
-    _pd: PhantomData<D>,
 }
 
-impl<D, F> Host<D, F>
-where
-    F: FnMut(D),
-{
-    /// A host that routes its inbound messages with `deliver`.
-    pub fn new(deliver: F) -> Self {
-        Self {
-            nodes: Vec::new(),
-            deliver,
-            exits: Vec::new(),
-            _pd: PhantomData,
-        }
+impl Host {
+    /// A host with no green actors yet.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// Take ownership of a green actor. Sweep order is adoption order.
@@ -147,13 +141,65 @@ where
     }
 }
 
-impl<D, F> Actor<D, Infallible, Infallible> for Host<D, F>
-where
-    F: FnMut(D),
-{
-    fn handle_data(&mut self, msg: D) -> HandlerResult {
-        (self.deliver)(msg);
+// ────────────────────────────────────────────────────────────────────────────
+// Feeding a green actor from outside its host
+// ────────────────────────────────────────────────────────────────────────────
+
+/// The sending end of a green actor's inbox, paired with its host's [`Waker`].
+///
+/// A green actor has no thread of its own, so nothing about pushing into its inbox will wake
+/// the host that owns it. This pairs the two halves that must always go together: **push the
+/// message, then ring the bell.**
+///
+/// The order is not stylistic. Waking first admits a lost wakeup — the host can wake, sweep,
+/// find the inbox still empty, report `Idle`, and go back to sleep just before the message
+/// lands. Pushing first means the host either sees the message on the sweep it is already
+/// doing, or is still holding the pending wake that will start another one.
+///
+/// A failed push is not followed by a wake: there is no new work to announce.
+pub struct GreenSender<T> {
+    tx: SpscSender<T>,
+    waker: Waker,
+}
+
+impl<T> GreenSender<T> {
+    /// Pair an inbox sender with the waker of the host that owns the receiving actor.
+    #[must_use]
+    pub fn new(tx: SpscSender<T>, waker: Waker) -> Self {
+        Self { tx, waker }
+    }
+
+    /// Deliver a message to the green actor and wake its host.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TrySendError::Full`] if the actor's inbox is full — the caller's
+    /// backpressure signal — or [`TrySendError::Disconnected`] if the actor is gone.
+    pub fn try_send(&self, msg: T) -> Result<(), TrySendError<T>> {
+        self.tx.try_send(msg)?;
+        self.waker.wake();
         Ok(())
+    }
+}
+
+impl<T> std::fmt::Debug for GreenSender<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GreenSender").finish_non_exhaustive()
+    }
+}
+
+/// An inbox for a green actor, whose sender wakes `waker` on every delivery.
+///
+/// The receiver goes to the [`Node`]; the sender goes to whoever feeds it.
+#[must_use]
+pub fn green_channel<T>(capacity: usize, waker: Waker) -> (GreenSender<T>, SpscReceiver<T>) {
+    let (tx, rx) = spsc_channel(capacity);
+    (GreenSender::new(tx, waker), rx)
+}
+
+impl Actor<Infallible, Infallible, Infallible> for Host {
+    fn handle_data(&mut self, msg: Infallible) -> HandlerResult {
+        match msg {}
     }
 
     fn handle_control(&mut self, msg: Infallible) -> HandlerResult {
@@ -177,6 +223,7 @@ where
 mod tests {
     use super::*;
     use crate::mealy::{Flush, send_port};
+    use crate::{ActorScheduler, Message};
     use crate::spsc::{SpscSender, spsc_channel};
 
     /// A stage that forwards its input onward, counting what it saw.
@@ -210,7 +257,7 @@ mod tests {
         let (tx_in, rx_in) = spsc_channel::<u32>(8);
         let (tx_out, mut rx_out) = spsc_channel::<u32>(8);
 
-        let mut host = Host::new(|_: u32| {});
+        let mut host = Host::new();
         host.adopt(Node::new(
             Forward { seen: 0 },
             rx_in,
@@ -229,7 +276,7 @@ mod tests {
         let (tx_in, rx_in) = spsc_channel::<u32>(8);
         let (tx_out, _rx_out) = spsc_channel::<u32>(8);
 
-        let mut host = Host::new(|_: u32| {});
+        let mut host = Host::new();
         host.adopt(Node::new(
             Forward { seen: 0 },
             rx_in,
@@ -253,7 +300,7 @@ mod tests {
         let (tx_23, rx_23) = spsc_channel::<u32>(8);
         let (tx_out, mut rx_out) = spsc_channel::<u32>(8);
 
-        let mut host = Host::new(|_: u32| {});
+        let mut host = Host::new();
         host.adopt(Node::new(
             Forward { seen: 0 },
             rx_in,
@@ -284,7 +331,7 @@ mod tests {
         let (tx_in, rx_in) = spsc_channel::<u32>(8);
         let (tx_out, _rx_out) = spsc_channel::<u32>(8);
 
-        let mut host = Host::new(|_: u32| {});
+        let mut host = Host::new();
         host.adopt(Node::new(
             Forward { seen: 0 },
             rx_in,
@@ -309,7 +356,7 @@ mod tests {
         let (tx_out, mut rx_out) = spsc_channel::<u32>(8);
         let (tx_sink, _rx_sink) = spsc_channel::<u32>(8);
 
-        let mut host = Host::new(|_: u32| {});
+        let mut host = Host::new();
         // Adopted: [stage1, doomed, stage2]. The doomed actor sits between the two stages.
         host.adopt(Node::new(
             Forward { seen: 0 },
@@ -339,30 +386,92 @@ mod tests {
         );
     }
 
-    #[test]
-    fn the_host_routes_its_own_inbound_messages_into_a_green_inbox() {
-        // End to end through the real scheduler: a message on the host's data lane is routed
-        // by `handle_data` into a green actor's inbox, and the following `park` sweep runs it.
-        use crate::{ActorScheduler, Message};
+    // ── Waking a sleeping host ──────────────────────────────────────────────
 
-        let (tx_in, rx_in) = spsc_channel::<u32>(8);
+    #[test]
+    fn a_green_send_wakes_a_host_asleep_on_its_doorbell() {
+        // The real thing, on a real thread: the host is blocked in `run()` with nothing to do
+        // — no message can reach it through its own lanes, because it has none — and a push
+        // into a green actor's inbox has to be what wakes it.
+        use std::time::{Duration, Instant};
+
+        let (handle, mut sched) = ActorScheduler::<Infallible, Infallible, Infallible>::new(4, 4);
+        let (tx_green, rx_green) = green_channel::<u32>(8, handle.waker());
         let (tx_out, mut rx_out) = spsc_channel::<u32>(8);
 
-        let mut host = Host::new(move |n: u32| {
-            tx_in.try_send(n).expect("green inbox sized for the test");
+        // The host is built on the thread that runs it: an owned green actor never migrates,
+        // so it is never required to be `Send`.
+        let worker = std::thread::spawn(move || {
+            let mut host = Host::new();
+            host.adopt(Node::new(
+                Forward { seen: 0 },
+                rx_green,
+                ForwardWiring { next: tx_out },
+            ));
+            sched.run(&mut host);
         });
-        host.adopt(Node::new(
-            Forward { seen: 0 },
-            rx_in,
-            ForwardWiring { next: tx_out },
-        ));
 
-        let (handle, mut sched) = ActorScheduler::<u32, Infallible, Infallible>::new(16, 16);
-        handle.send(Message::Data(41)).unwrap();
+        // Let the host reach its doorbell and block before sending, so this exercises the
+        // wake path rather than racing the host to its first sweep.
+        std::thread::sleep(Duration::from_millis(50));
+        tx_green.try_send(41).expect("green inbox has room");
 
-        // One scheduler wake: drains the data lane (routing 41 into the green inbox), then
-        // parks — and the park is the sweep that runs the green actor.
-        assert!(sched.poll_once(&mut host).is_none(), "still running");
-        assert_eq!(rx_out.try_recv().unwrap(), 42);
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let got = loop {
+            if let Ok(v) = rx_out.try_recv() {
+                break v;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "host never woke: a green send did not ring the doorbell"
+            );
+            std::thread::yield_now();
+        };
+        assert_eq!(got, 42);
+
+        handle.send(Message::Shutdown).unwrap();
+        worker.join().unwrap();
+    }
+
+    #[test]
+    fn many_green_sends_coalesce_into_one_pending_wake() {
+        // The doorbell holds one wake and coalesces the rest, so a burst cannot back it up or
+        // fail — the host sweeps everything that arrived once it gets there.
+        let (handle, _sched) = ActorScheduler::<Infallible, Infallible, Infallible>::new(4, 4);
+        let (tx_green, mut rx_green) = green_channel::<u32>(64, handle.waker());
+
+        for i in 0..64 {
+            tx_green
+                .try_send(i)
+                .expect("a burst of wakes must not fail the send");
+        }
+
+        let drained = std::iter::from_fn(|| rx_green.try_recv().ok()).count();
+        assert_eq!(drained, 64, "every message landed despite one pending wake");
+    }
+
+    #[test]
+    fn a_failed_send_reports_backpressure() {
+        // A full green inbox is the caller's backpressure signal, and no wake is announced
+        // for work that was not accepted.
+        let (handle, _sched) = ActorScheduler::<Infallible, Infallible, Infallible>::new(4, 4);
+        let (tx_green, _rx_green) = green_channel::<u32>(2, handle.waker());
+
+        let mut sent = 0;
+        while tx_green.try_send(1).is_ok() {
+            sent += 1;
+            assert!(sent < 1024, "a bounded inbox must eventually refuse");
+        }
+    }
+
+    #[test]
+    fn a_waker_outliving_its_scheduler_is_harmless() {
+        // A green actor can be fed after its host is gone; there is simply nobody to wake.
+        let waker = {
+            let (handle, _sched) = ActorScheduler::<Infallible, Infallible, Infallible>::new(4, 4);
+            handle.waker()
+        };
+        waker.wake();
+        waker.wake();
     }
 }

--- a/actor-scheduler/src/host.rs
+++ b/actor-scheduler/src/host.rs
@@ -222,7 +222,7 @@ impl Actor<Infallible, Infallible, Infallible> for Host {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::mealy::{Flush, send_port};
+    use crate::mealy::{Delivery, Flush, send_port};
     use crate::{ActorScheduler, Message};
     use crate::spsc::{SpscSender, spsc_channel};
 
@@ -238,7 +238,7 @@ mod tests {
     impl Wiring for ForwardWiring {
         type Out = Option<u32>;
         fn flush(&mut self, out: &mut Option<u32>) -> Flush {
-            send_port(out, &self.next)
+            send_port(out, &self.next, Delivery::Blocking)
         }
     }
 

--- a/actor-scheduler/src/lib.rs
+++ b/actor-scheduler/src/lib.rs
@@ -107,7 +107,7 @@ pub use lifecycle::Exit;
 pub use params::SchedulerParams;
 
 // Re-export macros from the proc-macro crate
-pub use actor_scheduler_macros::{actor_impl, troupe};
+pub use actor_scheduler_macros::{actor_impl, ports, troupe};
 
 use sharded::{InboxBuilder, ShardedInbox};
 use spsc::SpscSender;

--- a/actor-scheduler/src/lib.rs
+++ b/actor-scheduler/src/lib.rs
@@ -102,7 +102,7 @@ pub mod spsc;
 
 use error::DrainStatus;
 pub use error::{HandlerError, HandlerResult, SendError};
-pub use host::{Green, Host};
+pub use host::{Green, GreenSender, Host, green_channel};
 pub use lifecycle::Exit;
 pub use params::SchedulerParams;
 
@@ -817,6 +817,69 @@ impl<D, C, M> ActorHandle<D, C, M> {
             Err(mpsc::TrySendError::Disconnected(_)) => {
                 panic!("Doorbell receiver disconnected - scheduler dropped unexpectedly");
             }
+        }
+    }
+}
+
+/// Rings an actor's doorbell without sending it a message.
+///
+/// The scheduler blocks on its doorbell when idle, so anything that makes an actor runnable
+/// *without* going through its lanes has to ring that bell itself. The green tier is the
+/// case that needs it: a producer pushes straight into a green actor's inbox
+/// ([`GreenSender`](crate::host::GreenSender)) and then wakes the host that owns it.
+///
+/// This is the same contract as a `Waker` in a futures runtime — "there is work for you now"
+/// — and it is deliberately *not* `ActorHandle::send`: a wake carries no payload and cannot
+/// back up, because the doorbell holds one pending wake and coalesces the rest.
+///
+/// # Ordering
+///
+/// **Make the work visible, then wake.** Waking first admits a lost wakeup: the host can
+/// wake, find nothing, and go back to sleep before the message lands.
+#[derive(Clone)]
+pub struct Waker {
+    tx_doorbell: SyncSender<System>,
+    wake_handler: Option<Arc<dyn WakeHandler>>,
+}
+
+impl Waker {
+    /// Signal the actor that it has work.
+    ///
+    /// Never blocks and never fails. A full doorbell means a wake is already pending, and a
+    /// disconnected one means the actor is gone — in both cases there is nothing to do.
+    pub fn wake(&self) {
+        if let Some(waker) = &self.wake_handler {
+            waker.wake();
+        }
+        match self.tx_doorbell.try_send(System::Wake) {
+            Ok(()) => {}
+            // The doorbell holds one wake and coalesces the rest: full means a wake is
+            // already pending, which is exactly the signal this call wanted to send.
+            Err(mpsc::TrySendError::Full(_)) => {}
+            // Unlike `ActorHandle::wake`, a waker outliving its scheduler is ordinary — a
+            // green actor can be fed after its host is gone. There is nobody to wake.
+            Err(mpsc::TrySendError::Disconnected(_)) => {}
+        }
+    }
+}
+
+impl std::fmt::Debug for Waker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Waker")
+            .field("has_wake_handler", &self.wake_handler.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+impl<D, C, M> ActorHandle<D, C, M> {
+    /// A [`Waker`] for this actor's scheduler.
+    ///
+    /// Hand one to anything that can make this actor runnable without sending it a message.
+    #[must_use]
+    pub fn waker(&self) -> Waker {
+        Waker {
+            tx_doorbell: self.tx_doorbell.clone(),
+            wake_handler: self.wake_handler.clone(),
         }
     }
 }

--- a/actor-scheduler/src/mealy.rs
+++ b/actor-scheduler/src/mealy.rs
@@ -415,7 +415,11 @@ where
 
         // One full lap visits Control1, Management, Control2, and Data exactly once,
         // regardless of which slot the cycle happens to be sitting on when this call starts —
-        // Slot::next() is a 4-cycle, so four steps always covers all four positions.
+        // Slot::next() is a 4-cycle, so four steps always covers all four positions. This
+        // relies on `advance_if_exhausted` never leaving `self.slot` pointing at an
+        // already-spent slot between calls; without it, the first iteration of the *next*
+        // call would be spent discovering that instead of checking a lane, and one of the
+        // four real positions would go unchecked.
         let mut control_disconnected = false;
         let mut management_disconnected = false;
         let mut data_disconnected = false;
@@ -437,6 +441,7 @@ where
                 Slot::Control1 | Slot::Control2 => match self.control.take() {
                     Ok(msg) => {
                         self.slot_progress += 1;
+                        self.advance_if_exhausted(limit);
                         return self.dispatch(|actor| actor.step_control(msg));
                     }
                     Err(TryRecvError::Empty) => {
@@ -452,6 +457,7 @@ where
                 Slot::Management => match self.management.take() {
                     Ok(msg) => {
                         self.slot_progress += 1;
+                        self.advance_if_exhausted(limit);
                         return self.dispatch(|actor| actor.step_management(msg));
                     }
                     Err(TryRecvError::Empty) => {
@@ -467,6 +473,7 @@ where
                 Slot::Data => match self.data.take() {
                     Ok(msg) => {
                         self.slot_progress += 1;
+                        self.advance_if_exhausted(limit);
                         return self.dispatch(|actor| actor.step_data(msg));
                     }
                     Err(TryRecvError::Empty) => {
@@ -486,6 +493,22 @@ where
             Step::Halted(Exit::Completed)
         } else {
             Step::Idle
+        }
+    }
+
+    /// Roll over to the next slot the instant the current one's budget is spent.
+    ///
+    /// Load-bearing for the loop in `poll`: it visits at most 4 slots per call on the
+    /// assumption that whichever slot `self.slot` names when a call *begins* still has room
+    /// (so checking it costs one iteration, not one to discover it's exhausted and a second
+    /// to actually check the slot after it). A successful take is the only place progress
+    /// grows, so it is the only place this can be left undone — advancing lazily, only when
+    /// the *next* call finds the old slot still sitting at its limit, costs the extra
+    /// iteration that visiting all 4 slots doesn't have room for.
+    fn advance_if_exhausted(&mut self, limit: usize) {
+        if self.slot_progress >= limit {
+            self.slot = self.slot.next();
+            self.slot_progress = 0;
         }
     }
 
@@ -1536,6 +1559,56 @@ mod tests {
 
         drop(tx_d);
         assert_eq!(node.poll(), Step::Halted(Exit::Completed));
+    }
+
+    // Regression: a slot that finishes a poll() sitting exactly at its limit (e.g. Data,
+    // after delivering the one message its budget allowed) used to advance lazily — only
+    // when the *next* call found it still there. With small limits and idle control/
+    // management lanes, that costs the wraparound its one spare iteration: the call that
+    // should re-check Data instead spends its four iterations on Control1 (advance off the
+    // exhausted slot), Management, Control2, and lands back on a *fresh* Data one iteration
+    // too late to actually check it — reporting Idle with a message still queued. Caught by
+    // `bench_priority.rs`'s drain loop, which (unlike the small fixed poll counts above)
+    // keeps calling `poll` until every message is gone and so was long enough to wrap.
+    #[test]
+    fn many_data_messages_drain_steadily_with_idle_control_and_management() {
+        let params = SchedulerParams {
+            control_mgmt_buffer_size: 1,
+            control_burst_multiplier: 2,
+            management_burst_multiplier: 1,
+            default_data_burst_limit: 1,
+            ..SchedulerParams::DEFAULT
+        };
+
+        let (_tx_c, rx_c) = spsc_channel::<()>(4);
+        let (_tx_m, rx_m) = spsc_channel::<()>(4);
+        let (tx_d, rx_d) = spsc_channel::<()>(64);
+
+        let mut node = Node::new_with_lanes(
+            LaneLog { seen: Vec::new() },
+            Lanes {
+                control: rx_c,
+                management: rx_m,
+                data: rx_d,
+            },
+            NoWiring,
+            params,
+        );
+
+        const MESSAGES: usize = 50;
+        for _ in 0..MESSAGES {
+            tx_d.try_send(()).unwrap();
+        }
+
+        for i in 0..MESSAGES {
+            assert_eq!(
+                node.poll(),
+                Step::Ran,
+                "message {i} of {MESSAGES}: control/management are merely empty, not \
+                 disconnected, so this must never report Idle with data still queued"
+            );
+        }
+        assert_eq!(node.actor().seen.len(), MESSAGES);
     }
 
     // ── Topology: cycles are a bootstrap error, not a runtime deadlock ──────

--- a/actor-scheduler/src/mealy.rs
+++ b/actor-scheduler/src/mealy.rs
@@ -124,6 +124,24 @@ pub fn send_port<T>(port: &mut Option<T>, tx: &SpscSender<T>) -> Flush {
     }
 }
 
+/// Deliver one port, **discarding** the message if the target is full.
+///
+/// The runtime half of [`Topology::droppable_edge`]. This never returns [`Flush::Blocked`],
+/// so it can never park its producer — which is exactly what makes a droppable edge legal as
+/// the closing edge of a cycle (§3.1 of the design).
+///
+/// Use it for data that is only worth delivering if it is still current — "drop this frame if
+/// the display is busy" — and never for anything a consumer must not miss. Silence on a full
+/// ring is the whole point, and also the whole risk.
+pub fn send_port_droppable<T>(port: &mut Option<T>, tx: &SpscSender<T>) -> Flush {
+    if let Some(msg) = port.take() {
+        // Full and Disconnected are the same outcome here: nobody is taking this message, and
+        // a droppable port discards rather than waiting.
+        drop(tx.try_send(msg));
+    }
+    Flush::Done
+}
+
 /// Combine port outcomes: blocked if any port is blocked.
 #[must_use]
 pub fn all(outcomes: impl IntoIterator<Item = Flush>) -> Flush {
@@ -672,6 +690,34 @@ mod tests {
             delivered >= 3,
             "write port should have kept flowing past the engine ring's capacity, got {delivered}"
         );
+    }
+
+    #[test]
+    fn a_droppable_port_never_blocks_and_never_keeps_a_message() {
+        // The runtime half of `Topology::droppable_edge`: because it cannot park its
+        // producer, it cannot take part in a deadlock, which is what lets it close a cycle.
+        let (tx, mut rx) = spsc_channel::<Render>(2);
+
+        let mut delivered = 0;
+        for i in 0..32u8 {
+            let mut port = Some(Render(i));
+            assert_eq!(send_port_droppable(&mut port, &tx), Flush::Done);
+            assert!(port.is_none(), "a droppable port always clears");
+            if rx.try_recv().is_ok() {
+                delivered += 1;
+            }
+        }
+        assert!(delivered > 0, "some messages must actually get through");
+    }
+
+    #[test]
+    fn a_droppable_port_to_a_dead_target_is_still_done() {
+        let (tx, rx) = spsc_channel::<Render>(4);
+        drop(rx);
+
+        let mut port = Some(Render(1));
+        assert_eq!(send_port_droppable(&mut port, &tx), Flush::Done);
+        assert!(port.is_none());
     }
 
     #[test]

--- a/actor-scheduler/src/mealy.rs
+++ b/actor-scheduler/src/mealy.rs
@@ -292,6 +292,75 @@ where
 }
 
 // ────────────────────────────────────────────────────────────────────────────
+// Credit: bounding a request without a new port kind
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Bounds how many messages a request edge may have outstanding, without needing a third
+/// [`Delivery`] kind.
+///
+/// A request/response pair — send a request, later receive its reply — is a cycle. [`Topology`]
+/// only accepts a cycle closed by an edge that structurally cannot block: a continuation, or a
+/// [`Delivery::Droppable`] port. A credit-bounded request *is* a droppable port; `Credit` is the
+/// sender-side discipline that keeps the drop from ever actually happening.
+///
+/// The requester holds one `Credit` per edge, in its own `self` — never shared, never atomic,
+/// touched only during that actor's own step:
+///
+/// - `try_consume` before deciding whether to set the request port. Refuse to emit rather than
+///   emit past budget.
+/// - `release` when the step that handles the corresponding reply runs — an ordinary input, on
+///   whatever lane the reply arrives on.
+///
+/// As long as the constructor's `max` does not exceed the reply ring's capacity, and every
+/// request is gated by `try_consume`, the physical ring can never fill from this edge — the
+/// `[drop]` port is a backstop for a bug, not a path the well-behaved system ever takes. This
+/// replaces a hand-rolled global atomic token bucket (the kind a request/response actor pair
+/// reaches for today) with per-edge, non-atomic, typed state — cheaper, because nothing here is
+/// shared across threads, and checked, because a `Credit` that runs dry stops the sender from
+/// even trying rather than trusting a convention.
+#[derive(Debug, Clone, Copy)]
+pub struct Credit {
+    available: u32,
+    max: u32,
+}
+
+impl Credit {
+    /// A fresh budget of `max` outstanding requests.
+    #[must_use]
+    pub fn new(max: u32) -> Self {
+        Self {
+            available: max,
+            max,
+        }
+    }
+
+    /// Consume one unit of budget. `false` means: do not emit this request.
+    #[must_use]
+    pub fn try_consume(&mut self) -> bool {
+        if self.available > 0 {
+            self.available -= 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Return one unit, on receiving the reply that corresponds to an earlier `try_consume`.
+    ///
+    /// Saturates at `max` rather than panicking on a spurious extra release — a reply that
+    /// somehow arrives twice should not poison every later request on this edge.
+    pub fn release(&mut self) {
+        self.available = (self.available + 1).min(self.max);
+    }
+
+    /// Requests currently in flight.
+    #[must_use]
+    pub fn outstanding(&self) -> u32 {
+        self.max - self.available
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
 // Topology: blocking edges must form a DAG
 // ────────────────────────────────────────────────────────────────────────────
 
@@ -719,6 +788,91 @@ mod tests {
         let mut port = Some(Render(1));
         assert_eq!(send_port(&mut port, &tx, Delivery::Droppable), Flush::Done);
         assert!(port.is_none());
+    }
+
+    // ── Credit: a request/response edge bounded without a new port kind ─────
+
+    #[test]
+    fn credit_exhausts_and_refuses_further_requests() {
+        let mut credit = Credit::new(2);
+        assert!(credit.try_consume());
+        assert!(credit.try_consume());
+        assert!(!credit.try_consume(), "budget of 2 must refuse the third");
+        assert_eq!(credit.outstanding(), 2);
+    }
+
+    #[test]
+    fn releasing_credit_restores_budget() {
+        let mut credit = Credit::new(1);
+        assert!(credit.try_consume());
+        assert!(!credit.try_consume());
+
+        credit.release();
+        assert!(credit.try_consume(), "released budget must be usable again");
+    }
+
+    #[test]
+    fn credit_saturates_at_max_rather_than_overflowing_on_a_spurious_release() {
+        let mut credit = Credit::new(3);
+        credit.release(); // no matching consume — must not push available above max
+        credit.release();
+        assert_eq!(credit.outstanding(), 0);
+        assert!(credit.try_consume());
+        assert!(credit.try_consume());
+        assert!(credit.try_consume());
+        assert!(!credit.try_consume(), "a spurious release must not grant extra budget");
+    }
+
+    #[test]
+    fn credit_gating_keeps_a_droppable_reply_edge_from_ever_dropping() {
+        // The property that makes a droppable port the right closer for a credit-bounded
+        // cycle: as long as every send is gated by `try_consume` and max <= ring capacity,
+        // the ring can never fill, so the drop path this test's sibling exercises is never
+        // actually taken.
+        const RING_CAPACITY: u32 = 4;
+        let (tx, mut rx) = spsc_channel::<Render>(RING_CAPACITY as usize);
+        let mut credit = Credit::new(RING_CAPACITY);
+
+        let mut sent = 0;
+        for i in 0..64u8 {
+            if !credit.try_consume() {
+                break; // well-behaved: stop rather than send past budget
+            }
+            let mut port = Some(Render(i));
+            assert_eq!(
+                send_port(&mut port, &tx, Delivery::Droppable),
+                Flush::Done,
+                "gated by credit, so the ring never fills and nothing is ever dropped"
+            );
+            assert!(port.is_none());
+            sent += 1;
+        }
+
+        assert_eq!(sent, RING_CAPACITY as usize, "stopped exactly at the ring's capacity");
+        assert_eq!(
+            std::iter::from_fn(|| rx.try_recv().ok()).count(),
+            RING_CAPACITY as usize,
+            "every gated message actually arrived — the backstop was never needed"
+        );
+    }
+
+    #[test]
+    fn without_credit_gating_the_same_droppable_port_silently_drops_instead_of_deadlocking() {
+        // The contrast case: an ungated sender that ignores the ring's real capacity does not
+        // hang the way a Blocking port would — it drops. That is the backstop `Credit` exists
+        // to make unreachable in the well-behaved case above.
+        let (tx, mut rx) = spsc_channel::<Render>(4);
+
+        for i in 0..64u8 {
+            let mut port = Some(Render(i));
+            assert_eq!(send_port(&mut port, &tx, Delivery::Droppable), Flush::Done);
+        }
+
+        let delivered = std::iter::from_fn(|| rx.try_recv().ok()).count();
+        assert!(
+            delivered < 64,
+            "an ungated sender must have overrun the ring and dropped some messages"
+        );
     }
 
     #[test]

--- a/actor-scheduler/src/mealy.rs
+++ b/actor-scheduler/src/mealy.rs
@@ -17,20 +17,31 @@
 //! # Status
 //!
 //! Prototype. This module proves the runtime semantics (stage → partial flush → park →
-//! resume, and self-port yield) by hand, before the `troupe!`/typed-handle macros are
-//! retargeted to generate the port structs. It is additive: the existing
-//! [`Actor`](crate::Actor) / [`ActorScheduler`](crate::ActorScheduler) path is untouched.
+//! resume, self-port yield, and Control/Management/Data priority) by hand, before the
+//! `troupe!`/typed-handle macros are retargeted to generate the port structs. It is additive:
+//! the existing [`Actor`](crate::Actor) / [`ActorScheduler`](crate::ActorScheduler) path is
+//! untouched.
 //!
 //! # The three pieces
 //!
 //! | Piece | Role |
 //! |-------|------|
-//! | [`Transducer`] | The actor: one pure step, `(state, input) → (state, output)` |
+//! | [`Transducer`] | The actor: one pure step per lane, `(state, input) → (state, output)` |
 //! | [`Wiring`] | Where the output ports go. Delivers set ports; leaves blocked ones in place |
-//! | [`Node`] | Scheduler-side: owns actor + inbox + wiring + the parked outbox |
+//! | [`Node`] | Scheduler-side: actor + three lanes + wiring + the parked outbox |
 //!
 //! Splitting `Transducer` from `Wiring` is what makes the step pure: the actor produces
 //! *values* and never holds a sender, so it is table-testable with no scheduler in the loop.
+//!
+//! # Priority
+//!
+//! `Node` drains its three lanes in the same Control > Management > Data order, with the same
+//! burst-limit ratio, as [`ActorScheduler`](crate::ActorScheduler)'s `handle_wake` — ported,
+//! not redesigned, because a green actor that needs input responsiveness under load has
+//! exactly the same starvation hazard a dedicated-thread one does. The only difference is
+//! granularity: the OS-thread scheduler drains a whole burst per wake; `Node::poll` drains one
+//! message per call, so a green actor sharing a [`Host`](crate::Host) with others never holds
+//! the worker for longer than one step.
 //!
 //! # Yielding
 //!
@@ -38,7 +49,10 @@
 //! yourself and returning lets the scheduler run everyone else before feeding you your own
 //! message back. No coroutine, no `async`, no program counter — just a self-edge.
 
+use std::marker::PhantomData;
+
 use crate::HandlerError;
+use crate::SchedulerParams;
 use crate::lifecycle::Exit;
 use crate::spsc::{SpscSender, TryRecvError, TrySendError};
 
@@ -46,7 +60,8 @@ use crate::spsc::{SpscSender, TryRecvError, TrySendError};
 // The actor
 // ────────────────────────────────────────────────────────────────────────────
 
-/// A Mealy machine: one input symbol in, one output word out, state mutated in place.
+/// A Mealy machine on three priority lanes: one input symbol in, one output word out, state
+/// mutated in place.
 ///
 /// It is Mealy rather than Moore because the output is a function of state *and* input —
 /// you echo the byte you just received. Moore would only see state.
@@ -54,25 +69,50 @@ use crate::spsc::{SpscSender, TryRecvError, TrySendError};
 /// The step is pure in the sense that matters: it performs no effects. `Ok(out)` describes
 /// what should be emitted; `Err(e)` is a failed transition and emits nothing. "Emit *and*
 /// warn" is deliberately not expressible — that is a message variant, not an error.
+///
+/// # Three lanes, not one
+///
+/// A step is triggered by whichever lane [`Node::poll`] drains from — Control, Management, or
+/// Data — the same three lanes and the same priority ordering (Control > Management > Data)
+/// as [`Actor`](crate::Actor)/[`ActorScheduler`](crate::ActorScheduler). Only `step_data` is
+/// required; `step_control` and `step_management` default to the silent transition, so a
+/// single-lane actor writes `type Control = Infallible; type Management = Infallible;` and one
+/// method, exactly as [`Host`](crate::Host) already does for its own [`Actor`](crate::Actor)
+/// impl.
 pub trait Transducer {
-    /// The input symbol.
-    type In;
+    /// The control-lane input. Highest priority — set to `Infallible` if unused.
+    type Control;
+    /// The management-lane input. Middle priority — set to `Infallible` if unused.
+    type Management;
+    /// The data-lane input. Lowest priority, and the only lane every actor has.
+    type Data;
 
     /// The output word: a struct with one optional, typed slot per downstream port.
     ///
     /// `Default` is the silent transition (all ports unset), which is the common case.
     type Out: Default;
 
-    /// Advance one step.
-    fn step(&mut self, input: Self::In) -> Result<Self::Out, HandlerError>;
+    /// Advance one step from the data lane.
+    fn step_data(&mut self, msg: Self::Data) -> Result<Self::Out, HandlerError>;
+
+    /// Advance one step from the control lane. Defaults to the silent transition.
+    fn step_control(&mut self, _msg: Self::Control) -> Result<Self::Out, HandlerError> {
+        Ok(Self::Out::default())
+    }
+
+    /// Advance one step from the management lane. Defaults to the silent transition.
+    fn step_management(&mut self, _msg: Self::Management) -> Result<Self::Out, HandlerError> {
+        Ok(Self::Out::default())
+    }
 
     /// Take the self-addressed continuation out of an output word, if this machine yields.
     ///
     /// The default is `None`: no self-port, no yielding. A machine that yields overrides this
     /// to hand back its self-port, and the [`Node`] routes it to a dedicated single slot
     /// rather than through [`Wiring`] — see [`Node::poll`] for why that is the only way a
-    /// self-edge can be deadlock-free.
-    fn take_continuation(_out: &mut Self::Out) -> Option<Self::In> {
+    /// self-edge can be deadlock-free. A continuation always resumes on the data lane: it is
+    /// more work, not a control or management signal.
+    fn take_continuation(_out: &mut Self::Out) -> Option<Self::Data> {
         None
     }
 }
@@ -172,30 +212,6 @@ pub enum Step {
     Halted(Exit),
 }
 
-/// The scheduler side of one actor: the machine, its inbox, its wiring, and its outbox.
-///
-/// The outbox is the entire suspension state. Because a step runs to completion, a parked
-/// actor's `self` is always consistent — there is no half-finished handler to resume, only
-/// undelivered messages to retry. That is why this design needs no coroutine machinery.
-pub struct Node<T: Transducer, W: Wiring<Out = T::Out>, R> {
-    actor: T,
-    inbox: R,
-    wiring: W,
-    /// Undelivered ports from the last step. `Some` means parked.
-    outbox: Option<T::Out>,
-    /// The self-addressed continuation: capacity exactly one, drained before the inbox.
-    ///
-    /// This is the whole of the deadlock argument. A step consumes at most one continuation
-    /// and produces at most one (the output word has a single slot per port), and the slot is
-    /// emptied immediately before the step that could refill it — so it can never be full
-    /// when written, can never block, and can never park. A self-edge routed through a
-    /// *queue* instead would deadlock the moment that queue filled: the only actor that can
-    /// drain it is the one parked on writing to it.
-    continuation: Option<T::In>,
-    /// Steps taken. Lets tests assert that a parked actor is genuinely not stepped.
-    steps: u64,
-}
-
 /// Pulling one input symbol. Implemented for the SPSC receiver; a trait so tests can drive a
 /// node from a plain queue, and so an in-process worker can later use a non-atomic inbox.
 pub trait Inbox {
@@ -213,21 +229,146 @@ impl<T> Inbox for crate::spsc::SpscReceiver<T> {
     }
 }
 
-impl<T, W, R> Node<T, W, R>
+/// An inbox with no producer: always reports [`TryRecvError::Disconnected`].
+///
+/// Stands in for a lane a [`Transducer`] does not use, so [`Node::new`] can wire a data-only
+/// actor without a real control or management channel. Disconnected, not merely empty, is the
+/// honest state — there is not, and will never be, a sender for this lane — and it is what
+/// makes [`Node`]'s halt condition ("every lane disconnected") correct for a single-lane actor:
+/// it reduces to exactly "the data lane disconnected," since control/management already report
+/// disconnected unconditionally.
+pub struct NoLane<T>(PhantomData<T>);
+
+impl<T> NoLane<T> {
+    /// A permanently empty lane.
+    #[must_use]
+    pub fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<T> Default for NoLane<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> Inbox for NoLane<T> {
+    type Item = T;
+
+    fn take(&mut self) -> Result<T, TryRecvError> {
+        Err(TryRecvError::Disconnected)
+    }
+}
+
+/// Which of the three lanes [`Node::poll`] is currently favoring, and for how long, before it
+/// rotates to the next.
+///
+/// Mirrors `ActorScheduler::handle_wake`'s exact cycle — control (half budget) → management
+/// (full budget) → control (half budget again) → data (full budget) — ported to run one
+/// message at a time across many `poll()` calls instead of batched into one call. Control gets
+/// two turns per cycle so that anything arriving while management is favored is still seen
+/// promptly, without giving control the whole cycle and starving data.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Slot {
+    Control1,
+    Management,
+    Control2,
+    Data,
+}
+
+impl Slot {
+    fn next(self) -> Self {
+        match self {
+            Slot::Control1 => Slot::Management,
+            Slot::Management => Slot::Control2,
+            Slot::Control2 => Slot::Data,
+            Slot::Data => Slot::Control1,
+        }
+    }
+}
+
+/// The three inbox lanes a lane-aware [`Node`] reads from, bundled so
+/// [`Node::new_with_lanes`] takes one argument instead of three.
+pub struct Lanes<RC, RM, RD> {
+    /// Highest priority.
+    pub control: RC,
+    /// Middle priority.
+    pub management: RM,
+    /// Lowest priority, and the only lane every actor has.
+    pub data: RD,
+}
+
+/// The scheduler side of one actor: the machine, its three lanes, its wiring, and its outbox.
+///
+/// The outbox is the entire suspension state. Because a step runs to completion, a parked
+/// actor's `self` is always consistent — there is no half-finished handler to resume, only
+/// undelivered messages to retry. That is why this design needs no coroutine machinery.
+///
+/// `RC`/`RM` default to [`NoLane`] — a data-only actor is `Node<T, W, RD>`, exactly the call
+/// shape every single-lane actor already uses. A lane-aware actor spells out all five
+/// parameters (or, in practice, just calls [`Node::new_with_lanes`] and lets inference fill
+/// them in).
+pub struct Node<T: Transducer, W: Wiring<Out = T::Out>, RD, RC = NoLane<<T as Transducer>::Control>, RM = NoLane<<T as Transducer>::Management>>
+{
+    actor: T,
+    control: RC,
+    management: RM,
+    data: RD,
+    wiring: W,
+    /// Undelivered ports from the last step. `Some` means parked.
+    outbox: Option<T::Out>,
+    /// The self-addressed continuation: capacity exactly one, drained before any lane.
+    ///
+    /// This is the whole of the deadlock argument. A step consumes at most one continuation
+    /// and produces at most one (the output word has a single slot per port), and the slot is
+    /// emptied immediately before the step that could refill it — so it can never be full
+    /// when written, can never block, and can never park. A self-edge routed through a
+    /// *queue* instead would deadlock the moment that queue filled: the only actor that can
+    /// drain it is the one parked on writing to it.
+    continuation: Option<T::Data>,
+    /// Steps taken. Lets tests assert that a parked actor is genuinely not stepped.
+    steps: u64,
+    /// Current position in the control/management/control/data cycle.
+    slot: Slot,
+    /// Messages taken in the current `slot` visit, toward that slot's limit.
+    slot_progress: usize,
+    control_half_limit: usize,
+    management_limit: usize,
+    data_limit: usize,
+}
+
+impl<T, W, RD, RC, RM> Node<T, W, RD, RC, RM>
 where
     T: Transducer,
     W: Wiring<Out = T::Out>,
-    R: Inbox<Item = T::In>,
+    RD: Inbox<Item = T::Data>,
+    RC: Inbox<Item = T::Control>,
+    RM: Inbox<Item = T::Management>,
 {
-    /// Wire an actor to an inbox and a set of output ports.
-    pub fn new(actor: T, inbox: R, wiring: W) -> Self {
+    /// Wire an actor to all three lanes, its output ports, and burst-limit config.
+    ///
+    /// Reuses [`SchedulerParams`] verbatim, including its `default_data_burst_limit` — the
+    /// same config type, the same `control_burst_limit()`/`management_burst_limit()` the
+    /// dedicated-thread scheduler uses — so a lane-aware green actor is tuned exactly like an
+    /// OS-thread one, rather than by a second, parallel set of knobs. Override the data limit
+    /// the same way any `SchedulerParams` field is overridden: `SchedulerParams { default_data_
+    /// burst_limit: n, ..SchedulerParams::DEFAULT }`.
+    pub fn new_with_lanes(actor: T, lanes: Lanes<RC, RM, RD>, wiring: W, params: SchedulerParams) -> Self {
         Self {
             actor,
-            inbox,
+            control: lanes.control,
+            management: lanes.management,
+            data: lanes.data,
             wiring,
             outbox: None,
             continuation: None,
             steps: 0,
+            slot: Slot::Control1,
+            slot_progress: 0,
+            control_half_limit: (params.control_burst_limit() / 2).max(1),
+            management_limit: params.management_burst_limit(),
+            data_limit: params.default_data_burst_limit.max(1),
         }
     }
 
@@ -243,7 +384,8 @@ where
         &self.actor
     }
 
-    /// Drain the outbox, then take at most one input and step.
+    /// Drain the outbox, then take at most one input — from the continuation slot, or from
+    /// whichever lane the priority cycle currently favors — and step.
     ///
     /// Ordering is the whole contract:
     ///
@@ -251,10 +393,13 @@ where
     ///    outbox is non-empty. That is what makes backpressure propagate — a fast producer
     ///    stops advancing until its slow consumer catches up, without spinning and without
     ///    losing a message.
-    /// 2. **Take the continuation before the inbox**, so a machine finishes the work unit it
+    /// 2. **Take the continuation before any lane**, so a machine finishes the work unit it
     ///    started before accepting new work. That bounds the number of half-finished
     ///    computations in flight at one.
-    /// 3. **Lift the continuation out of the output word before flushing**, so the self-edge
+    /// 3. **Consult lanes in Control > Management > Data order**, budget-limited exactly like
+    ///    `ActorScheduler::handle_wake`, so control cannot starve data forever but does not
+    ///    wait behind it either.
+    /// 4. **Lift the continuation out of the output word before flushing**, so the self-edge
     ///    never reaches [`Wiring`] and so the slot is empty at the moment it is written.
     pub fn poll(&mut self) -> Step {
         if let Some(pending) = &mut self.outbox {
@@ -264,23 +409,99 @@ where
             self.outbox = None;
         }
 
-        let input = match self.continuation.take() {
-            Some(resumed) => resumed,
-            None => match self.inbox.take() {
-                Ok(input) => input,
-                Err(TryRecvError::Empty) => return Step::Idle,
-                Err(TryRecvError::Disconnected) => return Step::Halted(Exit::Completed),
-            },
-        };
+        if let Some(resumed) = self.continuation.take() {
+            return self.dispatch(|actor| actor.step_data(resumed));
+        }
 
-        let mut out = match self.actor.step(input) {
+        // One full lap visits Control1, Management, Control2, and Data exactly once,
+        // regardless of which slot the cycle happens to be sitting on when this call starts —
+        // Slot::next() is a 4-cycle, so four steps always covers all four positions.
+        let mut control_disconnected = false;
+        let mut management_disconnected = false;
+        let mut data_disconnected = false;
+
+        for _ in 0..4 {
+            let limit = match self.slot {
+                Slot::Control1 | Slot::Control2 => self.control_half_limit,
+                Slot::Management => self.management_limit,
+                Slot::Data => self.data_limit,
+            };
+
+            if self.slot_progress >= limit {
+                self.slot = self.slot.next();
+                self.slot_progress = 0;
+                continue;
+            }
+
+            match self.slot {
+                Slot::Control1 | Slot::Control2 => match self.control.take() {
+                    Ok(msg) => {
+                        self.slot_progress += 1;
+                        return self.dispatch(|actor| actor.step_control(msg));
+                    }
+                    Err(TryRecvError::Empty) => {
+                        self.slot = self.slot.next();
+                        self.slot_progress = 0;
+                    }
+                    Err(TryRecvError::Disconnected) => {
+                        control_disconnected = true;
+                        self.slot = self.slot.next();
+                        self.slot_progress = 0;
+                    }
+                },
+                Slot::Management => match self.management.take() {
+                    Ok(msg) => {
+                        self.slot_progress += 1;
+                        return self.dispatch(|actor| actor.step_management(msg));
+                    }
+                    Err(TryRecvError::Empty) => {
+                        self.slot = self.slot.next();
+                        self.slot_progress = 0;
+                    }
+                    Err(TryRecvError::Disconnected) => {
+                        management_disconnected = true;
+                        self.slot = self.slot.next();
+                        self.slot_progress = 0;
+                    }
+                },
+                Slot::Data => match self.data.take() {
+                    Ok(msg) => {
+                        self.slot_progress += 1;
+                        return self.dispatch(|actor| actor.step_data(msg));
+                    }
+                    Err(TryRecvError::Empty) => {
+                        self.slot = self.slot.next();
+                        self.slot_progress = 0;
+                    }
+                    Err(TryRecvError::Disconnected) => {
+                        data_disconnected = true;
+                        self.slot = self.slot.next();
+                        self.slot_progress = 0;
+                    }
+                },
+            }
+        }
+
+        if control_disconnected && management_disconnected && data_disconnected {
+            Step::Halted(Exit::Completed)
+        } else {
+            Step::Idle
+        }
+    }
+
+    /// Run one step, advance the step counter, extract the continuation, and flush.
+    ///
+    /// The one path every lane and the continuation resume through, so "step, then flush,
+    /// then maybe park" is written once rather than four times.
+    fn dispatch(&mut self, step: impl FnOnce(&mut T) -> Result<T::Out, HandlerError>) -> Step {
+        let mut out = match step(&mut self.actor) {
             Ok(out) => out,
             Err(HandlerError::Recoverable(msg)) => return Step::Halted(Exit::Failed(msg)),
             Err(HandlerError::Fatal(msg)) => panic!("Actor fatal error: {msg}"),
         };
         self.steps += 1;
 
-        // The slot was emptied above, so this write can never overflow.
+        // The slot was emptied before dispatch runs, so this write can never overflow.
         self.continuation = T::take_continuation(&mut out);
 
         if self.wiring.flush(&mut out) == Flush::Blocked {
@@ -288,6 +509,31 @@ where
         }
 
         Step::Ran
+    }
+}
+
+impl<T, W, RD> Node<T, W, RD>
+where
+    T: Transducer,
+    W: Wiring<Out = T::Out>,
+    RD: Inbox<Item = T::Data>,
+{
+    /// A data-only node: no control or management lane.
+    ///
+    /// The common case, and the same three-argument call every single-lane actor already
+    /// uses — `RC`/`RM` default to [`NoLane`], so this is `new_with_lanes` with both extra
+    /// lanes disconnected and default burst parameters.
+    pub fn new(actor: T, data: RD, wiring: W) -> Self {
+        Self::new_with_lanes(
+            actor,
+            Lanes {
+                control: NoLane::new(),
+                management: NoLane::new(),
+                data,
+            },
+            wiring,
+            SchedulerParams::DEFAULT,
+        )
     }
 }
 
@@ -564,6 +810,7 @@ impl Topology {
 mod tests {
     use super::*;
     use crate::spsc::spsc_channel;
+    use std::convert::Infallible;
 
     // ── An actor that fans out to two differently-typed targets ─────────────
     //
@@ -604,10 +851,12 @@ mod tests {
     }
 
     impl Transducer for App {
-        type In = u8;
+        type Control = Infallible;
+        type Management = Infallible;
+        type Data = u8;
         type Out = AppOut;
 
-        fn step(&mut self, byte: u8) -> Result<AppOut, HandlerError> {
+        fn step_data(&mut self, byte: u8) -> Result<AppOut, HandlerError> {
             self.seen += 1;
             if byte == 0 {
                 return Ok(AppOut::default());
@@ -625,11 +874,11 @@ mod tests {
         // with no scheduler, no wiring, and no mocked senders in the loop.
         let mut app = App { seen: 0 };
 
-        let out = app.step(b'x').unwrap();
+        let out = app.step_data(b'x').unwrap();
         assert_eq!(out.engine, Some(Render(b'x')));
         assert_eq!(out.write, Some(Echo(b'x')));
 
-        let quiet = app.step(0).unwrap();
+        let quiet = app.step_data(0).unwrap();
         assert!(quiet.engine.is_none() && quiet.write.is_none());
 
         assert_eq!(app.seen, 2, "state advanced on both inputs");
@@ -907,9 +1156,11 @@ mod tests {
             }
         }
         impl Transducer for Boom {
-            type In = u8;
+            type Control = Infallible;
+            type Management = Infallible;
+            type Data = u8;
             type Out = Option<u8>;
-            fn step(&mut self, _: u8) -> Result<Option<u8>, HandlerError> {
+            fn step_data(&mut self, _: u8) -> Result<Option<u8>, HandlerError> {
                 Err(HandlerError::Recoverable("boom".into()))
             }
         }
@@ -960,10 +1211,12 @@ mod tests {
     }
 
     impl Transducer for Countdown {
-        type In = u32;
+        type Control = Infallible;
+        type Management = Infallible;
+        type Data = u32;
         type Out = CountdownOut;
 
-        fn step(&mut self, n: u32) -> Result<CountdownOut, HandlerError> {
+        fn step_data(&mut self, n: u32) -> Result<CountdownOut, HandlerError> {
             if n == 0 {
                 self.finished = Some(0);
                 return Ok(CountdownOut {
@@ -1107,6 +1360,182 @@ mod tests {
             3,
             "the other actor made progress in between — no monopolisation"
         );
+    }
+
+    // ── Priority lanes: ported from ActorScheduler::handle_wake ─────────────
+
+    /// Records which lane each step came from. `Out = ()`: these tests are about input
+    /// ordering, not output, so there is nothing to wire.
+    struct LaneLog {
+        seen: Vec<&'static str>,
+    }
+
+    struct NoWiring;
+    impl Wiring for NoWiring {
+        type Out = ();
+        fn flush(&mut self, (): &mut ()) -> Flush {
+            Flush::Done
+        }
+    }
+
+    impl Transducer for LaneLog {
+        type Control = ();
+        type Management = ();
+        type Data = ();
+        type Out = ();
+
+        fn step_data(&mut self, (): ()) -> Result<(), HandlerError> {
+            self.seen.push("D");
+            Ok(())
+        }
+
+        fn step_control(&mut self, (): ()) -> Result<(), HandlerError> {
+            self.seen.push("C");
+            Ok(())
+        }
+
+        fn step_management(&mut self, (): ()) -> Result<(), HandlerError> {
+            self.seen.push("M");
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn one_message_per_lane_drains_control_then_management_then_data() {
+        let (tx_c, rx_c) = spsc_channel::<()>(4);
+        let (tx_m, rx_m) = spsc_channel::<()>(4);
+        let (tx_d, rx_d) = spsc_channel::<()>(4);
+
+        let mut node = Node::new_with_lanes(
+            LaneLog { seen: Vec::new() },
+            Lanes {
+                control: rx_c,
+                management: rx_m,
+                data: rx_d,
+            },
+            NoWiring,
+            SchedulerParams::DEFAULT,
+        );
+
+        tx_c.try_send(()).unwrap();
+        tx_m.try_send(()).unwrap();
+        tx_d.try_send(()).unwrap();
+
+        for _ in 0..3 {
+            assert_eq!(node.poll(), Step::Ran);
+        }
+        assert_eq!(
+            node.actor().seen,
+            vec!["C", "M", "D"],
+            "one message per lane must drain in priority order"
+        );
+    }
+
+    #[test]
+    fn control_backlog_does_not_starve_data_forever() {
+        // The property `ActorScheduler::handle_wake`'s half-control/mgmt/half-control/data
+        // split exists for: with control_burst_limit=2 (half=1) and no management traffic,
+        // control gets two turns per cycle (Control1, Control2) before data gets one — so
+        // data is guaranteed a turn every cycle, however deep the control backlog runs.
+        let params = SchedulerParams {
+            control_mgmt_buffer_size: 1,
+            control_burst_multiplier: 2, // control_burst_limit = 2, half = 1
+            management_burst_multiplier: 1,
+            default_data_burst_limit: 1,
+            ..SchedulerParams::DEFAULT
+        };
+
+        let (tx_c, rx_c) = spsc_channel::<()>(64);
+        let (_tx_m, rx_m) = spsc_channel::<()>(4);
+        let (tx_d, rx_d) = spsc_channel::<()>(4);
+
+        let mut node = Node::new_with_lanes(
+            LaneLog { seen: Vec::new() },
+            Lanes {
+                control: rx_c,
+                management: rx_m,
+                data: rx_d,
+            },
+            NoWiring,
+            params,
+        );
+
+        for _ in 0..5 {
+            tx_c.try_send(()).unwrap();
+        }
+        tx_d.try_send(()).unwrap();
+
+        for _ in 0..3 {
+            assert_eq!(node.poll(), Step::Ran);
+        }
+        assert_eq!(
+            node.actor().seen,
+            vec!["C", "C", "D"],
+            "data must be served after one cycle (2 control), not after the whole backlog"
+        );
+    }
+
+    // Regression: half_control = control_burst_limit / 2 used to truncate to 0 when the
+    // burst limit was 1, and a zero-limit slot could never make progress (mirrors
+    // control_lane_progresses_with_burst_limit_one in lib.rs for the OS-thread scheduler).
+    #[test]
+    fn control_lane_progresses_with_burst_limit_one() {
+        let params = SchedulerParams {
+            control_mgmt_buffer_size: 1,
+            control_burst_multiplier: 1, // control_burst_limit == 1
+            ..SchedulerParams::DEFAULT
+        };
+        assert_eq!(params.control_burst_limit(), 1);
+
+        let (tx_c, rx_c) = spsc_channel::<()>(4);
+        let (_tx_m, rx_m) = spsc_channel::<()>(4);
+        let (_tx_d, rx_d) = spsc_channel::<()>(4);
+
+        let mut node = Node::new_with_lanes(
+            LaneLog { seen: Vec::new() },
+            Lanes {
+                control: rx_c,
+                management: rx_m,
+                data: rx_d,
+            },
+            NoWiring,
+            params,
+        );
+
+        tx_c.try_send(()).unwrap();
+        assert_eq!(node.poll(), Step::Ran);
+        assert_eq!(
+            node.actor().seen,
+            vec!["C"],
+            "control message was never processed with control_burst_limit == 1"
+        );
+    }
+
+    #[test]
+    fn halts_only_once_every_lane_is_disconnected() {
+        let (tx_c, rx_c) = spsc_channel::<()>(4);
+        let (tx_m, rx_m) = spsc_channel::<()>(4);
+        let (tx_d, rx_d) = spsc_channel::<()>(4);
+
+        let mut node = Node::new_with_lanes(
+            LaneLog { seen: Vec::new() },
+            Lanes {
+                control: rx_c,
+                management: rx_m,
+                data: rx_d,
+            },
+            NoWiring,
+            SchedulerParams::DEFAULT,
+        );
+
+        drop(tx_c);
+        drop(tx_m);
+        // data's sender is still alive but has sent nothing: Empty, not Disconnected, so the
+        // node must stay Idle rather than halt on a partial disconnect.
+        assert_eq!(node.poll(), Step::Idle);
+
+        drop(tx_d);
+        assert_eq!(node.poll(), Step::Halted(Exit::Completed));
     }
 
     // ── Topology: cycles are a bootstrap error, not a runtime deadlock ──────

--- a/actor-scheduler/src/mealy.rs
+++ b/actor-scheduler/src/mealy.rs
@@ -105,41 +105,42 @@ pub trait Wiring {
     fn flush(&mut self, out: &mut Self::Out) -> Flush;
 }
 
-/// Deliver one port, restoring the message if the target is full.
+/// Whether a port's delivery may park its producer.
+///
+/// The two edge kinds [`Topology`] knows about (§3.1): a cycle among blocking edges is a
+/// bootstrap error, but a droppable edge cannot deadlock and so may legally close one. This
+/// is the runtime counterpart, and it is also what the macro's `[drop]` port attribute
+/// compiles to — one enum, not an accreting family of `send_port`/`send_port_*` functions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Delivery {
+    /// Park the producer when the target is full. Propagates backpressure.
+    Blocking,
+    /// Discard when the target is full. Can never return [`Flush::Blocked`], which is what
+    /// makes it legal as the closing edge of a cycle.
+    ///
+    /// Use it for data that is only worth delivering if still current — "drop this frame if
+    /// the display is busy" — never for anything a consumer must not miss. Silence on a full
+    /// ring is the whole point, and also the whole risk.
+    Droppable,
+}
+
+/// Deliver one port according to `delivery`.
 ///
 /// The building block every generated `Wiring::flush` is made of. A disconnected target
-/// drops the message and reports success — the target is gone, so there is nothing to wait
-/// for, and blocking forever on a dead consumer would deadlock the sender.
-pub fn send_port<T>(port: &mut Option<T>, tx: &SpscSender<T>) -> Flush {
+/// drops the message and reports success either way — the target is gone, so there is
+/// nothing to wait for, and blocking forever on a dead consumer would deadlock the sender.
+pub fn send_port<T>(port: &mut Option<T>, tx: &SpscSender<T>, delivery: Delivery) -> Flush {
     let Some(msg) = port.take() else {
         return Flush::Done;
     };
-    match tx.try_send(msg) {
-        Ok(()) => Flush::Done,
-        Err(TrySendError::Full(msg)) => {
+    match (tx.try_send(msg), delivery) {
+        (Ok(()), _) | (Err(TrySendError::Disconnected(_)), _) => Flush::Done,
+        (Err(TrySendError::Full(_)), Delivery::Droppable) => Flush::Done,
+        (Err(TrySendError::Full(msg)), Delivery::Blocking) => {
             *port = Some(msg);
             Flush::Blocked
         }
-        Err(TrySendError::Disconnected(_)) => Flush::Done,
     }
-}
-
-/// Deliver one port, **discarding** the message if the target is full.
-///
-/// The runtime half of [`Topology::droppable_edge`]. This never returns [`Flush::Blocked`],
-/// so it can never park its producer — which is exactly what makes a droppable edge legal as
-/// the closing edge of a cycle (§3.1 of the design).
-///
-/// Use it for data that is only worth delivering if it is still current — "drop this frame if
-/// the display is busy" — and never for anything a consumer must not miss. Silence on a full
-/// ring is the whole point, and also the whole risk.
-pub fn send_port_droppable<T>(port: &mut Option<T>, tx: &SpscSender<T>) -> Flush {
-    if let Some(msg) = port.take() {
-        // Full and Disconnected are the same outcome here: nobody is taking this message, and
-        // a droppable port discards rather than waiting.
-        drop(tx.try_send(msg));
-    }
-    Flush::Done
 }
 
 /// Combine port outcomes: blocked if any port is blocked.
@@ -522,8 +523,8 @@ mod tests {
 
         fn flush(&mut self, out: &mut AppOut) -> Flush {
             all([
-                send_port(&mut out.engine, &self.engine),
-                send_port(&mut out.write, &self.write),
+                send_port(&mut out.engine, &self.engine, Delivery::Blocking),
+                send_port(&mut out.write, &self.write, Delivery::Blocking),
             ])
         }
     }
@@ -701,7 +702,7 @@ mod tests {
         let mut delivered = 0;
         for i in 0..32u8 {
             let mut port = Some(Render(i));
-            assert_eq!(send_port_droppable(&mut port, &tx), Flush::Done);
+            assert_eq!(send_port(&mut port, &tx, Delivery::Droppable), Flush::Done);
             assert!(port.is_none(), "a droppable port always clears");
             if rx.try_recv().is_ok() {
                 delivered += 1;
@@ -716,7 +717,7 @@ mod tests {
         drop(rx);
 
         let mut port = Some(Render(1));
-        assert_eq!(send_port_droppable(&mut port, &tx), Flush::Done);
+        assert_eq!(send_port(&mut port, &tx, Delivery::Droppable), Flush::Done);
         assert!(port.is_none());
     }
 
@@ -748,7 +749,7 @@ mod tests {
         impl Wiring for BoomWiring {
             type Out = Option<u8>;
             fn flush(&mut self, out: &mut Option<u8>) -> Flush {
-                send_port(out, &self.out)
+                send_port(out, &self.out, Delivery::Blocking)
             }
         }
         impl Transducer for Boom {
@@ -800,7 +801,7 @@ mod tests {
         fn flush(&mut self, out: &mut CountdownOut) -> Flush {
             // The self-port never reaches the wiring: `take_continuation` lifts it out first.
             debug_assert!(out.again.is_none(), "continuation must not reach the wiring");
-            send_port(&mut out.done, &self.done)
+            send_port(&mut out.done, &self.done, Delivery::Blocking)
         }
     }
 

--- a/actor-scheduler/tests/ports.rs
+++ b/actor-scheduler/tests/ports.rs
@@ -6,6 +6,7 @@
 use actor_scheduler::mealy::{Flush, Node, Step, Transducer, Wiring};
 use actor_scheduler::spsc::spsc_channel;
 use actor_scheduler::{Exit, HandlerError, ports};
+use std::convert::Infallible;
 
 // ────────────────────────────────────────────────────────────────────────────
 // Fan-out to two differently-typed targets — the terminal's echo-and-draw shape
@@ -28,10 +29,12 @@ struct App {
 }
 
 impl Transducer for App {
-    type In = u8;
+    type Control = Infallible;
+    type Management = Infallible;
+    type Data = u8;
     type Out = AppOut;
 
-    fn step(&mut self, byte: u8) -> Result<AppOut, HandlerError> {
+    fn step_data(&mut self, byte: u8) -> Result<AppOut, HandlerError> {
         self.seen += 1;
         if byte == 0 {
             return Ok(AppOut::default()); // the silent transition
@@ -177,10 +180,12 @@ struct Countdown {
 }
 
 impl Transducer for Countdown {
-    type In = u32;
+    type Control = Infallible;
+    type Management = Infallible;
+    type Data = u32;
     type Out = CountdownOut;
 
-    fn step(&mut self, n: u32) -> Result<CountdownOut, HandlerError> {
+    fn step_data(&mut self, n: u32) -> Result<CountdownOut, HandlerError> {
         if n == 0 {
             self.finished = Some(0);
             return Ok(CountdownOut {
@@ -246,10 +251,12 @@ ports! {
 struct Batcher;
 
 impl Transducer for Batcher {
-    type In = u8;
+    type Control = Infallible;
+    type Management = Infallible;
+    type Data = u8;
     type Out = BatcherOut;
 
-    fn step(&mut self, byte: u8) -> Result<BatcherOut, HandlerError> {
+    fn step_data(&mut self, byte: u8) -> Result<BatcherOut, HandlerError> {
         Ok(BatcherOut {
             out: Some(vec![byte; 3]),
         })

--- a/actor-scheduler/tests/ports.rs
+++ b/actor-scheduler/tests/ports.rs
@@ -1,0 +1,278 @@
+//! `ports!` codegen: the output word and its wiring.
+//!
+//! These run from outside the crate because the generated code uses `::actor_scheduler::`
+//! paths, which only resolve for a dependent crate.
+
+use actor_scheduler::mealy::{Flush, Node, Step, Transducer, Wiring};
+use actor_scheduler::spsc::spsc_channel;
+use actor_scheduler::{Exit, HandlerError, ports};
+
+// ────────────────────────────────────────────────────────────────────────────
+// Fan-out to two differently-typed targets — the terminal's echo-and-draw shape
+// ────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, PartialEq, Eq)]
+struct Render(u8);
+#[derive(Debug, PartialEq, Eq)]
+struct Echo(u8);
+
+ports! {
+    App {
+        engine: Render,
+        write: Echo,
+    }
+}
+
+struct App {
+    seen: u32,
+}
+
+impl Transducer for App {
+    type In = u8;
+    type Out = AppOut;
+
+    fn step(&mut self, byte: u8) -> Result<AppOut, HandlerError> {
+        self.seen += 1;
+        if byte == 0 {
+            return Ok(AppOut::default()); // the silent transition
+        }
+        Ok(AppOut {
+            engine: Some(Render(byte)),
+            write: Some(Echo(byte)),
+        })
+    }
+}
+
+#[test]
+fn generated_ports_carry_their_own_types() {
+    let (tx_in, rx_in) = spsc_channel::<u8>(8);
+    let (tx_engine, mut rx_engine) = spsc_channel::<Render>(8);
+    let (tx_write, mut rx_write) = spsc_channel::<Echo>(8);
+
+    let mut node = Node::new(
+        App { seen: 0 },
+        rx_in,
+        AppWiring {
+            engine: tx_engine,
+            write: tx_write,
+        },
+    );
+
+    tx_in.try_send(b'q').unwrap();
+    assert_eq!(node.poll(), Step::Ran);
+
+    assert_eq!(rx_engine.try_recv().unwrap(), Render(b'q'));
+    assert_eq!(rx_write.try_recv().unwrap(), Echo(b'q'));
+}
+
+#[test]
+fn a_default_output_word_delivers_nothing() {
+    let mut out = AppOut::default();
+    assert!(out.engine.is_none() && out.write.is_none());
+
+    let (tx_engine, mut rx_engine) = spsc_channel::<Render>(4);
+    let (tx_write, mut rx_write) = spsc_channel::<Echo>(4);
+    let mut wiring = AppWiring {
+        engine: tx_engine,
+        write: tx_write,
+    };
+
+    assert_eq!(wiring.flush(&mut out), Flush::Done);
+    assert!(rx_engine.try_recv().is_err() && rx_write.try_recv().is_err());
+}
+
+#[test]
+fn generated_flush_parks_on_a_full_target_and_keeps_the_message() {
+    // The property that is easy to get wrong by hand: a blocked port must be left set, not
+    // dropped, so the node can retry it.
+    let (tx_engine, mut rx_engine) = spsc_channel::<Render>(1);
+    let (tx_write, _rx_write) = spsc_channel::<Echo>(64);
+    let mut wiring = AppWiring {
+        engine: tx_engine,
+        write: tx_write,
+    };
+
+    // Fill the engine ring.
+    let mut blocked_at = None;
+    for byte in 0..64u8 {
+        let mut out = AppOut {
+            engine: Some(Render(byte)),
+            write: Some(Echo(byte)),
+        };
+        if wiring.flush(&mut out) == Flush::Blocked {
+            assert_eq!(
+                out.engine,
+                Some(Render(byte)),
+                "a blocked port must keep its message for the retry"
+            );
+            assert!(out.write.is_none(), "the port that fit was still delivered");
+            blocked_at = Some(byte);
+            break;
+        }
+    }
+    assert!(blocked_at.is_some(), "the engine ring should have filled");
+
+    // Draining the target unblocks the same wiring.
+    while rx_engine.try_recv().is_ok() {}
+    let mut out = AppOut {
+        engine: Some(Render(9)),
+        write: Some(Echo(9)),
+    };
+    assert_eq!(wiring.flush(&mut out), Flush::Done);
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// A droppable port cannot park — the runtime half of `Topology::droppable_edge`
+// ────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, PartialEq, Eq)]
+struct Frame(u32);
+
+ports! {
+    Vsync {
+        display: Frame [drop],
+    }
+}
+
+#[test]
+fn a_droppable_port_discards_instead_of_parking() {
+    let (tx_display, mut rx_display) = spsc_channel::<Frame>(2);
+    let mut wiring = VsyncWiring {
+        display: tx_display,
+    };
+
+    // Far more frames than the ring holds: none of them may block.
+    for i in 0..64 {
+        let mut out = VsyncOut {
+            display: Some(Frame(i)),
+        };
+        assert_eq!(
+            wiring.flush(&mut out),
+            Flush::Done,
+            "a droppable port must never report Blocked"
+        );
+        assert!(out.display.is_none(), "a droppable port never keeps a message");
+    }
+
+    let delivered = std::iter::from_fn(|| rx_display.try_recv().ok()).count();
+    assert!(
+        delivered > 0 && delivered < 64,
+        "some frames delivered, the rest dropped; got {delivered}"
+    );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// A `[self]` port is a continuation, not a wiring field
+// ────────────────────────────────────────────────────────────────────────────
+
+ports! {
+    Countdown {
+        again: u32 [self],
+        done: u32,
+    }
+}
+
+struct Countdown {
+    finished: Option<u32>,
+}
+
+impl Transducer for Countdown {
+    type In = u32;
+    type Out = CountdownOut;
+
+    fn step(&mut self, n: u32) -> Result<CountdownOut, HandlerError> {
+        if n == 0 {
+            self.finished = Some(0);
+            return Ok(CountdownOut {
+                done: Some(0),
+                ..Default::default()
+            });
+        }
+        Ok(CountdownOut {
+            again: Some(n - 1),
+            ..Default::default()
+        })
+    }
+
+    fn take_continuation(out: &mut CountdownOut) -> Option<u32> {
+        out.take_continuation()
+    }
+}
+
+#[test]
+fn a_self_port_yields_through_the_continuation_slot() {
+    let (tx_in, rx_in) = spsc_channel::<u32>(8);
+    let (tx_done, mut rx_done) = spsc_channel::<u32>(8);
+
+    let mut node = Node::new(
+        Countdown { finished: None },
+        rx_in,
+        CountdownWiring { done: tx_done },
+    );
+
+    tx_in.try_send(5).unwrap();
+
+    let mut steps = 0;
+    while node.actor().finished.is_none() {
+        assert_eq!(node.poll(), Step::Ran);
+        steps += 1;
+        assert!(steps <= 8, "should finish in 6 steps");
+    }
+
+    assert_eq!(steps, 6, "5,4,3,2,1,0 — one step each, yielding between");
+    assert_eq!(rx_done.try_recv().unwrap(), 0);
+}
+
+#[test]
+fn a_self_port_has_no_wiring_field() {
+    // `CountdownWiring` is constructed with only `done`. If the macro had emitted a field for
+    // the `[self]` port, this would not compile — which is the point: a continuation cannot
+    // be wired to a queue.
+    let (tx_done, _rx_done) = spsc_channel::<u32>(4);
+    let wiring = CountdownWiring { done: tx_done };
+    drop(wiring);
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Generic port types pass through
+// ────────────────────────────────────────────────────────────────────────────
+
+ports! {
+    Batcher {
+        out: Vec<u8>,
+    }
+}
+
+struct Batcher;
+
+impl Transducer for Batcher {
+    type In = u8;
+    type Out = BatcherOut;
+
+    fn step(&mut self, byte: u8) -> Result<BatcherOut, HandlerError> {
+        Ok(BatcherOut {
+            out: Some(vec![byte; 3]),
+        })
+    }
+}
+
+#[test]
+fn a_generic_port_type_survives_codegen() {
+    let (tx_in, rx_in) = spsc_channel::<u8>(4);
+    let (tx_out, mut rx_out) = spsc_channel::<Vec<u8>>(4);
+
+    let mut node = Node::new(Batcher, rx_in, BatcherWiring { out: tx_out });
+    tx_in.try_send(7).unwrap();
+    assert_eq!(node.poll(), Step::Ran);
+    assert_eq!(rx_out.try_recv().unwrap(), vec![7, 7, 7]);
+}
+
+#[test]
+fn a_disconnected_inbox_halts_a_generated_node() {
+    let (tx_in, rx_in) = spsc_channel::<u8>(4);
+    let (tx_out, _rx_out) = spsc_channel::<Vec<u8>>(4);
+
+    let mut node = Node::new(Batcher, rx_in, BatcherWiring { out: tx_out });
+    drop(tx_in);
+    assert_eq!(node.poll(), Step::Halted(Exit::Completed));
+}

--- a/docs/designs/actor-scheduler-mealy-transducer.md
+++ b/docs/designs/actor-scheduler-mealy-transducer.md
@@ -304,6 +304,7 @@ tests over transition tables.
 | `ports!` generating the output word + wiring + flush from a port declaration | `actor-scheduler-macros/src/lib.rs` |
 | `Delivery` (`Blocking`/`Droppable`) as a `send_port` parameter — the runtime half of a droppable edge | `actor-scheduler/src/mealy.rs` |
 | `Credit`: sender-side budget that keeps a droppable request/response edge from ever actually dropping | `actor-scheduler/src/mealy.rs` |
+| `Transducer` gains `Control`/`Management`/`Data` + `step_control`/`step_management` (defaulted); `Node` gains three lanes (`Lanes`, `NoLane`, `Slot` cycle) reusing `SchedulerParams` | `actor-scheduler/src/mealy.rs` |
 
 ### 7.1 Measured (2026-07-24)
 
@@ -459,30 +460,36 @@ response? No — see §3.2. `Credit` plus the existing `Delivery::Droppable` is 
   Only the *implementation* of `Application` is erased, not the port's type — `ports!` needs
   nothing new here.
 
-### 9.5 The real gap: priority lanes do not exist in `Node`/`Transducer`
+### 9.5 Priority lanes: closed
 
-`Transducer::In` is one type; `Node` holds one inbox. There is no Control/Management/Data
-priority anywhere in the Mealy machinery, and `Host::sweep` round-robins its green nodes with no
-lane weighting either. The existing engine leans on the opposite — Control > Management > Data
-is what keeps `Quit`/resize/key-input responsive while a render is in flight, and it is core to
-the actor model as described in this repository's top-level `CLAUDE.md`. An actor migrated onto
-`Node` as it stands today would silently lose that.
+Was the real gap: `Transducer::In` was one type, `Node` held one inbox — no Control/Management/
+Data priority anywhere in the Mealy machinery, while the existing engine leans on exactly that
+ordering to keep `Quit`/resize/key-input responsive under render load.
 
-**Directive for closing this, given at the point this gap was found:** port the *existing*
-priority-drain algorithm — `ActorScheduler::handle_wake`'s half-control/management/half-control/
-data cycle with per-lane burst limits (`lib.rs`, the `DrainStatus`/`SystemStatus` machinery) —
-onto `Transducer`/`Node`, rather than designing new priority machinery from scratch. `Transducer`
-gains three input types (mirroring `ActorTypes`) and three step methods; `Node::poll` runs the
-same drain order before touching the continuation slot. This is scoped as its own follow-up, not
-bundled into the engine-mesh rewrite itself, since the engine rewrite needs it as a foundation.
+Closed by porting `ActorScheduler::handle_wake`'s drain algorithm rather than designing a new
+one, per the direction given at the point this gap was found. `Transducer` now has `Control`/
+`Management`/`Data` associated types (mirroring `ActorTypes`) and three step methods —
+`step_control`/`step_management` default to the silent transition, so a single-lane actor still
+writes one method and two `type X = Infallible;` lines, exactly as `Host` already does for its
+own `Actor` impl. `Node` holds three lanes (`RC`/`RM` default to [`NoLane`], a permanently-
+disconnected stand-in, so every existing call site — `Node::new(actor, data, wiring)` — is
+unchanged) and cycles Control(half) → Management → Control(half) → Data via a `Slot` state
+machine, reusing `SchedulerParams` verbatim for the limits.
+
+The one real translation decision: the old algorithm drains a *burst* of messages per lane per
+wake, because nothing else shares that OS thread. `Node::poll` still does at most one message
+per call — draining a burst here would let one green actor hog its `Host` for as long as its
+burst limit allowed, which is exactly what `Host::sweep`'s per-node fairness exists to prevent.
+So the same cycle is spread across many `poll()` calls instead of batched into one: the *ratio*
+of attention across lanes is preserved, the *granularity* is not.
+
+A continuation always resumes on the data lane — it is more work, not a control or management
+signal — and still bypasses the lane cycle entirely, exactly as before.
 
 ---
 
 ## 10. Open questions
 
-- [ ] **Priority lanes for `Transducer`/`Node`.** The real gap found in §9.5. Port
-  `ActorScheduler::handle_wake`'s existing drain algorithm rather than redesigning one; scoped
-  as a prerequisite for the engine-mesh rewrite, not part of it.
 - [ ] **Self-port as a named verb?** First-class `yield`/continuation syntax in the macro, or
   just "a port that points home." Vocabulary vs. emergent trick. (The runtime already treats it
   as distinct — it has its own slot — which argues for naming it.)
@@ -493,6 +500,12 @@ bundled into the engine-mesh rewrite itself, since the engine rewrite needs it a
   doorbell coalesces, so this is cheap and correct, but a parked/running flag on the host would
   let a producer skip the ring entirely while the host is already sweeping — the trick mio uses
   for its eventfd. Worth measuring before adding.
+- [ ] **`ports!` and three lanes.** The macro still only generates `Out`/`Wiring` from a port
+  declaration; it does not yet touch `Transducer`'s `Control`/`Management`/`Data` associated
+  types or the three `step_*` methods, which are still hand-written. Whether that is worth
+  generating (e.g. from an `in { control: X, management: Y, data: Z }` block) depends on how
+  verbose lane-aware actors turn out to be in practice.
 
-Resolved: credit-bounded edges (§9.3, §3.2) and timer ticks for the dedicated tier (§9.4, by
-existing precedent) — kept out of this list; see the case study for why.
+Resolved: credit-bounded edges (§9.3, §3.2), timer ticks for the dedicated tier (§9.4, by
+existing precedent), and priority lanes for `Transducer`/`Node` (§9.5) — kept out of this list;
+see the case study for why.

--- a/docs/designs/actor-scheduler-mealy-transducer.md
+++ b/docs/designs/actor-scheduler-mealy-transducer.md
@@ -280,6 +280,8 @@ tests over transition tables.
 | Kubelet / `PodSlot` registry / `ServiceHandle` deleted; `PodPhase` → `Exit` (two variants, both actually returned) | removed |
 | `Host`: an `Actor` whose `park` sweeps owned green `Node`s, `Busy`/`Idle` driving the thread | `actor-scheduler/src/host.rs` |
 | `Waker` + `GreenSender`/`green_channel`: push-then-wake, so a green actor can be fed from another thread | `actor-scheduler/src/lib.rs`, `host.rs` |
+| `ports!` generating the output word + wiring + flush from a port declaration | `actor-scheduler-macros/src/lib.rs` |
+| `send_port_droppable`: the runtime half of a droppable edge | `actor-scheduler/src/mealy.rs` |
 
 ### 7.1 Measured (2026-07-24)
 
@@ -297,6 +299,30 @@ Caveat both ways: the transducer arm needs no waker because the actors are co-lo
 multi-worker runtime will add some back; and the stages are cheap, so this measures coordination
 overhead, not parallel speedup. It argues for co-locating cheap actors, not for abolishing
 threads.
+
+### 7.2 `ports!`
+
+The output word and its wiring are pure boilerplate, and one of them is quietly dangerous: a
+port omitted from a hand-written `flush` is a message that vanishes with no error anywhere.
+`ports!` generates both from a declaration:
+
+```rust
+ports! {
+    App {
+        engine: Render,        // blocking: parks the actor when full
+        write: Echo [drop],    // droppable: discards when full, never parks
+        again: u32 [self],     // continuation: goes to the slot, not the wiring
+    }
+}
+```
+
+The port kinds are exactly the three delivery disciplines §3.1 needs, so the DAG rule becomes
+something an actor *declares* rather than something a reviewer has to notice. A `[self]` port
+gets **no wiring field at all** — a continuation cannot be attached to a queue even by
+mistake, and the generated `flush` `debug_assert!`s that the scheduler lifted it first.
+
+More than one `[self]` port is a compile-time panic, because the continuation slot holds
+exactly one message.
 
 Recommended first step: prove the runtime **before** touching the macro. Hand-write one actor in
 the `handle → Out struct` form that fans out and parks on a full downstream ring, and confirm the

--- a/docs/designs/actor-scheduler-mealy-transducer.md
+++ b/docs/designs/actor-scheduler-mealy-transducer.md
@@ -155,7 +155,28 @@ never find it full). The validator returns the topological order as a by-product
 the right polling order — upstream first drains a pipeline in one sweep instead of trickling one
 message per pass.
 
-### 3.2 Waking
+### 3.2 Credit-bounded edges (resolves §9.3)
+
+A credit-bounded request/response pair does not need a third [`Delivery`](../../actor-scheduler/src/mealy.rs)
+kind. It **is** a droppable port — `Credit` is the sender-side discipline that keeps the drop
+from ever actually firing:
+
+```rust
+struct Credit { available: u32, max: u32 }
+// try_consume() -> bool   before deciding whether to emit a request
+// release()               when the step handling the corresponding reply runs
+```
+
+The requester holds one `Credit` per edge in its own `self` — never shared, never atomic,
+touched only during that actor's own step. As long as `max` does not exceed the reply ring's
+capacity, and every request is gated by `try_consume`, the ring can never fill from this edge:
+the `[drop]` port is a backstop for a bug, not a path the well-behaved system ever takes.
+
+This is a straight replacement for a hand-rolled global atomic token bucket — the shape a
+request/response actor pair reaches for today (§9.1) — with per-edge, non-atomic, typed state.
+No new `Topology` primitive, no new port kind: `Credit` plus the `Delivery` that already existed.
+
+### 3.3 Waking
 
 The resume trigger is the existing wake ("target ring not-full" → wake the parked sender), which
 is a doorbell event on the **System lane** — the same lane that carries Wake/Shutdown, and the
@@ -282,6 +303,7 @@ tests over transition tables.
 | `Waker` + `GreenSender`/`green_channel`: push-then-wake, so a green actor can be fed from another thread | `actor-scheduler/src/lib.rs`, `host.rs` |
 | `ports!` generating the output word + wiring + flush from a port declaration | `actor-scheduler-macros/src/lib.rs` |
 | `Delivery` (`Blocking`/`Droppable`) as a `send_port` parameter — the runtime half of a droppable edge | `actor-scheduler/src/mealy.rs` |
+| `Credit`: sender-side budget that keeps a droppable request/response edge from ever actually dropping | `actor-scheduler/src/mealy.rs` |
 
 ### 7.1 Measured (2026-07-24)
 
@@ -369,20 +391,108 @@ Each removal made the primitive more opinionated, not less capable. That is the 
 
 ---
 
-## 9. Open questions
+## 9. Case study: auditing the pixelflow-runtime engine
 
+`pixelflow-runtime/src/engine_troupe.rs` is the intended eventual consumer of this design, and
+the stated end goal is to remove `EngineHandler` as a central mediator and let `driver`, `vsync`,
+`rasterizer`, and `app` communicate directly. Auditing that file against the DAG rule before any
+of this lands there surfaced findings worth recording so they are not rediscovered cold.
+
+### 9.1 Four real cycles, held together by hand today
+
+Every one of `EngineHandler`'s peer relationships is bidirectional:
+
+- **engine ↔ vsync** — engine sends `RenderedResponse`/`VsyncCommand`; `VsyncActor` independently
+  holds an `engine_handle` and sends `EngineData::VSync` ticks back (`vsync_actor.rs:138,261-272`).
+  The existing comment calls this "for feedback loop" (`engine_troupe.rs:47`).
+- **engine ↔ rasterizer** — engine sends `RenderRequest`; a forwarding thread reads responses and
+  calls `engine_handle.send(EngineData::RenderComplete)` (`engine_troupe.rs:341-373`). The
+  rasterizer is deliberately kept outside the `troupe!` macro's static topology via a bootstrap
+  handshake, which is itself a sign this edge doesn't fit the current model.
+- **engine ↔ app** — engine sends `RequestFrame`; app sends `EngineData::FromApp(AppData::
+  RenderSurface)` back (`engine_troupe.rs:98,108,384-402`).
+- **engine ↔ driver** — driver forwards `DisplayEvent`; engine sends `DisplayControl`/
+  `DisplayData`, and `PresentComplete` hands the `Window` buffer back so engine can reuse it —
+  the ping-pong buffer strategy is itself a resource-return cycle (`engine_troupe.rs:167-190`).
+
+All four are 2-cycles among **blocking** sends: `ActorHandle::send` spin-yields on a full Data
+ring (`lib.rs:761-775`) rather than returning or dropping. `Topology::validate` would reject
+every one of them today.
+
+This isn't hypothetical: `vsync_actor.rs:20-22` is a **global atomic token bucket**, decremented
+before a tick and incremented on frame completion — an unenforced, hand-rolled instance of
+exactly the credit-bounded edge §3.2 formalizes. `PendingRender.stale` (`engine_troupe.rs:37-
+39,129-152`) is a hand-written droppable policy: discard a render superseded by a resize. Both
+are the runtime already reaching for what `Credit` and `Delivery::Droppable` now give for free —
+this design isn't proposing new machinery so much as typing and checking machinery that already
+exists informally.
+
+### 9.2 Dropping is only safe for recoverable loss — an audit, not a rule
+
+`[drop]` is safe only for data whose loss the next message can recover from. In the current
+flow: vsync ticks themselves and a `RenderComplete` for an already-`stale` render are candidates.
+`PresentComplete` and a non-stale `RenderComplete` must never be `[drop]` — the former is the
+only path the `Window` buffer returns on (drop it and the ping-pong buffer is gone, forever,
+silently); the latter clears `pending_render` (drop it and the engine hangs waiting for a
+response that was discarded). The type system cannot tell "droppable frame" from "the only copy
+of this buffer" apart — that choice is a per-edge human decision this design does not, and
+should not try to, make automatically.
+
+### 9.3 Credit-bounded edges: resolved
+
+Was open (§10 below, formerly here): does the topology need a third edge kind for request/
+response? No — see §3.2. `Credit` plus the existing `Delivery::Droppable` is sufficient; no new
+`Topology` primitive was needed.
+
+### 9.4 What the audit reassures rather than worries about
+
+- `EngineHandler.render_threads` ("work-stealing parallelism", `engine_troupe.rs:65-66`) is a
+  real, present need for exactly the migratable/`Send`-bounded pool §5.2 carved out as the
+  opt-in exception to owned-by-default. That split wasn't speculative.
+- `VsyncActor`'s dedicated clock thread, sending explicit `Tick` messages specifically to avoid
+  depending on `park` timing (`vsync_actor.rs:6-9`), **resolves** the open question about where
+  timer ticks belong (previously listed in §10): a real actor sends ticks as ordinary messages;
+  `park` does not need to synthesize them.
+- The `Application` trait (a runtime-defined boundary wrapping an `ActorHandle`, so
+  `pixelflow-runtime` stays generic over `core-term`'s concrete app type) is not a gap: the wire
+  *message types* (`EngineEvent`, `AppData`, …) are already concrete within `pixelflow-runtime`.
+  Only the *implementation* of `Application` is erased, not the port's type — `ports!` needs
+  nothing new here.
+
+### 9.5 The real gap: priority lanes do not exist in `Node`/`Transducer`
+
+`Transducer::In` is one type; `Node` holds one inbox. There is no Control/Management/Data
+priority anywhere in the Mealy machinery, and `Host::sweep` round-robins its green nodes with no
+lane weighting either. The existing engine leans on the opposite — Control > Management > Data
+is what keeps `Quit`/resize/key-input responsive while a render is in flight, and it is core to
+the actor model as described in this repository's top-level `CLAUDE.md`. An actor migrated onto
+`Node` as it stands today would silently lose that.
+
+**Directive for closing this, given at the point this gap was found:** port the *existing*
+priority-drain algorithm — `ActorScheduler::handle_wake`'s half-control/management/half-control/
+data cycle with per-lane burst limits (`lib.rs`, the `DrainStatus`/`SystemStatus` machinery) —
+onto `Transducer`/`Node`, rather than designing new priority machinery from scratch. `Transducer`
+gains three input types (mirroring `ActorTypes`) and three step methods; `Node::poll` runs the
+same drain order before touching the continuation slot. This is scoped as its own follow-up, not
+bundled into the engine-mesh rewrite itself, since the engine rewrite needs it as a foundation.
+
+---
+
+## 10. Open questions
+
+- [ ] **Priority lanes for `Transducer`/`Node`.** The real gap found in §9.5. Port
+  `ActorScheduler::handle_wake`'s existing drain algorithm rather than redesigning one; scoped
+  as a prerequisite for the engine-mesh rewrite, not part of it.
 - [ ] **Self-port as a named verb?** First-class `yield`/continuation syntax in the macro, or
   just "a port that points home." Vocabulary vs. emergent trick. (The runtime already treats it
   as distinct — it has its own slot — which argues for naming it.)
-- [ ] **Credit-bounded edges.** The DAG rule admits droppable edges as cycle-closers; a
-  credit-bounded reply edge is the other legal form, but the topology cannot currently express
-  "this requester is limited to N outstanding" so the validator cannot check it.
 - [ ] **Burst cardinality.** A port fires at most once per step; bursts batch into one message
   (`ScreenOps(batch)`). Confirm no actor needs a port to emit a *variable number of distinct*
   messages per input (which would make that port carry a collection).
-- [ ] **`park` for the time-driven tier.** Timer ticks are just input symbols; confirm `park` on
-  the dedicated tier is the right place to synthesise them.
 - [ ] **Eliding the wake syscall.** `GreenSender` rings the doorbell on every delivery. The
   doorbell coalesces, so this is cheap and correct, but a parked/running flag on the host would
   let a producer skip the ring entirely while the host is already sweeping — the trick mio uses
   for its eventfd. Worth measuring before adding.
+
+Resolved: credit-bounded edges (§9.3, §3.2) and timer ticks for the dedicated tier (§9.4, by
+existing precedent) — kept out of this list; see the case study for why.

--- a/docs/designs/actor-scheduler-mealy-transducer.md
+++ b/docs/designs/actor-scheduler-mealy-transducer.md
@@ -229,7 +229,29 @@ The out-of-process tier carries no transport machinery here, deliberately. The a
 process isolation (a compiler actor) are low-rate — source in, artifact out — so ordinary
 messaging suffices. A shared-memory transport was considered and dropped (§8).
 
-### 5.3 The System lane is the reactor
+### 5.3 Waking a host
+
+A host with nothing to do sleeps on its doorbell, so anything that makes a green actor
+runnable without going through the host's own lanes has to ring that bell. `Waker` is that
+capability, and `GreenSender` is the pair that must always travel together: **push the message
+into the green actor's inbox, then wake the host.**
+
+The order is load-bearing. Waking first admits a lost wakeup — the host wakes, sweeps, finds
+the inbox still empty, reports `Idle`, and goes back to sleep just as the message lands.
+Pushing first means the host either sees the message on the sweep it is already doing, or is
+still holding the pending wake that will start another one.
+
+Two properties come free from the existing doorbell: it has capacity one and **coalesces**, so
+a burst of green sends cannot back it up or fail (one pending wake is all "you have work"
+needs); and a `Waker` that outlives its scheduler is harmless, because a wake with nobody to
+receive it is a no-op rather than an error. That is the one place `Waker` deliberately differs
+from `ActorHandle::wake`, which panics on a disconnected doorbell.
+
+This makes the host's own lanes unnecessary: all three of its message types are `Infallible`,
+so a host provably has no messages of its own and routes nothing. Work goes straight to the
+actor that will handle it.
+
+### 5.4 The System lane is the reactor
 
 Wake, Shutdown, IO readiness, and timers are all System-priority events sharing one park point
 (`epoll_wait` / `kqueue`). Priority ordering is unaffected — it is applied when lanes are
@@ -257,6 +279,7 @@ tests over transition tables.
 | `poll_once` removed from the public API | `actor-scheduler/src/lib.rs` |
 | Kubelet / `PodSlot` registry / `ServiceHandle` deleted; `PodPhase` → `Exit` (two variants, both actually returned) | removed |
 | `Host`: an `Actor` whose `park` sweeps owned green `Node`s, `Busy`/`Idle` driving the thread | `actor-scheduler/src/host.rs` |
+| `Waker` + `GreenSender`/`green_channel`: push-then-wake, so a green actor can be fed from another thread | `actor-scheduler/src/lib.rs`, `host.rs` |
 
 ### 7.1 Measured (2026-07-24)
 
@@ -333,6 +356,7 @@ Each removal made the primitive more opinionated, not less capable. That is the 
   messages per input (which would make that port carry a collection).
 - [ ] **`park` for the time-driven tier.** Timer ticks are just input symbols; confirm `park` on
   the dedicated tier is the right place to synthesise them.
-- [ ] **Waking a host from outside.** A host sleeps on its doorbell, so something must ring it
-  when a green actor's inbox is fed from another thread. Today that is a message on the host's
-  own data lane, routed by `handle_data`. The System-lane reactor (§5.3) is the real answer.
+- [ ] **Eliding the wake syscall.** `GreenSender` rings the doorbell on every delivery. The
+  doorbell coalesces, so this is cheap and correct, but a parked/running flag on the host would
+  let a producer skip the ring entirely while the host is already sweeping — the trick mio uses
+  for its eventfd. Worth measuring before adding.

--- a/docs/designs/actor-scheduler-mealy-transducer.md
+++ b/docs/designs/actor-scheduler-mealy-transducer.md
@@ -281,7 +281,7 @@ tests over transition tables.
 | `Host`: an `Actor` whose `park` sweeps owned green `Node`s, `Busy`/`Idle` driving the thread | `actor-scheduler/src/host.rs` |
 | `Waker` + `GreenSender`/`green_channel`: push-then-wake, so a green actor can be fed from another thread | `actor-scheduler/src/lib.rs`, `host.rs` |
 | `ports!` generating the output word + wiring + flush from a port declaration | `actor-scheduler-macros/src/lib.rs` |
-| `send_port_droppable`: the runtime half of a droppable edge | `actor-scheduler/src/mealy.rs` |
+| `Delivery` (`Blocking`/`Droppable`) as a `send_port` parameter — the runtime half of a droppable edge | `actor-scheduler/src/mealy.rs` |
 
 ### 7.1 Measured (2026-07-24)
 

--- a/docs/designs/actor-scheduler-mealy-transducer.md
+++ b/docs/designs/actor-scheduler-mealy-transducer.md
@@ -486,6 +486,16 @@ of attention across lanes is preserved, the *granularity* is not.
 A continuation always resumes on the data lane — it is more work, not a control or management
 signal — and still bypasses the lane cycle entirely, exactly as before.
 
+**A bug the unit tests missed, that a benchmark caught.** A slot that finished a `poll()` sitting
+exactly at its budget limit used to advance lazily — only when the *next* call found it still
+there. With small limits and idle other lanes, that costs the wraparound its one spare
+iteration, and a message could sit queued while `poll()` reported `Idle`. The existing tests
+used small message counts and never wrapped a full cycle within them; `bench_priority.rs`'s
+drain-to-completion loop did, immediately. Fixed by `Node::advance_if_exhausted`: roll over the
+instant the budget is spent, not on the next call's discovery of it. See
+`docs/results/2026-07-24-mealy-vs-actor.md` for the full account and the regression test added
+alongside it.
+
 ---
 
 ## 10. Open questions

--- a/docs/results/2026-07-24-mealy-vs-actor.md
+++ b/docs/results/2026-07-24-mealy-vs-actor.md
@@ -60,3 +60,61 @@ Single-thread throughput is flat at ~58 Melem/s across all sizes; the three-thre
   threads.
 - Rings are sized so nothing backs up, so this measures the unblocked path. Backpressure
   behavior is covered by the unit tests, not here.
+
+## Update (2026-07-25): after priority lanes + Credit
+
+Re-ran the dispatch/pipeline benchmarks above after porting Control/Management/Data priority
+lanes onto `Node` (`docs/designs/actor-scheduler-mealy-transducer.md` §9.5). Both arms —
+including `actor_sends`, the pre-existing `ActorScheduler` path this session did not touch —
+came back 15–70% faster than the 2026-07-24 run in this same container. That is environment
+variance between runs on a shared box, not a real speedup from either session's changes; the
+comparable, noise-resistant number is the *ratio* between arms within one run, which held at
+roughly the same order of magnitude as before (transducer path several× faster than the
+send-based path). Absolute cross-run timings in the table above should not be read as
+before/after for the lane work — no regression was found, but claim only that, not a 3–5×
+improvement from adding lane-checking overhead nobody would expect.
+
+## New: priority-lane contention demo (`bench_priority.rs`)
+
+`bench_mealy.rs` only exercises the data lane, so it can't show what porting priority lanes
+actually bought. `bench_priority.rs` drains 1,000 data messages on a lane-aware `Node`
+(`control_burst_limit = 2`, i.e. two control turns per cycle before one data turn), with no
+control traffic vs. a continuous control flood that is topped up after every poll:
+
+```
+delivering 1000 data messages:
+  no control traffic:        1000 polls (1.00 polls/message)
+  continuous control flood:  3000 polls (3.00 polls/message)
+  => every data message still arrived; the flood cost a bounded, predictable
+     ~3.0x more polls per message, not starvation.
+
+priority/data_uncontended          ~18.1 µs / 1000 msgs  (~18 ns/msg)
+priority/data_under_control_flood  ~26.1 µs / 1000 msgs  (~26 ns/msg)
+```
+
+The 3.0x figure is not a measurement — it's `2 control-slot-visits + 1 data-slot-visit` per
+cycle, exactly the ratio `control_burst_limit=2` declares, reproduced deterministically every
+run. All 1,000 data messages arrive either way; the flood costs a bounded, predictable multiple
+of polls, never an unbounded one. Wall-clock cost (~1.44×) is lower than the 3× poll-count
+ratio because a poll that only advances past an empty/exhausted slot does less work than one
+that dispatches a full step.
+
+### A real bug this caught
+
+Writing this benchmark's drain-to-completion loop (assert `Step::Ran` every call, no `Idle`
+allowed until every message lands) found a genuine bug the unit tests had not: a slot that
+finished a poll sitting exactly at its budget limit (e.g. `Data`, having just delivered the one
+message its limit allowed) advanced lazily — only when the *next* call discovered it was still
+there. With small custom limits and idle control/management lanes, the wraparound needed to
+recheck that slot is exactly 4 iterations, and the lazy advance consumes the first one just
+moving off the stale position, leaving only 3 to reach a lane with anything in it — one
+iteration short. The existing small-number tests (`control_backlog_does_not_starve_data_
+forever`, `control_lane_progresses_with_burst_limit_one`) never wrapped a full cycle within
+their few assertions and didn't hit it; a tight drain loop over many messages did immediately.
+
+Fixed by `Node::advance_if_exhausted`: roll a slot over to the next one the instant its budget
+is spent, in the same call that spent it, rather than waiting for the next call to discover it.
+Added `many_data_messages_drain_steadily_with_idle_control_and_management` as a unit-test
+regression (confirmed it fails without the fix, by reverting it locally and observing the
+assertion fire, before restoring it) so this doesn't require running the benchmark to catch
+again.


### PR DESCRIPTION
## What

Five commits closing out the green tier from #902 and porting priority scheduling onto it: waking a host from outside, `ports!` codegen, credit-bounded request/response edges, an engine audit, and Control/Management/Data priority lanes on `Node`/`Transducer`.

---

## 1. Waking a host when a green actor is fed

A host with nothing to do sleeps on its doorbell, so anything that makes a green actor runnable **without going through the host's own lanes** has to ring that bell.

- **`Waker`** — rings a scheduler's doorbell without sending a message. Obtained via `ActorHandle::waker()`; the private `ActorHandle::wake` stays private.
- **`GreenSender` / `green_channel`** — push into the green actor's inbox, **then** wake the host. Waking first admits a lost wakeup; pushing first means the host either sees the message on the sweep it's already doing, or still holds the pending wake that starts another one.

Capacity-one coalescing means a burst can't back up the doorbell or fail; a `Waker` outliving its scheduler is a no-op, not an error. This subtracts the routing closure `Host` carried as a stand-in — a host now has no lanes of its own (all `Infallible`) and routes nothing.

## 2. `ports!` codegen

```rust
ports! {
    App {
        engine: Render,        // blocking: parks the actor when full
        write: Echo [drop],    // droppable: discards when full, never parks
        again: u32 [self],     // continuation: goes to the slot, not the wiring
    }
}
```

Generates `AppOut`/`AppWiring`/`flush`. The three port kinds are exactly the delivery disciplines the DAG rule needs, so which edges may close a cycle becomes something an actor declares. A `[self]` port gets no wiring field at all. Also adds `send_port` with a `Delivery` parameter (`Blocking`/`Droppable`) — the runtime half of `Topology::droppable_edge`.

## 3. `Credit`: request/response edges without a third port kind

A credit-bounded request *is* a `Delivery::Droppable` port — `Credit` (`try_consume`/`release`, plain non-atomic state in the requester's own `self`) is the sender-side discipline that keeps the drop from ever actually firing. Replaces the shape of a hand-rolled global atomic token bucket with per-edge, typed, unshared state. No new `Topology` primitive needed.

## 4. Engine audit (docs only)

Audited `pixelflow-runtime/engine_troupe.rs` against the DAG rule ahead of a planned direct-actor-mesh rewrite (own session, later): four real bidirectional cycles (engine↔vsync/rasterizer/app/driver), all held together today by informal versions of `Credit`/`Droppable` this design now formalizes. Flags which edges must never be `[drop]` (`PresentComplete`, a non-stale `RenderComplete` — both carry unrecoverable state).

## 5. Priority lanes on `Node`/`Transducer`

The audit surfaced a real gap: `Transducer`/`Node` had no Control/Management/Data priority at all, while the engine leans on that ordering for input responsiveness. Ported `ActorScheduler::handle_wake`'s drain algorithm rather than designing a new one — `Transducer` gains `Control`/`Management`/`Data` associated types (defaulted step methods for unused lanes), `Node` gains a `Slot` cycle reusing `SchedulerParams` verbatim. `RC`/`RM` default to `NoLane`, so every existing `Node::new(actor, data, wiring)` call site is unchanged. The one real translation: the old algorithm bursts per wake (nothing else shares that thread); `Node::poll` still takes one message per call, so the *ratio* of attention across lanes is preserved but spread across many calls instead of batched, to keep `Host::sweep`'s per-actor fairness intact.

## Tests

**110 lib + 8 macro tests green; clippy clean on both crates; benches build.**

Highlights beyond what's in individual commits: a host asleep on its doorbell woken by a real green send on a real thread (15/15 for flakiness); credit-gated sends never drop while the same droppable port does drop when ungated (proving both the mechanism and the backstop); strict Control→Management→Data ordering for one message per lane; a 2:1 control:data ratio holding every cycle (not just once) under a control backlog; the burst-limit-of-1 regression ported from `lib.rs`; halts only once every lane reports `Disconnected`.

## Not in this PR

`poll_once` removal, eliding the wake while a host is already sweeping (mio's parked-flag trick), and generating the lane associated types/step methods from `ports!` (still hand-written) — all recorded as open questions.