### PR TITLE
feat(pixelflow-runtime): driver returns its events instead of sending them (rollout step 4)

### DIFF
--- a/docs/designs/pixelflow-runtime-engine-mesh-migration.md
+++ b/docs/designs/pixelflow-runtime-engine-mesh-migration.md
@@ -192,13 +192,64 @@ Order of attack, each step independently shippable and reviewable:
    handshake — which was itself a symptom of not fitting the old static-topology model, so this
    should *simplify*, not complicate).
 4. **`driver`**: convert the command/event edges; window-return `Credit` last, since it's the
-   one edge where getting the bound wrong is worst.
+   one edge where getting the bound wrong is worst. **See §5.1 — the shape of this step is not
+   what steps 2–3 assumed.**
 5. **`app`-facing edge + delete `EngineHandler`**: once every satellite speaks the new
    protocol directly to its real peer, the mediator has nothing left to route and is deleted,
    not refactored down.
 
 Each of steps 2–5 lands as its own PR with its own before/after behavioral tests against the
 running terminal, not just unit tests of the actor in isolation.
+
+### 5.1 Step 4 extracts the *send*, not a decision core
+
+Steps 2 and 3 both worked the same way: find the decision logic tangled up with I/O, pull it out
+into a pure `Transducer` (`VsyncCore`, `RasterCore`), leave a thin adapter holding the channels.
+Applying that template to the driver looks, at first, like it fails — `DriverActor` is a pure
+delegation shell with no state and no decisions, and the real logic lives in `PlatformOps` impls
+doing raw X11 and Cocoa calls, which will never be a pure transducer over a `*mut xlib::Display`.
+
+That reads as "step 4 is harder." It is the opposite, and the reason is worth writing down:
+**there is no decision core to extract because the platform state is already properly
+encapsulated.** `LinuxOps` holds `window: Option<X11Window>` and a waker; `MetalOps` holds
+`app`, `windows`, `window_map`. That is all OS resource, already owned by exactly the thing that
+should own it. Nothing wants moving.
+
+What the Mealy conversion actually asks for here is the *other* half of its rule — **effects are
+return values, not calls** — and the effect in question is the one thing these types do that
+couples them to another actor: `engine_handle.send(...)`. That is the whole of step 4.
+
+The sites are few and mechanical:
+
+| Impl | Site | Emits |
+|---|---|---|
+| `LinuxOps` | `handle_data` (Present) | `PresentComplete(window)` |
+| `LinuxOps` | `handle_management` (Create) | `FromDriver(WindowCreated)` |
+| `LinuxOps` | `park` — event pump | `FromDriver(event)` |
+| `LinuxOps` | `park` — drain loop | `FromDriver(event)` × N |
+| `MetalOps` | 7 sites, same two shapes | — |
+
+So: `PlatformOps`' methods stop sending and start yielding their outbound events, and
+`PlatformActor` — which **already exists as exactly this adapter**, wrapping `PlatformOps` into
+an `Actor` — performs the sends. Identical in shape to steps 2 and 3, with less work, because
+the encapsulation those steps had to create is already present here.
+
+The payoff is concrete and testable: `EngineActorHandle` disappears from `PlatformOps` entirely.
+Today every platform impl holds a live handle to the engine and can only be exercised with one
+running; afterwards they return `DisplayEvent`s and can be tested with no engine at all.
+
+Two real constraints on the implementation, neither a blocker:
+
+- **`park` emits *N* events**, not zero-or-one — the drain loop pulls every pending X11 event.
+  So the output is a sequence, unlike `VsyncCoreOut`/`RasterCoreOut`'s `Option`. Since `park`
+  runs every frame, this must not allocate per call (`CLAUDE.md`: "no per-frame heap
+  allocation"); the adapter owns one reusable buffer that the ops push into, so allocation is
+  amortized to zero in steady state rather than paid per frame.
+- **Only two impls exist** (`LinuxOps`, `MetalOps`) — headless and web still use the older
+  `DisplayDriver` trait and are untouched by this. Both are covered by CI (ubuntu + macOS), but
+  only the X11 half compiles on a Linux dev box, so the macOS half is verified in CI rather than
+  locally. That is the reason to land this as one deliberate PR rather than piecemeal: a
+  half-converted `PlatformOps` trait breaks the platform that cannot be compiled locally.
 
 ---
 

--- a/docs/designs/pixelflow-runtime-engine-mesh-migration.md
+++ b/docs/designs/pixelflow-runtime-engine-mesh-migration.md
@@ -241,10 +241,20 @@ running; afterwards they return `DisplayEvent`s and can be tested with no engine
 Two real constraints on the implementation, neither a blocker:
 
 - **`park` emits *N* events**, not zero-or-one — the drain loop pulls every pending X11 event.
-  So the output is a sequence, unlike `VsyncCoreOut`/`RasterCoreOut`'s `Option`. Since `park`
-  runs every frame, this must not allocate per call (`CLAUDE.md`: "no per-frame heap
-  allocation"); the adapter owns one reusable buffer that the ops push into, so allocation is
-  amortized to zero in steady state rather than paid per frame.
+  That does *not* make `Out` a list: it stays one output word, `DriverOut { events: Vec<..> }`,
+  exactly like `VsyncCoreOut { tick: Option<..> }` and `RasterCoreOut { response: Option<..> }`.
+  The struct's *fields* are the ports; a step still returns one `Out`. Keeping that uniform
+  matters more than it looks — `Out` being sometimes-a-word and sometimes-a-sequence is the kind
+  of special case that later has to be handled everywhere `Out` is touched.
+
+  This also disposes of an allocation concern that turned out not to exist. An earlier draft of
+  this section had the adapter own a reusable buffer for the ops to push into, on the grounds
+  that `park` runs every frame and `CLAUDE.md` forbids per-frame heap allocation. But an empty
+  `Vec` never touches the heap — `Vec::new()` allocates on first push, not on construction —
+  and the overwhelming majority of frames have no input events at all. Those frames allocate
+  nothing. A frame where the user actually types or moves the mouse pays one small amortized
+  growth, which is not a per-frame cost. The sink was machinery to solve a problem that
+  measurement of the type's own semantics dissolves, and it is deleted before being written.
 - **Only two impls exist** (`LinuxOps`, `MetalOps`) — headless and web still use the older
   `DisplayDriver` trait and are untouched by this. Both are covered by CI (ubuntu + macOS), but
   only the X11 half compiles on a Linux dev box, so the macOS half is verified in CI rather than

--- a/pixelflow-runtime/src/display/ops.rs
+++ b/pixelflow-runtime/src/display/ops.rs
@@ -1,10 +1,59 @@
-use super::messages::{DisplayControl, DisplayData, DisplayMgmt};
+use super::messages::{DisplayControl, DisplayData, DisplayEvent, DisplayMgmt, Window};
 use actor_scheduler::{ActorStatus, HandlerError, HandlerResult, SystemStatus};
 
+/// One thing the driver emits toward the engine.
+///
+/// These are exactly the two `driver → engine` edges in the target topology
+/// (`docs/designs/pixelflow-runtime-engine-mesh-migration.md` §3): the blocking input and
+/// window-lifecycle event stream, and the window return that closes the `Present` loop.
+#[derive(Debug)]
+pub enum DriverEmit {
+    /// An input or window-lifecycle event.
+    Event(DisplayEvent),
+    /// A window handed back after presentation, for reuse by the next frame.
+    PresentComplete(Window),
+}
+
+/// Output word for a [`PlatformOps`] step.
+///
+/// One `Out` per step, matching `VsyncCoreOut`/`RasterCoreOut` — the struct's *fields* are the
+/// ports, so a step never returns "sometimes a value, sometimes a list." `park` is the reason
+/// this field is a `Vec` rather than an `Option`: draining the OS event queue yields N events.
+///
+/// `Vec` is not a per-frame allocation despite `park` running every frame: an empty `Vec` never
+/// touches the heap, and the overwhelming majority of frames carry no input at all. Only a
+/// frame where the user actually did something pays one small amortized growth.
+#[derive(Debug, Default)]
+pub struct DriverOut {
+    pub emits: Vec<DriverEmit>,
+}
+
+impl DriverOut {
+    /// Queue an input or window-lifecycle event.
+    pub fn event(&mut self, event: DisplayEvent) {
+        self.emits.push(DriverEmit::Event(event));
+    }
+
+    /// Queue a window return.
+    pub fn present_complete(&mut self, window: Window) {
+        self.emits.push(DriverEmit::PresentComplete(window));
+    }
+}
+
 /// Backend-specific operations for the display platform.
+///
+/// Implementors own their platform resources (the X11 window, the `NSApplication`) and nothing
+/// else — in particular **not** a handle to the engine. Outbound events are *returned* via
+/// [`DriverOut`] rather than sent, so an implementation can be driven and observed with no
+/// engine, no scheduler, and no channels in the loop. Performing the real sends is
+/// `PlatformActor`'s job.
 pub trait PlatformOps: Send + 'static {
-    fn handle_data(&mut self, data: DisplayData) -> HandlerResult;
-    fn handle_control(&mut self, ctrl: DisplayControl) -> HandlerResult;
-    fn handle_management(&mut self, mgmt: DisplayMgmt) -> HandlerResult;
-    fn park(&mut self, status: SystemStatus) -> Result<ActorStatus, HandlerError>;
+    fn handle_data(&mut self, data: DisplayData, out: &mut DriverOut) -> HandlerResult;
+    fn handle_control(&mut self, ctrl: DisplayControl, out: &mut DriverOut) -> HandlerResult;
+    fn handle_management(&mut self, mgmt: DisplayMgmt, out: &mut DriverOut) -> HandlerResult;
+    fn park(
+        &mut self,
+        status: SystemStatus,
+        out: &mut DriverOut,
+    ) -> Result<ActorStatus, HandlerError>;
 }

--- a/pixelflow-runtime/src/display/platform.rs
+++ b/pixelflow-runtime/src/display/platform.rs
@@ -1,37 +1,72 @@
+use crate::api::private::{EngineActorHandle, EngineData};
 use crate::display::messages::{DisplayControl, DisplayData, DisplayMgmt};
-use crate::display::ops::PlatformOps;
-use actor_scheduler::{Actor, ActorStatus, HandlerError, HandlerResult, SystemStatus};
+use crate::display::ops::{DriverEmit, DriverOut, PlatformOps};
+use actor_scheduler::{Actor, ActorStatus, HandlerError, HandlerResult, Message, SystemStatus};
 
 /// The Platform Trait.
 /// Implementers must be an Actor that handles display messages.
 pub trait Platform: Actor<DisplayData, DisplayControl, DisplayMgmt> + Send + 'static {}
 
 /// A generic wrapper that turns any `PlatformOps` implementation into a `Platform` Actor.
+///
+/// This is the adapter half of the split described in
+/// `docs/designs/pixelflow-runtime-engine-mesh-migration.md` §5.1: [`PlatformOps`] decides and
+/// returns, this type performs the one effect it cannot — the actual send to the engine. The
+/// engine handle lives here rather than inside the ops precisely so that the ops stay drivable
+/// without an engine.
 pub struct PlatformActor<Ops: PlatformOps> {
     ops: Ops,
+    engine_handle: EngineActorHandle,
+    /// Reused across steps so a step's emits can be drained without reallocating the buffer.
+    out: DriverOut,
 }
 
 impl<Ops: PlatformOps> PlatformActor<Ops> {
-    pub fn new(ops: Ops) -> Self {
-        Self { ops }
+    pub fn new(ops: Ops, engine_handle: EngineActorHandle) -> Self {
+        Self {
+            ops,
+            engine_handle,
+            out: DriverOut::default(),
+        }
+    }
+
+    /// Deliver everything the last step emitted, leaving the buffer empty for the next one.
+    fn flush(&mut self) {
+        for emit in self.out.emits.drain(..) {
+            let data = match emit {
+                DriverEmit::Event(event) => EngineData::FromDriver(event),
+                DriverEmit::PresentComplete(window) => EngineData::PresentComplete(window),
+            };
+            self.engine_handle
+                .send(Message::Data(data))
+                .expect("failed to send engine event");
+        }
     }
 }
 
 impl<Ops: PlatformOps> Actor<DisplayData, DisplayControl, DisplayMgmt> for PlatformActor<Ops> {
     fn handle_data(&mut self, msg: DisplayData) -> HandlerResult {
-        self.ops.handle_data(msg)
+        let result = self.ops.handle_data(msg, &mut self.out);
+        self.flush();
+        result
     }
 
     fn handle_control(&mut self, msg: DisplayControl) -> HandlerResult {
-        self.ops.handle_control(msg)
+        let result = self.ops.handle_control(msg, &mut self.out);
+        self.flush();
+        result
     }
 
     fn handle_management(&mut self, msg: DisplayMgmt) -> HandlerResult {
-        self.ops.handle_management(msg)
+        let result = self.ops.handle_management(msg, &mut self.out);
+        self.flush();
+        result
     }
 
     fn park(&mut self, status: SystemStatus) -> Result<ActorStatus, HandlerError> {
-        self.ops.park(status)
+        let result = self.ops.park(status, &mut self.out);
+        self.flush();
+        result
     }
 }
 

--- a/pixelflow-runtime/src/engine_troupe.rs
+++ b/pixelflow-runtime/src/engine_troupe.rs
@@ -764,15 +764,15 @@ impl TroupeActor<Directory> for DriverActor<ActivePlatform> {
         #[cfg(target_os = "macos")]
         {
             use crate::platform::MetalOps;
-            let ops = MetalOps::new(dir.engine).expect("Failed to create Metal ops");
-            let platform = PlatformActor::new(ops);
+            let ops = MetalOps::new().expect("Failed to create Metal ops");
+            let platform = PlatformActor::new(ops, dir.engine);
             DriverActor::new(platform)
         }
         #[cfg(target_os = "linux")]
         {
             use crate::platform::linux::LinuxOps;
-            let ops = LinuxOps::new(dir.engine).expect("Failed to create Linux ops");
-            let platform = PlatformActor::new(ops);
+            let ops = LinuxOps::new().expect("Failed to create Linux ops");
+            let platform = PlatformActor::new(ops, dir.engine);
             DriverActor::new(platform)
         }
         #[cfg(not(any(target_os = "macos", target_os = "linux")))]

--- a/pixelflow-runtime/src/platform/linux/platform.rs
+++ b/pixelflow-runtime/src/platform/linux/platform.rs
@@ -2,14 +2,12 @@
 //!
 //! Bridge to X11DisplayDriver using the new PlatformOps trait.
 
-use crate::api::private::EngineActorHandle;
-use crate::api::private::EngineData;
 use crate::display::messages::{DisplayControl, DisplayData, DisplayEvent, DisplayMgmt, WindowId};
-use crate::display::ops::PlatformOps;
+use crate::display::ops::{DriverOut, PlatformOps};
 use crate::error::RuntimeError;
 use crate::platform::linux::window::X11Window;
 use crate::platform::waker::X11Waker;
-use actor_scheduler::{ActorStatus, Message, SystemStatus};
+use actor_scheduler::{ActorStatus, SystemStatus};
 use log::{error, info};
 use pixelflow_graphics::render::color::Bgra8;
 use pixelflow_graphics::render::Frame;
@@ -39,7 +37,6 @@ pub fn set_shared_waker(waker: X11Waker) {
 
 /// Linux platform operations - direct X11 implementation.
 pub struct LinuxOps {
-    engine_handle: EngineActorHandle,
     waker: X11Waker,
     window: Option<X11Window>,
 }
@@ -49,10 +46,12 @@ impl LinuxOps {
     ///
     /// Uses the shared waker set by `set_shared_waker()`, or creates a new
     /// one if not set (for backwards compatibility in tests).
-    pub fn new(engine_handle: EngineActorHandle) -> Result<Self, RuntimeError> {
+    ///
+    /// Takes no engine handle: outbound events are returned via `DriverOut`, so these ops can
+    /// be driven with no engine running at all. `PlatformActor` performs the sends.
+    pub fn new() -> Result<Self, RuntimeError> {
         let waker = SHARED_WAKER.get().cloned().unwrap_or_else(X11Waker::new);
         Ok(Self {
-            engine_handle,
             waker,
             window: None,
         })
@@ -60,7 +59,11 @@ impl LinuxOps {
 }
 
 impl PlatformOps for LinuxOps {
-    fn handle_data(&mut self, data: DisplayData) -> Result<(), actor_scheduler::HandlerError> {
+    fn handle_data(
+        &mut self,
+        data: DisplayData,
+        out: &mut DriverOut,
+    ) -> Result<(), actor_scheduler::HandlerError> {
         if let Some(x11_window) = &mut self.window {
             match data {
                 DisplayData::Present { mut window } => {
@@ -70,9 +73,7 @@ impl PlatformOps for LinuxOps {
                     }
                     window.frame = returned_frame;
                     // Return buffer to engine
-                    let _sent = self
-                        .engine_handle
-                        .send(Message::Data(EngineData::PresentComplete(window)));
+                    out.present_complete(window);
                 }
             }
         }
@@ -82,6 +83,7 @@ impl PlatformOps for LinuxOps {
     fn handle_control(
         &mut self,
         ctrl: DisplayControl,
+        _out: &mut DriverOut,
     ) -> Result<(), actor_scheduler::HandlerError> {
         if let Some(window) = &mut self.window {
             match ctrl {
@@ -116,6 +118,7 @@ impl PlatformOps for LinuxOps {
     fn handle_management(
         &mut self,
         mgmt: DisplayMgmt,
+        out: &mut DriverOut,
     ) -> Result<(), actor_scheduler::HandlerError> {
         match mgmt {
             DisplayMgmt::Create { settings } => {
@@ -137,12 +140,8 @@ impl PlatformOps for LinuxOps {
                             scale: window.scale_factor,
                         };
 
-                        // Send WindowCreated event
-                        let _sent = self
-                            .engine_handle
-                            .send(Message::Data(EngineData::FromDriver(
-                                DisplayEvent::WindowCreated { window: win },
-                            )));
+                        // Emit WindowCreated event
+                        out.event(DisplayEvent::WindowCreated { window: win });
                         self.window = Some(window);
                     }
                     Err(e) => {
@@ -158,7 +157,11 @@ impl PlatformOps for LinuxOps {
         Ok(())
     }
 
-    fn park(&mut self, status: SystemStatus) -> Result<ActorStatus, actor_scheduler::HandlerError> {
+    fn park(
+        &mut self,
+        status: SystemStatus,
+        out: &mut DriverOut,
+    ) -> Result<ActorStatus, actor_scheduler::HandlerError> {
         if let Some(window) = &mut self.window {
             let window_id = WindowId(window.window);
 
@@ -182,18 +185,14 @@ impl PlatformOps for LinuxOps {
                         if matches!(display_event, DisplayEvent::CloseRequested { .. }) {
                             info!("X11: CloseRequested");
                         }
-                        self.engine_handle
-                            .send(Message::Data(EngineData::FromDriver(display_event)))
-                            .expect("failed to send engine event");
+                        out.event(display_event);
                     }
 
                     // Drain remaining pending events non-blocking
                     while xlib::XPending(window.display) > 0 {
                         xlib::XNextEvent(window.display, &mut event);
                         if let Some(display_event) = events::map_event(&event, window, window_id) {
-                            let _sent = self
-                                .engine_handle
-                                .send(Message::Data(EngineData::FromDriver(display_event)));
+                            out.event(display_event);
                         }
                     }
                     return Ok(ActorStatus::Busy);

--- a/pixelflow-runtime/src/platform/macos/platform.rs
+++ b/pixelflow-runtime/src/platform/macos/platform.rs
@@ -1,13 +1,13 @@
-use crate::api::private::{EngineActorHandle, EngineData, WindowId};
+use crate::api::private::WindowId;
 use crate::display::messages::{DisplayControl, DisplayData, DisplayEvent, DisplayMgmt, Window};
-use crate::display::ops::PlatformOps;
+use crate::display::ops::{DriverOut, PlatformOps};
 use crate::error::RuntimeError;
 use crate::platform::macos::cocoa::{self, event_type, NSApplication, NSPasteboard};
 use crate::platform::macos::events;
 use crate::platform::macos::sys;
 use crate::platform::macos::window::MacWindow;
 use crate::platform::PlatformPixel;
-use actor_scheduler::{ActorStatus, HandlerError, HandlerResult, Message, SystemStatus};
+use actor_scheduler::{ActorStatus, HandlerError, HandlerResult, SystemStatus};
 use pixelflow_graphics::render::Frame;
 
 use std::collections::HashMap;
@@ -23,13 +23,12 @@ pub struct MetalOps {
     // Note: NSWindow is a wrapper around Id, so we cast Id to usize or wrap generic
     window_map: HashMap<usize, WindowId>,
     // Handle to send events back to the engine
-    event_tx: EngineActorHandle,
 }
 
 unsafe impl Send for MetalOps {}
 
 impl MetalOps {
-    pub fn new(event_tx: EngineActorHandle) -> Result<Self, RuntimeError> {
+    pub fn new() -> Result<Self, RuntimeError> {
         // Initialize Cocoa Application
         let app = unsafe {
             // Pool:
@@ -54,13 +53,12 @@ impl MetalOps {
             app,
             windows: HashMap::new(),
             window_map: HashMap::new(),
-            event_tx,
         })
     }
 }
 
 impl PlatformOps for MetalOps {
-    fn handle_data(&mut self, msg: DisplayData) -> HandlerResult {
+    fn handle_data(&mut self, msg: DisplayData, out: &mut DriverOut) -> HandlerResult {
         match msg {
             DisplayData::Present { mut window } => {
                 log::trace!("MetalOps: Presenting frame for window {:?}", window.id);
@@ -75,15 +73,13 @@ impl PlatformOps for MetalOps {
                     );
                 }
                 // Return the window to the engine for reuse
-                self.event_tx
-                    .send(Message::Data(EngineData::PresentComplete(window)))
-                    .expect("Failed to send PresentComplete to engine");
+                out.present_complete(window);
             }
         }
         Ok(())
     }
 
-    fn handle_control(&mut self, msg: DisplayControl) -> HandlerResult {
+    fn handle_control(&mut self, msg: DisplayControl, _out: &mut DriverOut) -> HandlerResult {
         match msg {
             DisplayControl::SetTitle { id, title } => {
                 if let Some(win) = self.windows.get_mut(&id) {
@@ -130,7 +126,7 @@ impl PlatformOps for MetalOps {
         Ok(())
     }
 
-    fn handle_management(&mut self, msg: DisplayMgmt) -> HandlerResult {
+    fn handle_management(&mut self, msg: DisplayMgmt, out: &mut DriverOut) -> HandlerResult {
         match msg {
             DisplayMgmt::Create { settings } => {
                 match MacWindow::new(settings) {
@@ -159,11 +155,7 @@ impl PlatformOps for MetalOps {
                         };
 
                         // Emit WindowCreated event so Engine knows initial size
-                        self.event_tx
-                            .send(Message::Data(EngineData::FromDriver(
-                                DisplayEvent::WindowCreated { window },
-                            )))
-                            .expect("Failed to send WindowCreated event to engine");
+                        out.event(DisplayEvent::WindowCreated { window });
                     }
                     Err(e) => {
                         eprintln!("Failed to create window: {}", e);
@@ -182,7 +174,11 @@ impl PlatformOps for MetalOps {
         Ok(())
     }
 
-    fn park(&mut self, status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+    fn park(
+        &mut self,
+        status: SystemStatus,
+        out: &mut DriverOut,
+    ) -> Result<ActorStatus, HandlerError> {
         // Logic for event loop interaction
         // The CocoaWaker posts an NSEvent when messages arrive, so distantFuture is safe.
         unsafe {
@@ -224,11 +220,7 @@ impl PlatformOps for MetalOps {
                         height_px: height,
                         scale: mac_window.scale_factor(),
                     };
-                    self.event_tx
-                        .send(Message::Data(EngineData::FromDriver(
-                            DisplayEvent::Resized { window },
-                        )))
-                        .expect("Failed to send Resized event to engine");
+                    out.event(DisplayEvent::Resized { window });
                 }
             }
 
@@ -274,11 +266,7 @@ impl PlatformOps for MetalOps {
                                 };
 
                                 if let Some(ev) = events::map_event(event, height) {
-                                    // Dispatch ev!
-                                    // We send it to the Engine via event_tx
-                                    self.event_tx
-                                        .send(Message::Data(EngineData::FromDriver(ev)))
-                                        .expect("Failed to send display event to engine");
+                                    out.event(ev);
                                 }
                             }
                         }
@@ -305,11 +293,7 @@ impl PlatformOps for MetalOps {
                 if let Some(id) = self.window_map.remove(&ptr) {
                     self.windows.remove(&id);
                     processed_any = true;
-                    self.event_tx
-                        .send(Message::Data(EngineData::FromDriver(
-                            DisplayEvent::CloseRequested { id },
-                        )))
-                        .expect("Failed to send CloseRequested to engine");
+                    out.event(DisplayEvent::CloseRequested { id });
                 }
             }
 
@@ -337,16 +321,8 @@ impl PlatformOps for MetalOps {
                         scale,
                     };
                     processed_any = true;
-                    self.event_tx
-                        .send(Message::Data(EngineData::FromDriver(
-                            DisplayEvent::Resized { window },
-                        )))
-                        .expect("Failed to send Resized (scale change) to engine");
-                    self.event_tx
-                        .send(Message::Data(EngineData::FromDriver(
-                            DisplayEvent::ScaleChanged { id, scale },
-                        )))
-                        .expect("Failed to send ScaleChanged to engine");
+                    out.event(DisplayEvent::Resized { window });
+                    out.event(DisplayEvent::ScaleChanged { id, scale });
                 }
             }
 

--- a/pixelflow-runtime/tests/macos_integration_tests.rs
+++ b/pixelflow-runtime/tests/macos_integration_tests.rs
@@ -1,67 +1,32 @@
 #[cfg(target_os = "macos")]
 mod tests {
-    use actor_scheduler::{Actor, ActorStatus, HandlerError, HandlerResult, SystemStatus};
-    use pixelflow_runtime::api::private::{create_engine_actor, EngineControl, EngineData};
-    use pixelflow_runtime::api::public::{AppManagement, WindowDescriptor};
-    use pixelflow_runtime::display::messages::{DisplayControl, DisplayMgmt};
-    use pixelflow_runtime::display::ops::PlatformOps;
+    //! `MetalOps` against a real window server.
+    //!
+    //! This file used to stand up an entire engine actor, a `MockEngine` to capture events, a
+    //! background scheduler thread, and a 100ms sleep — all of it existing only to observe the
+    //! `WindowCreated` event that `MetalOps` sent. Since rollout step 4
+    //! (`docs/designs/pixelflow-runtime-engine-mesh-migration.md` §5.1) `PlatformOps` *returns*
+    //! its outbound events in a `DriverOut` instead of sending them, so all of that apparatus is
+    //! gone: the events are read directly out of the value the call fills in.
+    //!
+    //! That also removes the `thread::sleep`-then-check, which was the one genuinely
+    //! flake-prone thing here — it asserted an event had arrived by an arbitrary wall-clock
+    //! deadline while racing a background thread. There is no longer anything asynchronous to
+    //! race.
+
+    use actor_scheduler::SystemStatus;
+    use pixelflow_runtime::api::public::WindowDescriptor;
+    use pixelflow_runtime::display::messages::{DisplayControl, DisplayEvent, DisplayMgmt};
+    use pixelflow_runtime::display::ops::{DriverEmit, DriverOut, PlatformOps};
     use pixelflow_runtime::platform::macos::MetalOps;
-    use std::sync::{Arc, Mutex};
-    use std::thread;
-    use std::time::Duration;
-
-    // A mock Engine actor to capture events
-    struct MockEngine {
-        pub captured_events: Arc<Mutex<Vec<pixelflow_runtime::display::messages::DisplayEvent>>>,
-    }
-
-    impl MockEngine {
-        fn new(
-            captured_events: Arc<Mutex<Vec<pixelflow_runtime::display::messages::DisplayEvent>>>,
-        ) -> Self {
-            Self { captured_events }
-        }
-    }
-
-    // Use generics as required by the Actor trait definition
-    impl Actor<EngineData, EngineControl, AppManagement> for MockEngine {
-        fn handle_data(&mut self, msg: EngineData) -> HandlerResult {
-            if let EngineData::FromDriver(evt) = msg {
-                self.captured_events.lock().unwrap().push(evt);
-            }
-            Ok(())
-        }
-
-        fn handle_control(&mut self, _msg: EngineControl) -> HandlerResult {
-            Ok(())
-        }
-        fn handle_management(&mut self, _msg: AppManagement) -> HandlerResult {
-            Ok(())
-        }
-        fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
-            Ok(ActorStatus::Idle)
-        }
-    }
 
     #[test]
     #[ignore = "Requires UI interaction or window server"]
     fn metal_ops_lifecycle() {
-        let events = Arc::new(Mutex::new(Vec::new()));
-        let events_clone = events.clone();
+        // No engine, no scheduler, no background thread, no sleep.
+        let mut ops = MetalOps::new().expect("Failed to create MetalOps");
+        let mut out = DriverOut::default();
 
-        // 1. Create Engine Actor (Scheduler + Handle)
-        let (handle, mut scheduler) = create_engine_actor(None);
-
-        // 2. Spawn Scheduler in background
-        thread::spawn(move || {
-            let mut mock_engine = MockEngine::new(events_clone);
-            scheduler.run(&mut mock_engine);
-        });
-
-        // 3. Instantiate MetalOps
-        let mut ops = MetalOps::new(handle).expect("Failed to create MetalOps");
-
-        // 4. Create a Window
         let settings = WindowDescriptor {
             title: "Integration Test Window".to_string(),
             width: 800,
@@ -69,39 +34,32 @@ mod tests {
             ..Default::default()
         };
 
-        let _ = ops.handle_management(DisplayMgmt::Create { settings });
+        ops.handle_management(DisplayMgmt::Create { settings }, &mut out)
+            .expect("Create failed");
 
-        // 5. Emulate run loop step (Platform)
-        // This should trigger window creation and send event to Engine
-        let _ = ops.park(SystemStatus::Busy);
+        // Emulate a run-loop step, which drains the Cocoa event queue.
+        let _status = ops
+            .park(SystemStatus::Busy, &mut out)
+            .expect("park failed");
 
-        // Give some time for message passing
-        thread::sleep(Duration::from_millis(100));
-
-        // 6. Verify Window Creation Event within MockEngine
-        let captured = events.lock().unwrap();
-        let found_window_id = captured.iter().find_map(|e| {
-            if let pixelflow_runtime::display::messages::DisplayEvent::WindowCreated { window } = e
-            {
-                Some(window.id)
-            } else {
-                None
-            }
+        let found_window_id = out.emits.iter().find_map(|emit| match emit {
+            DriverEmit::Event(DisplayEvent::WindowCreated { window }) => Some(window.id),
+            _ => None,
         });
         assert!(
             found_window_id.is_some(),
             "Expected WindowCreated event, found: {:?}",
-            *captured
+            out.emits
         );
 
-        // 7. Update Window Title
-        let win_id = found_window_id.unwrap();
-        let _ = ops.handle_control(DisplayControl::SetTitle {
-            id: win_id,
-            title: "Updated Title".to_string(),
-        });
-
-        // 8. Explicitly drop ops to close the handle, allowing scheduler to exit (though thread detach is fine for test)
-        drop(ops);
+        let win_id = found_window_id.expect("checked immediately above");
+        ops.handle_control(
+            DisplayControl::SetTitle {
+                id: win_id,
+                title: "Updated Title".to_string(),
+            },
+            &mut out,
+        )
+        .expect("SetTitle failed");
     }
 }

--- a/pixelflow-runtime/tests/platform_actor_tests.rs
+++ b/pixelflow-runtime/tests/platform_actor_tests.rs
@@ -1,7 +1,8 @@
 use actor_scheduler::{Actor, ActorStatus, HandlerError, HandlerResult, SystemStatus};
 use pixelflow_graphics::render::Frame;
 use pixelflow_runtime::display::messages::{DisplayControl, DisplayData, DisplayMgmt};
-use pixelflow_runtime::display::ops::PlatformOps;
+use pixelflow_runtime::display::ops::{DriverOut, PlatformOps};
+use pixelflow_runtime::api::private::create_engine_actor;
 use pixelflow_runtime::display::platform::PlatformActor;
 use std::sync::{Arc, Mutex};
 
@@ -27,7 +28,7 @@ impl MockOps {
 unsafe impl Send for MockOps {}
 
 impl PlatformOps for MockOps {
-    fn handle_data(&mut self, msg: DisplayData) -> HandlerResult {
+    fn handle_data(&mut self, msg: DisplayData, _out: &mut DriverOut) -> HandlerResult {
         match msg {
             DisplayData::Present { window } => {
                 self.push_log(&format!("Present {:?}", window.id));
@@ -36,7 +37,7 @@ impl PlatformOps for MockOps {
         Ok(())
     }
 
-    fn handle_control(&mut self, msg: DisplayControl) -> HandlerResult {
+    fn handle_control(&mut self, msg: DisplayControl, _out: &mut DriverOut) -> HandlerResult {
         match msg {
             DisplayControl::SetTitle { id, title } => {
                 self.push_log(&format!("SetTitle {:?} {}", id, title));
@@ -46,7 +47,7 @@ impl PlatformOps for MockOps {
         Ok(())
     }
 
-    fn handle_management(&mut self, msg: DisplayMgmt) -> HandlerResult {
+    fn handle_management(&mut self, msg: DisplayMgmt, _out: &mut DriverOut) -> HandlerResult {
         match msg {
             DisplayMgmt::Create { .. } => {
                 self.push_log("Create");
@@ -56,7 +57,11 @@ impl PlatformOps for MockOps {
         Ok(())
     }
 
-    fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+    fn park(
+        &mut self,
+        _status: SystemStatus,
+        _out: &mut DriverOut,
+    ) -> Result<ActorStatus, HandlerError> {
         self.push_log("Park");
         Ok(ActorStatus::Idle)
     }
@@ -69,7 +74,10 @@ fn platform_actor_delegation() {
     let log_ref = ops.log.clone();
 
     // 2. Create PlatformActor
-    let mut actor = PlatformActor::new(ops);
+    // The adapter is what performs sends, so it needs a handle even though MockOps never
+    // emits. `_sched` stays bound to keep the receiving end alive for the actor's lifetime.
+    let (engine_handle, _sched) = create_engine_actor(None);
+    let mut actor = PlatformActor::new(ops, engine_handle);
 
     // 3. Send messages manually to verify delegation
     // Note: We test `Actor` trait implementation directly, skipping Scheduler for unit test simplicity
@@ -112,4 +120,75 @@ fn platform_actor_delegation() {
     assert!(log[1].contains("SetTitle WindowId(1) Test Window"));
     assert!(log[2].contains("Present WindowId(1)"));
     assert_eq!(log[3], "Park");
+}
+
+
+/// The point of moving sends out of `PlatformOps`: an implementation can now be driven and
+/// observed with no engine, no adapter, no scheduler and no channels anywhere in the picture.
+/// Before this, `PlatformOps` held a live `EngineActorHandle` and its outbound events could
+/// only be seen by standing up an engine to receive them.
+#[test]
+fn platform_ops_emit_without_an_engine() {
+    use pixelflow_runtime::display::messages::{DisplayEvent, Window};
+    use pixelflow_runtime::api::private::WindowId;
+    use pixelflow_runtime::display::ops::DriverEmit;
+    use pixelflow_runtime::platform::PlatformPixel;
+
+    /// Emits on every lane, so the test can show `DriverOut` accumulating rather than sending.
+    struct EmittingOps;
+
+    impl PlatformOps for EmittingOps {
+        fn handle_data(&mut self, msg: DisplayData, out: &mut DriverOut) -> HandlerResult {
+            let DisplayData::Present { window } = msg;
+            // The window-return edge: handed back for reuse instead of sent.
+            out.present_complete(window);
+            Ok(())
+        }
+        fn handle_control(&mut self, _: DisplayControl, _out: &mut DriverOut) -> HandlerResult {
+            Ok(())
+        }
+        fn handle_management(&mut self, _: DisplayMgmt, _out: &mut DriverOut) -> HandlerResult {
+            Ok(())
+        }
+        fn park(
+            &mut self,
+            _status: SystemStatus,
+            out: &mut DriverOut,
+        ) -> Result<ActorStatus, HandlerError> {
+            // `park` is the reason `DriverOut` carries a Vec rather than an Option: draining
+            // the OS queue yields N events from one step.
+            out.event(DisplayEvent::FocusGained { id: WindowId(1) });
+            out.event(DisplayEvent::FocusLost { id: WindowId(1) });
+            Ok(ActorStatus::Idle)
+        }
+    }
+
+    let mut ops = EmittingOps;
+    let mut out = DriverOut::default();
+
+    // An empty step emits nothing, and costs no allocation.
+    ops.handle_control(DisplayControl::Bell, &mut out).unwrap();
+    assert!(out.emits.is_empty(), "a step that does nothing must emit nothing");
+
+    // One step, N events.
+    ops.park(SystemStatus::Idle, &mut out).unwrap();
+    assert_eq!(out.emits.len(), 2, "park drains N events in a single step");
+    assert!(matches!(out.emits[0], DriverEmit::Event(DisplayEvent::FocusGained { .. })));
+    assert!(matches!(out.emits[1], DriverEmit::Event(DisplayEvent::FocusLost { .. })));
+
+    // The window-return edge travels as a value, so the test can inspect the window itself
+    // rather than needing an engine to receive it.
+    out.emits.clear();
+    let window = Window {
+        id: WindowId(7),
+        frame: Frame::<PlatformPixel>::new(4, 4),
+        width_px: 4,
+        height_px: 4,
+        scale: 1.0,
+    };
+    ops.handle_data(DisplayData::Present { window }, &mut out).unwrap();
+    match &out.emits[..] {
+        [DriverEmit::PresentComplete(returned)] => assert_eq!(returned.id, WindowId(7)),
+        other => panic!("expected exactly one window return, got {:?}", other),
+    }
 }


### PR DESCRIPTION
## Why this step looked hard and wasn't

Steps 2 and 3 worked by prising a pure decision core out of tangled I/O (`VsyncCore`, `RasterCore`) and leaving a thin adapter holding the channels. That template appears to fail on the driver: `DriverActor` is a pure delegation shell, and the real logic is `PlatformOps` making raw X11 and Cocoa calls, which will never be a pure transducer over a `*mut xlib::Display`.

That reads as "harder." It's the opposite — **there is no decision core to extract because the platform state is already properly encapsulated.** `LinuxOps` holds `window` + `waker`; `MetalOps` holds `app`, `windows`, `window_map`. All OS resource, already owned by the right thing. Nothing wanted moving.

What the conversion actually asks for here is the *other* half of the rule — **effects are return values, not calls** — and the effect is the one thing coupling these types to another actor: `engine_handle.send(...)`.

## What changed

`PlatformOps` methods take `&mut DriverOut` and push events into it; `PlatformActor` — which **already existed as exactly this adapter** — performs the sends. All 11 sites converted: 4 in `LinuxOps`, 7 in `MetalOps`.

**`EngineActorHandle` is gone from both platform impls.** `LinuxOps::new()` and `MetalOps::new()` now take no arguments at all. Every platform impl previously held a live engine handle, so its outbound events could only be observed by standing up an engine to receive them.

```rust
pub enum DriverEmit {
    Event(DisplayEvent),          // blocking input + window-lifecycle edge
    PresentComplete(Window),      // the window return closing the Present loop
}
```

Two variants, matching the two `driver → engine` edges in the target topology exactly.

## Two design points

**`DriverOut` is one output word containing a `Vec`, not a `Vec` as `Out`.** It matches `VsyncCoreOut { tick: Option<..> }` and `RasterCoreOut { response: Option<..> }` — the struct's *fields* are the ports, so a step never returns "sometimes a value, sometimes a list." `park` is why the field is a `Vec`: draining the OS queue yields N events from one step.

**No reusable-buffer machinery, despite `park` running every frame.** An earlier draft of the plan had the adapter own a sink, on the grounds that `CLAUDE.md` forbids per-frame heap allocation. But an empty `Vec` never touches the heap — `Vec::new()` allocates on first push, not on construction — and the overwhelming majority of frames carry no input at all, so they allocate nothing. A frame where the user actually types pays one small amortized growth, which isn't a per-frame cost. The sink was deleted before being written.

## Testing

New `platform_ops_emit_without_an_engine` drives a `PlatformOps` impl with no engine, no adapter, no scheduler and no channels anywhere, asserts `park` yields N events from one step, and inspects the returned `Window` directly — none of which was expressible before this change.

- `cargo test -p pixelflow-runtime` — full suite green, incl. the existing `platform_actor_delegation` and the unmodified vsync harness
- `cargo clippy -p pixelflow-runtime --all-targets` — clean
- `cargo build -p core-term` — clean

**macOS is verified in CI, not locally** — only the X11 half compiles on a Linux box. That's precisely why the trait change lands as one deliberate PR: a half-converted `PlatformOps` breaks the platform that can't be compiled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Y5cNzR9PnASfGfjBh5kJc

---
_Generated by [Claude Code](https://claude.ai/code/session_015Y5cNzR9PnASfGfjBh5kJc)_