### PR TITLE
feat(pixelflow-runtime): delete pending_render and the stale flag

### DIFF
--- a/docs/designs/pixelflow-runtime-engine-mesh-migration.md
+++ b/docs/designs/pixelflow-runtime-engine-mesh-migration.md
@@ -314,7 +314,7 @@ coupling as the `VSYNC_TOKEN_BUCKET` global that step 2 removed, just local inst
 | `pending_manifold` | the app → rasterizer edge, as a droppable keep-latest port | §3 already called this: the *port is* the staleness policy, so the hand-rolled "keep newest, drop old" logic is deleted along with the field. |
 | `window` | **driver** | It already creates the window (`WindowCreated`) and presents it. With the mediator gone the buffer circulates driver → rasterizer → driver; the driver is the only actor that outlives every stage of that loop. |
 | `frame_number` | **rasterizer** | It is a count of completed renders, and its only consumer is the FPS telemetry edge to vsync. It belongs to the thing doing the counting. |
-| `render_threads` | **nowhere — already duplicated** | `RasterCore::num_threads` is the real one; the engine's copy exists only to pass at spawn. |
+| `render_threads` | **bootstrap config, needs a real owner** | *Corrected during implementation.* This row first claimed the field was a redundant copy of `RasterCore::num_threads`, deletable outright. It isn't: the engine passes it to `spawn_with_setup` at bootstrap, so it is the *source* of the rasterizer's value, not a duplicate of it. It has to be supplied by whoever spawns the rasterizer once the engine no longer does — small, but a genuine open question rather than a deletion. |
 | `driver` / `vsync` / `rasterizer` / `app_handle` / `self_handle` / `rasterizer_forward_handle` | topology edges | Handles are what a mediator is made of. They are the thing being deleted, not state needing a home. |
 
 So `EngineHandler` collapses to: two fields deleted outright (`pending_render`, `render_threads`),

--- a/pixelflow-runtime/src/api/private.rs
+++ b/pixelflow-runtime/src/api/private.rs
@@ -10,7 +10,7 @@ use crate::pixel::PlatformPixel;
 // Re-export WindowId from public API for backward compatibility
 pub use crate::api::public::WindowId;
 
-use crate::display::messages::{DisplayEvent, Window};
+use crate::display::messages::{DisplayEvent, Window, WindowMeta};
 
 /// Commands sent to the Display Driver.
 #[derive(Debug)]
@@ -56,9 +56,9 @@ pub enum EngineData {
         refresh_interval: std::time::Duration,
     },
     PresentComplete(Window),
-    /// Render complete - carries the render response (cooked frame + timing).
-    /// Window is reconstructed from pending_render metadata in the engine.
-    RenderComplete(RenderResponse<PlatformPixel>),
+    /// Render complete - carries the cooked frame, timing, and the window metadata that
+    /// travelled out with the request, from which the `Window` is reassembled.
+    RenderComplete(RenderResponse<PlatformPixel, WindowMeta>),
 }
 
 impl std::fmt::Debug for EngineData {

--- a/pixelflow-runtime/src/display/messages.rs
+++ b/pixelflow-runtime/src/display/messages.rs
@@ -24,6 +24,20 @@ pub struct Window {
     pub scale: f64,
 }
 
+/// The half of a [`Window`] that isn't the frame buffer.
+///
+/// Rendering has to take the `Window` apart — the rasterizer needs the `Frame` and knows
+/// nothing about windows — so this is what's left. It travels with the render request as
+/// `RenderRequest::meta` and comes back untouched in `RenderResponse::meta`, which is what lets
+/// the `Window` be reassembled at completion instead of stashed somewhere in the meantime.
+#[derive(Debug, Clone, Copy)]
+pub struct WindowMeta {
+    pub id: WindowId,
+    pub width_px: u32,
+    pub height_px: u32,
+    pub scale: f64,
+}
+
 /// Data messages for the display driver (high throughput, high priority).
 ///
 /// Data messages are used for continuous, high-frequency operations like frame presentation.

--- a/pixelflow-runtime/src/engine_troupe.rs
+++ b/pixelflow-runtime/src/engine_troupe.rs
@@ -7,7 +7,9 @@ use crate::api::public::{
 };
 use crate::config::EngineConfig;
 use crate::display::driver::DriverActor;
-use crate::display::messages::{DisplayControl, DisplayData, DisplayEvent, DisplayMgmt, Window};
+use crate::display::messages::{
+    DisplayControl, DisplayData, DisplayEvent, DisplayMgmt, Window, WindowMeta,
+};
 use crate::display::platform::PlatformActor;
 use crate::error::RuntimeError;
 use crate::input::MouseButton;
@@ -15,6 +17,7 @@ use crate::platform::{ActivePlatform, PlatformPixel};
 use crate::vsync_actor::{
     RenderedResponse, VsyncActor, VsyncCommand, VsyncConfig, VsyncManagement,
 };
+use actor_scheduler::mealy::Credit;
 use actor_scheduler::{
     Actor, ActorHandle, ActorStatus, ActorTypes, HandlerError, HandlerResult, Message,
     SystemStatus, TroupeActor,
@@ -28,17 +31,6 @@ use std::time::Instant;
 
 const LOG_FRAME_INTERVAL: u64 = 60;
 
-/// Metadata for a window being rendered (frame extracted, waiting for response).
-struct PendingRender {
-    id: crate::api::public::WindowId,
-    width_px: u32,
-    height_px: u32,
-    scale: f64,
-    /// True if a resize event arrived while this render was in progress.
-    /// Stale renders are discarded because the frame dimensions don't match the window.
-    stale: bool,
-}
-
 /// Engine handler - coordinates app, rendering, display.
 pub struct EngineHandler {
     /// Handle to the display driver actor.
@@ -46,7 +38,7 @@ pub struct EngineHandler {
     /// Handle to the vsync actor (for feedback loop).
     vsync: ActorHandle<RenderedResponse, VsyncCommand, VsyncManagement>,
     /// Handle to the rasterizer actor (set after bootstrap completes).
-    rasterizer: Option<RasterizerHandle<PlatformPixel>>,
+    rasterizer: Option<RasterizerHandle<PlatformPixel, WindowMeta>>,
     /// Handle to self (for shutdown).
     self_handle: Option<ActorHandle<EngineData, EngineControl, AppManagement>>,
     /// Pre-created dedicated SPSC handle for rasterizer response forwarding thread.
@@ -58,10 +50,14 @@ pub struct EngineHandler {
     frame_number: u64,
     /// The active window (owns frame buffer, returned by driver after presentation).
     window: Option<Window>,
-    /// Window metadata for the frame currently being rendered.
-    /// When we send a frame to the rasterizer, we store the window metadata here.
-    /// When the render completes, we combine the cooked frame with this metadata.
-    pending_render: Option<PendingRender>,
+    /// The one-outstanding-render bound on the engine → rasterizer edge.
+    ///
+    /// `pending_render` used to serve double duty: carrying the torn-off window metadata *and*
+    /// standing in as an "is a render in flight" flag. The metadata now rides with the request,
+    /// leaving only the bound — which the target topology already specifies as `Credit(1)`
+    /// (`docs/designs/pixelflow-runtime-engine-mesh-migration.md` §3), so it is that, rather
+    /// than an `Option` being checked for `is_none`.
+    render_credit: Credit,
     /// Number of render threads for work-stealing parallelism.
     render_threads: usize,
     /// Latest manifold from app - always keep the most recent, drop old ones.
@@ -124,44 +120,39 @@ impl Actor<EngineData, EngineControl, AppManagement> for EngineHandler {
                 }
             }
             EngineData::RenderComplete(response) => {
-                // Reconstruct Window from pending_render metadata + cooked frame
-                if let Some(pending) = self.pending_render.take() {
-                    if pending.stale {
-                        // Resize happened during this render - frame dimensions are wrong.
-                        // Discard the stale frame. The correct window is already in self.window
-                        // (set by the resize handler).
-                        log::debug!(
-                            "Discarding stale render ({}x{}) - resize happened during render",
-                            pending.width_px,
-                            pending.height_px
-                        );
-                        // Don't present the stale frame - just drop it.
-                        // Now check if we have a pending manifold to render with correct dimensions.
-                        if let Some(manifold) = self.pending_manifold.take() {
-                            if let Some(window) = self.window.take() {
-                                log::debug!(
-                                    "Triggering render with correct dimensions after stale discard: {}x{}",
-                                    window.width_px,
-                                    window.height_px
-                                );
-                                self.trigger_render_with_window(manifold, window);
-                            } else {
-                                // Window not available yet - keep manifold pending
-                                self.pending_manifold = Some(manifold);
-                            }
-                        }
+                // The render is done, so the edge's one credit is free again.
+                self.render_credit.release();
+
+                // Staleness is now something we *observe* rather than something the resize
+                // handler reaches in and marks. The engine hands its window to the rasterizer
+                // by value, so `self.window` is None for the whole duration of a render — the
+                // only way it can be Some here is if a resize delivered a newer one meanwhile.
+                // That is exactly the condition the `stale` flag encoded, read off the state
+                // that already implies it.
+                if let Some(current) = self.window.take() {
+                    log::debug!(
+                        "Discarding stale render ({}x{}) - resize to {}x{} happened during render",
+                        response.meta.width_px,
+                        response.meta.height_px,
+                        current.width_px,
+                        current.height_px
+                    );
+                    // Drop the stale frame and re-render at the correct size.
+                    if let Some(manifold) = self.pending_manifold.take() {
+                        self.trigger_render_with_window(manifold, current);
                     } else {
-                        let window = Window {
-                            id: pending.id,
-                            frame: response.frame,
-                            width_px: pending.width_px,
-                            height_px: pending.height_px,
-                            scale: pending.scale,
-                        };
-                        self.present_cooked_frame(response.render_time, window);
+                        self.window = Some(current);
                     }
                 } else {
-                    log::warn!("RenderComplete received but no pending_render metadata");
+                    // Reassembled from the metadata that travelled with the request.
+                    let window = Window {
+                        id: response.meta.id,
+                        frame: response.frame,
+                        width_px: response.meta.width_px,
+                        height_px: response.meta.height_px,
+                        scale: response.meta.scale,
+                    };
+                    self.present_cooked_frame(response.render_time, window);
                 }
             }
             EngineData::PresentComplete(returned_window) => {
@@ -352,11 +343,11 @@ impl EngineHandler {
 
         // Step 1: Spawn rasterizer with setup handle
         let (setup_handle, _rasterizer_thread) =
-            RasterizerActor::<PlatformPixel>::spawn_with_setup(self.render_threads);
+            RasterizerActor::<PlatformPixel, WindowMeta>::spawn_with_setup(self.render_threads);
 
         // Step 2: Create response channel (engine receives render results here)
         let (response_tx, response_rx) =
-            std::sync::mpsc::channel::<RenderResponse<PlatformPixel>>();
+            std::sync::mpsc::channel::<RenderResponse<PlatformPixel, WindowMeta>>();
 
         // Step 3: Start forwarding thread - receives responses and sends to engine
         std::thread::spawn(move || {
@@ -426,14 +417,13 @@ impl EngineHandler {
             scale,
         } = window;
 
-        // Store window metadata - will be combined with cooked frame when render completes
-        self.pending_render = Some(PendingRender {
-            id,
-            width_px,
-            height_px,
-            scale,
-            stale: false,
-        });
+        // Take the edge's single credit. Callers already gate on `outstanding()`, so this
+        // failing means a second render was started while one was in flight — the bound the
+        // topology declares, now enforced rather than implied by an Option being Some.
+        if !self.render_credit.try_consume() {
+            log::warn!("Render already in flight, dropping request");
+            return;
+        }
 
         // The scene is authored in point space; the frame is the platform's
         // sample lattice and may be denser (device pixels on HiDPI displays).
@@ -461,25 +451,28 @@ impl EngineHandler {
                 })
             };
 
-        // Build render request (no response_tx - rasterizer uses registered channel).
-        // `meta` stays () until the follow-up slice moves `pending_render`'s contents into it
-        // (docs/designs/pixelflow-runtime-engine-mesh-migration.md §7.1).
+        // The window's other half travels with the frame instead of being stashed here.
         let request = RenderRequest {
             manifold,
             frame,
-            meta: (),
+            meta: WindowMeta {
+                id,
+                width_px,
+                height_px,
+                scale,
+            },
         };
 
-        // Send to rasterizer
+        // Send to rasterizer. On any failure the render never happens, so give the credit back
+        // — otherwise the edge would be permanently blocked by a request that was never sent.
         if let Some(rasterizer) = &self.rasterizer {
             if let Err(e) = rasterizer.send(Message::Data(request)) {
                 log::warn!("Failed to send render request to rasterizer: {}", e);
-                // Restore pending_render on failure so we don't lose the metadata
-                self.pending_render = None;
+                self.render_credit.release();
             }
         } else {
             log::warn!("Rasterizer not initialized, dropping render request");
-            self.pending_render = None;
+            self.render_credit.release();
         }
     }
 
@@ -557,28 +550,17 @@ impl EngineHandler {
                 let width_px = window.width_px;
                 let height_px = window.height_px;
 
-                // Mark any in-progress render as stale - its frame dimensions won't match
-                if let Some(pending) = &mut self.pending_render {
-                    log::debug!(
-                        "Resize during render: marking stale (was {}x{}, now {}x{})",
-                        pending.width_px,
-                        pending.height_px,
-                        width_px,
-                        height_px
-                    );
-                    pending.stale = true;
-                }
+                // Nothing to mark: storing the new window below *is* the staleness signal, and
+                // `RenderComplete` reads it off that rather than off a flag set from here.
 
                 // Update window with new one from driver
                 self.window = Some(window);
 
-                // DON'T start a new render here if one is already in flight.
-                // The stale render will complete, be discarded, and then we can
-                // render with the correct dimensions. Starting a new render now
-                // would overwrite pending_render metadata for the in-flight render.
-                //
-                // If no render is in flight and we have a pending manifold, render now.
-                if self.pending_render.is_none() {
+                // DON'T start a new render here if one is already in flight. The stale render
+                // will complete, be discarded, and then we render at the correct dimensions.
+                // Starting one now would be refused by the credit anyway — this check is what
+                // keeps that from becoming a dropped frame and a warning.
+                if self.render_credit.outstanding() == 0 {
                     if let Some(manifold) = self.pending_manifold.take() {
                         if let Some(window) = self.window.take() {
                             self.trigger_render_with_window(manifold, window);
@@ -757,7 +739,7 @@ impl TroupeActor<Directory> for EngineHandler {
             app_handle: None,
             frame_number: 0,
             window: None,
-            pending_render: None,
+            render_credit: Credit::new(1),
             render_threads: 1, // Default, will be set by Configure message
             pending_manifold: None,
         }


### PR DESCRIPTION
§7.1/7.2 of the migration plan, on top of the render request's opaque payload.

## `pending_render` was doing two unrelated jobs

**Carrying the torn-off metadata.** It held the four fields of a `Window` that aren't the frame buffer, so `RenderComplete` could reassemble one. That half now rides with the request as `RenderRequest::meta` and comes back in `RenderResponse::meta` — there is nothing left to stash.

**Standing in as an "is a render in flight" flag**, checked as `is_none()` by the resize handler. That half is a `Credit(1)` — which the target topology already specifies for the engine → rasterizer edge.

Both halves had a primitive waiting for them. Neither needed a field.

## The `stale` flag is the better deletion

It was set by the resize handler reaching *into* an in-flight record to mutate it, then read once at completion.

But the engine hands its window to the rasterizer **by value**, so `self.window` is `None` for the entire duration of a render. The only way it can be `Some` at `RenderComplete` is if a resize delivered a newer one meanwhile — which is exactly what the flag encoded, already implied by state we hold. Reading it off directly means no mutable flag and no cross-message reach-in: the same coupling step 2 removed with `VSYNC_TOKEN_BUCKET`, local rather than static.

## Also

`WindowMeta` lands in `display::messages` beside `Window`, since that's what it is — the non-frame half. `EngineData::RenderComplete` is typed on it, so the reassembly is checked rather than conventional.

**One behavioral tightening:** a second render started while one is in flight now fails `try_consume` and is dropped with a warning. Previously it would silently overwrite the in-flight metadata and lose the frame. The bound was always intended — it's why the edge is `Credit(1)` — but nothing enforced it.

## Testing

- `cargo test -p pixelflow-runtime` — full suite green
- `cargo build -p core-term` — clean
- `cargo clippy -p pixelflow-runtime --all-targets` — clean

## Remaining for step 5

`window` → driver, `frame_number` → rasterizer, `pending_manifold` → the app→rasterizer droppable port, then the mediator goes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Y5cNzR9PnASfGfjBh5kJc

---
_Generated by [Claude Code](https://claude.ai/code/session_015Y5cNzR9PnASfGfjBh5kJc)_