### PR TITLE
docs: retire expression-template opt-level workaround

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ cargo bundle-run --features profiling  # Flamegraph on exit
 
 ### Build Profiles
 
-- **dev** - opt-level=1 because deep Manifold recursion causes stack overflow without inlining. panic=abort.
+- **dev** - opt-level=0, panic=abort. The former opt-level=1/2 workaround for deeply nested expression-template types is obsolete: the JIT-first `Kernel`/`ExprArena` architecture superseded that layer (see `docs/plans/2026-07-20-kernel-unification.md`).
 - **release** - opt-level=3, panic=abort
 - **bench** - LTO, codegen-units=1
 - **dist** - LTO, strip, codegen-units=1, panic=abort

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,11 @@ members = ["core-term", "pixelflow-core", "pixelflow-graphics", "pixelflow-compi
 exclude = ["pixelflow-core/fuzz"]
 resolver = "2"
 
-# Dev profile - use opt-level=2 because deep Manifold recursion causes
-# stack overflow without aggressive inlining. opt-level=1 isn't enough.
+# The old opt-level=1/2 workaround for deeply nested expression-template types
+# is obsolete. Kernel/ExprArena superseded that layer; see
+# docs/plans/2026-07-20-kernel-unification.md.
 [profile.dev]
-opt-level = 1
+opt-level = 0
 panic = "abort"
 
 # Workspace-wide lints - prevents swallowing errors with `let _ = `

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -45,7 +45,7 @@ The project is a Rust workspace with the following key members:
 *   **Benchmarks:** `cargo bench -p pixelflow-core`
 
 ### Build Profiles
-*   **`dev`**: `opt-level = 1` (Required to prevent stack overflows from deep Manifold recursion).
+*   **`dev`**: `opt-level = 0`, `panic = "abort"`. The former opt-level 1-2 workaround for deeply nested expression-template types is obsolete: the JIT-first `Kernel`/`ExprArena` architecture superseded that layer (see `docs/plans/2026-07-20-kernel-unification.md`).
 *   **`release`**: `opt-level = 3`, `panic = "abort"`.
 *   **`bench`**: `lto = true`, `codegen-units = 1`.
 *   **`dist`**: inherits `release`, adds `lto = true`, `codegen-units = 1`, `strip = true`.


### PR DESCRIPTION
### Motivation

- The historical `opt-level = 1/2` dev workaround was introduced to avoid stack overflows caused by a now-removed expression-template (ZST combinator) layer.  
- The project has moved to a JIT-first `Kernel`/`ExprArena` architecture which supersedes that expression-template design, so the old workaround is obsolete.  

### Description

- Restore the dev build profile to the unoptimized default by setting `opt-level = 0` in `Cargo.toml` and add a short comment pointing to the kernel-unification plan (`docs/plans/2026-07-20-kernel-unification.md`).
- Update contributor-facing docs in `CLAUDE.md` and `GEMINI.md` to reflect the new `dev` profile (`opt-level = 0`) and to explain that the prior opt-level 1–2 workaround belonged to the superseded expression-template architecture and is no longer required. 
- A lightweight wording sync was applied only to workspace configuration and build/profile documentation (no code behavior changes beyond build-profile default).

### Testing

- Ran `git diff --check` to validate diffs with no whitespace errors and it succeeded.  
- Ran `cargo metadata --no-deps --format-version 1` to validate workspace metadata and it succeeded.  
- Ran `cargo test --workspace` and the full workspace test-suite completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a64476345248333aeadec12b04819b4)