### PR TITLE
feat(actor-scheduler): a reusable Timer in a ready-to-go actors module

### DIFF
--- a/actor-scheduler/src/actors/mod.rs
+++ b/actor-scheduler/src/actors/mod.rs
@@ -1,0 +1,9 @@
+//! Ready-to-go actors.
+//!
+//! Small, general-purpose actors that most systems end up needing and would otherwise
+//! hand-roll once per crate. Nothing here knows anything about the application using it —
+//! if a type in this module mentions a domain concept, it's in the wrong place.
+
+pub mod timer;
+
+pub use timer::{Schedule, Timer};

--- a/actor-scheduler/src/actors/timer.rs
+++ b/actor-scheduler/src/actors/timer.rs
@@ -1,0 +1,281 @@
+//! A timer that fires on a schedule.
+//!
+//! Actors can't wait on time themselves: a scheduler blocks on its doorbell, so an actor that
+//! wanted to wake "in 16ms" would have to block the very loop that delivers its messages. The
+//! way out is the one this crate already uses everywhere else — *something else sends it a
+//! message*. A [`Timer`] is that something: a thread whose only job is to wait, fire, and wait
+//! again.
+//!
+//! ```ignore
+//! let timer = Timer::spawn("vsync-clock", Schedule::Every(interval), move || {
+//!     match handle.send(VsyncManagement::Tick) {
+//!         Ok(()) => ControlFlow::Continue(()),
+//!         // The actor is gone; there is nobody left to tick.
+//!         Err(_) => ControlFlow::Break(()),
+//!     }
+//! });
+//! ```
+//!
+//! The callback returns [`ControlFlow`] rather than `bool` because "keep going / stop" is
+//! exactly what `ControlFlow` means, and a `-> bool` would need a doc comment explaining which
+//! way round it goes.
+//!
+//! # Lifetime
+//!
+//! A timer stops when any of these happens, whichever comes first:
+//!
+//! - [`Timer::stop`] is called — the only one that is *synchronous*: it joins the thread, so
+//!   when it returns the timer has provably fired for the last time.
+//! - the callback returns [`ControlFlow::Break`].
+//! - the [`Timer`] is dropped — the command channel disconnects and the thread notices.
+//!
+//! Dropping is the loose one: the thread may be mid-wait, so a fire already in flight can still
+//! land. Use [`stop`](Timer::stop) when "no more fires after this point" has to be a fact rather
+//! than a very likely outcome — a test asserting an exact fire count needs that guarantee, and
+//! so does any teardown that tears down something the callback touches.
+
+use std::ops::ControlFlow;
+use std::sync::mpsc::{self, RecvTimeoutError, Sender};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+/// When a [`Timer`] fires.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Schedule {
+    /// Fire repeatedly, waiting this long before each fire.
+    ///
+    /// The wait is between fires, not between fire *starts*: a slow callback delays the next
+    /// fire rather than stacking up behind it. A timer never runs its callback re-entrantly.
+    Every(Duration),
+    /// Fire once, after this long, then stop.
+    After(Duration),
+}
+
+/// Commands to a running timer thread.
+enum TimerCommand {
+    /// Change the wait. Takes effect on the *next* wait, not the one already in progress.
+    SetInterval(Duration),
+    /// Stop the timer.
+    Stop,
+}
+
+/// A handle to a running timer thread.
+///
+/// See the [module docs](self) for the schedule and lifetime rules.
+#[derive(Debug)]
+#[must_use = "dropping a Timer stops it; bind it to a variable to keep it running"]
+pub struct Timer {
+    tx: Sender<TimerCommand>,
+    /// `None` only after [`stop`](Timer::stop) has taken it to join.
+    join: Option<JoinHandle<()>>,
+}
+
+impl Timer {
+    /// Spawn a timer thread that runs `on_fire` on the given schedule.
+    ///
+    /// `name` names the OS thread, so it shows up in debuggers and profilers.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the OS refuses to spawn the thread.
+    pub fn spawn<F>(name: &str, schedule: Schedule, mut on_fire: F) -> Self
+    where
+        F: FnMut() -> ControlFlow<()> + Send + 'static,
+    {
+        let (tx, rx) = mpsc::channel();
+
+        let (mut interval, repeats) = match schedule {
+            Schedule::Every(d) => (d, true),
+            Schedule::After(d) => (d, false),
+        };
+
+        let join = thread::Builder::new()
+            .name(name.to_string())
+            .spawn(move || {
+                loop {
+                    match rx.recv_timeout(interval) {
+                        Ok(TimerCommand::SetInterval(d)) => interval = d,
+                        Ok(TimerCommand::Stop) => break,
+                        // The wait elapsed uninterrupted: that *is* the tick.
+                        Err(RecvTimeoutError::Timeout) => {
+                            if on_fire().is_break() || !repeats {
+                                break;
+                            }
+                        }
+                        // The `Timer` was dropped, so nobody can stop us later either.
+                        Err(RecvTimeoutError::Disconnected) => break,
+                    }
+                }
+            })
+            .expect("failed to spawn timer thread");
+
+        Self {
+            tx,
+            join: Some(join),
+        }
+    }
+
+    /// Send a command, tolerating a timer thread that has already exited.
+    ///
+    /// Both commands are *moot* rather than failed in that state: a stopped timer has no next
+    /// wait to reschedule and nothing left to stop. Since the caller could take no useful
+    /// action on the error, it is handled here, once, instead of being propagated to every
+    /// call site that would only discard it.
+    fn command(&self, cmd: TimerCommand) {
+        if self.tx.send(cmd).is_err() {
+            // Already stopped — the callback broke, or a one-shot fired. Nothing to do.
+        }
+    }
+
+    /// Change how long the timer waits between fires.
+    ///
+    /// Applies to the next wait; a wait already in progress runs out at its original length.
+    /// Does nothing if the timer has already stopped — a timer outliving its usefulness is
+    /// ordinary, not an error worth propagating to every caller.
+    pub fn set_interval(&self, interval: Duration) {
+        self.command(TimerCommand::SetInterval(interval));
+    }
+
+    /// Stop the timer and wait for its thread to exit.
+    ///
+    /// When this returns, the callback has provably run for the last time. That guarantee is
+    /// the reason to prefer this over just dropping the timer.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the timer thread panicked — i.e. if `on_fire` panicked.
+    pub fn stop(mut self) {
+        self.command(TimerCommand::Stop);
+        // Runs whether or not the command landed, so the "provably fired for the last time"
+        // guarantee holds identically for a thread that had already exited on its own.
+        if let Some(join) = self.join.take() {
+            join.join().expect("timer callback panicked");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Long enough that a test never waits on it, short enough that a test that *wants* a fire
+    /// isn't slow. Nothing asserts a fire count against elapsed time, so this only trades test
+    /// latency against CPU churn — never correctness.
+    const QUICK: Duration = Duration::from_millis(5);
+
+    /// Far longer than any test's own runtime: a timer on this schedule will not fire during a
+    /// test unless the test explicitly waits for it, which none do.
+    const NEVER_WITHIN_THIS_TEST: Duration = Duration::from_secs(3600);
+
+    fn counter() -> (Arc<AtomicUsize>, impl FnMut() -> ControlFlow<()>) {
+        let count = Arc::new(AtomicUsize::new(0));
+        let handle = count.clone();
+        (count, move || {
+            handle.fetch_add(1, Ordering::SeqCst);
+            ControlFlow::Continue(())
+        })
+    }
+
+    /// Blocks until `count` reaches `target`. No deadline: a timer that never fires must hang
+    /// the test rather than race a deadline that a loaded CI runner can lose. The test harness
+    /// timeout is the real backstop, and it doesn't produce false failures.
+    fn wait_until_at_least(count: &AtomicUsize, target: usize) {
+        while count.load(Ordering::SeqCst) < target {
+            std::hint::spin_loop();
+        }
+    }
+
+    #[test]
+    fn a_repeating_timer_fires_more_than_once() {
+        let (count, on_fire) = counter();
+        let timer = Timer::spawn("test-repeat", Schedule::Every(QUICK), on_fire);
+
+        wait_until_at_least(&count, 2);
+
+        timer.stop();
+    }
+
+    #[test]
+    fn a_one_shot_timer_fires_exactly_once() {
+        let (count, on_fire) = counter();
+        let timer = Timer::spawn("test-one-shot", Schedule::After(QUICK), on_fire);
+
+        // Wait for the fire *before* stopping: `stop` is immediate, so stopping first would
+        // beat the schedule and prove nothing. Then `stop` joins — so the exact count below is
+        // a fact about a thread that has provably exited, not a race against a deadline.
+        wait_until_at_least(&count, 1);
+        timer.stop();
+
+        assert_eq!(count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn breaking_from_the_callback_stops_a_repeating_timer() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let handle = count.clone();
+
+        let timer = Timer::spawn("test-break", Schedule::Every(QUICK), move || {
+            handle.fetch_add(1, Ordering::SeqCst);
+            ControlFlow::Break(())
+        });
+
+        wait_until_at_least(&count, 1);
+        timer.stop();
+
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            1,
+            "Break must stop a repeating timer after its first fire"
+        );
+    }
+
+    #[test]
+    fn set_interval_shortens_a_timer_that_would_not_otherwise_fire() {
+        let (count, on_fire) = counter();
+        let timer = Timer::spawn(
+            "test-set-interval",
+            Schedule::Every(NEVER_WITHIN_THIS_TEST),
+            on_fire,
+        );
+
+        // The timer is parked on an hour-long wait, so any fire at all proves the new interval
+        // took effect — no timing assertion needed, and no way for a slow runner to fake it.
+        timer.set_interval(QUICK);
+        wait_until_at_least(&count, 1);
+
+        timer.stop();
+    }
+
+    #[test]
+    fn stop_is_safe_before_the_first_fire() {
+        let (count, on_fire) = counter();
+        let timer = Timer::spawn(
+            "test-stop-early",
+            Schedule::Every(NEVER_WITHIN_THIS_TEST),
+            on_fire,
+        );
+
+        timer.stop();
+
+        assert_eq!(count.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn dropping_a_timer_stops_its_thread() {
+        let (count, on_fire) = counter();
+
+        {
+            let _timer = Timer::spawn(
+                "test-drop",
+                Schedule::Every(NEVER_WITHIN_THIS_TEST),
+                on_fire,
+            );
+        }
+
+        // Nothing to join on a dropped timer, so this asserts the weaker of the two guarantees
+        // documented in the module docs: a dropped timer that never fired still never fires.
+        assert_eq!(count.load(Ordering::SeqCst), 0);
+    }
+}

--- a/actor-scheduler/src/lib.rs
+++ b/actor-scheduler/src/lib.rs
@@ -92,6 +92,7 @@
 //! tx.send(Message::Control("high priority control".to_string())).unwrap();
 //! ```
 
+pub mod actors;
 mod error;
 pub mod host;
 mod lifecycle;

--- a/docs/designs/pixelflow-runtime-engine-mesh-migration.md
+++ b/docs/designs/pixelflow-runtime-engine-mesh-migration.md
@@ -36,8 +36,8 @@ not by re-reading it), and only then touch a live actor.
 | `Present` | engine → driver | **Credit(1) + Droppable backstop** | Not a judgment call this doc is inventing: `DisplayData::Present`'s own doc comment already specifies the receiver's contract as "3. NOT block the sender (use backpressure if buffer full)". The original table lumped it into a generic "commands, never lose" bucket and missed that the code already disagrees. Exactly one window is ever in flight (the ping-pong buffer), so this is the *same* structurally-unreachable shape as the row below, not a new risk. |
 | `PresentComplete` (window return) | driver → engine | **Credit(1) + Droppable backstop** | The reply half of `Present`, sharing its credit. Exactly one window is ever in flight, so the reply ring's capacity is provisioned ≥ 1 and can **never actually be full** when the reply lands — the droppable backstop exists for `Topology`'s proof, but is unreachable by construction, not merely rare. Not the same case as a true "acceptable loss" droppable edge (§9.2) — safe only because the credit bound is airtight. |
 | `SetTitle` / `SetSize` / `SetCursor` / `Copy` | engine → driver | **Droppable, no credit needed** | Idempotent, "latest write wins" state — the exact shape already handled for `pending_manifold` below. Two queued `SetTitle`s only ever needed the second one anyway. |
-| `RequestPaste` | engine → driver | **Credit(1) + Droppable backstop** | Paired with `PasteData` below; engine never has more than one outstanding paste request. |
-| `PasteData` (reply to `RequestPaste`) | driver → engine | **Credit(1) + Droppable backstop, shared with `RequestPaste`** | A dropped reply here just means one failed paste, recoverable by the user pressing paste again — closer to "acceptable loss" than "unreachable," since the 1-outstanding bound comes from usage, not an engineered invariant like the window buffer. Recorded as that weaker guarantee on purpose, not conflated with `PresentComplete`. |
+| `RequestPaste` | engine → driver | **Droppable, no credit** — *revised, see §3.2* | Originally planned as Credit(1); that would deadlock paste permanently. |
+| `PasteData` (reply to `RequestPaste`) | driver → engine | **Droppable, no credit** — *revised, see §3.2* | The reply is not merely losable, it is *routinely absent*: pasting from an empty clipboard produces no reply at all, by design. A credit released only by the reply would never come back. |
 | `Create` (window creation) | engine → driver | **Not part of the steady-state graph — see §3.1** | One-shot bootstrap per window, not a member of the continuously-live mesh at all. |
 | VSync tick | vsync → engine | **Credit(100) + Droppable backstop** | Direct replacement for `VSYNC_TOKEN_BUCKET`. A dropped tick under a bug is a missed/late frame, genuinely tolerable — this *is* an ordinary acceptable-loss droppable edge, unlike the row above. |
 | Frame-rendered notice (`RenderedResponse`, FPS tracking only) | engine → vsync | **Droppable, no credit needed** | Pure telemetry. Losing a sample changes nothing but a displayed FPS number. |
@@ -79,9 +79,10 @@ already established for other actors:
 - **`SetTitle`/`SetSize`/`SetCursor`/`Copy` are idempotent state pushes** — exactly the
   "keep latest, drop stale" shape `pending_manifold` already implements by hand elsewhere in
   this file. Plain `[drop]`, no credit needed, nothing new invented.
-- **`RequestPaste`/`PasteData` is its own tiny 1:1 request/reply**, structurally identical to
-  every other credit-bounded pair in §3, just lower-stakes (a dropped reply costs one retried
-  keystroke, not a lost buffer).
+- **`RequestPaste`/`PasteData` is its own tiny 1:1 request/reply** — originally classified here
+  as "structurally identical to every other credit-bounded pair, just lower-stakes." That was
+  wrong, and §3.2 corrects it: the reply is *routinely absent*, so a credit released only by the
+  reply is a deadlock, not a bound.
 - **`Create` is a bootstrap-phase message**, not a steady-state one — the same category the
   *current* code already puts the rasterizer's handshake in (`engine_troupe.rs`: "Rasterizer is
   NOT in the troupe - it uses a bootstrap handshake pattern"). `Topology`'s DAG check governs the
@@ -94,11 +95,46 @@ direction between a pair is never a cycle by itself. Nothing that matters was ma
 get there: every discrete, non-idempotent, must-not-lose message (input, window lifecycle) stays
 exactly as reliable as it is today.
 
-The one edge worth flagging as a deliberately *weaker* guarantee than its siblings:
-`PasteData`'s credit bound comes from how paste is actually used (nobody issues a second
-`RequestPaste` before the first replies), not from an engineered invariant like the single
-window buffer. If that assumption is ever wrong, the failure mode is a dropped paste, not a
-hang — an explicit, accepted trade, not an oversight.
+### 3.2 The paste credit was a deadlock, not a weaker guarantee
+
+§3.1 originally flagged `RequestPaste`/`PasteData` as carrying a *weaker* credit bound than its
+siblings — "nobody issues a second `RequestPaste` before the first replies" — and accepted that
+as a recorded trade-off. Implementation found that framing to be wrong in kind, not just in
+degree, and this section is the correction.
+
+**A reply is not merely rare to lose here. It is routinely, correctly absent.** Pasting from an
+empty or unowned clipboard produces *no reply at all*, by design and at the protocol level. On
+X11, `request_paste()` issues an async `XConvertSelection`; when nothing owns the selection the
+server answers `SelectionNotify` with `property == None`, and
+`platform/linux/events.rs::handle_selection_notify` correctly returns `None` rather than
+inventing an empty `PasteData`. That is the normal, specified path for "clipboard is empty" —
+not an error, not an edge case worth engineering around.
+
+A `Credit(1)` released only by `PasteData` would therefore be consumed and never returned the
+first time a user hits paste with an empty clipboard, and **every subsequent paste for the life
+of the process would be silently gated off**. The bound's failure mode is not "a dropped paste";
+it is "paste stops working permanently." That is strictly worse than the unbounded status quo.
+
+The fix is to *subtract*, not to add a rescue mechanism. A timeout that releases the credit when
+no reply arrives would work, but it answers a question this edge never needed to ask: `Credit`
+exists to make a droppable edge's drop **unreachable**, and it earns its keep only where the
+drop would be catastrophic (`PresentComplete` losing the sole window buffer). Here the drop is
+*already* the acceptable outcome — §3.1's own words, "a dropped reply costs one retried
+keystroke" — so there is nothing for a credit to protect. The edge is plain Droppable, exactly
+like `SetTitle`/`SetSize`/`SetCursor`/`Copy`: lose it and the user presses paste again.
+
+This is the two-category distinction from §3 doing its job in the direction it was meant to.
+Those categories — *structurally unreachable* vs. *genuinely acceptable loss* — exist so that
+"safe to `[drop]`" is never allowed to blur into one word. Paste was filed under the first and
+belongs under the second; a credit bolted onto an acceptable-loss edge bought no safety and
+introduced a hang.
+
+Worth noting what did *not* change: `pixelflow-runtime/tests/target_topology.rs` needed no edit
+to its edges for this correction, because `Credit` is a sender-side discipline and not a
+`Topology` concept at all — both directions were already `droppable_edge`. The proof was
+indifferent to a distinction the prose had gotten wrong, which is a useful reminder that the
+mechanical check constrains the *shape* of the graph and never the judgment about what may be
+lost.
 
 ## 4. Placement
 

--- a/pixelflow-runtime/src/vsync_actor.rs
+++ b/pixelflow-runtime/src/vsync_actor.rs
@@ -33,9 +33,11 @@
 //! only in [`Transducer::step_control`] on a new [`VsyncCommand::ReturnToken`] — a real message,
 //! not a shared global. `engine_troupe.rs`'s two call sites become sends of that command.
 
+use actor_scheduler::actors::{Schedule, Timer};
 use actor_scheduler::mealy::{Credit, Transducer};
 use actor_scheduler::{Actor, ActorBuilder, ActorHandle, HandlerError, HandlerResult, SystemStatus};
 use log::info;
+use std::ops::ControlFlow;
 use std::sync::mpsc::Sender;
 use std::thread;
 use std::time::{Duration, Instant};
@@ -106,15 +108,6 @@ pub enum VsyncManagement {
     },
 }
 actor_scheduler::impl_management_message!(VsyncManagement);
-
-/// Internal commands sent to the clock thread
-#[derive(Debug)]
-enum ClockCommand {
-    /// Update the tick interval
-    SetInterval(Duration),
-    /// Stop the clock thread
-    Stop,
-}
 
 // ────────────────────────────────────────────────────────────────────────────
 // VsyncCore: the pure decision logic
@@ -302,40 +295,26 @@ impl Transducer for VsyncCore {
 /// side effect this whole actor performs — `engine_handle.send(...)`.
 pub struct VsyncActor {
     engine_handle: Option<crate::api::private::EngineActorHandle>,
-    clock_control: Option<Sender<ClockCommand>>,
+    clock: Option<Timer>,
     core: VsyncCore,
 }
 
 impl VsyncActor {
-    /// Helper to spawn the clock thread.
-    fn spawn_clock_thread(
+    /// Spawn the clock: a plain [`Timer`] whose callback is the one thing this actor's clock
+    /// ever did — send itself a `Tick`. The hand-rolled `recv_timeout` loop this replaces was
+    /// a timer with a vsync-shaped name on it; nothing about waiting on a duration was
+    /// specific to vsync.
+    fn spawn_clock(
         interval: Duration,
         self_handle: ActorHandle<RenderedResponse, VsyncCommand, VsyncManagement>,
-    ) -> Sender<ClockCommand> {
-        let (clock_tx, clock_rx) = std::sync::mpsc::channel();
-
-        thread::Builder::new()
-            .name("vsync-clock".to_string())
-            .spawn(move || {
-                let mut current_interval = interval;
-                loop {
-                    match clock_rx.recv_timeout(current_interval) {
-                        Ok(ClockCommand::Stop) => break,
-                        Ok(ClockCommand::SetInterval(d)) => current_interval = d,
-                        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-                            // Time to tick
-                            if self_handle.send(VsyncManagement::Tick).is_err() {
-                                // Actor is gone
-                                break;
-                            }
-                        }
-                        Err(_) => break, // Channel disconnected
-                    }
-                }
-            })
-            .expect("Failed to spawn vsync clock thread");
-
-        clock_tx
+    ) -> Timer {
+        Timer::spawn("vsync-clock", Schedule::Every(interval), move || {
+            match self_handle.send(VsyncManagement::Tick) {
+                Ok(()) => ControlFlow::Continue(()),
+                // The actor is gone; there is nobody left to tick.
+                Err(_) => ControlFlow::Break(()),
+            }
+        })
     }
 
     /// Create empty VsyncActor for troupe pattern - configured via SetConfig management message.
@@ -343,7 +322,7 @@ impl VsyncActor {
     pub fn new_empty() -> Self {
         Self {
             engine_handle: None,
-            clock_control: None,
+            clock: None,
             core: VsyncCore::new(DEFAULT_REFRESH_RATE),
         }
     }
@@ -363,12 +342,12 @@ impl VsyncActor {
             MAX_TOKENS
         );
 
-        // Spawn the clock thread — self_handle is a dedicated SPSC channel
-        let clock_tx = Self::spawn_clock_thread(interval, self_handle);
+        // Spawn the clock — self_handle is a dedicated SPSC channel
+        let clock = Self::spawn_clock(interval, self_handle);
 
         Self {
             engine_handle: Some(engine_handle),
-            clock_control: Some(clock_tx),
+            clock: Some(clock),
             core: VsyncCore::new(refresh_rate),
         }
     }
@@ -439,15 +418,15 @@ impl Actor<RenderedResponse, VsyncCommand, VsyncManagement> for VsyncActor {
         let out = self.core.step_control(cmd)?;
 
         if update_clock_interval {
-            if let Some(ref tx) = self.clock_control {
-                tx.send(ClockCommand::SetInterval(self.core.interval()))
-                    .expect("Failed to update clock thread interval");
+            if let Some(ref clock) = self.clock {
+                clock.set_interval(self.core.interval());
             }
         }
         if stop_clock {
-            if let Some(ref tx) = self.clock_control {
-                tx.send(ClockCommand::Stop)
-                    .expect("Failed to stop clock thread on shutdown");
+            // `stop` consumes the Timer and joins its thread, so once this returns no further
+            // Tick can land — the shutdown is complete, not merely requested.
+            if let Some(clock) = self.clock.take() {
+                clock.stop();
             }
         }
 
@@ -476,8 +455,7 @@ impl Actor<RenderedResponse, VsyncCommand, VsyncManagement> for VsyncActor {
 
                 info!("VsyncActor: Configured with {:.2} Hz", config.refresh_rate);
 
-                let clock_tx = Self::spawn_clock_thread(self.core.interval(), *self_handle);
-                self.clock_control = Some(clock_tx);
+                self.clock = Some(Self::spawn_clock(self.core.interval(), *self_handle));
 
                 info!("VsyncActor: Auto-started after configuration");
             }

--- a/pixelflow-runtime/tests/target_topology.rs
+++ b/pixelflow-runtime/tests/target_topology.rs
@@ -48,8 +48,11 @@ fn the_target_engine_mesh_is_a_dag() {
     // Idempotent "latest wins" state pushes: no credit needed at all.
     topo.droppable_edge(engine, driver); // SetTitle / SetSize / SetCursor / Copy
 
-    // RequestPaste / PasteData: its own small credit-bounded pair, weaker guarantee than the
-    // window buffer (usage-based bound, not an engineered invariant) — see §3.1.
+    // RequestPaste / PasteData: plain droppable, deliberately *not* credit-bounded — see §3.2.
+    // A reply is not merely rare-to-lose here, it is routinely absent: X11 answers a paste
+    // request against an unowned clipboard with `property == None`, which the driver correctly
+    // turns into no event at all. A Credit(1) released only by the reply would therefore be
+    // spent forever the first time a user pastes from an empty clipboard.
     topo.droppable_edge(engine, driver); // RequestPaste
     topo.droppable_edge(driver, engine); // PasteData
 


### PR DESCRIPTION
## Why

Actors can't wait on time themselves: a scheduler blocks on its doorbell, so an actor that wanted to wake "in 16ms" would block the very loop that delivers its messages. The way out is the one this crate uses everywhere else — *something else sends it a message*.

vsync had already built exactly that, as a private `recv_timeout` loop named `vsync-clock`. But nothing about waiting on a duration was specific to vsync, and the next thing that needs a timeout would have hand-rolled it a second time.

## What

New `actor_scheduler::actors` module — small general-purpose actors most systems end up hand-rolling once per crate — starting with `Timer`:

```rust
Timer::spawn("vsync-clock", Schedule::Every(interval), move || {
    match handle.send(VsyncManagement::Tick) {
        Ok(()) => ControlFlow::Continue(()),
        Err(_) => ControlFlow::Break(()),   // the actor is gone
    }
})
```

- `Schedule::Every` / `Schedule::After` (one-shot).
- The callback returns `ControlFlow` rather than `bool` because "keep going / stop" is exactly what `ControlFlow` means, and `-> bool` would need a doc comment explaining which way round it goes.
- `set_interval` applies to the next wait.

### `stop()` is the load-bearing piece

`stop()` joins the thread, so **when it returns, the callback has provably run for the last time**. That turns "no more fires after this point" from a timing hope into a structural fact — which is what lets the tests here assert *exact* fire counts with no sleep-then-check-nothing-happened race anywhere in the file. Dropping a `Timer` also stops it, but only loosely (a fire already in flight can still land); both guarantees are documented as distinct, since only one of them is safe to build an assertion on.

## vsync rebuilt on it

`spawn_clock_thread` and the private `ClockCommand` enum are deleted; `VsyncActor` holds an `Option<Timer>`. `Shutdown` now *joins* the clock instead of firing a `Stop` into the void, so shutdown is complete rather than merely requested.

The real-`VsyncActor` regression harness passes **with no assertion changed** — the swap is behaviorally invisible.

## Notes

Two things this deliberately does *not* do, both from review feedback on the step-4 (driver) design questions that prompted it:

- **No non-blocking send machinery anywhere.** That was a category error on my part: in the Mealy model a converted actor has no `send` — `step_*` returns `Out`, `Wiring` delivers it, and `Blocking`/`Droppable` is a property of the declared edge, not a variant of some call site. Droppable `SetTitle`/`SetSize`/etc. falls out when the driver edge actually becomes a port; there is nothing to hand-roll before then.
- **No coalescing buffer in `EngineHandler`.** Coalescing is already automatic — the driver drains at frame rate, so queued title/size/cursor updates collapse on their own.

## Testing

- 6 new `Timer` unit tests — repeat, one-shot-fires-exactly-once, `Break` stops a repeater, `set_interval` shortens an hour-long wait (any fire at all proves it took effect), stop-before-first-fire, drop-stops-thread.
- `actor-scheduler`: 117 lib tests pass (111 pre-existing + 6 new).
- `pixelflow-runtime`: full suite green, including the unmodified real-`VsyncActor` harness.
- `core-term` builds; clippy clean on both crates (incl. the workspace's `let_underscore_must_use = "deny"` — the two tolerable send failures are handled in one documented helper rather than discarded).

## Test plan

- [x] `cargo test -p actor-scheduler`
- [x] `cargo test -p pixelflow-runtime`
- [x] `cargo build -p core-term`
- [x] `cargo clippy -p actor-scheduler -p pixelflow-runtime --all-targets`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Y5cNzR9PnASfGfjBh5kJc

---
_Generated by [Claude Code](https://claude.ai/code/session_015Y5cNzR9PnASfGfjBh5kJc)_