### PR TITLE
test(pixelflow-runtime): prove the render pipeline's edges before wiring them

### DIFF
--- a/docs/designs/pixelflow-runtime-engine-mesh-migration.md
+++ b/docs/designs/pixelflow-runtime-engine-mesh-migration.md
@@ -329,3 +329,79 @@ The metadata round-trip (7.1/7.2) is a `pixelflow-graphics` change and lands fir
 it is independently correct, deletes `pending_render` and `stale` while `EngineHandler` still
 exists, and shrinks the surface the collapse has to move. Only then do `window` and
 `frame_number` relocate and the mediator go away.
+
+---
+
+## 8. The render pipeline's actual edges — proven before wiring anything
+
+§7 decided where `EngineHandler`'s *state* goes. It didn't decide who performs the one
+remaining piece of logic that isn't state: matching "a window is free" against "a manifold is
+waiting" to decide when to render. That decision, and the edges it implies, needed the same
+treatment every edge in §3 got — proven before any live actor changes — because it invents two
+edges (`driver` ↔ `rasterizer`) that never existed in the mesh before.
+
+**The match logic lives in `rasterizer`.** `driver` pushes a window the moment one is free
+(`WindowCreated`, or a window returned from a prior `Present`) rather than tracking whether a
+manifold is waiting — it stays exactly as stateless about the render pipeline as §7.3 already
+said. `app` pushes its latest manifold (droppable, keep-latest, same semantics as today).
+`rasterizer` holds both, and renders when it has a window, a manifold, and its own `Credit(1)`
+allows it — colocated with the credit that already gates rendering, rather than split across an
+actor that only relays.
+
+The resulting edges, added to `pixelflow-runtime/tests/target_topology.rs`:
+
+| Edge | Direction | Kind |
+|---|---|---|
+| Window available (created, or returned from Present) | driver → rasterizer | Droppable, no credit |
+| Manifold submission | app → rasterizer | Droppable, keep-latest |
+| Present | rasterizer → driver | Droppable, shares the ping-pong buffer's Credit(1) |
+| Frame-rendered notice (FPS telemetry) | rasterizer → vsync | Droppable, no credit |
+| `ReturnToken` | app → vsync | Droppable, no credit |
+
+Two of these delete an existing edge rather than add one: `engine → driver` (`Present`) and
+`driver → engine` (`PresentComplete`) are gone — `rasterizer` presents directly now. `engine ↔
+rasterizer` and `engine → vsync` (`RenderedResponse`) are gone entirely; nothing uses that pair
+any more. `app → engine` (`AppData::RenderSurface`) is also gone: the message that used to
+double as both "here is the manifold" and "return my vsync token" now travels as two direct
+sends, to the two actors that actually need each half.
+
+`ReturnToken` closes a small pre-existing gap in this proof: it was already an `engine → vsync`
+Control-lane send, but never modeled as its own edge — modeled now, since it travels a new edge
+anyway.
+
+`the_target_engine_mesh_is_a_dag` is **updated in place**, not duplicated, matching this file's
+own stated purpose of staying valid across the rollout. A new `regressed_render_pipeline_
+framing_is_cyclic` test records the shape of mistake most likely to recur here: treating "only
+one window ever circulates" as license to make the driver ↔ rasterizer hand-off synchronous in
+both directions. It's the identical error §3.1 caught for driver ↔ engine, just with a fresh
+pair of actors — two blocking edges between the same pair is a cycle regardless of whether the
+conversations are logically unrelated.
+
+### 8.1 Explicitly out of scope for this slice
+
+`engine` remains a node in the proven graph — this is a render-pipeline-only cut, not the full
+deletion. Left alone, and routed through `engine` exactly as today:
+
+- Input-event forwarding (`driver → engine`, Blocking).
+- `AppManagement` commands — `SetTitle`, `SetSize`, `SetCursor`, `Copy`, `RequestPaste`,
+  `CreateWindow` — and their replies (`PasteData`).
+- The vsync-tick → `RequestFrame` relay (`vsync → engine → app`).
+
+Moving these is a separate, later slice: none of them touch the state this doc's §7 already
+redistributed, and folding them in here would make one change cover two independent decisions.
+
+### 8.2 What implementing this actually requires
+
+Wiring these edges for real is a larger change than §7's field deletions were, and is scoped as
+its own follow-up rather than bundled with the proof:
+
+- `rasterizer`'s bootstrap (today `EngineHandler::spawn_rasterizer`) moves out of
+  `EngineHandler` entirely — the rasterizer becomes a directly-wired mesh participant with its
+  own initialization, not something the mediator stands up on the mediator's behalf.
+- A new piece of runtime-side state holds `latest_window`, the render `Credit(1)`, and performs
+  the point-space → pixel-space dimap warp that `trigger_render_with_window` does today — this
+  logic stays in `pixelflow-runtime`, not `pixelflow-graphics`, since it's runtime coordinate
+  mapping, not general rasterization (`CLAUDE.md`: no terminal-adjacent logic in the graphics
+  crate).
+- `app`'s handle setup gains a second target: today `Application` only reaches `engine`; it
+  needs a way to reach `rasterizer` (manifold) and `vsync` (`ReturnToken`) directly.

--- a/pixelflow-runtime/tests/target_topology.rs
+++ b/pixelflow-runtime/tests/target_topology.rs
@@ -18,10 +18,25 @@
 //! vocabulary every other edge in §3 uses (`Present` even has its own non-blocking contract in
 //! the code already, which the aggregate framing had simply missed). `regressed_aggregate_
 //! framing_is_cyclic` below keeps that mistake on record so it isn't repeated.
+//!
+//! # §7: the render pipeline moves off `engine` entirely
+//!
+//! Deleting `EngineHandler` means its render-pipeline edges (window hand-off, manifold
+//! submission, present, FPS telemetry, token return) need to become direct edges among
+//! `driver`, `rasterizer`, `vsync`, and `app` — and those specific edges were never checked.
+//! Every edge through `engine` up to this point was individually proven; a direct
+//! `driver` ↔ `rasterizer` edge was not, because it didn't exist yet. `the_target_engine_mesh_
+//! is_a_dag` below is updated in place (not duplicated) to the corrected edge set, per this
+//! file's own stated purpose of staying valid across the rollout rather than accumulating a
+//! stale copy per step.
+//!
+//! `engine` remains a node for what this slice deliberately leaves alone: input-event
+//! forwarding, `AppManagement` commands (`SetTitle`/`CreateWindow`/etc.), and the
+//! vsync-tick → `RequestFrame` relay. Those are a separate, later slice.
 
 use actor_scheduler::mealy::Topology;
 
-/// Every edge from §3 of the migration doc, decomposed per message rather than lumped into
+/// Every edge from §3/§7 of the migration doc, decomposed per message rather than lumped into
 /// "input events" / "display commands". `Create` (bootstrap-only, §3.1) is deliberately not
 /// part of this graph at all — the same way the rasterizer's bootstrap handshake isn't part of
 /// today's `troupe!` topology.
@@ -36,16 +51,13 @@ fn the_target_engine_mesh_is_a_dag() {
     let app = topo.actor("app");
 
     // The one edge that stays genuinely Blocking: discrete, non-idempotent input and
-    // window-lifecycle events. Nothing on the engine -> driver side is Blocking any more, so
-    // this alone cannot form a cycle with anything below.
+    // window-lifecycle events. Nothing else in this graph is Blocking, so this alone cannot
+    // form a cycle with anything below.
     topo.blocking_edge(driver, engine); // DisplayEvent, minus PasteData
 
-    // Present / PresentComplete: structurally-unreachable droppable backstop, Credit(1) via
-    // the single ping-pong window buffer.
-    topo.droppable_edge(engine, driver); // Present
-    topo.droppable_edge(driver, engine); // PresentComplete
-
-    // Idempotent "latest wins" state pushes: no credit needed at all.
+    // Idempotent "latest wins" state pushes: no credit needed at all. Present/PresentComplete
+    // used to live here too — they moved to the rasterizer <-> driver edges below, since
+    // rasterizer is what actually presents once engine no longer mediates.
     topo.droppable_edge(engine, driver); // SetTitle / SetSize / SetCursor / Copy
 
     // RequestPaste / PasteData: plain droppable, deliberately *not* credit-bounded — see §3.2.
@@ -56,20 +68,50 @@ fn the_target_engine_mesh_is_a_dag() {
     topo.droppable_edge(engine, driver); // RequestPaste
     topo.droppable_edge(driver, engine); // PasteData
 
-    // The other three satellite relationships, unchanged from the first draft of this proof.
-    topo.droppable_edge(engine, rasterizer); // render request
-    topo.droppable_edge(rasterizer, engine); // render complete
+    // vsync-tick -> RequestFrame relay: unchanged, still routed through engine. Out of scope
+    // for this slice (§7.4's remaining-work note).
     topo.droppable_edge(vsync, engine); // vsync tick (Credit-gated)
-    topo.droppable_edge(engine, vsync); // RenderedResponse (FPS telemetry only)
     topo.droppable_edge(engine, app); // RequestFrame (Credit-gated)
-    topo.droppable_edge(app, engine); // AppData::RenderSurface (already "keep latest" today)
+
+    // The render pipeline, now wired directly instead of through engine (§7 of the migration
+    // doc). rasterizer is where §7's chosen design puts the window/manifold pairing: driver
+    // pushes a window the moment one is free (created, or returned from a prior Present) and
+    // app pushes its latest manifold; rasterizer renders when both are held and its own
+    // Credit(1) allows it, then presents directly and tells vsync.
+    topo.droppable_edge(driver, rasterizer); // window available (created, or returned)
+    topo.droppable_edge(app, rasterizer); // manifold submission (keep-latest, as today)
+    topo.droppable_edge(rasterizer, driver); // Present, once rendered
+    topo.droppable_edge(rasterizer, vsync); // RenderedResponse (FPS telemetry only)
+    topo.droppable_edge(app, vsync); // ReturnToken — previously an engine->vsync Control-lane
+                                      // send this proof never modeled separately; modeled here
+                                      // now that it travels a new edge anyway.
 
     let order = topo.validate().expect(
-        "every engine -> driver edge is droppable and driver -> engine is the only Blocking \
-         one, so this must be a DAG — if it isn't, an edge above needs reclassifying before \
-         any live actor is converted",
+        "every blocking edge has no return path and every reply is droppable, so this must be \
+         a DAG — if it isn't, an edge above needs reclassifying before any live actor is \
+         converted",
     );
     assert_eq!(order.len(), 5);
+}
+
+/// The same mistake `regressed_aggregate_framing_is_cyclic` records, in the shape someone
+/// converting the render pipeline is likely to make fresh: treating "exactly one window
+/// circulates" as license to make the hand-off synchronous in both directions. It doesn't
+/// matter that "hand me a window" and "here's your rendered frame" are logically distinct
+/// conversations — two blocking edges between the same pair is a cycle regardless.
+#[test]
+fn regressed_render_pipeline_framing_is_cyclic() {
+    let mut topo = Topology::new();
+    let driver = topo.actor("driver");
+    let rasterizer = topo.actor("rasterizer");
+
+    topo.blocking_edge(driver, rasterizer); // "hand off the window synchronously"
+    topo.blocking_edge(rasterizer, driver); // "and block until it's presented"
+
+    let cycle = topo
+        .validate()
+        .expect_err("two blocking edges between the same pair must be rejected");
+    assert!(cycle.actors.contains(&"driver") && cycle.actors.contains(&"rasterizer"));
 }
 
 /// The mistake the first draft of this proof made, kept as a permanent regression test rather


### PR DESCRIPTION
## Why this is its own PR

§7 decided where `EngineHandler`'s *state* goes. It left one thing undecided: who matches "a window is free" against "a manifold is waiting" to trigger a render — the one piece of engine that isn't state. Answering it invents two edges, `driver` ↔ `rasterizer`, that have never existed in this mesh and were never checked by `target_topology.rs`.

That's exactly the situation this doc's own methodology (§2) exists for: prove the graph first, mechanically, before touching a live actor — the same discipline that caught the original `driver`↔`engine` mistake in §3.1. So this PR is *only* the proof. Pure test + doc change, zero runtime code touched, zero behavioral risk.

## The design (resolved via a quick check-in, not guessed)

**The match logic lives in `rasterizer`.** `driver` pushes a window the moment one is free (created, or returned from a prior `Present`) without tracking whether a manifold is waiting — stays exactly as stateless as §7.3 said. `app` pushes its latest manifold (droppable, keep-latest, same semantics as today). `rasterizer` holds both and renders when it has a window, a manifold, and its own `Credit(1)` allows it — colocated with the credit that already gates rendering.

## The edges

| Edge | Direction | Kind |
|---|---|---|
| Window available (created, or returned from Present) | driver → rasterizer | Droppable |
| Manifold submission | app → rasterizer | Droppable, keep-latest |
| Present | rasterizer → driver | Droppable, shares the ping-pong Credit(1) |
| Frame-rendered notice (FPS telemetry) | rasterizer → vsync | Droppable |
| `ReturnToken` | app → vsync | Droppable |

Four edges disappear entirely: `engine ↔ rasterizer` (both directions), `engine → driver` (`Present`), `driver → engine` (`PresentComplete`), `engine → vsync` (`RenderedResponse`), `app → engine` (`RenderSurface`) — the message that used to double as "here's the manifold" *and* "return my token" now travels as two direct sends to the two actors that actually need each half.

`ReturnToken` closes a small pre-existing gap: it was already an `engine → vsync` Control-lane send, never modeled as its own edge. Modeled now, since it travels a new edge anyway.

`the_target_engine_mesh_is_a_dag` is **updated in place**, not duplicated — matching the file's own stated purpose of staying valid across the rollout. New `regressed_render_pipeline_framing_is_cyclic` records the mistake most likely to recur here: treating "only one window ever circulates" as license to make the `driver`↔`rasterizer` hand-off synchronous in both directions. Identical shape to the original `driver`↔`engine` mistake, fresh pair of actors.

## Explicitly out of scope

`engine` remains a node in the proven graph — this is render-pipeline-only. Input-event forwarding, `AppManagement` commands (`SetTitle`/`CreateWindow`/etc.), and the vsync-tick → `RequestFrame` relay stay routed through `engine`, unchanged. Recorded as a separate, later slice (§8.1) — folding them in here would cover two independent decisions with one change.

## What implementing this actually requires (§8.2, next PR)

Larger than §7's field deletions, and scoped separately on purpose:
- `rasterizer`'s bootstrap moves out of `EngineHandler` entirely.
- New runtime-side state does the window/manifold pairing and the dimap warp — stays in `pixelflow-runtime`, not `pixelflow-graphics` (`CLAUDE.md`: no terminal-adjacent logic in the graphics crate).
- `Application`'s handle setup gains direct paths to `rasterizer` and `vsync`.

## Testing

- `cargo test -p pixelflow-runtime --test target_topology` — 3/3 passing (both original tests unchanged in behavior, new regression test passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Y5cNzR9PnASfGfjBh5kJc

---
_Generated by [Claude Code](https://claude.ai/code/session_015Y5cNzR9PnASfGfjBh5kJc)_