### PR TITLE
docs(pixelflow-runtime): window lifecycle tears, it does not copy

### DIFF
--- a/docs/designs/pixelflow-runtime-engine-mesh-migration.md
+++ b/docs/designs/pixelflow-runtime-engine-mesh-migration.md
@@ -405,3 +405,28 @@ its own follow-up rather than bundled with the proof:
   crate).
 - `app`'s handle setup gains a second target: today `Application` only reaches `engine`; it
   needs a way to reach `rasterizer` (manifold) and `vsync` (`ReturnToken`) directly.
+
+### 8.3 Window-lifecycle events: tear, don't copy, and don't reroute
+
+`WindowCreated`/`Resized` have two consumers with genuinely different needs: `app` wants to know
+the new dimensions, and the render pipeline wants the buffer. A first pass at §8 handled this by
+adding a `rasterizer → app` edge — rasterizer would open the `Window`, pull the metadata out, and
+relay it onward — on the reasoning that feeding both consumers otherwise meant cloning the frame
+buffer, which `Frame: Clone` makes silently possible and which would be a real per-frame cost.
+
+That reasoning was wrong at its root: **a frame buffer copy was never an option to weigh.** The
+`Window` circulates by ownership transfer; that *is* the ping-pong buffer. Treating a clone as
+one arm of a trade-off, even to reject it, is how a copy eventually ends up in the render loop.
+
+The correct answer is the one §7.1 already established, applied a second time: a `Window` tears
+into `WindowMeta` (four scalars, `Copy`) and `Frame` (expensive, moves). So the driver sends
+**metadata** to engine over the existing Blocking `DisplayEvent` edge — engine relays to app
+exactly as it does today, unchanged — and sends **the window** to rasterizer. Both consumers are
+served, nothing is copied, and the graph gains no edge at all.
+
+This also keeps `rasterizer` from learning about `app`, which the discarded version required.
+Colocating a relay with the data sounds tidy until it means the renderer holds a handle to the
+application to forward window metadata it doesn't otherwise care about.
+
+The general rule this is the second instance of: **when two actors need different parts of one
+value, split the value — don't duplicate it, and don't reroute one consumer through the other.**

--- a/docs/designs/pixelflow-runtime-engine-mesh-migration.md
+++ b/docs/designs/pixelflow-runtime-engine-mesh-migration.md
@@ -438,26 +438,27 @@ the DAG result either way.
 The moment that stops being true — if the worker ever gains a handle to a third actor — it stops
 being collapsible and has to enter the proof as its own node. That is the tripwire.
 
-### 8.5 The window is pulled, not pushed — and why §8 needed three tries
+### 8.5 The window is pulled, not pushed — and why the first attempts failed
 
 This section replaces two earlier ones (a "tear the Window, send metadata to engine and the
 buffer to rasterizer" split, and a follow-up "resize must not mint a window" patch). Both are
 deleted rather than annotated, because keeping a chain of superseded fixes would obscure what
 turned out to be a single wrong decision underneath all three.
 
-**What went wrong, three times.** Automated review caught each in turn: (1) a `rasterizer → app`
-edge invented to avoid a frame-buffer clone that was never an acceptable option to begin with;
-(2) resize windows sent over a droppable edge, where a full ring discards the *new* message and
-keep-latest requires discarding the *old* one — so the only correctly-sized buffer could be lost
-with no replacement until the next resize; (3) the fix for (2) left the coordinator responsible
-for reallocating on resize while giving it no edge over which to learn the dimensions had
-changed, and routing that metadata over a droppable edge would have reproduced (2) exactly.
+**What went wrong.** Automated review caught a run of defects that all turned out to share one
+cause: a `rasterizer → app` edge invented to dodge a frame-buffer clone that was never an
+acceptable option; resize windows sent over a droppable edge, where a full ring discards the
+*new* message while keep-latest requires discarding the *old* one, losing the only
+correctly-sized buffer with no replacement until the next resize; and then a fix for *that* which
+left the coordinator responsible for reallocating on resize without any edge over which to learn
+the dimensions had changed — where routing that metadata over a droppable edge would have
+reproduced the previous defect exactly.
 
-Three patches, each exposing the next problem, is a decomposition error rather than a detail
-error. **The root cause: frame allocation was on the coordinator, but window size is
-driver-authoritative** — the OS decides it. Putting the allocator on the side that doesn't know
-the size forces size information to chase it across the mesh, and every route it can take is
-either unreliable (droppable, loses state permanently) or blocks the main thread.
+Each patch exposing the next is a decomposition error rather than a detail error. **The root
+cause: frame allocation was on the coordinator, but window size is driver-authoritative** — the
+OS decides it. Putting the allocator on the side that doesn't know the size forces size
+information to chase it across the mesh, and every route it can take is either unreliable
+(droppable, loses state permanently) or blocks the main thread.
 
 **The fix is to move allocation, not to route information better.** The driver keeps the window
 between frames and remains its allocator. The coordinator *pulls* one when it actually has work:
@@ -507,8 +508,12 @@ no reallocation logic, no dimension tracking. It still performs the point→pixe
 the dimensions of the window it was handed.
 
 **Consequence for `Present`/`PresentComplete`.** `PresentComplete` disappears entirely as a
-message. The driver never gave the window away permanently, so there is nothing to hand back —
-the "return" half of the ping-pong is just the driver keeping what it always owned. That also
-retires an invariant §3 had been asserting but not holding: "exactly one window circulates" was
-untrue while resize could mint a second one mid-flight. Now exactly one window *exists*, and it
-never leaves the driver except for the duration of a single render.
+message. Previously the window made a full circuit — `Present` carried it to the driver and
+`PresentComplete` carried it back to the engine, which was its resting owner between frames. Now
+the **driver** is the resting owner, so `Present` *is* the return: it hands the window back to
+the actor that already keeps it, and no separate acknowledgement is needed. The window still
+moves by value on every hop; what's gone is the second hop.
+
+That also retires an invariant §3 had been asserting but not holding: "exactly one window
+circulates" was untrue while resize could mint a second one mid-flight. Now exactly one window
+*exists*, and it is away from the driver only for the duration of a single render.

--- a/docs/designs/pixelflow-runtime-engine-mesh-migration.md
+++ b/docs/designs/pixelflow-runtime-engine-mesh-migration.md
@@ -452,3 +452,50 @@ the DAG result either way.
 
 The moment that stops being true — if the worker ever gains a handle to a third actor — it stops
 being collapsible and has to enter the proof as its own node. That is the tripwire.
+
+### 8.5 Resize must not mint a window — droppable is the opposite of keep-latest
+
+Automated review (Codex, on #920) caught a real defect in §8.3's split, and it is worth recording
+in full because it is the *third* instance this session of the same underlying mistake.
+
+**The defect.** `send_port` with `Delivery::Droppable` discards the **new** message when the ring
+is full (`actor-scheduler/src/mealy.rs`: `Err(TrySendError::Full(_)) => Flush::Done`, payload
+dropped). Keep-latest semantics need the **old** one dropped. Those are opposites. For manifold
+submission the difference is harmless — another manifold arrives next frame — but the platform
+mints a *fresh, correctly sized* `Frame` on every `Resized`/scale-change
+(`Frame::<PlatformPixel>::new(px_w, px_h)`, in two places). Dropping that message discards the
+only correctly-sized buffer in existence, and nothing replaces it until the next resize. The app
+would be told the new dimensions over the reliable Blocking edge while the rasterizer kept
+rendering at the old size. Reachable during any resize drag, since rasterization is synchronous.
+
+This is precisely the §3 distinction — *structurally unreachable* vs *genuinely acceptable loss*
+— applied wrongly: the window edge was filed under the second when it belonged under neither.
+
+**The fix is to stop minting windows on resize, not to change how delivery works.** A resize does
+not produce a rendered buffer; it produces *new dimensions* plus an empty allocation. Sending an
+empty correctly-sized buffer is an expensive way to communicate two integers. `Frame<P>` is a
+plain `Vec<P>` — verified: no XShm segment, no IOSurface, nothing platform-backed; X11's
+`present` merely points an `XImage` at the `Vec`'s data — so there is no reason the *driver* must
+be the allocator.
+
+So: on resize the driver sends **metadata only** (`WindowMeta`, `Copy`, over the existing
+reliable edge). The rasterizer coordinator owns `latest_window` and reallocates its own frame
+when it observes the dimensions changed, before the next render.
+
+Two things fall out, and the second is the one that matters:
+
+1. **The bug is gone by construction.** No window travels on resize, so there is no window to
+   drop. Delivery semantics didn't need changing.
+2. **"Exactly one window circulates" becomes actually true.** It wasn't. Today a resize mints a
+   second `Window` while another may still be in flight to or from the rasterizer — which
+   quietly invalidated the `Credit(1)` reasoning that §3 rests on for `Present`/`PresentComplete`.
+   The invariant was being asserted, not held. Now windows travel on exactly three occasions:
+   `WindowCreated` (bootstrap, one-shot), `Present`, and `PresentComplete`.
+
+The graph is unchanged — `driver → rasterizer` still exists, it just carries `PresentComplete`
+and the one bootstrap `WindowCreated` rather than resize windows. No edge added, none removed.
+
+**The general lesson, third instance.** "Droppable" is not a synonym for "keep-latest." An edge
+is only safe to declare droppable if losing *that specific message* is recoverable by a
+subsequent one. Where the message is the sole carrier of unique state, dropping it is
+unrecoverable no matter how idempotent the *concept* sounds.

--- a/docs/designs/pixelflow-runtime-engine-mesh-migration.md
+++ b/docs/designs/pixelflow-runtime-engine-mesh-migration.md
@@ -352,18 +352,16 @@ The resulting edges, added to `pixelflow-runtime/tests/target_topology.rs`:
 
 | Edge | Direction | Kind |
 |---|---|---|
-| Window request ("I have work, give me a buffer") | rasterizer → driver | Droppable, **Credit(1) consumed here** |
-| Window grant (correctly sized, driver-allocated) | driver → rasterizer | Droppable, same credit still held |
-| `Present` | rasterizer → driver | Droppable, **credit released here** |
+| Window request ("I have work, give me a buffer") | rasterizer → driver | Droppable — genuinely losable, carries nothing |
+| Window grant (correctly sized, driver-allocated) | driver → rasterizer | Droppable, **unreachable**: driver can't grant what it doesn't hold |
+| `Present` | rasterizer → driver | Droppable, **unreachable**: coordinator can't present what it doesn't hold |
 | Manifold submission | app → rasterizer | Droppable, keep-latest |
 | Frame-rendered notice (FPS telemetry) | rasterizer → vsync | Droppable, no credit |
 | `ReturnToken` | app → vsync | Droppable, no credit |
 
-**The one credit spans the entire round trip** — request → grant → render → `Present` — and is
-released only when the window is back with the driver. It is emphatically *not* released at the
-grant: doing so would let a second manifold trigger a request the driver cannot satisfy, since
-it no longer holds a window to give. See §8.5; this is what makes the three droppable backstops
-structurally unreachable rather than merely unlikely.
+**There is no `Credit` on this loop.** Ownership of the single `Window` is already the bound —
+see §8.6. Rust will not let an actor send a window it does not hold, so "at most one in flight"
+is a property of the type rather than a counter that has to be kept in sync with it.
 
 Two of these delete an existing edge rather than add one: `engine → driver` (`Present`) and
 `driver → engine` (`PresentComplete`) are gone — `rasterizer` presents directly now. `engine ↔
@@ -517,3 +515,72 @@ moves by value on every hop; what's gone is the second hop.
 That also retires an invariant §3 had been asserting but not holding: "exactly one window
 circulates" was untrue while resize could mint a second one mid-flight. Now exactly one window
 *exists*, and it is away from the driver only for the duration of a single render.
+
+### 8.6 Ownership is the bound — delete the credit
+
+§8.5 put a `Credit(1)` on the render loop, consumed at the request and released when `Present`
+returned the window. Review showed that cannot work, and the reason is worth keeping:
+
+**`Credit` is requester-local, and `send_port` reports `Flush::Done` whether it delivered or
+dropped.** So the coordinator can never learn that its `Present` arrived. Release the credit when
+*emitting* `Present` and a dropped delivery restores the credit while destroying the only window
+— which makes the drop-impossibility argument circular, since it assumed the credit bounded the
+edge. Never release it and rendering halts after one frame. With a coordinator-local credit and
+no acknowledgement, there is no third option.
+
+The available fixes were to reinstate a `PresentComplete` acknowledgement, or invent a
+transferable permit. Both are machinery. **The subtraction is to notice the credit was modelling
+something the type system already guarantees: you cannot send a `Window` you do not hold.**
+
+There is exactly one `Window`, and it is moved, never copied. Therefore:
+
+- **The driver can only grant while it holds the window.** Having granted, it holds nothing and
+  cannot grant again until `Present` returns it. At most one grant is ever in flight, and the
+  ring is provisioned ≥ 1 — so the grant ring is never full, and its droppable backstop is dead
+  code. No counter required; `Option<Window>` *is* the counter.
+- **The coordinator can only `Present` while it holds the window**, which it does only between a
+  grant and that `Present`. Same argument, same conclusion.
+- **The request carries no resource**, so it is the one genuinely losable message here. A dropped
+  request costs one frame and the next vsync tick issues another — *actual* acceptable loss, of
+  the kind §3 distinguishes from structural unreachability.
+
+The coordinator's gate becomes a plain question about its own state: *do I hold a manifold, am I
+not currently holding a window, and is no request outstanding?* The middle clause is what covers
+the render window — while rendering it holds the window, so it cannot request another regardless
+of how many manifolds arrive. That is the concern §8.5's round-trip credit was introduced to
+address, handled by ownership instead of by a counter.
+
+**Rule.** Where a resource is unique and moved rather than copied, ownership already enforces
+the bound a `Credit` would encode. Adding one duplicates the invariant into a place it can drift
+out of sync with — and, as here, into a place that needs an acknowledgement message to maintain.
+Reach for `Credit` when the bound is *not* expressible as ownership: a count of outstanding
+requests (vsync's tick budget), or a permit held across actors that never move a value.
+
+### 8.7 Resize while the window is out being rendered
+
+§8.5 said "on resize the driver swaps its held buffer." That is only true when it *has* one.
+Between granting and `Present`, the driver holds nothing — and a resize in that gap is not a
+corner case: it is the race today's `stale` flag exists to handle, and `engine_troupe.rs`
+explicitly handles resizes arriving during both rendering and presentation.
+
+Following §8.5 literally leaves two bad options: ignore the resize and reuse the stale-sized
+buffer indefinitely, or allocate a second window and break the exactly-one invariant §8.6 now
+depends on.
+
+**The driver records pending dimensions instead of acting immediately.** It is already the size
+authority and the allocator, so remembering "the OS told me 1920×1080 while the buffer was out"
+is state that belongs to it:
+
+- Resize while the driver **holds** the window: swap the buffer now, as §8.5 said.
+- Resize while the window is **out**: store the new dimensions. Do nothing else.
+- On `Present` with pending dimensions set: the returned frame was rendered at the old size, so
+  **skip the blit** — presenting it would show a stretched or clipped frame — then replace the
+  buffer with a correctly-sized one and clear the pending dimensions. The next grant is correct.
+
+That reproduces today's behaviour exactly. The `stale` flag §7.2 deleted did precisely this job
+from the engine's side; the work does not disappear, it moves to the actor that owns the buffer,
+where it needs no cross-actor flag to coordinate — the driver observes the mismatch locally by
+comparing what it stored against what came back.
+
+One dropped frame per resize, same as today. The alternative — presenting a wrong-sized frame —
+is visibly worse and is what today's code already declines to do.

--- a/docs/designs/pixelflow-runtime-engine-mesh-migration.md
+++ b/docs/designs/pixelflow-runtime-engine-mesh-migration.md
@@ -430,3 +430,25 @@ application to forward window metadata it doesn't otherwise care about.
 
 The general rule this is the second instance of: **when two actors need different parts of one
 value, split the value — don't duplicate it, and don't reroute one consumer through the other.**
+
+### 8.4 What the `rasterizer` node actually is
+
+The proof's `rasterizer` node is **not** `pixelflow-graphics`'s `RasterizerActor`. It can't be:
+that crate is deliberately runtime-agnostic and names no runtime concept — no `Window`, no
+`driver`, no `vsync`, no `Application` — and §8.2 already places the window/manifold pairing and
+the point→pixel dimap warp in `pixelflow-runtime`. Left implicit, this reads as "driver sends
+windows straight to `RasterizerActor`," which is not implementable and not what was proven.
+
+So `rasterizer` in the graph is a **runtime-side coordinator**: it holds `latest_window`, the
+latest manifold, and the render `Credit(1)`; it does the coordinate warp; it owns the graphics
+`RasterizerActor` as a worker behind it, via the same bootstrap handshake used today.
+
+Collapsing those two into one node is sound rather than convenient, and the reason is worth
+stating because it's the property that must not silently change: **`RasterizerActor` is a leaf.**
+Its only outbound channel is `response_tx`, back to whoever registered it — it holds no handle to
+any other actor and initiates contact with nobody. A node whose sole peer is its caller, with a
+droppable reply, cannot participate in a cycle with the rest of the graph, so it cannot affect
+the DAG result either way.
+
+The moment that stops being true — if the worker ever gains a handle to a third actor — it stops
+being collapsible and has to enter the proof as its own node. That is the tripwire.

--- a/docs/designs/pixelflow-runtime-engine-mesh-migration.md
+++ b/docs/designs/pixelflow-runtime-engine-mesh-migration.md
@@ -361,6 +361,15 @@ non-blocking**, and it is: the worker replies over an unbounded `mpsc::Sender`, 
 block or fill. If that ever becomes a bounded/`SyncSender` channel — or the worker gains a peer
 — the collapse is invalid and it needs its own node in the proof.
 
+**The coordinator owns the point→pixel warp.** The scene is authored in point space; the frame
+is the platform's sample lattice and may be denser (Retina). `trigger_render_with_window`
+currently contramaps the manifold by the measured points/pixels ratio per axis before handing it
+to the rasterizer. That responsibility has to land somewhere explicit when `EngineHandler` goes —
+forwarding the manifold straight to the graphics worker renders at the wrong scale on any HiDPI
+display, and the bug is invisible on a 1:1 monitor. It stays in `pixelflow-runtime`: it's runtime
+coordinate mapping, not general rasterization (`CLAUDE.md` — no terminal-adjacent logic in the
+graphics crate). Worth a test at a non-1:1 logical/frame ratio, which nothing currently covers.
+
 ### The judgment calls
 
 `Topology` proves acyclicity. It cannot tell you what may be lost — that's per-edge judgment, and
@@ -399,6 +408,12 @@ checked:
   message, not the oldest. If the app's final state change is the one dropped and subsequent
   frame requests return `Skipped`, a stale surface stays on screen indefinitely. Needs either a
   real drop-oldest delivery or an explicit coalescing slot before that state is removed.
+- **Stale-return protocol under pull.** §7.2 has the *coordinator* detect a stale render by
+  comparing against the current window — but under pull the coordinator never learns dimensions,
+  and the driver alone knows a resize is pending. Nothing yet defines how the driver rejects the
+  old-size frame, swaps the buffer, and triggers a new grant. §7.2 is superseded on this point
+  and the replacement is unwritten; the generation stamping in `EngineHandler` is the closest
+  existing mechanism.
 - **Zero-copy.** Tracked separately; the copy in both backends is a defect, not the target.
 
 ### Out of scope here

--- a/docs/designs/pixelflow-runtime-engine-mesh-migration.md
+++ b/docs/designs/pixelflow-runtime-engine-mesh-migration.md
@@ -402,8 +402,10 @@ its own follow-up rather than bundled with the proof:
 - `rasterizer`'s bootstrap (today `EngineHandler::spawn_rasterizer`) moves out of
   `EngineHandler` entirely — the rasterizer becomes a directly-wired mesh participant with its
   own initialization, not something the mediator stands up on the mediator's behalf.
-- A new piece of runtime-side state holds `latest_window`, the render `Credit(1)`, and performs
-  the point-space → pixel-space dimap warp that `trigger_render_with_window` does today — this
+- A new piece of runtime-side state holds the latest manifold and the render `Credit(1)`, and
+  performs the point-space → pixel-space dimap warp that `trigger_render_with_window` does today
+  — using the dimensions of whichever window it was granted, since under §8.5 it holds no window
+  of its own between frames and never allocates one. This
   logic stays in `pixelflow-runtime`, not `pixelflow-graphics`, since it's runtime coordinate
   mapping, not general rasterization (`CLAUDE.md`: no terminal-adjacent logic in the graphics
   crate).
@@ -418,9 +420,10 @@ that crate is deliberately runtime-agnostic and names no runtime concept — no 
 the point→pixel dimap warp in `pixelflow-runtime`. Left implicit, this reads as "driver sends
 windows straight to `RasterizerActor`," which is not implementable and not what was proven.
 
-So `rasterizer` in the graph is a **runtime-side coordinator**: it holds `latest_window`, the
-latest manifold, and the render `Credit(1)`; it does the coordinate warp; it owns the graphics
-`RasterizerActor` as a worker behind it, via the same bootstrap handshake used today.
+So `rasterizer` in the graph is a **runtime-side coordinator**: it holds the latest manifold and
+the render `Credit(1)`; it does the coordinate warp; it owns the graphics `RasterizerActor` as a
+worker behind it, via the same bootstrap handshake used today. It does *not* hold a window
+between frames — §8.5 explains why that would put the allocator on the wrong side.
 
 Collapsing those two into one node is sound rather than convenient, and the reason is worth
 stating because it's the property that must not silently change: **`RasterizerActor` is a leaf.**

--- a/docs/designs/pixelflow-runtime-engine-mesh-migration.md
+++ b/docs/designs/pixelflow-runtime-engine-mesh-migration.md
@@ -507,10 +507,10 @@ the window is still out being rendered, and the driver would have nothing to gra
 **Droppable is safe when the drop cannot occur, or when the message is genuinely replaceable.**
 Never because a sender "could resend" something it moved away.
 
-**Consequence for the coordinator.** It shrinks: the latest manifold plus a "request
-outstanding" flag — no `latest_window`, no reallocation logic, no dimension tracking, and (per
-§8.6) no `Credit`. It still performs the point→pixel dimap warp, using the dimensions of the
-window it was handed.
+**Consequence for the coordinator.** It shrinks to the latest manifold and whether a buffer is
+currently in hand — no `latest_window`, no reallocation logic, no dimension tracking, no
+`Credit` (§8.6), and no outstanding-request flag (§8.8). It still performs the point→pixel dimap
+warp, using the dimensions of the window it was handed.
 
 **Consequence for `Present`/`PresentComplete`.** `PresentComplete` disappears entirely as a
 message. Previously the window made a full circuit — `Present` carried it to the driver and
@@ -622,8 +622,17 @@ delivery failure.** Two places currently violate that, both found by review:
 "outstanding request" flag, cleared only by a grant. Since the request edge is droppable, a
 dropped request leaves the flag set with no grant coming — the coordinator never asks again and
 the driver holds the window while rendering halts. Fixed by deleting the flag: the coordinator
-re-requests every tick while it holds a manifold and no buffer, and duplicate requests are
-harmless because the driver can only grant what it holds.
+re-requests while it holds a manifold and no buffer, and duplicate requests are harmless because
+the driver can only grant what it holds.
+
+That fix needed a second half. "Re-requests every tick" is not implementable unless a tick
+actually reaches the coordinator — it is a reactive actor, waking only on messages it receives,
+and the proven graph gave it only manifolds and grants. A dropped request could then be retried
+only if the app happened to submit another manifold, which it may legitimately not do for many
+frames. So the graph gains a **`vsync → rasterizer` tick edge**: droppable and genuinely
+losable, because the next tick is the retry. This is also the shape a pull-based renderer wants
+anyway — the thing that decides when to draw should hear from the clock directly rather than
+inferring it from data arriving.
 
 **2. The graphics worker destroys the frame when paused.** `RasterCore::step_data` currently
 returns `RasterCoreOut::default()` on the paused path, consuming the `RenderRequest` — and the

--- a/docs/designs/pixelflow-runtime-engine-mesh-migration.md
+++ b/docs/designs/pixelflow-runtime-engine-mesh-migration.md
@@ -403,10 +403,11 @@ its own follow-up rather than bundled with the proof:
 - `rasterizer`'s bootstrap (today `EngineHandler::spawn_rasterizer`) moves out of
   `EngineHandler` entirely — the rasterizer becomes a directly-wired mesh participant with its
   own initialization, not something the mediator stands up on the mediator's behalf.
-- A new piece of runtime-side state holds the latest manifold and the render `Credit(1)`, and
-  performs the point-space → pixel-space dimap warp that `trigger_render_with_window` does today
-  — using the dimensions of whichever window it was granted, since under §8.5 it holds no window
-  of its own between frames and never allocates one. This
+- A new piece of runtime-side state holds the latest manifold and a "request outstanding" flag,
+  and performs the point-space → pixel-space dimap warp that `trigger_render_with_window` does
+  today — using the dimensions of whichever window it was granted, since under §8.5 it holds no
+  window of its own between frames and never allocates one. No `Credit`: §8.6 explains why
+  ownership of the window already carries that bound. This
   logic stays in `pixelflow-runtime`, not `pixelflow-graphics`, since it's runtime coordinate
   mapping, not general rasterization (`CLAUDE.md`: no terminal-adjacent logic in the graphics
   crate).
@@ -422,9 +423,10 @@ the point→pixel dimap warp in `pixelflow-runtime`. Left implicit, this reads a
 windows straight to `RasterizerActor`," which is not implementable and not what was proven.
 
 So `rasterizer` in the graph is a **runtime-side coordinator**: it holds the latest manifold and
-the render `Credit(1)`; it does the coordinate warp; it owns the graphics `RasterizerActor` as a
-worker behind it, via the same bootstrap handshake used today. It does *not* hold a window
-between frames — §8.5 explains why that would put the allocator on the wrong side.
+a "request outstanding" flag; it does the coordinate warp; it owns the graphics
+`RasterizerActor` as a worker behind it, via the same bootstrap handshake used today. It does
+*not* hold a window between frames — §8.5 explains why that would put the allocator on the wrong
+side — and carries no `Credit`, since §8.6 shows ownership of the window already bounds the loop.
 
 Collapsing those two into one node is sound rather than convenient, and the reason is worth
 stating because it's the property that must not silently change: **`RasterizerActor` is a leaf.**
@@ -461,12 +463,14 @@ information to chase it across the mesh, and every route it can take is either u
 **The fix is to move allocation, not to route information better.** The driver keeps the window
 between frames and remains its allocator. The coordinator *pulls* one when it actually has work:
 
-1. `rasterizer → driver`: window request, sent when a manifold is held and `Credit(1)` allows.
-   **The credit is consumed here and held for the whole round trip.**
+1. `rasterizer → driver`: window request, sent when a manifold is held, no window is held, and
+   no request is already outstanding. (An earlier draft gated this on a `Credit(1)` held across
+   the round trip; §8.6 shows why that cannot work and why ownership already suffices.)
 2. `driver → rasterizer`: the window it already holds — always correctly sized, because the
    driver resized it in place when the OS said so.
 3. `rasterizer → driver`: `Present` once rendered. The driver presents it and retains it, ready
-   for the next request. **The credit is released only here**, once the window is home.
+   for the next request — and now holds the window again, which is what re-enables the next
+   grant.
 
 **There is no resize notification anywhere in the render pipeline, so none can be dropped.** On
 resize the driver swaps its held buffer for a correctly-sized one and tells nobody. The

--- a/docs/designs/pixelflow-runtime-engine-mesh-migration.md
+++ b/docs/designs/pixelflow-runtime-engine-mesh-migration.md
@@ -403,7 +403,7 @@ its own follow-up rather than bundled with the proof:
 - `rasterizer`'s bootstrap (today `EngineHandler::spawn_rasterizer`) moves out of
   `EngineHandler` entirely — the rasterizer becomes a directly-wired mesh participant with its
   own initialization, not something the mediator stands up on the mediator's behalf.
-- A new piece of runtime-side state holds the latest manifold and a "request outstanding" flag,
+- A new piece of runtime-side state holds the latest manifold (no request flag — see §8.8),
   and performs the point-space → pixel-space dimap warp that `trigger_render_with_window` does
   today — using the dimensions of whichever window it was granted, since under §8.5 it holds no
   window of its own between frames and never allocates one. No `Credit`: §8.6 explains why
@@ -423,7 +423,7 @@ the point→pixel dimap warp in `pixelflow-runtime`. Left implicit, this reads a
 windows straight to `RasterizerActor`," which is not implementable and not what was proven.
 
 So `rasterizer` in the graph is a **runtime-side coordinator**: it holds the latest manifold and
-a "request outstanding" flag; it does the coordinate warp; it owns the graphics
+no request flag (§8.8); it does the coordinate warp; it owns the graphics
 `RasterizerActor` as a worker behind it, via the same bootstrap handshake used today. It does
 *not* hold a window between frames — §8.5 explains why that would put the allocator on the wrong
 side — and carries no `Credit`, since §8.6 shows ownership of the window already bounds the loop.
@@ -463,9 +463,11 @@ information to chase it across the mesh, and every route it can take is either u
 **The fix is to move allocation, not to route information better.** The driver keeps the window
 between frames and remains its allocator. The coordinator *pulls* one when it actually has work:
 
-1. `rasterizer → driver`: window request, sent when a manifold is held, no window is held, and
-   no request is already outstanding. (An earlier draft gated this on a `Credit(1)` held across
-   the round trip; §8.6 shows why that cannot work and why ownership already suffices.)
+1. `rasterizer → driver`: window request, re-sent on every tick while a manifold is held and no
+   buffer is in hand or out at the worker. Deliberately **not** gated on an outstanding-request
+   flag — §8.8 explains why that stalls forever the first time a request is dropped. (An earlier
+   draft gated it on a `Credit(1)` held across the round trip; §8.6 shows why that cannot work
+   and why ownership already suffices.)
 2. `driver → rasterizer`: the window it already holds — always correctly sized, because the
    driver resized it in place when the OS said so.
 3. `rasterizer → driver`: `Present` once rendered. The driver presents it and retains it, ready
@@ -543,17 +545,20 @@ There is exactly one `Window`, and it is moved, never copied. Therefore:
   cannot grant again until `Present` returns it. At most one grant is ever in flight, and the
   ring is provisioned ≥ 1 — so the grant ring is never full, and its droppable backstop is dead
   code. No counter required; `Option<Window>` *is* the counter.
-- **The coordinator can only `Present` while it holds the window**, which it does only between a
-  grant and that `Present`. Same argument, same conclusion.
+- **The coordinator *and its worker* hold the buffer for the whole interval between a grant and
+  the matching `Present`.** An earlier draft said "the coordinator holds it," which is false:
+  §7.1 tears the granted `Window` into the request's `frame` and `meta`, and the frame is inside
+  the request the graphics worker owns while rendering. The bound survives — but only because the
+  *pair* holds it, which puts a real obligation on the internal hand-off (§8.8).
 - **The request carries no resource**, so it is the one genuinely losable message here. A dropped
-  request costs one frame and the next vsync tick issues another — *actual* acceptable loss, of
-  the kind §3 distinguishes from structural unreachability.
+  request costs one frame and the next tick issues another — *actual* acceptable loss, of the
+  kind §3 distinguishes from structural unreachability.
 
-The coordinator's gate becomes a plain question about its own state: *do I hold a manifold, am I
-not currently holding a window, and is no request outstanding?* The middle clause is what covers
-the render window — while rendering it holds the window, so it cannot request another regardless
-of how many manifolds arrive. That is the concern §8.5's round-trip credit was introduced to
-address, handled by ownership instead of by a counter.
+The coordinator's gate becomes a plain question about its own state: *do I hold a manifold, and
+is no buffer currently in hand or out at the worker?* Deliberately **not** "is a request
+outstanding" — see §8.8: a flag only a grant could clear stalls forever the first time a request
+is dropped. Re-requesting every tick is safe because the driver can only grant what it holds, so
+a duplicate finds nothing to give.
 
 **Rule.** Where a resource is unique and moved rather than copied, ownership already enforces
 the bound a `Credit` would encode. Adding one duplicates the invariant into a place it can drift
@@ -600,8 +605,18 @@ the only actor that can obtain OS-backed memory at all, and a dropped buffer is 
 frame," it is a lost allocation that must be remade, in the one place the design is trying to
 never allocate.
 
-So the rule is stronger than uniqueness: **a buffer is never dropped, on any path.** Two places
-currently violate it, both found by review:
+So the rule is stronger than uniqueness — but it is not "never destroy a buffer," because §8.7
+*requires* destroying one: on resize the old buffer is the wrong size and must be replaced. The
+distinction is **who decides**:
+
+- **Deliberate replacement by the owner** is correct and necessary. The driver holds the buffer,
+  observes the OS changed the size, frees it, allocates the right one. Nothing is lost, because
+  the actor responsible for the buffer chose this and knows the new state.
+- **Accidental loss in transit** is what must never happen. A message drop destroys a buffer that
+  *nobody decided* to destroy, and — worse — leaves both parties believing the other has it.
+
+**So: a buffer is only ever destroyed by the actor that owns it, deliberately, never by a
+delivery failure.** Two places currently violate that, both found by review:
 
 **1. A dropped request stalls rendering forever.** An earlier draft gated requests on an
 "outstanding request" flag, cleared only by a grant. Since the request edge is droppable, a

--- a/docs/designs/pixelflow-runtime-engine-mesh-migration.md
+++ b/docs/designs/pixelflow-runtime-engine-mesh-migration.md
@@ -340,27 +340,30 @@ waiting" to decide when to render. That decision, and the edges it implies, need
 treatment every edge in §3 got — proven before any live actor changes — because it invents two
 edges (`driver` ↔ `rasterizer`) that never existed in the mesh before.
 
-**The match logic lives in `rasterizer`.** `driver` pushes a window the moment one is free
-(`WindowCreated`, or a window returned from a prior `Present`) rather than tracking whether a
-manifold is waiting — it stays exactly as stateless about the render pipeline as §7.3 already
-said. `app` pushes its latest manifold (droppable, keep-latest, same semantics as today).
-`rasterizer` holds both, and renders when it has a window, a manifold, and its own `Credit(1)`
-allows it — colocated with the credit that already gates rendering, rather than split across an
-actor that only relays.
+**The match logic lives in `rasterizer`, and the window is pulled rather than pushed** (§8.5
+explains why). `app` pushes its latest manifold (droppable, keep-latest, same semantics as
+today). `rasterizer` holds that manifold and a `Credit(1)`; when it has work and the credit
+allows, it *requests* a window. `driver` keeps the window between frames, stays its allocator,
+and grants the one it already holds — always correctly sized, because the driver resized it in
+place when the OS said so. `rasterizer` renders into it and `Present`s it back; the driver
+presents and retains it for the next request.
 
 The resulting edges, added to `pixelflow-runtime/tests/target_topology.rs`:
 
 | Edge | Direction | Kind |
 |---|---|---|
-| Window request ("I have work, give me a buffer") | rasterizer → driver | Droppable, Credit(1) |
-| Window grant (correctly sized, driver-allocated) | driver → rasterizer | Droppable, shares that credit |
+| Window request ("I have work, give me a buffer") | rasterizer → driver | Droppable, **Credit(1) consumed here** |
+| Window grant (correctly sized, driver-allocated) | driver → rasterizer | Droppable, same credit still held |
+| `Present` | rasterizer → driver | Droppable, **credit released here** |
 | Manifold submission | app → rasterizer | Droppable, keep-latest |
-| `Present` | rasterizer → driver | Droppable |
 | Frame-rendered notice (FPS telemetry) | rasterizer → vsync | Droppable, no credit |
 | `ReturnToken` | app → vsync | Droppable, no credit |
 
-**The window is pulled, not pushed** — see §8.5 for why that specific choice, which is what
-makes every "Droppable" in this table honest rather than asserted.
+**The one credit spans the entire round trip** — request → grant → render → `Present` — and is
+released only when the window is back with the driver. It is emphatically *not* released at the
+grant: doing so would let a second manifold trigger a request the driver cannot satisfy, since
+it no longer holds a window to give. See §8.5; this is what makes the three droppable backstops
+structurally unreachable rather than merely unlikely.
 
 Two of these delete an existing edge rather than add one: `engine → driver` (`Present`) and
 `driver → engine` (`PresentComplete`) are gone — `rasterizer` presents directly now. `engine ↔
@@ -460,28 +463,44 @@ either unreliable (droppable, loses state permanently) or blocks the main thread
 between frames and remains its allocator. The coordinator *pulls* one when it actually has work:
 
 1. `rasterizer → driver`: window request, sent when a manifold is held and `Credit(1)` allows.
+   **The credit is consumed here and held for the whole round trip.**
 2. `driver → rasterizer`: the window it already holds — always correctly sized, because the
    driver resized it in place when the OS said so.
-3. `rasterizer → driver`: `Present` once rendered. The driver presents it and **retains it**,
-   ready for the next request.
+3. `rasterizer → driver`: `Present` once rendered. The driver presents it and retains it, ready
+   for the next request. **The credit is released only here**, once the window is home.
 
 **There is no resize notification anywhere in the render pipeline, so none can be dropped.** On
 resize the driver swaps its held buffer for a correctly-sized one and tells nobody. The
 coordinator never learns dimensions because it never allocates. The problem isn't solved, it's
 absent.
 
-This also makes every droppable edge here safe for the *stated* reason rather than an asserted
-one, satisfying the test §8.5's predecessor articulated — losing a message must be recoverable by
-a subsequent one:
+**Why the credit must span the round trip, and why "recoverable" was the wrong justification.**
 
-- A dropped **request** costs one frame; the next vsync tick issues another.
-- A dropped **grant** costs one frame; the credit is released and the next request re-asks.
-- A dropped **`Present`** costs one frame; the driver still holds a valid window.
+An earlier draft of this section argued the droppable edges were safe because a dropped message
+costs one frame and *the sender still holds the authoritative copy to resend*. **That argument is
+false**, and review was right to reject it: `Window` owns the framebuffer and is sent **by
+value**. `send_port` destroys the message on a full droppable ring. So a dropped grant leaves the
+driver with nothing — it moved the window out — and a dropped `Present` leaves nobody holding it.
+The sole render buffer is destroyed, permanently, not delayed by a frame. There is exactly one
+`Window`; no edge carrying it is ever safe on "recovery" grounds.
 
-In every case the *sender retains the authoritative copy*. That is the property that was missing
-before: the original design had the driver send its only window and forget it, which is what made
-a dropped message unrecoverable. **Droppable is safe when the sender can resend** — not when the
-message merely sounds idempotent.
+Safety here comes from the drop being **impossible**, which is §3's *structurally unreachable*
+category — the argument this doc already established for `Present`/`PresentComplete` and which
+the "recoverable" framing needlessly abandoned:
+
+- The coordinator cannot request without consuming the single credit.
+- The credit is not released until the window is back with the driver, so **at most one message
+  carrying the window is in flight across all three edges at any instant.**
+- Each ring is provisioned ≥ 1. A ring holding at most one message, sent only when the previous
+  round trip completed, is never full at the moment of sending.
+
+So the droppable backstop on all three edges is dead code in the well-behaved system, exactly as
+§3 intends — present for `Topology`'s proof, unreachable by construction. Releasing the credit at
+the *grant* instead would break this directly: a second manifold could trigger a request while
+the window is still out being rendered, and the driver would have nothing to grant.
+
+**Droppable is safe when the drop cannot occur, or when the message is genuinely replaceable.**
+Never because a sender "could resend" something it moved away.
 
 **Consequence for the coordinator.** It shrinks: manifold plus `Credit(1)`, no `latest_window`,
 no reallocation logic, no dimension tracking. It still performs the point→pixel dimap warp, using

--- a/docs/designs/pixelflow-runtime-engine-mesh-migration.md
+++ b/docs/designs/pixelflow-runtime-engine-mesh-migration.md
@@ -352,11 +352,15 @@ The resulting edges, added to `pixelflow-runtime/tests/target_topology.rs`:
 
 | Edge | Direction | Kind |
 |---|---|---|
-| Window available (created, or returned from Present) | driver → rasterizer | Droppable, no credit |
+| Window request ("I have work, give me a buffer") | rasterizer → driver | Droppable, Credit(1) |
+| Window grant (correctly sized, driver-allocated) | driver → rasterizer | Droppable, shares that credit |
 | Manifold submission | app → rasterizer | Droppable, keep-latest |
-| Present | rasterizer → driver | Droppable, shares the ping-pong buffer's Credit(1) |
+| `Present` | rasterizer → driver | Droppable |
 | Frame-rendered notice (FPS telemetry) | rasterizer → vsync | Droppable, no credit |
 | `ReturnToken` | app → vsync | Droppable, no credit |
+
+**The window is pulled, not pushed** — see §8.5 for why that specific choice, which is what
+makes every "Droppable" in this table honest rather than asserted.
 
 Two of these delete an existing edge rather than add one: `engine → driver` (`Present`) and
 `driver → engine` (`PresentComplete`) are gone — `rasterizer` presents directly now. `engine ↔
@@ -406,31 +410,6 @@ its own follow-up rather than bundled with the proof:
 - `app`'s handle setup gains a second target: today `Application` only reaches `engine`; it
   needs a way to reach `rasterizer` (manifold) and `vsync` (`ReturnToken`) directly.
 
-### 8.3 Window-lifecycle events: tear, don't copy, and don't reroute
-
-`WindowCreated`/`Resized` have two consumers with genuinely different needs: `app` wants to know
-the new dimensions, and the render pipeline wants the buffer. A first pass at §8 handled this by
-adding a `rasterizer → app` edge — rasterizer would open the `Window`, pull the metadata out, and
-relay it onward — on the reasoning that feeding both consumers otherwise meant cloning the frame
-buffer, which `Frame: Clone` makes silently possible and which would be a real per-frame cost.
-
-That reasoning was wrong at its root: **a frame buffer copy was never an option to weigh.** The
-`Window` circulates by ownership transfer; that *is* the ping-pong buffer. Treating a clone as
-one arm of a trade-off, even to reject it, is how a copy eventually ends up in the render loop.
-
-The correct answer is the one §7.1 already established, applied a second time: a `Window` tears
-into `WindowMeta` (four scalars, `Copy`) and `Frame` (expensive, moves). So the driver sends
-**metadata** to engine over the existing Blocking `DisplayEvent` edge — engine relays to app
-exactly as it does today, unchanged — and sends **the window** to rasterizer. Both consumers are
-served, nothing is copied, and the graph gains no edge at all.
-
-This also keeps `rasterizer` from learning about `app`, which the discarded version required.
-Colocating a relay with the data sounds tidy until it means the renderer holds a handle to the
-application to forward window metadata it doesn't otherwise care about.
-
-The general rule this is the second instance of: **when two actors need different parts of one
-value, split the value — don't duplicate it, and don't reroute one consumer through the other.**
-
 ### 8.4 What the `rasterizer` node actually is
 
 The proof's `rasterizer` node is **not** `pixelflow-graphics`'s `RasterizerActor`. It can't be:
@@ -453,49 +432,61 @@ the DAG result either way.
 The moment that stops being true — if the worker ever gains a handle to a third actor — it stops
 being collapsible and has to enter the proof as its own node. That is the tripwire.
 
-### 8.5 Resize must not mint a window — droppable is the opposite of keep-latest
+### 8.5 The window is pulled, not pushed — and why §8 needed three tries
 
-Automated review (Codex, on #920) caught a real defect in §8.3's split, and it is worth recording
-in full because it is the *third* instance this session of the same underlying mistake.
+This section replaces two earlier ones (a "tear the Window, send metadata to engine and the
+buffer to rasterizer" split, and a follow-up "resize must not mint a window" patch). Both are
+deleted rather than annotated, because keeping a chain of superseded fixes would obscure what
+turned out to be a single wrong decision underneath all three.
 
-**The defect.** `send_port` with `Delivery::Droppable` discards the **new** message when the ring
-is full (`actor-scheduler/src/mealy.rs`: `Err(TrySendError::Full(_)) => Flush::Done`, payload
-dropped). Keep-latest semantics need the **old** one dropped. Those are opposites. For manifold
-submission the difference is harmless — another manifold arrives next frame — but the platform
-mints a *fresh, correctly sized* `Frame` on every `Resized`/scale-change
-(`Frame::<PlatformPixel>::new(px_w, px_h)`, in two places). Dropping that message discards the
-only correctly-sized buffer in existence, and nothing replaces it until the next resize. The app
-would be told the new dimensions over the reliable Blocking edge while the rasterizer kept
-rendering at the old size. Reachable during any resize drag, since rasterization is synchronous.
+**What went wrong, three times.** Automated review caught each in turn: (1) a `rasterizer → app`
+edge invented to avoid a frame-buffer clone that was never an acceptable option to begin with;
+(2) resize windows sent over a droppable edge, where a full ring discards the *new* message and
+keep-latest requires discarding the *old* one — so the only correctly-sized buffer could be lost
+with no replacement until the next resize; (3) the fix for (2) left the coordinator responsible
+for reallocating on resize while giving it no edge over which to learn the dimensions had
+changed, and routing that metadata over a droppable edge would have reproduced (2) exactly.
 
-This is precisely the §3 distinction — *structurally unreachable* vs *genuinely acceptable loss*
-— applied wrongly: the window edge was filed under the second when it belonged under neither.
+Three patches, each exposing the next problem, is a decomposition error rather than a detail
+error. **The root cause: frame allocation was on the coordinator, but window size is
+driver-authoritative** — the OS decides it. Putting the allocator on the side that doesn't know
+the size forces size information to chase it across the mesh, and every route it can take is
+either unreliable (droppable, loses state permanently) or blocks the main thread.
 
-**The fix is to stop minting windows on resize, not to change how delivery works.** A resize does
-not produce a rendered buffer; it produces *new dimensions* plus an empty allocation. Sending an
-empty correctly-sized buffer is an expensive way to communicate two integers. `Frame<P>` is a
-plain `Vec<P>` — verified: no XShm segment, no IOSurface, nothing platform-backed; X11's
-`present` merely points an `XImage` at the `Vec`'s data — so there is no reason the *driver* must
-be the allocator.
+**The fix is to move allocation, not to route information better.** The driver keeps the window
+between frames and remains its allocator. The coordinator *pulls* one when it actually has work:
 
-So: on resize the driver sends **metadata only** (`WindowMeta`, `Copy`, over the existing
-reliable edge). The rasterizer coordinator owns `latest_window` and reallocates its own frame
-when it observes the dimensions changed, before the next render.
+1. `rasterizer → driver`: window request, sent when a manifold is held and `Credit(1)` allows.
+2. `driver → rasterizer`: the window it already holds — always correctly sized, because the
+   driver resized it in place when the OS said so.
+3. `rasterizer → driver`: `Present` once rendered. The driver presents it and **retains it**,
+   ready for the next request.
 
-Two things fall out, and the second is the one that matters:
+**There is no resize notification anywhere in the render pipeline, so none can be dropped.** On
+resize the driver swaps its held buffer for a correctly-sized one and tells nobody. The
+coordinator never learns dimensions because it never allocates. The problem isn't solved, it's
+absent.
 
-1. **The bug is gone by construction.** No window travels on resize, so there is no window to
-   drop. Delivery semantics didn't need changing.
-2. **"Exactly one window circulates" becomes actually true.** It wasn't. Today a resize mints a
-   second `Window` while another may still be in flight to or from the rasterizer — which
-   quietly invalidated the `Credit(1)` reasoning that §3 rests on for `Present`/`PresentComplete`.
-   The invariant was being asserted, not held. Now windows travel on exactly three occasions:
-   `WindowCreated` (bootstrap, one-shot), `Present`, and `PresentComplete`.
+This also makes every droppable edge here safe for the *stated* reason rather than an asserted
+one, satisfying the test §8.5's predecessor articulated — losing a message must be recoverable by
+a subsequent one:
 
-The graph is unchanged — `driver → rasterizer` still exists, it just carries `PresentComplete`
-and the one bootstrap `WindowCreated` rather than resize windows. No edge added, none removed.
+- A dropped **request** costs one frame; the next vsync tick issues another.
+- A dropped **grant** costs one frame; the credit is released and the next request re-asks.
+- A dropped **`Present`** costs one frame; the driver still holds a valid window.
 
-**The general lesson, third instance.** "Droppable" is not a synonym for "keep-latest." An edge
-is only safe to declare droppable if losing *that specific message* is recoverable by a
-subsequent one. Where the message is the sole carrier of unique state, dropping it is
-unrecoverable no matter how idempotent the *concept* sounds.
+In every case the *sender retains the authoritative copy*. That is the property that was missing
+before: the original design had the driver send its only window and forget it, which is what made
+a dropped message unrecoverable. **Droppable is safe when the sender can resend** — not when the
+message merely sounds idempotent.
+
+**Consequence for the coordinator.** It shrinks: manifold plus `Credit(1)`, no `latest_window`,
+no reallocation logic, no dimension tracking. It still performs the point→pixel dimap warp, using
+the dimensions of the window it was handed.
+
+**Consequence for `Present`/`PresentComplete`.** `PresentComplete` disappears entirely as a
+message. The driver never gave the window away permanently, so there is nothing to hand back —
+the "return" half of the ping-pong is just the driver keeping what it always owned. That also
+retires an invariant §3 had been asserting but not holding: "exactly one window circulates" was
+untrue while resize could mint a second one mid-flight. Now exactly one window *exists*, and it
+never leaves the driver except for the duration of a single render.

--- a/docs/designs/pixelflow-runtime-engine-mesh-migration.md
+++ b/docs/designs/pixelflow-runtime-engine-mesh-migration.md
@@ -332,376 +332,67 @@ exists, and shrinks the surface the collapse has to move. Only then do `window` 
 
 ---
 
-## 8. The render pipeline's actual edges — proven before wiring anything
-
-§7 decided where `EngineHandler`'s *state* goes. It didn't decide who performs the one
-remaining piece of logic that isn't state: matching "a window is free" against "a manifold is
-waiting" to decide when to render. That decision, and the edges it implies, needed the same
-treatment every edge in §3 got — proven before any live actor changes — because it invents two
-edges (`driver` ↔ `rasterizer`) that never existed in the mesh before.
-
-**The match logic lives in `rasterizer`, and the window is pulled rather than pushed** (§8.5
-explains why). `app` pushes its latest manifold (droppable, keep-latest, same semantics as
-today). `rasterizer` holds that manifold; when it has work and is not already holding a window
-or awaiting one, it *requests* a window. `driver` keeps the window between frames, stays its allocator,
-and grants the one it already holds — always correctly sized, because the driver resized it in
-place when the OS said so. `rasterizer` renders into it and `Present`s it back; the driver
-presents and retains it for the next request.
-
-The resulting edges, added to `pixelflow-runtime/tests/target_topology.rs`:
-
-| Edge | Direction | Kind |
-|---|---|---|
-| Tick (drives request retries) | vsync → rasterizer | Droppable — genuinely losable, next tick retries |
-| Window request ("I have work, give me a buffer") | rasterizer → driver | Droppable, **Management lane** — genuinely losable, carries nothing |
-| Window grant (correctly sized, driver-allocated) | driver → rasterizer | Droppable, **unreachable**: driver can't grant what it doesn't hold |
-| `Present` | rasterizer → driver | Droppable, **Data lane**, **unreachable** — see §8.9 for why the lane matters |
-| Manifold submission | app → rasterizer | Droppable, keep-latest |
-| Frame-rendered notice (FPS telemetry) | rasterizer → vsync | Droppable, no credit |
-| `ReturnToken` | app → vsync | Droppable, no credit |
-
-**There is no `Credit` on this loop.** Ownership of the single `Window` is already the bound —
-see §8.6. Rust will not let an actor send a window it does not hold, so "at most one in flight"
-is a property of the type rather than a counter that has to be kept in sync with it.
-
-Two of these delete an existing edge rather than add one: `engine → driver` (`Present`) and
-`driver → engine` (`PresentComplete`) are gone — `rasterizer` presents directly now. `engine ↔
-rasterizer` and `engine → vsync` (`RenderedResponse`) are gone entirely; nothing uses that pair
-any more. `app → engine` (`AppData::RenderSurface`) is also gone: the message that used to
-double as both "here is the manifold" and "return my vsync token" now travels as two direct
-sends, to the two actors that actually need each half.
-
-`ReturnToken` closes a small pre-existing gap in this proof: it was already an `engine → vsync`
-Control-lane send, but never modeled as its own edge — modeled now, since it travels a new edge
-anyway.
-
-`the_target_engine_mesh_is_a_dag` is **updated in place**, not duplicated, matching this file's
-own stated purpose of staying valid across the rollout. A new `regressed_render_pipeline_
-framing_is_cyclic` test records the shape of mistake most likely to recur here: treating "only
-one window ever circulates" as license to make the driver ↔ rasterizer hand-off synchronous in
-both directions. It's the identical error §3.1 caught for driver ↔ engine, just with a fresh
-pair of actors — two blocking edges between the same pair is a cycle regardless of whether the
-conversations are logically unrelated.
-
-### 8.1 Explicitly out of scope for this slice
-
-`engine` remains a node in the proven graph — this is a render-pipeline-only cut, not the full
-deletion. Left alone, and routed through `engine` exactly as today:
-
-- Input-event forwarding (`driver → engine`, Blocking).
-- `AppManagement` commands — `SetTitle`, `SetSize`, `SetCursor`, `Copy`, `RequestPaste`,
-  `CreateWindow` — and their replies (`PasteData`).
-- The vsync-tick → `RequestFrame` relay (`vsync → engine → app`).
-
-Moving these is a separate, later slice: none of them touch the state this doc's §7 already
-redistributed, and folding them in here would make one change cover two independent decisions.
-
-### 8.2 What implementing this actually requires
-
-Wiring these edges for real is a larger change than §7's field deletions were, and is scoped as
-its own follow-up rather than bundled with the proof:
-
-- `rasterizer`'s bootstrap (today `EngineHandler::spawn_rasterizer`) moves out of
-  `EngineHandler` entirely — the rasterizer becomes a directly-wired mesh participant with its
-  own initialization, not something the mediator stands up on the mediator's behalf.
-- A new piece of runtime-side state holds the latest manifold (no request flag — see §8.8),
-  and performs the point-space → pixel-space dimap warp that `trigger_render_with_window` does
-  today — using the dimensions of whichever window it was granted, since under §8.5 it holds no
-  window of its own between frames and never allocates one. No `Credit`: §8.6 explains why
-  ownership of the window already carries that bound. This
-  logic stays in `pixelflow-runtime`, not `pixelflow-graphics`, since it's runtime coordinate
-  mapping, not general rasterization (`CLAUDE.md`: no terminal-adjacent logic in the graphics
-  crate).
-- `app`'s handle setup gains a second target: today `Application` only reaches `engine`; it
-  needs a way to reach `rasterizer` (manifold) and `vsync` (`ReturnToken`) directly.
-
-### 8.4 What the `rasterizer` node actually is
-
-The proof's `rasterizer` node is **not** `pixelflow-graphics`'s `RasterizerActor`. It can't be:
-that crate is deliberately runtime-agnostic and names no runtime concept — no `Window`, no
-`driver`, no `vsync`, no `Application` — and §8.2 already places the window/manifold pairing and
-the point→pixel dimap warp in `pixelflow-runtime`. Left implicit, this reads as "driver sends
-windows straight to `RasterizerActor`," which is not implementable and not what was proven.
-
-So `rasterizer` in the graph is a **runtime-side coordinator**: it holds the latest manifold and
-no request flag (§8.8); it does the coordinate warp; it owns the graphics
-`RasterizerActor` as a worker behind it, via the same bootstrap handshake used today. It does
-*not* hold a window between frames — §8.5 explains why that would put the allocator on the wrong
-side — and carries no `Credit`, since §8.6 shows ownership of the window already bounds the loop.
-
-Collapsing those two into one node is sound rather than convenient, and the reason is worth
-stating because it's the property that must not silently change: **`RasterizerActor` is a leaf.**
-Its only outbound channel is `response_tx`, back to whoever registered it — it holds no handle to
-any other actor and initiates contact with nobody. A node whose sole peer is its caller, with a
-droppable reply, cannot participate in a cycle with the rest of the graph, so it cannot affect
-the DAG result either way.
-
-The moment that stops being true — if the worker ever gains a handle to a third actor — it stops
-being collapsible and has to enter the proof as its own node. That is the tripwire.
-
-### 8.5 The window is pulled, not pushed — and why the first attempts failed
-
-This section replaces two earlier ones (a "tear the Window, send metadata to engine and the
-buffer to rasterizer" split, and a follow-up "resize must not mint a window" patch). Both are
-deleted rather than annotated, because keeping a chain of superseded fixes would obscure what
-turned out to be a single wrong decision underneath all three.
-
-**What went wrong.** Automated review caught a run of defects that all turned out to share one
-cause: a `rasterizer → app` edge invented to dodge a frame-buffer clone that was never an
-acceptable option; resize windows sent over a droppable edge, where a full ring discards the
-*new* message while keep-latest requires discarding the *old* one, losing the only
-correctly-sized buffer with no replacement until the next resize; and then a fix for *that* which
-left the coordinator responsible for reallocating on resize without any edge over which to learn
-the dimensions had changed — where routing that metadata over a droppable edge would have
-reproduced the previous defect exactly.
-
-Each patch exposing the next is a decomposition error rather than a detail error. **The root
-cause: frame allocation was on the coordinator, but window size is driver-authoritative** — the
-OS decides it. Putting the allocator on the side that doesn't know the size forces size
-information to chase it across the mesh, and every route it can take is either unreliable
-(droppable, loses state permanently) or blocks the main thread.
-
-**The fix is to move allocation, not to route information better.** The driver keeps the window
-between frames and remains its allocator. The coordinator *pulls* one when it actually has work:
-
-1. `rasterizer → driver`: window request, re-sent on every tick while a manifold is held and no
-   buffer is in hand or out at the worker. Deliberately **not** gated on an outstanding-request
-   flag — §8.8 explains why that stalls forever the first time a request is dropped. (An earlier
-   draft gated it on a `Credit(1)` held across the round trip; §8.6 shows why that cannot work
-   and why ownership already suffices.)
-2. `driver → rasterizer`: the window it already holds — always correctly sized, because the
-   driver resized it in place when the OS said so.
-3. `rasterizer → driver`: `Present` once rendered. The driver presents it and retains it, ready
-   for the next request — and now holds the window again, which is what re-enables the next
-   grant.
-
-**There is no resize notification anywhere in the render pipeline, so none can be dropped.** On
-resize the driver swaps its held buffer for a correctly-sized one and tells nobody. The
-coordinator never learns dimensions because it never allocates. The problem isn't solved, it's
-absent.
-
-**Why the credit must span the round trip, and why "recoverable" was the wrong justification.**
-
-An earlier draft of this section argued the droppable edges were safe because a dropped message
-costs one frame and *the sender still holds the authoritative copy to resend*. **That argument is
-false**, and review was right to reject it: `Window` owns the framebuffer and is sent **by
-value**. `send_port` destroys the message on a full droppable ring. So a dropped grant leaves the
-driver with nothing — it moved the window out — and a dropped `Present` leaves nobody holding it.
-The sole render buffer is destroyed, permanently, not delayed by a frame. There is exactly one
-`Window`; no edge carrying it is ever safe on "recovery" grounds.
-
-Safety here comes from the drop being **impossible**, which is §3's *structurally unreachable*
-category — the argument this doc already established for `Present`/`PresentComplete` and which
-the "recoverable" framing needlessly abandoned:
-
-- The coordinator cannot request without consuming the single credit.
-- The credit is not released until the window is back with the driver, so **at most one message
-  carrying the window is in flight across all three edges at any instant.**
-- Each ring is provisioned ≥ 1. A ring holding at most one message, sent only when the previous
-  round trip completed, is never full at the moment of sending.
-
-So the droppable backstop on all three edges is dead code in the well-behaved system, exactly as
-§3 intends — present for `Topology`'s proof, unreachable by construction. Releasing the credit at
-the *grant* instead would break this directly: a second manifold could trigger a request while
-the window is still out being rendered, and the driver would have nothing to grant.
-
-**Droppable is safe when the drop cannot occur, or when the message is genuinely replaceable.**
-Never because a sender "could resend" something it moved away.
-
-**Consequence for the coordinator.** It shrinks to the latest manifold and whether a buffer is
-currently in hand — no `latest_window`, no reallocation logic, no dimension tracking, no
-`Credit` (§8.6), and no outstanding-request flag (§8.8). It still performs the point→pixel dimap
-warp, using the dimensions of the window it was handed.
-
-**Consequence for `Present`/`PresentComplete`.** `PresentComplete` disappears entirely as a
-message. Previously the window made a full circuit — `Present` carried it to the driver and
-`PresentComplete` carried it back to the engine, which was its resting owner between frames. Now
-the **driver** is the resting owner, so `Present` *is* the return: it hands the window back to
-the actor that already keeps it, and no separate acknowledgement is needed. The window still
-moves by value on every hop; what's gone is the second hop.
-
-That also retires an invariant §3 had been asserting but not holding: "exactly one window
-circulates" was untrue while resize could mint a second one mid-flight. Now exactly one window
-*exists*, and it is away from the driver only for the duration of a single render.
-
-### 8.6 Ownership is the bound — delete the credit
-
-§8.5 put a `Credit(1)` on the render loop, consumed at the request and released when `Present`
-returned the window. Review showed that cannot work, and the reason is worth keeping:
-
-**`Credit` is requester-local, and `send_port` reports `Flush::Done` whether it delivered or
-dropped.** So the coordinator can never learn that its `Present` arrived. Release the credit when
-*emitting* `Present` and a dropped delivery restores the credit while destroying the only window
-— which makes the drop-impossibility argument circular, since it assumed the credit bounded the
-edge. Never release it and rendering halts after one frame. With a coordinator-local credit and
-no acknowledgement, there is no third option.
-
-The available fixes were to reinstate a `PresentComplete` acknowledgement, or invent a
-transferable permit. Both are machinery. **The subtraction is to notice the credit was modelling
-something the type system already guarantees: you cannot send a `Window` you do not hold.**
-
-There is exactly one `Window`, and it is moved, never copied. Therefore:
-
-- **The driver can only grant while it holds the window.** Having granted, it holds nothing and
-  cannot grant again until `Present` returns it. At most one grant is ever in flight, and the
-  ring is provisioned ≥ 1 — so the grant ring is never full, and its droppable backstop is dead
-  code. No counter required; `Option<Window>` *is* the counter.
-- **The coordinator *and its worker* hold the buffer for the whole interval between a grant and
-  the matching `Present`.** An earlier draft said "the coordinator holds it," which is false:
-  §7.1 tears the granted `Window` into the request's `frame` and `meta`, and the frame is inside
-  the request the graphics worker owns while rendering. The bound survives — but only because the
-  *pair* holds it, which puts a real obligation on the internal hand-off (§8.8).
-- **The request carries no resource**, so it is the one genuinely losable message here. A dropped
-  request costs one frame and the next tick issues another — *actual* acceptable loss, of the
-  kind §3 distinguishes from structural unreachability.
-
-The coordinator's gate becomes a plain question about its own state: *do I hold a manifold, and
-is no buffer currently in hand or out at the worker?* Deliberately **not** "is a request
-outstanding" — see §8.8: a flag only a grant could clear stalls forever the first time a request
-is dropped. Re-requesting every tick is safe because the driver can only grant what it holds, so
-a duplicate finds nothing to give.
-
-**Rule.** Where a resource is unique and moved rather than copied, ownership already enforces
-the bound a `Credit` would encode. Adding one duplicates the invariant into a place it can drift
-out of sync with — and, as here, into a place that needs an acknowledgement message to maintain.
-Reach for `Credit` when the bound is *not* expressible as ownership: a count of outstanding
-requests (vsync's tick budget), or a permit held across actors that never move a value.
-
-### 8.7 Resize while the window is out being rendered
-
-§8.5 said "on resize the driver swaps its held buffer." That is only true when it *has* one.
-Between granting and `Present`, the driver holds nothing — and a resize in that gap is not a
-corner case: it is the race today's `stale` flag exists to handle, and `engine_troupe.rs`
-explicitly handles resizes arriving during both rendering and presentation.
-
-Following §8.5 literally leaves two bad options: ignore the resize and reuse the stale-sized
-buffer indefinitely, or allocate a second window and break the exactly-one invariant §8.6 now
-depends on.
-
-**The driver records pending dimensions instead of acting immediately.** It is already the size
-authority and the allocator, so remembering "the OS told me 1920×1080 while the buffer was out"
-is state that belongs to it:
-
-- Resize while the driver **holds** the window: swap the buffer now, as §8.5 said.
-- Resize while the window is **out**: store the new dimensions. Do nothing else.
-- On `Present` with pending dimensions set: the returned frame was rendered at the old size, so
-  **skip the blit** — presenting it would show a stretched or clipped frame — then replace the
-  buffer with a correctly-sized one and clear the pending dimensions. The next grant is correct.
-
-That reproduces today's behaviour exactly. The `stale` flag §7.2 deleted did precisely this job
-from the engine's side; the work does not disappear, it moves to the actor that owns the buffer,
-where it needs no cross-actor flag to coordinate — the driver observes the mismatch locally by
-comparing what it stored against what came back.
-
-One dropped frame per resize, same as today. The alternative — presenting a wrong-sized frame —
-is visibly worse and is what today's code already declines to do.
-
-### 8.8 Never drop a buffer — the ping-pong exists to reuse it
-
-The invariants above were written as "don't lose the *only* window." That undersells the
-constraint. **The ping-pong buffer exists so the framebuffer is reused rather than reallocated
-every frame.**
-
-**The design is zero-copy: the renderer writes directly into the OS framebuffer.** Under that,
-the driver is the only actor that can obtain the memory at all, which is why buffer allocation
-belongs to it and why a buffer lost in transit is not "one dropped frame" but a lost allocation
-in the one place this design is trying never to allocate.
-
-*Known deviation, tracked separately:* the current backends do not yet honour this. `Frame<P>`
-owns an ordinary `Vec<P>` and presentation **copies** it into the platform surface — macOS via
-`replaceRegion:mipmapLevel:withBytes:bytesPerRow:`, X11 via `XPutImage`. That is a defect against
-the intended design, not a constraint on it, and this section is written against the design. An
-earlier draft of this paragraph made the opposite mistake — reading the current copy as ground
-truth and concluding the driver "is not the only actor that could allocate," which would have
-weakened the ownership rule to match a bug.
-
-So the rule is stronger than uniqueness — but it is not "never destroy a buffer," because §8.7
-*requires* destroying one: on resize the old buffer is the wrong size and must be replaced. The
-distinction is **who decides**:
-
-- **Deliberate replacement by the owner** is correct and necessary. The driver holds the buffer,
-  observes the OS changed the size, frees it, allocates the right one. Nothing is lost, because
-  the actor responsible for the buffer chose this and knows the new state.
-- **Accidental loss in transit** is what must never happen. A message drop destroys a buffer that
-  *nobody decided* to destroy, and — worse — leaves both parties believing the other has it.
-
-**So: a buffer is only ever destroyed by the actor that owns it, deliberately, never by a
-delivery failure.** Two places currently violate that, both found by review:
-
-**1. A dropped request stalls rendering forever.** An earlier draft gated requests on an
-"outstanding request" flag, cleared only by a grant. Since the request edge is droppable, a
-dropped request leaves the flag set with no grant coming — the coordinator never asks again and
-the driver holds the window while rendering halts. Fixed by deleting the flag: the coordinator
-re-requests while it holds a manifold and no buffer, and duplicate requests are harmless because
-the driver can only grant what it holds.
-
-That fix needed a second half. "Re-requests every tick" is not implementable unless a tick
-actually reaches the coordinator — it is a reactive actor, waking only on messages it receives,
-and the proven graph gave it only manifolds and grants. A dropped request could then be retried
-only if the app happened to submit another manifold, which it may legitimately not do for many
-frames. So the graph gains a **`vsync → rasterizer` tick edge**: droppable and genuinely
-losable, because the next tick is the retry. This is also the shape a pull-based renderer wants
-anyway — the thing that decides when to draw should hear from the clock directly rather than
-inferring it from data arriving.
-
-**2. The graphics worker destroys the frame when paused.** `RasterCore::step_data` currently
-returns `RasterCoreOut::default()` on the paused path, consuming the `RenderRequest` — and the
-granted frame with it. Nothing then returns it to the driver. This is the same class as the outer
-edges, but *inside* the coordinator/worker pair, which is exactly why §8.6's ownership argument
-has to name the pair rather than the coordinator alone.
-
-**Required change (`pixelflow-graphics`):** every accepted `RenderRequest` must return its frame,
-including the pause path and any future error path. Paused should hand the frame back unrendered
-rather than swallow it. The worker never owns the caller's buffer — it borrows it for the
-duration of one render and is obliged to give it back regardless of outcome.
-
-That obligation is worth stating as the general form: **an actor that accepts a buffer owes it
-back on every exit path.** "Drop the work" is a safe policy for a request that carries only a
-description; it is never safe for one that carries a resource.
-
-### 8.9 `Present` and the retry requests must not share a ring
-
-§8.6 argued that ownership bounds the window-bearing messages to one in flight, so their rings
-are never full. That argument is sound about *window-bearing* traffic and silent about everything
-else — and review found the gap: **window requests and `Present` are both `rasterizer → driver`,
-so by default they share the driver's Data inbox.**
-
-Retries accumulate there. The coordinator stops requesting once a buffer is in hand, so no *new*
-request is generated during a render — but requests already queued from earlier ticks are still
-sitting in the ring when the render finishes. `Present` then arrives at a ring occupied by stale
-requests, is dropped, and destroys the sole buffer. Ownership bounds the resource; it does not
-bound the unrelated traffic sharing the resource's channel.
-
-**Fix: put them on different lanes.** The actor model already provides three
-(Control > Management > Data), each with its own ring:
-
-- **`Present` → Data lane.** It carries the frame; it is the bulk path, and it must never be
-  crowded out.
-- **Window request → Management lane.** Tiny, control-shaped, and genuinely losable. Retries
-  piling up there cannot touch the Data ring.
-
-That restores §8.6's argument by making its precondition true rather than assumed: the Data ring
-carries only window-bearing messages, of which ownership guarantees at most one.
-
-**The general form**, worth carrying into implementation: *a structural-unreachability argument
-about one message class only holds if that class has the channel to itself.* Sharing a ring with
-unbounded traffic silently converts "unreachable" into "unlikely," and unlikely is not what
-§3 means by structurally unreachable.
-
-### 8.10 Generations, not inference, decide whether a returned buffer is live
-
-§8.7 had the driver detect a superseded buffer by comparing stored dimensions against what came
-back. Implementation went further and better (`825a7d46`): buffers carry a **`Generation`**, and
-the driver decides from that rather than inferring.
-
-The inference it replaces was the weak point. Asking "is a render outstanding?" only establishes
-that *some* buffer is busy, not *which* — and dimensions alone can't distinguish a stale buffer
-from a live one that happens to match a size the window has since returned to. A generation is
-explicit: the driver stamps each buffer it allocates, tracks `current_generation`, and a returned
-buffer is live exactly when its stamp matches. No comparison of proxies, no ambiguity when sizes
-repeat.
-
-This supersedes §8.7's dimension comparison as the *mechanism*; §8.7's policy is unchanged — a
-superseded buffer's contents are not presented, and the driver replaces it before the next grant.
-Where §7.2 removed a `stale` flag one actor set inside another's record, the generation is the
-same decision made locally by the actor that owns the buffer, from data the buffer carries.
+## 8. Moving the render pipeline off `engine`
+
+Deleting the mediator means `driver`, `rasterizer`, `vsync` and `app` talk directly. This section
+is **context, not specification** — the protocol lives in the code, and
+`pixelflow-runtime/tests/target_topology.rs` is the machine-checked statement of the graph. What
+follows is the part you can't recover by reading either.
+
+### The shape
+
+The window is **pulled, not pushed**: the driver owns the framebuffer and hands it out on
+request; the coordinator asks when it has something to draw, renders, and gives it back.
+
+That direction isn't arbitrary. The OS decides window size, so the driver is the size authority —
+and the intended design is **zero-copy, the renderer writing directly into the OS framebuffer**,
+under which the driver is the only actor that can obtain the memory at all. Put allocation
+anywhere else and size information has to chase the buffer across the mesh, over edges that are
+either unreliable or block the main thread. (The current backends still copy — `Vec<P>` plus
+`replaceRegion:`/`XPutImage`. That's a known defect against the design, not a constraint on it.)
+
+The `rasterizer` node in the topology is a **runtime-side coordinator**, not
+`pixelflow-graphics`'s `RasterizerActor` — that crate is runtime-agnostic and can't name `Window`.
+The graphics actor sits behind it as a leaf worker. It's collapsed into one node in the proof
+because a leaf whose only peer is its caller can't participate in a cycle; **if it ever gains a
+handle to a third actor, that stops being true and it needs its own node.**
+
+### The judgment calls
+
+`Topology` proves acyclicity. It cannot tell you what may be lost — that's per-edge judgment, and
+it's the reason this doc exists at all:
+
+- **`[drop]` has two very different justifications.** *Structurally unreachable* (the drop path is
+  dead code) versus *genuinely acceptable loss* (dropping is normal). Conflating them is how a
+  catastrophic edge gets marked safe because it superficially resembles a harmless one.
+- **Droppable is not keep-latest.** A full ring discards the *newest* message; keep-latest needs
+  the *oldest* gone. Safe only where a subsequent message genuinely replaces the lost one.
+- **A moved resource can't be "retried."** Buffers move by value — a drop destroys them, and the
+  sender kept nothing to resend. Only messages carrying descriptions are recoverable by retry.
+- **Ownership already bounds what a `Credit` would count.** You can't send a buffer you don't
+  hold. Reach for `Credit` where the bound *isn't* ownership — outstanding request counts, permits
+  that don't move a value.
+- **A buffer is destroyed only by its owner, deliberately** — resize legitimately replaces one —
+  **never by a delivery failure**, which destroys something nobody chose to and leaves both sides
+  believing the other has it.
+
+### Known-unsettled
+
+Recorded so they aren't mistaken for solved. Each needs to be answered in code, where it can be
+checked:
+
+- **Lane separation.** Requests and `Present` share a `rasterizer → driver` direction; if they
+  share a ring, queued retries can force a `Present` drop. `Topology` doesn't model lanes, so
+  nothing currently checks this.
+- **Disconnected receivers.** `send_port` treats `Disconnected` as success and drops the payload
+  regardless of delivery kind — so a coordinator restart can destroy the buffer. Ring capacity
+  arguments don't cover this; it needs a stated terminal-failure policy.
+- **Credit-bearing replies that can be dropped.** `ReturnToken` releases vsync's tick budget; if
+  its edge can lose messages, the budget shrinks permanently. Same shape as the paste deadlock
+  in §3.2 — worth checking every credit whose release travels a droppable edge.
+- **Zero-copy.** Tracked separately; the copy in both backends is a defect, not the target.
+
+### Out of scope here
+
+`engine` remains a node for input-event forwarding, `AppManagement` commands, and the
+vsync-tick → `RequestFrame` relay. Those move in a later slice.

--- a/docs/designs/pixelflow-runtime-engine-mesh-migration.md
+++ b/docs/designs/pixelflow-runtime-engine-mesh-migration.md
@@ -602,18 +602,18 @@ The invariants above were written as "don't lose the *only* window." That unders
 constraint. **The ping-pong buffer exists so the framebuffer is reused rather than reallocated
 every frame.**
 
-*Stated precisely, because an earlier draft of this paragraph overreached:* today `Frame<P>` owns
-an ordinary `Vec<P>` and presentation **copies** it into the platform's surface — macOS via
-`replaceRegion:mipmapLevel:withBytes:bytesPerRow:`, X11 via `XPutImage`. So the driver is *not*
-currently the only actor that could allocate it. The intended direction is a pull-based renderer
-writing **directly into the OS framebuffer, zero-copy**, and under *that* the driver becomes the
-only actor able to obtain the memory at all — which is why keeping allocation there now is worth
-doing even though nothing yet forces it.
+**The design is zero-copy: the renderer writes directly into the OS framebuffer.** Under that,
+the driver is the only actor that can obtain the memory at all, which is why buffer allocation
+belongs to it and why a buffer lost in transit is not "one dropped frame" but a lost allocation
+in the one place this design is trying never to allocate.
 
-The ownership rule does not rest on that future, though, and shouldn't be read as if it does.
-It stands on what is true today: there is exactly one buffer, it is reused every frame, and a
-buffer lost in transit is a lost allocation that must be remade — in the one place this design is
-trying never to allocate.
+*Known deviation, tracked separately:* the current backends do not yet honour this. `Frame<P>`
+owns an ordinary `Vec<P>` and presentation **copies** it into the platform surface — macOS via
+`replaceRegion:mipmapLevel:withBytes:bytesPerRow:`, X11 via `XPutImage`. That is a defect against
+the intended design, not a constraint on it, and this section is written against the design. An
+earlier draft of this paragraph made the opposite mistake — reading the current copy as ground
+truth and concluding the driver "is not the only actor that could allocate," which would have
+weakened the ownership rule to match a bug.
 
 So the rule is stronger than uniqueness — but it is not "never destroy a buffer," because §8.7
 *requires* destroying one: on resize the old buffer is the wrong size and must be replaced. The
@@ -687,3 +687,21 @@ carries only window-bearing messages, of which ownership guarantees at most one.
 about one message class only holds if that class has the channel to itself.* Sharing a ring with
 unbounded traffic silently converts "unreachable" into "unlikely," and unlikely is not what
 §3 means by structurally unreachable.
+
+### 8.10 Generations, not inference, decide whether a returned buffer is live
+
+§8.7 had the driver detect a superseded buffer by comparing stored dimensions against what came
+back. Implementation went further and better (`825a7d46`): buffers carry a **`Generation`**, and
+the driver decides from that rather than inferring.
+
+The inference it replaces was the weak point. Asking "is a render outstanding?" only establishes
+that *some* buffer is busy, not *which* — and dimensions alone can't distinguish a stale buffer
+from a live one that happens to match a size the window has since returned to. A generation is
+explicit: the driver stamps each buffer it allocates, tracks `current_generation`, and a returned
+buffer is live exactly when its stamp matches. No comparison of proxies, no ambiguity when sizes
+repeat.
+
+This supersedes §8.7's dimension comparison as the *mechanism*; §8.7's policy is unchanged — a
+superseded buffer's contents are not presented, and the driver replaces it before the next grant.
+Where §7.2 removed a `stale` flag one actor set inside another's record, the generation is the
+same decision made locally by the actor that owns the buffer, from data the buffer carries.

--- a/docs/designs/pixelflow-runtime-engine-mesh-migration.md
+++ b/docs/designs/pixelflow-runtime-engine-mesh-migration.md
@@ -589,3 +589,38 @@ comparing what it stored against what came back.
 
 One dropped frame per resize, same as today. The alternative — presenting a wrong-sized frame —
 is visibly worse and is what today's code already declines to do.
+
+### 8.8 Never drop a buffer — the ping-pong exists to reuse it
+
+The invariants above were written as "don't lose the *only* window." That undersells the
+constraint. **The ping-pong buffer exists so the framebuffer is reused rather than reallocated
+every frame**, and the direction of travel is a pull-based renderer writing *directly into the OS
+framebuffer, zero-copy.* Under that goal the driver is not merely a convenient allocator — it is
+the only actor that can obtain OS-backed memory at all, and a dropped buffer is not "one lost
+frame," it is a lost allocation that must be remade, in the one place the design is trying to
+never allocate.
+
+So the rule is stronger than uniqueness: **a buffer is never dropped, on any path.** Two places
+currently violate it, both found by review:
+
+**1. A dropped request stalls rendering forever.** An earlier draft gated requests on an
+"outstanding request" flag, cleared only by a grant. Since the request edge is droppable, a
+dropped request leaves the flag set with no grant coming — the coordinator never asks again and
+the driver holds the window while rendering halts. Fixed by deleting the flag: the coordinator
+re-requests every tick while it holds a manifold and no buffer, and duplicate requests are
+harmless because the driver can only grant what it holds.
+
+**2. The graphics worker destroys the frame when paused.** `RasterCore::step_data` currently
+returns `RasterCoreOut::default()` on the paused path, consuming the `RenderRequest` — and the
+granted frame with it. Nothing then returns it to the driver. This is the same class as the outer
+edges, but *inside* the coordinator/worker pair, which is exactly why §8.6's ownership argument
+has to name the pair rather than the coordinator alone.
+
+**Required change (`pixelflow-graphics`):** every accepted `RenderRequest` must return its frame,
+including the pause path and any future error path. Paused should hand the frame back unrendered
+rather than swallow it. The worker never owns the caller's buffer — it borrows it for the
+duration of one render and is obliged to give it back regardless of outcome.
+
+That obligation is worth stating as the general form: **an actor that accepts a buffer owes it
+back on every exit path.** "Drop the work" is a safe policy for a request that carries only a
+description; it is never safe for one that carries a resource.

--- a/docs/designs/pixelflow-runtime-engine-mesh-migration.md
+++ b/docs/designs/pixelflow-runtime-engine-mesh-migration.md
@@ -352,9 +352,10 @@ The resulting edges, added to `pixelflow-runtime/tests/target_topology.rs`:
 
 | Edge | Direction | Kind |
 |---|---|---|
-| Window request ("I have work, give me a buffer") | rasterizer → driver | Droppable — genuinely losable, carries nothing |
+| Tick (drives request retries) | vsync → rasterizer | Droppable — genuinely losable, next tick retries |
+| Window request ("I have work, give me a buffer") | rasterizer → driver | Droppable, **Management lane** — genuinely losable, carries nothing |
 | Window grant (correctly sized, driver-allocated) | driver → rasterizer | Droppable, **unreachable**: driver can't grant what it doesn't hold |
-| `Present` | rasterizer → driver | Droppable, **unreachable**: coordinator can't present what it doesn't hold |
+| `Present` | rasterizer → driver | Droppable, **Data lane**, **unreachable** — see §8.9 for why the lane matters |
 | Manifold submission | app → rasterizer | Droppable, keep-latest |
 | Frame-rendered notice (FPS telemetry) | rasterizer → vsync | Droppable, no credit |
 | `ReturnToken` | app → vsync | Droppable, no credit |
@@ -599,11 +600,20 @@ is visibly worse and is what today's code already declines to do.
 
 The invariants above were written as "don't lose the *only* window." That undersells the
 constraint. **The ping-pong buffer exists so the framebuffer is reused rather than reallocated
-every frame**, and the direction of travel is a pull-based renderer writing *directly into the OS
-framebuffer, zero-copy.* Under that goal the driver is not merely a convenient allocator — it is
-the only actor that can obtain OS-backed memory at all, and a dropped buffer is not "one lost
-frame," it is a lost allocation that must be remade, in the one place the design is trying to
-never allocate.
+every frame.**
+
+*Stated precisely, because an earlier draft of this paragraph overreached:* today `Frame<P>` owns
+an ordinary `Vec<P>` and presentation **copies** it into the platform's surface — macOS via
+`replaceRegion:mipmapLevel:withBytes:bytesPerRow:`, X11 via `XPutImage`. So the driver is *not*
+currently the only actor that could allocate it. The intended direction is a pull-based renderer
+writing **directly into the OS framebuffer, zero-copy**, and under *that* the driver becomes the
+only actor able to obtain the memory at all — which is why keeping allocation there now is worth
+doing even though nothing yet forces it.
+
+The ownership rule does not rest on that future, though, and shouldn't be read as if it does.
+It stands on what is true today: there is exactly one buffer, it is reused every frame, and a
+buffer lost in transit is a lost allocation that must be remade — in the one place this design is
+trying never to allocate.
 
 So the rule is stronger than uniqueness — but it is not "never destroy a buffer," because §8.7
 *requires* destroying one: on resize the old buffer is the wrong size and must be replaced. The
@@ -648,3 +658,32 @@ duration of one render and is obliged to give it back regardless of outcome.
 That obligation is worth stating as the general form: **an actor that accepts a buffer owes it
 back on every exit path.** "Drop the work" is a safe policy for a request that carries only a
 description; it is never safe for one that carries a resource.
+
+### 8.9 `Present` and the retry requests must not share a ring
+
+§8.6 argued that ownership bounds the window-bearing messages to one in flight, so their rings
+are never full. That argument is sound about *window-bearing* traffic and silent about everything
+else — and review found the gap: **window requests and `Present` are both `rasterizer → driver`,
+so by default they share the driver's Data inbox.**
+
+Retries accumulate there. The coordinator stops requesting once a buffer is in hand, so no *new*
+request is generated during a render — but requests already queued from earlier ticks are still
+sitting in the ring when the render finishes. `Present` then arrives at a ring occupied by stale
+requests, is dropped, and destroys the sole buffer. Ownership bounds the resource; it does not
+bound the unrelated traffic sharing the resource's channel.
+
+**Fix: put them on different lanes.** The actor model already provides three
+(Control > Management > Data), each with its own ring:
+
+- **`Present` → Data lane.** It carries the frame; it is the bulk path, and it must never be
+  crowded out.
+- **Window request → Management lane.** Tiny, control-shaped, and genuinely losable. Retries
+  piling up there cannot touch the Data ring.
+
+That restores §8.6's argument by making its precondition true rather than assumed: the Data ring
+carries only window-bearing messages, of which ownership guarantees at most one.
+
+**The general form**, worth carrying into implementation: *a structural-unreachability argument
+about one message class only holds if that class has the channel to itself.* Sharing a ring with
+unbounded traffic silently converts "unreachable" into "unlikely," and unlikely is not what
+§3 means by structurally unreachable.

--- a/docs/designs/pixelflow-runtime-engine-mesh-migration.md
+++ b/docs/designs/pixelflow-runtime-engine-mesh-migration.md
@@ -353,9 +353,13 @@ either unreliable or block the main thread. (The current backends still copy —
 
 The `rasterizer` node in the topology is a **runtime-side coordinator**, not
 `pixelflow-graphics`'s `RasterizerActor` — that crate is runtime-agnostic and can't name `Window`.
-The graphics actor sits behind it as a leaf worker. It's collapsed into one node in the proof
-because a leaf whose only peer is its caller can't participate in a cycle; **if it ever gains a
-handle to a third actor, that stops being true and it needs its own node.**
+The graphics actor sits behind it as a leaf worker, collapsed into one node in the proof. An
+earlier draft justified that by "a leaf whose only peer is its caller can't cycle" — which is
+false, and `regressed_render_pipeline_framing_is_cyclic` in the proof demonstrates exactly that
+two-actor shape. **The real condition is that one direction of the internal exchange must be
+non-blocking**, and it is: the worker replies over an unbounded `mpsc::Sender`, which cannot
+block or fill. If that ever becomes a bounded/`SyncSender` channel — or the worker gains a peer
+— the collapse is invalid and it needs its own node in the proof.
 
 ### The judgment calls
 
@@ -390,6 +394,11 @@ checked:
 - **Credit-bearing replies that can be dropped.** `ReturnToken` releases vsync's tick budget; if
   its edge can lose messages, the budget shrinks permanently. Same shape as the paste deadlock
   in §3.2 — worth checking every credit whose release travels a droppable edge.
+- **Keep-latest for manifold submission.** §3 and §7.3 delete `pending_manifold` on the grounds
+  that the droppable port *is* the staleness policy — but droppable discards the **newest**
+  message, not the oldest. If the app's final state change is the one dropped and subsequent
+  frame requests return `Skipped`, a stale surface stays on screen indefinitely. Needs either a
+  real drop-oldest delivery or an explicit coalescing slot before that state is removed.
 - **Zero-copy.** Tracked separately; the copy in both backends is a defect, not the target.
 
 ### Out of scope here

--- a/docs/designs/pixelflow-runtime-engine-mesh-migration.md
+++ b/docs/designs/pixelflow-runtime-engine-mesh-migration.md
@@ -342,8 +342,8 @@ edges (`driver` ↔ `rasterizer`) that never existed in the mesh before.
 
 **The match logic lives in `rasterizer`, and the window is pulled rather than pushed** (§8.5
 explains why). `app` pushes its latest manifold (droppable, keep-latest, same semantics as
-today). `rasterizer` holds that manifold and a `Credit(1)`; when it has work and the credit
-allows, it *requests* a window. `driver` keeps the window between frames, stays its allocator,
+today). `rasterizer` holds that manifold; when it has work and is not already holding a window
+or awaiting one, it *requests* a window. `driver` keeps the window between frames, stays its allocator,
 and grants the one it already holds — always correctly sized, because the driver resized it in
 place when the OS said so. `rasterizer` renders into it and `Present`s it back; the driver
 presents and retains it for the next request.
@@ -505,9 +505,10 @@ the window is still out being rendered, and the driver would have nothing to gra
 **Droppable is safe when the drop cannot occur, or when the message is genuinely replaceable.**
 Never because a sender "could resend" something it moved away.
 
-**Consequence for the coordinator.** It shrinks: manifold plus `Credit(1)`, no `latest_window`,
-no reallocation logic, no dimension tracking. It still performs the point→pixel dimap warp, using
-the dimensions of the window it was handed.
+**Consequence for the coordinator.** It shrinks: the latest manifold plus a "request
+outstanding" flag — no `latest_window`, no reallocation logic, no dimension tracking, and (per
+§8.6) no `Credit`. It still performs the point→pixel dimap warp, using the dimensions of the
+window it was handed.
 
 **Consequence for `Present`/`PresentComplete`.** `PresentComplete` disappears entirely as a
 message. Previously the window made a full circuit — `Present` carried it to the driver and

--- a/pixelflow-graphics/src/render/rasterizer/actor.rs
+++ b/pixelflow-graphics/src/render/rasterizer/actor.rs
@@ -50,8 +50,12 @@ use std::time::Instant;
 // RasterCore: the pure decision logic
 // ────────────────────────────────────────────────────────────────────────────
 
-/// What a render request decides to emit. `Default` (no response) covers the paused case —
-/// mirrors `VsyncCoreOut` in `vsync_actor.rs`: at most one output value per step.
+/// What a step decides to emit. `Default` (no response) is for the control and management steps,
+/// which legitimately emit nothing — mirrors `VsyncCoreOut` in `vsync_actor.rs`.
+///
+/// **`step_data` never uses the `None` case.** A render always returns its frame, paused or not;
+/// see [`RasterCore::render`], where the return type makes that a compile-time obligation rather
+/// than a convention.
 pub(crate) struct RasterCoreOut<P: Pixel, Meta = ()> {
     pub(crate) response: Option<RenderResponse<P, Meta>>,
 }
@@ -84,6 +88,54 @@ impl<P: Pixel, Meta> RasterCore<P, Meta> {
         }
     }
 
+    /// Render a request, **always returning its frame**.
+    ///
+    /// The obligation is in the signature rather than in a comment: this returns
+    /// `RenderResponse`, which requires a `Frame`, and the only frame in scope is the one that
+    /// arrived in `request`. A paused early-return that dropped the request would leave nothing
+    /// to build the return value from, so it does not compile. That matters because the frame is
+    /// the caller's sole render buffer — losing it is not a dropped frame, it is a lost
+    /// allocation the caller can never recover.
+    ///
+    /// Infallible on purpose. Rasterisation writes pixels into a buffer and has no failure mode,
+    /// and a `Result` here would reintroduce exactly the hole this signature closes: an `Err`
+    /// path carrying no frame.
+    fn render(&mut self, request: RenderRequest<P, Meta>) -> RenderResponse<P, Meta> {
+        let RenderRequest {
+            manifold,
+            mut frame,
+            meta,
+        } = request;
+
+        if self.paused {
+            log::debug!("Rasterizer paused; returning the frame unrendered");
+            return RenderResponse {
+                frame,
+                render_time: None,
+                meta,
+            };
+        }
+
+        let start = Instant::now();
+        rasterize(&manifold, &mut frame, self.num_threads);
+        let render_time = start.elapsed();
+
+        log::trace!(
+            "Rendered {}x{} frame in {:?} ({} threads)",
+            frame.width,
+            frame.height,
+            render_time,
+            self.num_threads
+        );
+
+        // `meta` is handed straight back, never inspected — see `RenderRequest::meta`.
+        RenderResponse {
+            frame,
+            render_time: Some(render_time),
+            meta,
+        }
+    }
+
     fn config(&self) -> RasterConfig {
         RasterConfig {
             num_threads: self.num_threads,
@@ -98,40 +150,14 @@ impl<P: Pixel, Meta> Transducer for RasterCore<P, Meta> {
     type Data = RenderRequest<P, Meta>;
     type Out = RasterCoreOut<P, Meta>;
 
+    /// Delegates to [`RasterCore::render`], which is where the frame-return obligation is
+    /// enforced. Deliberately a one-liner: there is no branch here that could lose a frame.
     fn step_data(
         &mut self,
         request: RenderRequest<P, Meta>,
     ) -> Result<RasterCoreOut<P, Meta>, HandlerError> {
-        if self.paused {
-            log::debug!("Rasterizer paused, dropping render request");
-            return Ok(RasterCoreOut::default());
-        }
-
-        let RenderRequest {
-            manifold,
-            mut frame,
-            meta,
-        } = request;
-
-        let start = Instant::now();
-        rasterize(&manifold, &mut frame, self.num_threads);
-        let render_time = start.elapsed();
-
-        log::trace!(
-            "Rendered {}x{} frame in {:?} ({} threads)",
-            frame.width,
-            frame.height,
-            render_time,
-            self.num_threads
-        );
-
         Ok(RasterCoreOut {
-            // `meta` is handed straight back, never inspected — see `RenderRequest::meta`.
-            response: Some(RenderResponse {
-                frame,
-                render_time,
-                meta,
-            }),
+            response: Some(self.render(request)),
         })
     }
 
@@ -243,14 +269,23 @@ mod core_tests {
     }
 
     #[test]
-    fn a_paused_core_drops_the_request_without_rendering() {
+    fn a_paused_core_returns_the_frame_unrendered() {
+        // Previously this asserted the response was `None` — i.e. that pausing *dropped* the
+        // request. That destroyed the caller's sole render buffer, which is a lost allocation
+        // rather than a skipped frame. The frame now comes back either way; only `render_time`
+        // reports whether it was drawn into.
         let mut core = RasterCore::<Rgba8>::new(1);
         core.step_control(RasterControl::Pause).unwrap();
+
         let out = core.step_data(request(8)).unwrap();
+        let response = out
+            .response
+            .expect("a paused core must still return the caller's frame");
         assert!(
-            out.response.is_none(),
-            "a paused core must not render or emit a response"
+            response.render_time.is_none(),
+            "and must report that it did not render"
         );
+        assert_eq!(response.frame.width, 8, "the frame comes back intact");
     }
 
     #[test]
@@ -465,7 +500,10 @@ mod tests {
         // Verify frame was rendered
         assert_eq!(response.frame.width, 64);
         assert_eq!(response.frame.height, 64);
-        assert!(response.render_time.as_nanos() > 0);
+        assert!(
+            response.render_time.is_some_and(|d| d.as_nanos() > 0),
+            "an unpaused rasterizer reports the time it spent"
+        );
 
         // Shutdown
         handle
@@ -540,10 +578,15 @@ mod tests {
             .send(Message::Data(request))
             .expect("Failed to send render request");
 
-        // Should timeout because rendering is paused
-        assert!(response_rx
-            .recv_timeout(std::time::Duration::from_millis(100))
-            .is_err());
+        // The frame comes back even while paused — losing it would cost the caller its only
+        // render buffer. `render_time: None` is how "not drawn into" is reported.
+        let response = response_rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .expect("a paused rasterizer must still return the frame");
+        assert!(
+            response.render_time.is_none(),
+            "paused means not rendered, not buffer withheld"
+        );
 
         // Resume
         handle

--- a/pixelflow-graphics/src/render/rasterizer/messages.rs
+++ b/pixelflow-graphics/src/render/rasterizer/messages.rs
@@ -46,8 +46,11 @@ pub struct RenderRequest<P: Pixel, Meta = ()> {
 pub struct RenderResponse<P: Pixel, Meta = ()> {
     /// The rendered frame.
     pub frame: Frame<P>,
-    /// Time taken to render the frame.
-    pub render_time: Duration,
+    /// Time taken to render, or `None` if the rasterizer was paused and did not render.
+    ///
+    /// The frame comes back either way — see [`RenderRequest::frame`]. Whether it was *rendered*
+    /// is the optional part; whether the caller gets its buffer back never was.
+    pub render_time: Option<Duration>,
     /// The [`RenderRequest::meta`] payload, returned exactly as it was given.
     pub meta: Meta,
 }

--- a/pixelflow-runtime/src/engine_troupe.rs
+++ b/pixelflow-runtime/src/engine_troupe.rs
@@ -166,13 +166,22 @@ impl Actor<EngineData, EngineControl, AppManagement> for EngineHandler {
                         "two live buffers of generation {}: one held, one just rendered",
                         response.meta.generation
                     );
-                    self.present_cooked_frame(
-                        response.render_time,
-                        StampedWindow {
-                            generation: response.meta.generation,
-                            window,
-                        },
-                    );
+                    let stamped = StampedWindow {
+                        generation: response.meta.generation,
+                        window,
+                    };
+                    match response.render_time {
+                        Some(render_time) => self.present_cooked_frame(render_time, stamped),
+                        // The rasterizer was paused, so it handed the buffer back unrendered.
+                        // Presenting it would blit whatever stale pixels it still holds; keeping
+                        // it is the whole point of the frame coming back at all. This arm exists
+                        // because `render_time: Option<Duration>` forces the question — the
+                        // buffer's return is unconditional, its having been drawn into is not.
+                        None => {
+                            log::debug!("Render skipped (paused); retaining the buffer unpresented");
+                            self.window = Some(stamped);
+                        }
+                    }
                 }
             }
             EngineData::PresentComplete(returned_window) => {
@@ -1087,7 +1096,7 @@ mod tests {
                 .expect("a render must be outstanding to complete");
             self.feed(EngineData::RenderComplete(RenderResponse {
                 frame: Frame::new(meta.width_px, meta.height_px),
-                render_time: Duration::from_millis(1),
+                render_time: Some(Duration::from_millis(1)),
                 meta,
             }));
         }

--- a/pixelflow-runtime/tests/target_topology.rs
+++ b/pixelflow-runtime/tests/target_topology.rs
@@ -96,6 +96,12 @@ fn the_target_engine_mesh_is_a_dag() {
     // Note there is no resize edge at all. The driver owns the buffer and resizes it locally,
     // deferring to `Present` if the window is out at the time (§8.7), so no resize message
     // exists that could be dropped.
+    // The coordinator is reactive — it acts only on messages it receives. A tick edge is what
+    // makes "re-request until granted" implementable at all: without it, a dropped request could
+    // only be retried if another manifold happened to arrive, and the app may legitimately send
+    // nothing for many frames. Droppable and genuinely losable: the next tick is the retry.
+    topo.droppable_edge(vsync, rasterizer); // tick — drives request retries
+
     topo.droppable_edge(rasterizer, driver); // window request (losable; carries nothing)
     topo.droppable_edge(driver, rasterizer); // window grant (unreachable: can't grant unheld)
     topo.droppable_edge(app, rasterizer); // manifold submission (keep-latest, as today)

--- a/pixelflow-runtime/tests/target_topology.rs
+++ b/pixelflow-runtime/tests/target_topology.rs
@@ -62,8 +62,8 @@ fn the_target_engine_mesh_is_a_dag() {
 
     // Idempotent "latest wins" state pushes: no credit needed at all. `Present` used to live
     // here too; it is now a rasterizer -> driver edge below. `PresentComplete` is gone as a
-    // message entirely — the driver never gives the window away permanently, so there is
-    // nothing to hand back (§8.5).
+    // message entirely: the driver is now the window's resting owner, so `Present` *is* the
+    // return and no separate acknowledgement is needed (§8.5).
     topo.droppable_edge(engine, driver); // SetTitle / SetSize / SetCursor / Copy
 
     // RequestPaste / PasteData: plain droppable, deliberately *not* credit-bounded — see §3.2.
@@ -81,22 +81,25 @@ fn the_target_engine_mesh_is_a_dag() {
 
     // The render pipeline, wired directly instead of through engine (§7/§8). The window is
     // *pulled*, not pushed (§8.5): the driver keeps and allocates it, and rasterizer asks for
-    // one only when it holds a manifold and its Credit(1) allows.
+    // one only when it holds a manifold and is not already holding a window.
     //
-    // The single credit spans the WHOLE round trip — consumed at the request, released only
-    // when `Present` puts the window back with the driver. So at most one message carrying the
-    // window is in flight across these three edges at any instant, each ring is provisioned
-    // >= 1, and the droppable backstop is therefore unreachable by construction (§3's
-    // "structurally unreachable" category). That is the only thing making these safe: `Window`
-    // moves by value, so a drop would destroy the sole framebuffer outright — no sender can
-    // "resend" something it moved away.
+    // There is no Credit on this loop: ownership of the single Window is already the bound
+    // (§8.6). An actor cannot send a window it does not hold, so "at most one grant in flight"
+    // and "at most one Present in flight" are properties of the type, not of a counter — and
+    // each ring is provisioned >= 1, so neither is ever full when sent. Their droppable
+    // backstops are dead code. That matters because `Window` moves by value: an actually
+    // reachable drop would destroy the sole framebuffer, not delay a frame.
     //
-    // Note there is no resize edge at all. On resize the driver swaps its own buffer and tells
-    // nobody, so there is no resize message that can be dropped.
-    topo.droppable_edge(rasterizer, driver); // window request (consumes Credit(1))
-    topo.droppable_edge(driver, rasterizer); // window grant, correctly sized (credit still held)
+    // The request is the one genuinely losable message here — it carries no resource, so a drop
+    // costs one frame and the next vsync tick re-asks.
+    //
+    // Note there is no resize edge at all. The driver owns the buffer and resizes it locally,
+    // deferring to `Present` if the window is out at the time (§8.7), so no resize message
+    // exists that could be dropped.
+    topo.droppable_edge(rasterizer, driver); // window request (losable; carries nothing)
+    topo.droppable_edge(driver, rasterizer); // window grant (unreachable: can't grant unheld)
     topo.droppable_edge(app, rasterizer); // manifold submission (keep-latest, as today)
-    topo.droppable_edge(rasterizer, driver); // Present, once rendered (releases the credit)
+    topo.droppable_edge(rasterizer, driver); // Present (unreachable: can't present unheld)
     topo.droppable_edge(rasterizer, vsync); // RenderedResponse (FPS telemetry only)
     topo.droppable_edge(app, vsync); // ReturnToken — previously an engine->vsync Control-lane
                                      // send this proof never modeled separately; modeled here

--- a/pixelflow-runtime/tests/target_topology.rs
+++ b/pixelflow-runtime/tests/target_topology.rs
@@ -57,13 +57,13 @@ fn the_target_engine_mesh_is_a_dag() {
     // `WindowCreated`/`Resized` notify engine over this edge as `WindowMeta` (scalar, `Copy`)
     // purely so engine can relay dimensions to app. No frame buffer travels here, and the
     // render pipeline does not consume these at all — the driver keeps the window and hands it
-    // out on request (§8.5), so nothing downstream needs telling that it was resized.
+    // out on request (§8, "The shape"), so nothing downstream needs telling that it was resized.
     topo.blocking_edge(driver, engine); // DisplayEvent (window lifecycle as WindowMeta)
 
     // Idempotent "latest wins" state pushes: no credit needed at all. `Present` used to live
     // here too; it is now a rasterizer -> driver edge below. `PresentComplete` is gone as a
     // message entirely: the driver is now the window's resting owner, so `Present` *is* the
-    // return and no separate acknowledgement is needed (§8.5).
+    // return and no separate acknowledgement is needed (§8, "The shape").
     topo.droppable_edge(engine, driver); // SetTitle / SetSize / SetCursor / Copy
 
     // RequestPaste / PasteData: plain droppable, deliberately *not* credit-bounded — see §3.2.
@@ -80,11 +80,11 @@ fn the_target_engine_mesh_is_a_dag() {
     topo.droppable_edge(engine, app); // RequestFrame (Credit-gated)
 
     // The render pipeline, wired directly instead of through engine (§7/§8). The window is
-    // *pulled*, not pushed (§8.5): the driver keeps and allocates it, and rasterizer asks for
+    // *pulled*, not pushed (§8, "The shape"): the driver keeps and allocates it, and rasterizer asks for
     // one only when it holds a manifold and is not already holding a window.
     //
     // There is no Credit on this loop: ownership of the single Window is already the bound
-    // (§8.6). An actor cannot send a window it does not hold, so "at most one grant in flight"
+    // (§8, "The judgment calls"). An actor cannot send a window it does not hold, so "at most one grant in flight"
     // and "at most one Present in flight" are properties of the type, not of a counter — and
     // each ring is provisioned >= 1, so neither is ever full when sent. Their droppable
     // backstops are dead code. That matters because `Window` moves by value: an actually
@@ -94,7 +94,7 @@ fn the_target_engine_mesh_is_a_dag() {
     // costs one frame and the next vsync tick re-asks.
     //
     // Note there is no resize edge at all. The driver owns the buffer and resizes it locally,
-    // deferring to `Present` if the window is out at the time (§8.7), so no resize message
+    // deferring to `Present` if the window is out at the time (§8, "The judgment calls"), so no resize message
     // exists that could be dropped.
     // The coordinator is reactive — it acts only on messages it receives. A tick edge is what
     // makes "re-request until granted" implementable at all: without it, a dropped request could
@@ -103,7 +103,7 @@ fn the_target_engine_mesh_is_a_dag() {
     topo.droppable_edge(vsync, rasterizer); // tick — drives request retries
 
     // Requests ride the Management lane, `Present` the Data lane — deliberately different rings
-    // (§8.9). Both are rasterizer -> driver, so sharing one inbox would let queued retries fill
+    // (§8, "Known-unsettled"). Both are rasterizer -> driver, so sharing one inbox would let queued retries fill
     // it and force a `Present` drop, destroying the sole buffer. Ownership bounds the
     // window-bearing traffic; it says nothing about unrelated messages in the same ring.
     topo.droppable_edge(rasterizer, driver); // window request (Management lane; carries nothing)

--- a/pixelflow-runtime/tests/target_topology.rs
+++ b/pixelflow-runtime/tests/target_topology.rs
@@ -81,16 +81,22 @@ fn the_target_engine_mesh_is_a_dag() {
 
     // The render pipeline, wired directly instead of through engine (§7/§8). The window is
     // *pulled*, not pushed (§8.5): the driver keeps and allocates it, and rasterizer asks for
-    // one only when it holds a manifold and its Credit(1) allows. That is what makes every
-    // droppable edge here recoverable rather than merely idempotent-sounding — a dropped
-    // message costs one frame, and the sender still holds the authoritative copy to resend.
+    // one only when it holds a manifold and its Credit(1) allows.
+    //
+    // The single credit spans the WHOLE round trip — consumed at the request, released only
+    // when `Present` puts the window back with the driver. So at most one message carrying the
+    // window is in flight across these three edges at any instant, each ring is provisioned
+    // >= 1, and the droppable backstop is therefore unreachable by construction (§3's
+    // "structurally unreachable" category). That is the only thing making these safe: `Window`
+    // moves by value, so a drop would destroy the sole framebuffer outright — no sender can
+    // "resend" something it moved away.
     //
     // Note there is no resize edge at all. On resize the driver swaps its own buffer and tells
     // nobody, so there is no resize message that can be dropped.
-    topo.droppable_edge(rasterizer, driver); // window request (Credit(1))
-    topo.droppable_edge(driver, rasterizer); // window grant, correctly sized (shares credit)
+    topo.droppable_edge(rasterizer, driver); // window request (consumes Credit(1))
+    topo.droppable_edge(driver, rasterizer); // window grant, correctly sized (credit still held)
     topo.droppable_edge(app, rasterizer); // manifold submission (keep-latest, as today)
-    topo.droppable_edge(rasterizer, driver); // Present, once rendered
+    topo.droppable_edge(rasterizer, driver); // Present, once rendered (releases the credit)
     topo.droppable_edge(rasterizer, vsync); // RenderedResponse (FPS telemetry only)
     topo.droppable_edge(app, vsync); // ReturnToken — previously an engine->vsync Control-lane
                                      // send this proof never modeled separately; modeled here

--- a/pixelflow-runtime/tests/target_topology.rs
+++ b/pixelflow-runtime/tests/target_topology.rs
@@ -102,7 +102,11 @@ fn the_target_engine_mesh_is_a_dag() {
     // nothing for many frames. Droppable and genuinely losable: the next tick is the retry.
     topo.droppable_edge(vsync, rasterizer); // tick — drives request retries
 
-    topo.droppable_edge(rasterizer, driver); // window request (losable; carries nothing)
+    // Requests ride the Management lane, `Present` the Data lane — deliberately different rings
+    // (§8.9). Both are rasterizer -> driver, so sharing one inbox would let queued retries fill
+    // it and force a `Present` drop, destroying the sole buffer. Ownership bounds the
+    // window-bearing traffic; it says nothing about unrelated messages in the same ring.
+    topo.droppable_edge(rasterizer, driver); // window request (Management lane; carries nothing)
     topo.droppable_edge(driver, rasterizer); // window grant (unreachable: can't grant unheld)
     topo.droppable_edge(app, rasterizer); // manifold submission (keep-latest, as today)
     topo.droppable_edge(rasterizer, driver); // Present (unreachable: can't present unheld)

--- a/pixelflow-runtime/tests/target_topology.rs
+++ b/pixelflow-runtime/tests/target_topology.rs
@@ -54,16 +54,16 @@ fn the_target_engine_mesh_is_a_dag() {
     // window-lifecycle events. Nothing else in this graph is Blocking, so this alone cannot
     // form a cycle with anything below.
     //
-    // `WindowCreated`/`Resized` still notify engine over this edge, but carry `WindowMeta`
-    // (scalar, `Copy`) rather than the `Window` — the same tearing §7.1 already established
-    // for the render request. The `Window` itself *moves* to rasterizer on the edge below. So
-    // both consumers are served with no copy of the frame buffer anywhere: engine gets the
-    // few scalars it needs to relay to app, rasterizer gets ownership of the buffer.
+    // `WindowCreated`/`Resized` notify engine over this edge as `WindowMeta` (scalar, `Copy`)
+    // purely so engine can relay dimensions to app. No frame buffer travels here, and the
+    // render pipeline does not consume these at all — the driver keeps the window and hands it
+    // out on request (§8.5), so nothing downstream needs telling that it was resized.
     topo.blocking_edge(driver, engine); // DisplayEvent (window lifecycle as WindowMeta)
 
-    // Idempotent "latest wins" state pushes: no credit needed at all. Present/PresentComplete
-    // used to live here too — they moved to the rasterizer <-> driver edges below, since
-    // rasterizer is what actually presents once engine no longer mediates.
+    // Idempotent "latest wins" state pushes: no credit needed at all. `Present` used to live
+    // here too; it is now a rasterizer -> driver edge below. `PresentComplete` is gone as a
+    // message entirely — the driver never gives the window away permanently, so there is
+    // nothing to hand back (§8.5).
     topo.droppable_edge(engine, driver); // SetTitle / SetSize / SetCursor / Copy
 
     // RequestPaste / PasteData: plain droppable, deliberately *not* credit-bounded — see §3.2.
@@ -79,16 +79,16 @@ fn the_target_engine_mesh_is_a_dag() {
     topo.droppable_edge(vsync, engine); // vsync tick (Credit-gated)
     topo.droppable_edge(engine, app); // RequestFrame (Credit-gated)
 
-    // The render pipeline, now wired directly instead of through engine (§7 of the migration
-    // doc). rasterizer is where §7's chosen design puts the window/manifold pairing: driver
-    // pushes a window the moment one is free (created, or returned from a prior Present) and
-    // app pushes its latest manifold; rasterizer renders when both are held and its own
-    // Credit(1) allows it, then presents directly and tells vsync.
-    // Carries `PresentComplete` (the buffer coming back) and the one bootstrap
-    // `WindowCreated`. Deliberately NOT resize windows — see §8.5: a droppable ring drops the
-    // *new* message on overflow, which for a freshly-sized resize buffer is unrecoverable,
-    // where keep-latest would need the *old* one dropped. Resize sends metadata only.
-    topo.droppable_edge(driver, rasterizer); // PresentComplete + bootstrap WindowCreated
+    // The render pipeline, wired directly instead of through engine (§7/§8). The window is
+    // *pulled*, not pushed (§8.5): the driver keeps and allocates it, and rasterizer asks for
+    // one only when it holds a manifold and its Credit(1) allows. That is what makes every
+    // droppable edge here recoverable rather than merely idempotent-sounding — a dropped
+    // message costs one frame, and the sender still holds the authoritative copy to resend.
+    //
+    // Note there is no resize edge at all. On resize the driver swaps its own buffer and tells
+    // nobody, so there is no resize message that can be dropped.
+    topo.droppable_edge(rasterizer, driver); // window request (Credit(1))
+    topo.droppable_edge(driver, rasterizer); // window grant, correctly sized (shares credit)
     topo.droppable_edge(app, rasterizer); // manifold submission (keep-latest, as today)
     topo.droppable_edge(rasterizer, driver); // Present, once rendered
     topo.droppable_edge(rasterizer, vsync); // RenderedResponse (FPS telemetry only)

--- a/pixelflow-runtime/tests/target_topology.rs
+++ b/pixelflow-runtime/tests/target_topology.rs
@@ -53,7 +53,13 @@ fn the_target_engine_mesh_is_a_dag() {
     // The one edge that stays genuinely Blocking: discrete, non-idempotent input and
     // window-lifecycle events. Nothing else in this graph is Blocking, so this alone cannot
     // form a cycle with anything below.
-    topo.blocking_edge(driver, engine); // DisplayEvent, minus PasteData
+    //
+    // `WindowCreated`/`Resized` still notify engine over this edge, but carry `WindowMeta`
+    // (scalar, `Copy`) rather than the `Window` — the same tearing §7.1 already established
+    // for the render request. The `Window` itself *moves* to rasterizer on the edge below. So
+    // both consumers are served with no copy of the frame buffer anywhere: engine gets the
+    // few scalars it needs to relay to app, rasterizer gets ownership of the buffer.
+    topo.blocking_edge(driver, engine); // DisplayEvent (window lifecycle as WindowMeta)
 
     // Idempotent "latest wins" state pushes: no credit needed at all. Present/PresentComplete
     // used to live here too — they moved to the rasterizer <-> driver edges below, since
@@ -83,8 +89,8 @@ fn the_target_engine_mesh_is_a_dag() {
     topo.droppable_edge(rasterizer, driver); // Present, once rendered
     topo.droppable_edge(rasterizer, vsync); // RenderedResponse (FPS telemetry only)
     topo.droppable_edge(app, vsync); // ReturnToken — previously an engine->vsync Control-lane
-                                      // send this proof never modeled separately; modeled here
-                                      // now that it travels a new edge anyway.
+                                     // send this proof never modeled separately; modeled here
+                                     // now that it travels a new edge anyway.
 
     let order = topo.validate().expect(
         "every blocking edge has no return path and every reply is droppable, so this must be \

--- a/pixelflow-runtime/tests/target_topology.rs
+++ b/pixelflow-runtime/tests/target_topology.rs
@@ -84,7 +84,11 @@ fn the_target_engine_mesh_is_a_dag() {
     // pushes a window the moment one is free (created, or returned from a prior Present) and
     // app pushes its latest manifold; rasterizer renders when both are held and its own
     // Credit(1) allows it, then presents directly and tells vsync.
-    topo.droppable_edge(driver, rasterizer); // window available (created, or returned)
+    // Carries `PresentComplete` (the buffer coming back) and the one bootstrap
+    // `WindowCreated`. Deliberately NOT resize windows — see §8.5: a droppable ring drops the
+    // *new* message on overflow, which for a freshly-sized resize buffer is unrecoverable,
+    // where keep-latest would need the *old* one dropped. Resize sends metadata only.
+    topo.droppable_edge(driver, rasterizer); // PresentComplete + bootstrap WindowCreated
     topo.droppable_edge(app, rasterizer); // manifold submission (keep-latest, as today)
     topo.droppable_edge(rasterizer, driver); // Present, once rendered
     topo.droppable_edge(rasterizer, vsync); // RenderedResponse (FPS telemetry only)


### PR DESCRIPTION
## The mistake

`WindowCreated`/`Resized` have two consumers with genuinely different needs: `app` wants the new dimensions, the render pipeline wants the buffer. My first pass at §8 handled that by adding a `rasterizer → app` edge — rasterizer would open the `Window`, pull metadata out, and relay it onward — justified on the grounds that serving both consumers otherwise meant cloning the frame buffer, which `Frame: Clone` makes silently possible.

**That reasoning was wrong at its root.** A frame buffer copy was never an option to weigh. The `Window` circulates by ownership transfer; that *is* the ping-pong buffer. Treating a clone as one arm of a trade-off, even to reject it, is how a copy eventually ends up in the render loop.

And the invented copy led to an invented edge: it would have handed the renderer an `Application` handle purely to forward window metadata it doesn't otherwise care about.

## The fix

§7.1's tearing, applied a second time. A `Window` splits into:

- **`WindowMeta`** — four scalars, already `#[derive(Copy)]` from the earlier slice
- **`Frame`** — expensive, moves

So the driver sends **metadata** to engine over the existing Blocking `DisplayEvent` edge (engine relays to app exactly as today, unchanged), and sends **the window** to rasterizer. Both consumers served, nothing copied, and **the graph gains no edge at all** — `target_topology.rs` returns to precisely the edge set proven in #918.

## The general rule

Recorded as §8.3, since this is now the second instance:

> When two actors need different parts of one value, split the value — don't duplicate it, and don't reroute one consumer through the other.

## Testing

- `cargo test -p pixelflow-runtime --test target_topology` — 3/3 passing
- Verified `WindowMeta` is `Copy`, so the notification path carries no allocation and no buffer copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Y5cNzR9PnASfGfjBh5kJc

---
_Generated by [Claude Code](https://claude.ai/code/session_015Y5cNzR9PnASfGfjBh5kJc)_