### PR TITLE
docs(pixelflow-runtime): plan the engine-mesh migration; prove the target topology

### DIFF
--- a/docs/designs/pixelflow-runtime-engine-mesh-migration.md
+++ b/docs/designs/pixelflow-runtime-engine-mesh-migration.md
@@ -32,9 +32,13 @@ not by re-reading it), and only then touch a live actor.
 
 | Edge | Direction | Kind | Why |
 |------|-----------|------|-----|
-| Input events (`DisplayEvent`) | driver → engine | **Blocking — ⚠️ see §3.1** | Input must never be lost. |
-| Display commands (`SetTitle`/`SetSize`/`Present`/…) | engine → driver | **Blocking — ⚠️ see §3.1** | Commands must never be lost. |
-| Window return (`PresentComplete`) | driver → engine | **Credit(1) + Droppable backstop** | The *reply* half of Present. Exactly one window is ever in flight (the ping-pong buffer), so the reply ring's capacity is provisioned ≥ 1 and can **never actually be full** when the reply lands — the droppable backstop exists for `Topology`'s proof, but is unreachable by construction, not merely rare. This is *not* the same case as a true "acceptable loss" droppable edge (§9.2) — it is safe only because the credit bound is airtight. |
+| Input + window-lifecycle events (`DisplayEvent` minus `PasteData`: key, mouse, scroll, focus, resize, close, scale, window created/destroyed, clipboard-data-requested) | driver → engine | **Blocking** | Discrete, non-idempotent events. None may be lost, and none coalesce with another. |
+| `Present` | engine → driver | **Credit(1) + Droppable backstop** | Not a judgment call this doc is inventing: `DisplayData::Present`'s own doc comment already specifies the receiver's contract as "3. NOT block the sender (use backpressure if buffer full)". The original table lumped it into a generic "commands, never lose" bucket and missed that the code already disagrees. Exactly one window is ever in flight (the ping-pong buffer), so this is the *same* structurally-unreachable shape as the row below, not a new risk. |
+| `PresentComplete` (window return) | driver → engine | **Credit(1) + Droppable backstop** | The reply half of `Present`, sharing its credit. Exactly one window is ever in flight, so the reply ring's capacity is provisioned ≥ 1 and can **never actually be full** when the reply lands — the droppable backstop exists for `Topology`'s proof, but is unreachable by construction, not merely rare. Not the same case as a true "acceptable loss" droppable edge (§9.2) — safe only because the credit bound is airtight. |
+| `SetTitle` / `SetSize` / `SetCursor` / `Copy` | engine → driver | **Droppable, no credit needed** | Idempotent, "latest write wins" state — the exact shape already handled for `pending_manifold` below. Two queued `SetTitle`s only ever needed the second one anyway. |
+| `RequestPaste` | engine → driver | **Credit(1) + Droppable backstop** | Paired with `PasteData` below; engine never has more than one outstanding paste request. |
+| `PasteData` (reply to `RequestPaste`) | driver → engine | **Credit(1) + Droppable backstop, shared with `RequestPaste`** | A dropped reply here just means one failed paste, recoverable by the user pressing paste again — closer to "acceptable loss" than "unreachable," since the 1-outstanding bound comes from usage, not an engineered invariant like the window buffer. Recorded as that weaker guarantee on purpose, not conflated with `PresentComplete`. |
+| `Create` (window creation) | engine → driver | **Not part of the steady-state graph — see §3.1** | One-shot bootstrap per window, not a member of the continuously-live mesh at all. |
 | VSync tick | vsync → engine | **Credit(100) + Droppable backstop** | Direct replacement for `VSYNC_TOKEN_BUCKET`. A dropped tick under a bug is a missed/late frame, genuinely tolerable — this *is* an ordinary acceptable-loss droppable edge, unlike the row above. |
 | Frame-rendered notice (`RenderedResponse`, FPS tracking only) | engine → vsync | **Droppable, no credit needed** | Pure telemetry. Losing a sample changes nothing but a displayed FPS number. |
 | Render request | engine → rasterizer | **Credit(1) + Droppable backstop** | Mirrors the window-return case: `pending_render` tracks exactly one outstanding render, so ring capacity ≥ 1 makes the backstop unreachable by construction. |
@@ -54,36 +58,47 @@ makes that backstop unreachable by construction. **Two different reasons an edge
 
 Conflating these two would be exactly the mistake §9.2 warned against.
 
-### 3.1 Open finding: driver ↔ engine is not yet a DAG
+### 3.1 driver ↔ engine: resolved by decomposing, not by picking an excuse
 
-`pixelflow-runtime/tests/target_topology.rs` was written to prove the table above validates —
-and instead it proved the table wrong. Input events and display commands were both marked
-Blocking on the reasoning "genuinely one-way, nothing here closes a cycle." That reasoning was
-false: `Topology` correctly rejects it, because **two independent blocking edges between the
-same pair of actors are a cycle regardless of whether the two message flows are logically
-unrelated.** driver blocked pushing an event into a full engine inbox, at the same moment
-engine is blocked pushing a command into a full driver inbox, is the identical deadlock shape
-as the app↔compiler example the Mealy doc uses to motivate the DAG rule in the first place —
-"they're different conversations" does not save it.
+`pixelflow-runtime/tests/target_topology.rs` was first written with `DisplayEvent` and "display
+commands" each as one aggregate edge, both Blocking — and immediately proved that wrong.
+`Topology` correctly rejects it: **two independent blocking edges between the same pair of
+actors are a cycle regardless of whether the two message flows are logically unrelated.** driver
+blocked pushing an event into a full engine inbox, at the same moment engine is blocked pushing a
+command into a full driver inbox, is the identical shape to the app↔compiler example the Mealy
+doc uses to motivate the DAG rule — "they're different conversations" does not save it.
 
-This is deliberately left **unresolved in this doc**, not quietly patched, because every fix
-available is a real behavioral trade-off, not a mechanical one:
+The fix is not picking one lucky excuse to drop the whole aggregate — it's noticing "display
+commands" was never one thing. Per-message, it decomposes entirely into edge kinds this doc had
+already established for other actors:
 
-- Mark `DisplayEvent` droppable — user input can be silently lost under backpressure.
-- Mark display commands droppable — a `Present` can be silently skipped, or `SetTitle`/`SetSize`
-  coalesced to "latest wins" (plausible for those two; almost certainly wrong for `Present`).
-- Deepen one ring so it is provisioned never to fill under realistic load, the way the
-  window-return edge is provisioned at exactly 1 — plausible if input volume is bounded and
-  measurable, but "provably never fills" needs an actual argument, not a big number.
-- Split display commands into a genuinely droppable stream (`SetTitle`, cursor, coalescible
-  state) and a separate, still-blocking one for `Present` alone, if `Present` turns out to be
-  the only command that truly cannot tolerate loss.
+- **`Present` already has a non-blocking contract in the code itself** (`DisplayData`'s own doc
+  comment — see the table), which the original aggregate framing simply missed by lumping it in
+  with "commands, must never be lost." It's the same Credit(1) shape as `PresentComplete`,
+  because the ping-pong buffer means the two were always one relationship, not two.
+- **`SetTitle`/`SetSize`/`SetCursor`/`Copy` are idempotent state pushes** — exactly the
+  "keep latest, drop stale" shape `pending_manifold` already implements by hand elsewhere in
+  this file. Plain `[drop]`, no credit needed, nothing new invented.
+- **`RequestPaste`/`PasteData` is its own tiny 1:1 request/reply**, structurally identical to
+  every other credit-bounded pair in §3, just lower-stakes (a dropped reply costs one retried
+  keystroke, not a lost buffer).
+- **`Create` is a bootstrap-phase message**, not a steady-state one — the same category the
+  *current* code already puts the rasterizer's handshake in (`engine_troupe.rs`: "Rasterizer is
+  NOT in the troupe - it uses a bootstrap handshake pattern"). `Topology`'s DAG check governs the
+  continuously-live mesh; a message sent once per window before that mesh is even fully up
+  doesn't belong in the same graph, the same way the rasterizer handshake doesn't today.
 
-**This is a decision for a human, not a default the DAG checker should pick.** Recorded here so
-step 4 of the rollout (§5) starts from a known question instead of rediscovering it, and so
-`target_topology.rs`'s test for the full mesh does not silently paper over it — it currently
-tests everything except this pair, plus a dedicated test proving the pair really is cyclic as
-specified, so the gap stays visible in `cargo test` output rather than in a comment.
+With every engine → driver edge now either Credit+Droppable, plain Droppable, or bootstrap-only,
+**driver → engine is the only edge left that's genuinely Blocking** — and a single blocking
+direction between a pair is never a cycle by itself. Nothing that matters was made droppable to
+get there: every discrete, non-idempotent, must-not-lose message (input, window lifecycle) stays
+exactly as reliable as it is today.
+
+The one edge worth flagging as a deliberately *weaker* guarantee than its siblings:
+`PasteData`'s credit bound comes from how paste is actually used (nobody issues a second
+`RequestPaste` before the first replies), not from an engineered invariant like the single
+window buffer. If that assumption is ever wrong, the failure mode is a dropped paste, not a
+hang — an explicit, accepted trade, not an oversight.
 
 ## 4. Placement
 

--- a/docs/designs/pixelflow-runtime-engine-mesh-migration.md
+++ b/docs/designs/pixelflow-runtime-engine-mesh-migration.md
@@ -1,0 +1,145 @@
+# Design Doc: pixelflow-runtime Engine — from Mediator to Mesh
+
+## Metadata
+- **Author**: jppittman (with Claude)
+- **Status**: Draft — plan + topology proof only, no live actor code changed
+- **Created**: 2026-07-25
+- **Builds on**: `docs/designs/actor-scheduler-mealy-transducer.md` §9 (the audit)
+
+---
+
+## 1. Goal
+
+Delete `EngineHandler` as a central mediator. Today `driver`, `vsync`, `rasterizer`, and `app`
+all talk *through* engine; the target is that they talk to **each other** directly, over edges
+the `Topology` validator checks at bootstrap. Scoped as its own body of work, separate from the
+actor-scheduler primitives it depends on (§9 of the Mealy doc): those primitives (`Node`,
+`ports!`, `Credit`, `Topology`, priority lanes) are now in place. This doc is the plan for
+spending them on the real system.
+
+## 2. Why this doc exists before any engine code changes
+
+This is production code driving a real, running terminal renderer, not a prototype. The audit
+(§9) found four real bidirectional cycles held together today by an untyped global atomic and a
+hand-rolled `stale` flag. Reclassifying each edge is a per-edge *judgment call* about what may be
+lost — the audit was explicit that the type system cannot make this call automatically
+(`PresentComplete` dropped is catastrophic; `AppData::RenderSurface` dropped is nothing, the code
+already treats it that way). Getting one of these wrong is worse than the status quo, not better.
+So: classify every edge on paper first, prove the resulting graph is actually a DAG (mechanically,
+not by re-reading it), and only then touch a live actor.
+
+## 3. The target topology
+
+| Edge | Direction | Kind | Why |
+|------|-----------|------|-----|
+| Input events (`DisplayEvent`) | driver → engine | **Blocking — ⚠️ see §3.1** | Input must never be lost. |
+| Display commands (`SetTitle`/`SetSize`/`Present`/…) | engine → driver | **Blocking — ⚠️ see §3.1** | Commands must never be lost. |
+| Window return (`PresentComplete`) | driver → engine | **Credit(1) + Droppable backstop** | The *reply* half of Present. Exactly one window is ever in flight (the ping-pong buffer), so the reply ring's capacity is provisioned ≥ 1 and can **never actually be full** when the reply lands — the droppable backstop exists for `Topology`'s proof, but is unreachable by construction, not merely rare. This is *not* the same case as a true "acceptable loss" droppable edge (§9.2) — it is safe only because the credit bound is airtight. |
+| VSync tick | vsync → engine | **Credit(100) + Droppable backstop** | Direct replacement for `VSYNC_TOKEN_BUCKET`. A dropped tick under a bug is a missed/late frame, genuinely tolerable — this *is* an ordinary acceptable-loss droppable edge, unlike the row above. |
+| Frame-rendered notice (`RenderedResponse`, FPS tracking only) | engine → vsync | **Droppable, no credit needed** | Pure telemetry. Losing a sample changes nothing but a displayed FPS number. |
+| Render request | engine → rasterizer | **Credit(1) + Droppable backstop** | Mirrors the window-return case: `pending_render` tracks exactly one outstanding render, so ring capacity ≥ 1 makes the backstop unreachable by construction. |
+| Render complete | rasterizer → engine | **Credit(1) + Droppable backstop** (same credit as above; it's the reply half) | Same reasoning as `PresentComplete`. If this bound is ever wrong (more than 1 outstanding), the failure mode changes from "spin-forever under adversarial timing" (today) to "one dropped frame, `pending_render` never clears, next resize/vsync recovers" — recorded as an explicit design trade-off, not an oversight. |
+| Frame request (`RequestFrame`) | engine → app | **Credit(N) + Droppable backstop** | N-outstanding-requests bound; a dropped request is recovered by the next vsync tick. |
+| Manifold submission (`AppData::RenderSurface`) | app → engine | **Droppable, no credit needed** | The *existing* code already implements "always keep the most recent, drop old ones" for `pending_manifold` by hand. This edge doesn't need `Credit` — it needs to be declared `[drop]` and the hand-rolled staleness logic deleted, because the port *is* the staleness policy. |
+
+Every reply edge above is the closing edge of a cycle; every one is legal under the DAG rule
+(§3.1 of the Mealy doc) specifically because it's Droppable, whether or not `Credit` additionally
+makes that backstop unreachable by construction. **Two different reasons an edge is safe to mark
+`[drop]`, and this doc keeps them distinct on purpose:**
+
+- **Structurally unreachable** (window return, render complete): the credit bound is airtight,
+  so the drop path is dead code in the well-behaved system and only fires on an actual bug.
+- **Genuinely acceptable loss** (vsync tick, FPS notice, manifold submission): dropping is a
+  normal, expected outcome, not a bug symptom.
+
+Conflating these two would be exactly the mistake §9.2 warned against.
+
+### 3.1 Open finding: driver ↔ engine is not yet a DAG
+
+`pixelflow-runtime/tests/target_topology.rs` was written to prove the table above validates —
+and instead it proved the table wrong. Input events and display commands were both marked
+Blocking on the reasoning "genuinely one-way, nothing here closes a cycle." That reasoning was
+false: `Topology` correctly rejects it, because **two independent blocking edges between the
+same pair of actors are a cycle regardless of whether the two message flows are logically
+unrelated.** driver blocked pushing an event into a full engine inbox, at the same moment
+engine is blocked pushing a command into a full driver inbox, is the identical deadlock shape
+as the app↔compiler example the Mealy doc uses to motivate the DAG rule in the first place —
+"they're different conversations" does not save it.
+
+This is deliberately left **unresolved in this doc**, not quietly patched, because every fix
+available is a real behavioral trade-off, not a mechanical one:
+
+- Mark `DisplayEvent` droppable — user input can be silently lost under backpressure.
+- Mark display commands droppable — a `Present` can be silently skipped, or `SetTitle`/`SetSize`
+  coalesced to "latest wins" (plausible for those two; almost certainly wrong for `Present`).
+- Deepen one ring so it is provisioned never to fill under realistic load, the way the
+  window-return edge is provisioned at exactly 1 — plausible if input volume is bounded and
+  measurable, but "provably never fills" needs an actual argument, not a big number.
+- Split display commands into a genuinely droppable stream (`SetTitle`, cursor, coalescible
+  state) and a separate, still-blocking one for `Present` alone, if `Present` turns out to be
+  the only command that truly cannot tolerate loss.
+
+**This is a decision for a human, not a default the DAG checker should pick.** Recorded here so
+step 4 of the rollout (§5) starts from a known question instead of rediscovering it, and so
+`target_topology.rs`'s test for the full mesh does not silently paper over it — it currently
+tests everything except this pair, plus a dedicated test proving the pair really is cyclic as
+specified, so the gap stays visible in `cargo test` output rather than in a comment.
+
+## 4. Placement
+
+- **driver**: `[main]` / dedicated thread. Unchanged — Cocoa/X11 requires it (`CLAUDE.md`:
+  "Platform on main thread").
+- **vsync**: dedicated thread. It already runs one (plus its own clock thread sending `Tick` as
+  an ordinary message — this precedent already answers the Mealy doc's §9.4 open question about
+  where timer ticks belong, and does not change here).
+- **rasterizer**: dedicated thread(s) — `render_threads`/work-stealing is real (§9.4), the
+  `Send`-bounded migratable-pool exception the Mealy doc's §5.2 carved out, not the owned-green
+  default.
+- **engine**: ceases to exist as a distinct actor. `EngineHandler` today isn't a pure router —
+  it holds real coordination state (`window`, `pending_render`, `pending_manifold`,
+  `frame_number`) and makes real decisions (stale-render discarding, catch-up rendering).
+  Deleting it means that state and logic goes *somewhere*: split across the actor that
+  naturally owns each piece (driver already owns window lifecycle; app already owns the
+  manifold it produces), or a new, deliberately small coordinator that does only the glue
+  `EngineHandler` cannot shed — **not decided here**. The edge table in §3 is written against
+  "whatever ends up owning that state," under the working name `engine`, because every edge in
+  it holds regardless of how that question resolves; resolving it is explicitly step 5, once
+  the other four actors already speak the new protocol and it's clear what's actually left to
+  coordinate.
+- **app**: unchanged placement (a real actor the embedding crate, e.g. `core-term`, owns) — only
+  the wire types at the boundary matter here, and they're already concrete within
+  `pixelflow-runtime` (§9.4 of the Mealy doc already found no gap here).
+
+## 5. Rollout order
+
+Big-bang replacement of a live, running actor system is the risk this whole doc exists to avoid.
+Order of attack, each step independently shippable and reviewable:
+
+1. **This doc + the topology proof** (§6) — no live code changes. *Landed.*
+2. **`vsync` first**: smallest actor, already isolated, already has the credit-shaped token
+   bucket crying out to become real `Credit`. Convert to `Transducer`/`Node`, replace
+   `VSYNC_TOKEN_BUCKET` with `Credit`, keep talking to the *unconverted* engine across an
+   adapter that speaks the old `ActorHandle` shape on the engine-facing side. Proves the pattern
+   on the smallest possible surface.
+3. **`rasterizer`**: same shape as vsync (request/reply, already isolated via its bootstrap
+   handshake — which was itself a symptom of not fitting the old static-topology model, so this
+   should *simplify*, not complicate).
+4. **`driver`**: convert the command/event edges; window-return `Credit` last, since it's the
+   one edge where getting the bound wrong is worst.
+5. **`app`-facing edge + delete `EngineHandler`**: once every satellite speaks the new
+   protocol directly to its real peer, the mediator has nothing left to route and is deleted,
+   not refactored down.
+
+Each of steps 2–5 lands as its own PR with its own before/after behavioral tests against the
+running terminal, not just unit tests of the actor in isolation.
+
+---
+
+## 6. Proof: the target topology is a DAG
+
+Before any of §5's steps touch a real actor, the target graph above is checked mechanically —
+`pixelflow-runtime/tests/target_topology.rs` builds exactly the nine edges in the table with
+their declared kinds and asserts `Topology::validate()` succeeds. This is deliberately built
+from the *same* five actor names and *same* edge classification this doc commits to, so a
+future change to either has to touch both or the proof drifts from the plan it's supposed to
+prove.

--- a/pixelflow-runtime/tests/target_topology.rs
+++ b/pixelflow-runtime/tests/target_topology.rs
@@ -8,26 +8,25 @@
 //! kinds — this file is deliberately actor-agnostic, so it stays valid across the rollout in
 //! the plan's §5 regardless of which actor is mid-conversion.
 //!
-//! # Status: driver ↔ engine is a known-open gap, not a passing proof
+//! # History: the first version of this proof failed, on purpose left visible
 //!
-//! Writing the "does the whole mesh validate" test found that it doesn't: input events and
-//! display commands were both specified Blocking, and two independent blocking edges between
-//! the same pair of actors are a cycle regardless of the flows being logically unrelated (§3.1
-//! of the migration doc). Fixing that requires a real behavioral trade-off — which stream may
-//! lose messages under backpressure, or whether a ring can be proven never to fill — not a
-//! mechanical edit, so it is **not resolved here**. The two tests below say so directly: one
-//! proves everything *except* that pair is already a valid DAG, the other proves that pair, as
-//! currently specified, is not.
+//! The first cut declared `DisplayEvent` and "display commands" as one aggregate edge each,
+//! both Blocking, and the proof immediately failed: two blocking edges between the same pair
+//! are a cycle regardless of the flows being logically unrelated (§3.1 of the migration doc).
+//! The fix wasn't picking one side to weaken — it was noticing "display commands" was never
+//! one thing. Decomposed per message, it turned out to already fit the same Credit/Droppable
+//! vocabulary every other edge in §3 uses (`Present` even has its own non-blocking contract in
+//! the code already, which the aggregate framing had simply missed). `regressed_aggregate_
+//! framing_is_cyclic` below keeps that mistake on record so it isn't repeated.
 
 use actor_scheduler::mealy::Topology;
 
-/// Every edge from §3 of the migration doc except driver↔engine, which is not yet resolved
-/// (see the module doc and §3.1). Confirms the four satellite relationships — vsync,
-/// rasterizer, app, and driver's *own* structurally-unreachable window-return edge — validate
-/// as specified, so the rollout in §5 can proceed on those independent of how driver↔engine is
-/// eventually settled.
+/// Every edge from §3 of the migration doc, decomposed per message rather than lumped into
+/// "input events" / "display commands". `Create` (bootstrap-only, §3.1) is deliberately not
+/// part of this graph at all — the same way the rasterizer's bootstrap handshake isn't part of
+/// today's `troupe!` topology.
 #[test]
-fn the_resolved_part_of_the_target_mesh_is_a_dag() {
+fn the_target_engine_mesh_is_a_dag() {
     let mut topo = Topology::new();
 
     let driver = topo.actor("driver");
@@ -36,46 +35,55 @@ fn the_resolved_part_of_the_target_mesh_is_a_dag() {
     let rasterizer = topo.actor("rasterizer");
     let app = topo.actor("app");
 
-    // driver -> engine (input events) and engine -> driver (display commands) are
-    // deliberately NOT declared here — see `driver_and_engine_are_not_yet_resolved` below.
+    // The one edge that stays genuinely Blocking: discrete, non-idempotent input and
+    // window-lifecycle events. Nothing on the engine -> driver side is Blocking any more, so
+    // this alone cannot form a cycle with anything below.
+    topo.blocking_edge(driver, engine); // DisplayEvent, minus PasteData
 
-    // Structurally-unreachable droppable backstops: exactly one request ever outstanding,
-    // so the ring can never actually be full when the reply lands (migration doc §3).
-    topo.droppable_edge(driver, engine); // PresentComplete (window return)
+    // Present / PresentComplete: structurally-unreachable droppable backstop, Credit(1) via
+    // the single ping-pong window buffer.
+    topo.droppable_edge(engine, driver); // Present
+    topo.droppable_edge(driver, engine); // PresentComplete
+
+    // Idempotent "latest wins" state pushes: no credit needed at all.
+    topo.droppable_edge(engine, driver); // SetTitle / SetSize / SetCursor / Copy
+
+    // RequestPaste / PasteData: its own small credit-bounded pair, weaker guarantee than the
+    // window buffer (usage-based bound, not an engineered invariant) — see §3.1.
+    topo.droppable_edge(engine, driver); // RequestPaste
+    topo.droppable_edge(driver, engine); // PasteData
+
+    // The other three satellite relationships, unchanged from the first draft of this proof.
     topo.droppable_edge(engine, rasterizer); // render request
     topo.droppable_edge(rasterizer, engine); // render complete
-
-    // Genuinely acceptable loss: dropping is a normal outcome, not a bug symptom.
     topo.droppable_edge(vsync, engine); // vsync tick (Credit-gated)
     topo.droppable_edge(engine, vsync); // RenderedResponse (FPS telemetry only)
     topo.droppable_edge(engine, app); // RequestFrame (Credit-gated)
     topo.droppable_edge(app, engine); // AppData::RenderSurface (already "keep latest" today)
 
     let order = topo.validate().expect(
-        "every edge here is droppable, so this must already be a DAG — if it isn't, an edge \
-         above needs reclassifying before any live actor is converted",
+        "every engine -> driver edge is droppable and driver -> engine is the only Blocking \
+         one, so this must be a DAG — if it isn't, an edge above needs reclassifying before \
+         any live actor is converted",
     );
     assert_eq!(order.len(), 5);
 }
 
-/// The open finding itself, kept as a running test rather than a comment: as currently
-/// specified (both directions Blocking), driver and engine form a real cycle. This should keep
-/// failing to validate until someone makes the actual decision in §3.1 of the migration doc —
-/// at which point this test should be rewritten to assert the *chosen* resolution validates,
-/// not deleted.
+/// The mistake the first draft of this proof made, kept as a permanent regression test rather
+/// than deleted once fixed: declaring *both* directions between driver and engine Blocking —
+/// even for logically unrelated message flows — is a real cycle, not a false positive from an
+/// overly strict checker.
 #[test]
-fn driver_and_engine_are_not_yet_resolved() {
+fn regressed_aggregate_framing_is_cyclic() {
     let mut topo = Topology::new();
     let driver = topo.actor("driver");
     let engine = topo.actor("engine");
 
-    topo.blocking_edge(driver, engine); // input events — must not be lost
-    topo.blocking_edge(engine, driver); // display commands — must not be lost
+    topo.blocking_edge(driver, engine); // input events
+    topo.blocking_edge(engine, driver); // "display commands", undifferentiated
 
-    let cycle = topo.validate().expect_err(
-        "driver<->engine validates now — §3.1 of the migration doc has been resolved; \
-         replace this test with one asserting the chosen fix (a droppable/coalesced stream, \
-         a provably-bounded ring, or a split into blocking + droppable command streams)",
-    );
+    let cycle = topo
+        .validate()
+        .expect_err("two blocking edges between the same pair must be rejected");
     assert!(cycle.actors.contains(&"driver") && cycle.actors.contains(&"engine"));
 }

--- a/pixelflow-runtime/tests/target_topology.rs
+++ b/pixelflow-runtime/tests/target_topology.rs
@@ -1,0 +1,81 @@
+//! Proves the target engine-mesh topology from
+//! `docs/designs/pixelflow-runtime-engine-mesh-migration.md` §3 — built from the *same* five
+//! actor names and *same* edge classifications that document commits to, so a change to either
+//! the plan or this test without the other is a diff someone has to notice and reconcile, not a
+//! silent drift.
+//!
+//! No `pixelflow-runtime` actor code is exercised here. `Topology` only needs names and edge
+//! kinds — this file is deliberately actor-agnostic, so it stays valid across the rollout in
+//! the plan's §5 regardless of which actor is mid-conversion.
+//!
+//! # Status: driver ↔ engine is a known-open gap, not a passing proof
+//!
+//! Writing the "does the whole mesh validate" test found that it doesn't: input events and
+//! display commands were both specified Blocking, and two independent blocking edges between
+//! the same pair of actors are a cycle regardless of the flows being logically unrelated (§3.1
+//! of the migration doc). Fixing that requires a real behavioral trade-off — which stream may
+//! lose messages under backpressure, or whether a ring can be proven never to fill — not a
+//! mechanical edit, so it is **not resolved here**. The two tests below say so directly: one
+//! proves everything *except* that pair is already a valid DAG, the other proves that pair, as
+//! currently specified, is not.
+
+use actor_scheduler::mealy::Topology;
+
+/// Every edge from §3 of the migration doc except driver↔engine, which is not yet resolved
+/// (see the module doc and §3.1). Confirms the four satellite relationships — vsync,
+/// rasterizer, app, and driver's *own* structurally-unreachable window-return edge — validate
+/// as specified, so the rollout in §5 can proceed on those independent of how driver↔engine is
+/// eventually settled.
+#[test]
+fn the_resolved_part_of_the_target_mesh_is_a_dag() {
+    let mut topo = Topology::new();
+
+    let driver = topo.actor("driver");
+    let engine = topo.actor("engine");
+    let vsync = topo.actor("vsync");
+    let rasterizer = topo.actor("rasterizer");
+    let app = topo.actor("app");
+
+    // driver -> engine (input events) and engine -> driver (display commands) are
+    // deliberately NOT declared here — see `driver_and_engine_are_not_yet_resolved` below.
+
+    // Structurally-unreachable droppable backstops: exactly one request ever outstanding,
+    // so the ring can never actually be full when the reply lands (migration doc §3).
+    topo.droppable_edge(driver, engine); // PresentComplete (window return)
+    topo.droppable_edge(engine, rasterizer); // render request
+    topo.droppable_edge(rasterizer, engine); // render complete
+
+    // Genuinely acceptable loss: dropping is a normal outcome, not a bug symptom.
+    topo.droppable_edge(vsync, engine); // vsync tick (Credit-gated)
+    topo.droppable_edge(engine, vsync); // RenderedResponse (FPS telemetry only)
+    topo.droppable_edge(engine, app); // RequestFrame (Credit-gated)
+    topo.droppable_edge(app, engine); // AppData::RenderSurface (already "keep latest" today)
+
+    let order = topo.validate().expect(
+        "every edge here is droppable, so this must already be a DAG — if it isn't, an edge \
+         above needs reclassifying before any live actor is converted",
+    );
+    assert_eq!(order.len(), 5);
+}
+
+/// The open finding itself, kept as a running test rather than a comment: as currently
+/// specified (both directions Blocking), driver and engine form a real cycle. This should keep
+/// failing to validate until someone makes the actual decision in §3.1 of the migration doc —
+/// at which point this test should be rewritten to assert the *chosen* resolution validates,
+/// not deleted.
+#[test]
+fn driver_and_engine_are_not_yet_resolved() {
+    let mut topo = Topology::new();
+    let driver = topo.actor("driver");
+    let engine = topo.actor("engine");
+
+    topo.blocking_edge(driver, engine); // input events — must not be lost
+    topo.blocking_edge(engine, driver); // display commands — must not be lost
+
+    let cycle = topo.validate().expect_err(
+        "driver<->engine validates now — §3.1 of the migration doc has been resolved; \
+         replace this test with one asserting the chosen fix (a droppable/coalesced stream, \
+         a provably-bounded ring, or a split into blocking + droppable command streams)",
+    );
+    assert!(cycle.actors.contains(&"driver") && cycle.actors.contains(&"engine"));
+}


### PR DESCRIPTION
## What

Starts the work deferred from the actor-scheduler audit (`docs/designs/actor-scheduler-mealy-transducer.md` §9): replacing `EngineHandler` as a central mediator with `driver`/`vsync`/`rasterizer`/`app` talking directly, over edges `Topology` checks at bootstrap.

**No live actor code changes.** This is deliberately plan-then-prove before touching a running actor system.

## The plan (`docs/designs/pixelflow-runtime-engine-mesh-migration.md`)

Classifies every one of the audit's cycles as **Blocking**, **Credit + Droppable**, or **plain Droppable** — keeping two different reasons an edge is safe to `[drop]` distinct: **structurally unreachable** (window return, render complete — exactly one request is ever outstanding, so the ring can never actually be full) vs. **genuinely acceptable loss** (vsync ticks, FPS telemetry, state pushes). Conflating those two is exactly the mistake the audit warned about.

**Where `EngineHandler`'s coordination state ends up is explicitly not decided here** — it holds real state today, so removing it means that state moves somewhere; forcing that call before the satellite actors speak the new protocol would be architecture-on-paper. Recorded as step 5 of a 5-step rollout (vsync → rasterizer → driver → collapse engine), each its own reviewable PR.

## The proof, and a genuine correction mid-PR

`pixelflow-runtime/tests/target_topology.rs` mechanically checks the plan's table — and its first draft immediately caught a real planning bug: `driver ↔ engine` had **both directions marked Blocking** as one aggregate edge each, which is a cycle regardless of the two flows being logically unrelated (two blocking edges between the same pair, the same shape as `app ↔ compiler`).

The fix wasn't picking one side to weaken — "display commands" was never one thing. Decomposed per message, it turns out to already fit the exact Credit/Droppable vocabulary established for every other edge:

- **`Present`** already has a documented non-blocking contract in the code itself (missed by the original aggregate framing) — same Credit(1) shape as `PresentComplete`, since the ping-pong buffer means they were always one relationship.
- **`SetTitle`/`SetSize`/`SetCursor`/`Copy`** are idempotent "latest wins" state — exactly what `pending_manifold` already does by hand elsewhere. Plain droppable, no credit needed.
- **`RequestPaste`/`PasteData`** is its own small 1:1 credit-bounded pair, with an explicitly *weaker* guarantee than the window buffer (usage-based bound, not an engineered invariant) — recorded as an accepted trade-off, not conflated with the stronger cases.
- **`Create`** (window creation) is bootstrap-phase, not steady-state — the same category the current code already puts the rasterizer's handshake in.

With every `engine → driver` edge non-blocking, `driver → engine` (input + window-lifecycle events) is the only genuinely Blocking edge, and one blocking direction between a pair is never a cycle. Nothing that matters became droppable to get there.

`target_topology.rs` now has:
- `the_target_engine_mesh_is_a_dag` — the full, resolved mesh, genuinely passing.
- `regressed_aggregate_framing_is_cyclic` — the original mistake, kept as a permanent regression test rather than deleted, since it's a real failure mode worth remembering.

## Verification

`cargo test -p pixelflow-runtime --test target_topology` — 2/2 passing. `cargo test -p actor-scheduler` — 111/111 unaffected. Clippy clean on both.