### PR TITLE
docs: add documentation landing page and mark search-pipeline design as historical

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Manifolds compose via operator overloading, and the type tree *is* the compute g
 
 ### Documentation
 
+- **[docs/README.md](docs/README.md)** — Documentation landing page, status taxonomy, and index
 - **[CLAUDE.md](CLAUDE.md)** — Architectural constraints, workspace structure, and development guidelines
 - **[docs/STYLE.md](docs/STYLE.md)** — Code style guide and design principles
 - **[docs/designs/](docs/designs/)** — Design docs for the compiler, e-graph search, and actor scheduler

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,102 @@
+# PixelFlow Documentation
+
+This page is the landing page for repository documentation. A document's classification
+describes how it should be read today; directory names alone do not establish currency.
+
+## Classification vocabulary
+
+- **Current architecture** — describes the system as it exists now.
+- **Plan of record** — approved or active direction for work not yet fully implemented.
+- **Experiment/result** — an observation, audit, benchmark, investigation, or research
+  reference; it is evidence rather than a promise about current architecture.
+- **Historical/superseded** — retained for rationale or archaeology, but not authoritative.
+- **Active bug** — a known unresolved defect or quality gap.
+- **Fixed bug** — a defect report whose described fault has been corrected.
+
+Classification is separate from design workflow status. **Every future plan and design must
+use exactly one of `Draft`, `Review`, `Approved`, or `Implemented` in its metadata**, as
+specified by [`templates/DESIGN_DOC.md`](templates/DESIGN_DOC.md). Use `Supersedes` or
+`Superseded by` metadata to record lineage rather than creating new status words.
+
+## Current architecture
+
+- [`EGRAPH_OPTIMIZATION_ARCHITECTURE.md`](EGRAPH_OPTIMIZATION_ARCHITECTURE.md) — active
+  e-graph optimization and training spine.
+- [`designs/2026-07-24-totality-and-the-cost-model.md`](designs/2026-07-24-totality-and-the-cost-model.md)
+  — kernel-language axiom and cost-model boundary.
+- [`designs/KERNELS_AND_LATTICES.md`](designs/KERNELS_AND_LATTICES.md) — implemented kernel
+  and lattice architecture, with remaining milestones called out in the document.
+- [`designs/pty-actor-troupe.md`](designs/pty-actor-troupe.md) — implemented PTY actor wiring.
+- [`STYLE.md`](STYLE.md) — current coding and review conventions.
+
+## Plan of record
+
+- [`plans/2026-07-20-kernel-unification.md`](plans/2026-07-20-kernel-unification.md) — the
+  active kernel-unification plan.
+- [`plans/2026-07-07-guided-saturation-redesign.md`](plans/2026-07-07-guided-saturation-redesign.md)
+  — supervised guided-saturation direction and its completed decision gates.
+- [`designs/2026-07-23-lower-realize-boundary.md`](designs/2026-07-23-lower-realize-boundary.md)
+  — design for the P5 rebuild.
+- [`designs/actor-scheduler-mealy-transducer.md`](designs/actor-scheduler-mealy-transducer.md)
+  and [`designs/pixelflow-runtime-engine-mesh-migration.md`](designs/pixelflow-runtime-engine-mesh-migration.md)
+  — draft actor/runtime designs.
+- [`designs/LATTICE_EVAL.md`](designs/LATTICE_EVAL.md),
+  [`designs/lattice-scheduling-types.md`](designs/lattice-scheduling-types.md),
+  [`designs/REDUCTIONS_AND_FOLDS.md`](designs/REDUCTIONS_AND_FOLDS.md),
+  [`designs/ML_AND_LINEAR_ALGEBRA.md`](designs/ML_AND_LINEAR_ALGEBRA.md), and
+  [`designs/ML_AUTODIFF_PIPELINE.md`](designs/ML_AUTODIFF_PIPELINE.md) — related language
+  and scheduling designs that remain directional rather than descriptions of completed code.
+
+## Experiments and results
+
+- [`results/`](results/) — recorded extraction, rewrite-rule, JIT-cost, and actor benchmark
+  results. These are point-in-time evidence; heed corrections in each report.
+- [`COMPILER_ANALYSIS.md`](COMPILER_ANALYSIS.md),
+  [`COMPILER_OPPORTUNITIES.md`](COMPILER_OPPORTUNITIES.md),
+  [`KERNEL_PARAM_LIMIT_INVESTIGATION.md`](KERNEL_PARAM_LIMIT_INVESTIGATION.md), and
+  [`function-namespace-audit.md`](function-namespace-audit.md) — analyses and audits.
+- [`designs/2026-07-23-jit-orthodoxy-survey.md`](designs/2026-07-23-jit-orthodoxy-survey.md),
+  [`AUTODIFF_RENDERING.md`](AUTODIFF_RENDERING.md), and the papers and paper notes in this
+  directory — research context, not implementation contracts.
+- [`designs/BRAINSTORM_VARIANCE_EGRAPH.md`](designs/BRAINSTORM_VARIANCE_EGRAPH.md) and
+  [`GNN_REWRITE_GUIDANCE_VISION.md`](GNN_REWRITE_GUIDANCE_VISION.md) — exploratory ideas.
+
+## Historical or superseded
+
+- [`SEARCH_PIPELINE_DESIGN.md`](SEARCH_PIPELINE_DESIGN.md) — unshipped MCTS/REINFORCE
+  interface proposal, superseded by the guided-saturation redesign.
+- [`NNUE_TRAINING_RECIPE.md`](NNUE_TRAINING_RECIPE.md),
+  [`plans/2026-02-25-unified-training-design.md`](plans/2026-02-25-unified-training-design.md),
+  and [`plans/2026-02-25-unified-training-plan.md`](plans/2026-02-25-unified-training-plan.md)
+  — obsolete critic/REINFORCE training path.
+- [`designs/nnue-training-pipeline.md`](designs/nnue-training-pipeline.md) — earlier curriculum
+  and best-first proposal.
+- [`NNUE_INTEGRATION_STATUS.md`](NNUE_INTEGRATION_STATUS.md) and
+  [`EGRAPH_SEARCH_INTEGRATION.md`](EGRAPH_SEARCH_INTEGRATION.md) — point-in-time status
+  audits; use the current architecture and guided-saturation documents above instead.
+- [`designs/actor-scheduler-supervisor-migration.md`](designs/actor-scheduler-supervisor-migration.md)
+  — explicitly superseded by the Mealy-transducer design.
+- [`plans/2025-02-21-kernel-jit-feature-parity-design.md`](plans/2025-02-21-kernel-jit-feature-parity-design.md),
+  [`plans/2025-02-21-kernel-jit-feature-parity.md`](plans/2025-02-21-kernel-jit-feature-parity.md),
+  and [`superpowers/`](superpowers/) — completed or superseded implementation-era plans.
+- [`FLAT_CONTEXT_TUPLE_PROTOTYPE.md`](FLAT_CONTEXT_TUPLE_PROTOTYPE.md),
+  [`MESSAGE_CUJ_COVERAGE.md`](MESSAGE_CUJ_COVERAGE.md), and
+  [`designs/compiler-architecture-2026.md`](designs/compiler-architecture-2026.md) — retained
+  point-in-time proposals; verify their claims against current code before use.
+
+## Bugs
+
+### Active bugs
+
+- [`bugs/2026-07-15-pty-fork-malloc-deadlock.md`](bugs/2026-07-15-pty-fork-malloc-deadlock.md)
+  — diagnosed and explicitly not yet fixed.
+- [`bugs/2026-07-20-test-quality-audit.md`](bugs/2026-07-20-test-quality-audit.md) — mixed
+  audit report with unresolved test-quality findings; classified active until those gaps are
+  dispositioned.
+
+### Fixed bugs
+
+- [`bugs/2026-07-21-openpty-not-thread-safe.md`](bugs/2026-07-21-openpty-not-thread-safe.md)
+  — concurrent-test contract fix.
+- [`bugs/2026-07-22-trig-chebyshev-coefficients-wrong.md`](bugs/2026-07-22-trig-chebyshev-coefficients-wrong.md)
+  — trigonometric approximation and regression-test fixes.

--- a/docs/SEARCH_PIPELINE_DESIGN.md
+++ b/docs/SEARCH_PIPELINE_DESIGN.md
@@ -1,5 +1,25 @@
 # Search Pipeline Design
 
+**Classification:** Historical/superseded.
+**Status:** Superseded by
+[`plans/2026-07-07-guided-saturation-redesign.md`](plans/2026-07-07-guided-saturation-redesign.md).
+
+This document records an unshipped composable-search proposal. Its traits and Rust snippets
+are illustrative and are not the current `pixelflow-search` API. In particular, neither MCTS
+nor REINFORCE is an active training or production path. The redesign found that MCTS/A* had
+never been integrated into the compiler and removed REINFORCE because its deterministic
+policy did not provide a valid policy-gradient estimator. The current plan uses supervised
+provenance labels for greedy guidance, with shallow rollback/beam search only as a
+conditional later phase.
+
+`pixelflow-pipeline/src/training/unified_backward.rs` remains, despite its old name, only as
+the hand-derived backward pass for the NNUE **value/extraction head** used by the current
+`bootstrap_extraction_head` binary. It computes MSE gradients against measured JIT costs.
+Its policy-gradient backward path was deleted; policy/mask gradient fields remain zero during
+value-only training so that the shared `ExprNnue` parameter/update layout stays intact. It is
+therefore support code for supervised extraction-cost bootstrapping, not evidence that the
+superseded unified REINFORCE loop still exists.
+
 ## Overview
 
 This document defines clean interfaces for composable search strategies in e-graph optimization.
@@ -12,23 +32,24 @@ We have multiple overlapping ideas that need to be organized:
 ### Search Strategies
 | Name | Status | Core Idea |
 |------|--------|-----------|
-| **Best-First + ε-greedy** | In plan doc, implemented | Priority queue, random exploration |
-| **MCTS (AlphaZero)** | "Abandoned" in doc, but implemented | Tree search with UCB, backprop |
-| **Guided Search** | Implemented | Match prediction filter |
+| **Best-First + ε-greedy** | Historical prototype; not a compiler path | Priority queue, random exploration |
+| **MCTS (AlphaZero)** | Historical prototype; never integrated | Tree search with UCB, backprop |
+| **Guided Search** | Plan of record, Phase 3 not yet recorded complete | Supervised provenance-based match guidance |
 
 ### Training Signals
 | Name | Status | Core Idea |
 |------|--------|-----------|
-| **Curriculum (Supervised)** | In plan doc | Saturate small kernels → ground truth |
-| **REINFORCE** | Implemented | Sparse reward, policy gradient |
-| **Synthetic Oracle** | Implemented in train_mcts | Use judge to generate targets |
+| **Curriculum (Supervised)** | Historical proposal | Saturate small kernels → ground truth |
+| **REINFORCE** | Removed/superseded | Sparse reward, policy gradient |
+| **Synthetic Oracle** | Historical proposal; no current binary | Use judge to generate targets |
+| **Provenance supervision** | Plan of record; labeler implemented | Derivation participation and hindsight outcomes |
 
 ### Neural Components
 | Name | Current Usage | Note |
 |------|---------------|------|
-| **Value Head** | Cost prediction | Used everywhere |
-| **Mask/Policy Head** | Rule scoring | Plan doc says "not needed" |
-| **Guide Net** | Match probability | Separate small network |
+| **Value Head** | Optional extraction-cost research | Static latency prior is the compiler default |
+| **Mask/Policy Head** | Retained parameters, no REINFORCE training | Intended to be retargeted as a supervised guide |
+| **Guide Net** | Planned match ordering | Phase 3 of the redesign |
 
 ## The Three Orthogonal Axes
 
@@ -68,9 +89,9 @@ The differences are:
 
 ---
 
-## Implemented Architecture
+## Proposed Architecture (Historical)
 
-See `pixelflow-search/src/search/mod.rs` for the actual trait definitions.
+The following was a proposed interface decomposition, not the current API.
 
 ```
 ┌─────────────────────────────────────────────────────────────────────┐
@@ -407,17 +428,22 @@ let hybrid = SearchPipeline {
 
 ## Migration Path
 
+> **Historical plan:** these binaries were proposed but do not exist in the current tree.
+> The current training executable is `bootstrap_extraction_head`, which trains only the
+> extraction/value head. Guided-saturation work is tracked by the redesign plan rather than
+> by an MCTS or REINFORCE binary.
+
 ### Phase 1: Extract Traits
 1. Define trait files in `pixelflow-search/src/search/`
 2. Implement for existing code without changing behavior
 
 ### Phase 2: Refactor Binaries
-1. `train_mcts.rs` -> uses `SyntheticTrainer`
-2. `train_mask_reinforce.rs` -> uses `ReinforceTrainer`
-3. `train_guide.rs` -> uses `SupervisedTrainer`
+1. Historical proposal: an MCTS trainer using `SyntheticTrainer` (never shipped)
+2. Historical proposal: a mask trainer using `ReinforceTrainer` (removed/superseded)
+3. Future plan: a supervised Guide trained from provenance labels
 
 ### Phase 3: A/B Testing
-1. Create unified `train_search.rs` that accepts config
+1. Historical proposal: create a unified search-training executable
 2. Config specifies which proposer/evaluator/trainer to use
 3. Easy comparison of approaches on same data
 

--- a/docs/templates/DESIGN_DOC.md
+++ b/docs/templates/DESIGN_DOC.md
@@ -2,11 +2,15 @@
 
 ## Metadata
 - **Author**:
-- **Status**: Draft | Review | Approved | Implemented
+- **Status**: Draft | Review | Approved | Implemented (required; choose exactly one)
 - **Created**: YYYY-MM-DD
 - **Reviewers**:
 
 ---
+
+Every new plan or design must retain this metadata block and use one of the four
+status values above. Describe archival relationships separately with `Supersedes:` or
+`Superseded by:`; do not invent another workflow status for them.
 
 ## 1. Overview
 


### PR DESCRIPTION
### Motivation
- Provide a single documentation landing page that classifies major docs by currency and intent so readers know which documents are authoritative today.
- Reconcile the search/training design narrative so the repo does not accidentally advertise MCTS/REINFORCE as active production paths when the guided-saturation redesign is the plan of record.
- Make the role of the existing backward math explicit so readers understand that `unified_backward.rs` is used for supervised value/extraction training only and not the removed REINFORCE loop.
- Enforce consistent design-doc metadata so future plans must use the shared status vocabulary and record supersession via `Supersedes`/`Superseded by` instead of ad-hoc status words.

### Description
- Added `docs/README.md` as a documentation landing page with the six classifications: Current architecture, Plan of record, Experiment/result, Historical/superseded, Active bug, and Fixed bug, and linked canonical documents into each category.
- Updated the root `README.md` to link the new `docs/README.md` from the Documentation section via a single index entry (`docs/README.md`).
- Marked `docs/SEARCH_PIPELINE_DESIGN.md` as **Historical/superseded**, reconciled its MCTS/REINFORCE status with the `plans/2026-07-07-guided-saturation-redesign.md`, removed active/binary-level claims and relabeled obsolete trainer binaries as historical proposals or future plans, and added an explicit note that `pixelflow-pipeline/src/training/unified_backward.rs` now supports value/extraction-head MSE training only (policy gradient code paths were deleted).
- Tightened the `docs/templates/DESIGN_DOC.md` template to require exactly one workflow status (`Draft`, `Review`, `Approved`, or `Implemented`) and added guidance to record lineage via `Supersedes` / `Superseded by`.

### Testing
- Ran local Markdown link validation (scripted `python3` check) over the updated files to ensure all internal links resolve and the check succeeded with no missing targets.
- Ran `git diff --check`/staging checks and a targeted `rg` search for obsolete training-binary identifiers (e.g., `train_mcts`, `train_mask_reinforce`, `train_guide`) to confirm they were removed or relabeled, and both checks passed. 
- Performed a final working-tree inspection to ensure the updated files are syntactically valid Markdown and the documentation landing page is reachable from the root `README.md` (validation succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6447c5acd48333a6acceace5f0e04d)