### PR TITLE
Multi-ISA test matrix, AVX2 backend, AVX-512 completion, and the backend completeness contract

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -102,3 +102,45 @@ jobs:
       - name: Run doctests
         shell: bash
         run: cargo test --workspace --doc
+
+  isa-matrix:
+    name: ISA matrix (SSE2/AVX2/AVX-512)
+    runs-on: ubuntu-latest
+    # Three full `cargo test --workspace` + `cargo clippy` passes (one per
+    # supported ISA level) in one job; each pass alone can take several
+    # minutes on a cold cache.
+    timeout-minutes: 45
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Install X11 dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libx11-dev libxcursor-dev libxrandr-dev libxi-dev
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-isa-matrix-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-isa-matrix-
+
+      # .cargo/config.toml sets no target-cpu/target-feature, so the jobs
+      # above only ever exercise whichever ISA level SSE2-baseline codegen
+      # happens to be. This runs cargo test + clippy again under +avx2,+fma
+      # and +avx512f -- skipping cleanly (not silently) whichever of those
+      # ubuntu-latest's actual hardware doesn't support; see
+      # `xtask isa-matrix`'s own doc comment for the per-level detection.
+      - name: Run ISA matrix (test + clippy per supported level)
+        shell: bash
+        run: cargo run -p xtask -- isa-matrix --clippy

--- a/docs/designs/2026-07-25-two-level-ir-and-backend-completeness.md
+++ b/docs/designs/2026-07-25-two-level-ir-and-backend-completeness.md
@@ -1,0 +1,467 @@
+# Two-level IR, backend completeness, and where the loop binder belongs
+
+**Date:** 2026-07-25
+**Status:** Design + landed slice (completeness check + first Instruction/
+Assembler split). Binder-in-IR migration is NOT implemented here — see
+"What's follow-up" at the end.
+
+## The question
+
+Adding one feature — a bounded-loop/reduction binder — looked like it would
+require hand-writing assembly in three backends. That prompted two distinct
+questions from the project owner, quoted directly:
+
+1. "Do languages ever do two levels of IR, or maybe our IR is too big? ...
+   Something is wrong/missing here for this to turn up/require work in 3
+   backends?"
+2. "I want a worker making sure this is the only version of this, because I
+   feel like this project has written a lot of assembly."
+
+Both are answered below from the actual code, file:line, not from "multi-ISA
+backends are just like this." Two-level (or staged) IR is close to universal
+in real compilers — LLVM IR -> SelectionDAG/GlobalISel -> MachineIR, Cranelift
+CLIF -> VCode, GCC GENERIC -> GIMPLE -> RTL, Halide's single-IR-with-staged-
+lowering-passes — so "should there be staging" was never the interesting
+question. The interesting question is whether this codebase already has
+staging, informally, and whether the boundary sits in the right place.
+
+**Short answer: yes to staging (it already exists and is sound); no to "one
+version of this" (there are three competing loop-emission strategies, only
+one of which is even used in production, and none of them are wired to what
+actually renders); and the missing piece is not a backend problem at all —
+the reduction binder (`Kernel::over`) has never emitted a loop, ever, on any
+backend, because it always unrolls.**
+
+## Part 1 — Is there a two-level IR, and is the boundary right?
+
+Yes. It already exists, and it is sound as far as it goes. Every compile
+entry point that matters runs the same two stages:
+
+**Stage 1 — ISA-agnostic canonicalization.** A fixed sequence of pure
+`ExprArena -> ExprArena` endomorphisms in `pixelflow-ir/src/backend/emit/lowering.rs`,
+run identically regardless of target:
+
+```
+lower_dwrt_owned -> expand_reduce_owned -> expand_gather_owned -> expand_transcendentals_owned
+```
+
+(see the call sites in `compile_arena_dag_with_ctx` for both architectures,
+`mod.rs:645-648` aarch64 / `mod.rs:3287-3290` x86). Each pass eliminates one
+op family entirely: `Dwrt` (symbolic differentiation via chain rule),
+`Reduce` (the binder — currently *always* unrolled, see Part 3), the ternary
+`Gather` (lowered to index arithmetic + `RawGather`), and all transcendentals
+(`Sin`/`Cos`/`Exp`/.../`Pow`, expanded to polynomial arithmetic). What
+survives this stage is a small, closed arithmetic/comparison/bit-manip
+subset — this is the actual IR boundary, and it is a real one: no backend
+ever needs to know how to differentiate, fold, gather, or evaluate a sine.
+
+**Stage 2 — scheduling, allocation, and per-ISA leaf encoding.**
+`arena_to_schedule` (linearization — free, since the arena is already
+topologically ordered) -> `regalloc::linear_scan` (Belady eviction,
+ISA-agnostic) -> `analyze_select_guards` (short-circuit branch analysis for
+`Select`, ISA-agnostic) -> the `IsaBackend` trait's leaf methods
+(`emit_plan`/`emit_mov`/`emit_jump`/`patch_branch`/...), which is the only
+part that differs per architecture. This is `emit_dag_body`
+(`mod.rs:1985-2184`) plus `compile_dag_via_backend`
+(`mod.rs:2192-2223`), and it is genuinely shared: `Aarch64Backend`
+(`mod.rs:2225`), `X86Backend` (`mod.rs:3385`), and `Avx512Backend`
+(`mod.rs:3663`) are ~15-method trait impls that only encode bytes; none of
+them re-implement scheduling, allocation, or `Select` guard analysis.
+
+So the codebase already has exactly the shape the owner was asking about —
+LLVM's SelectionDAG/MachineIR split, Cranelift's CLIF/VCode split — it was
+just never named or documented as a boundary. `docs/designs/
+2026-07-23-jit-orthodoxy-survey.md` independently reached the same
+"orthodox for the Halide/XLA/shader-compiler family" verdict by a different
+route (comparing tiering/speculation machinery, not IR staging), and did not
+identify this staging explicitly. This doc names it.
+
+**Where the boundary is NOT sound: encoding has no internal structure.**
+Stage 2's per-ISA leaf is not itself two-level. Each backend's `emit_binary`/
+`emit_unary`/`emit_ternary` is one flat function that both *decides which ops
+it supports* and *emits their bytes* in the same `match`, e.g. (before this
+session's change) `x86_64.rs`:
+
+```rust
+match op {
+    OpKind::Add => emit_addps(code, dst, src2),
+    ...
+    OpKind::BitOr => emit_vorps(code, dst, dst, src2),
+    _ => panic!("x86_64 binary emit not implemented for {:?}", op),
+}
+```
+
+`avx512.rs`'s equivalent (`emit_binary`, pre-existing, untouched by this
+session per the out-of-scope note) implements 6 of the 15 ops this match
+covers and returns `Err` for the rest — a graceful failure, but the *point*
+is that "which 6" was never written down anywhere except as the literal set
+of arms present in that one match. Nothing enumerated "the ops a backend
+must support"; a match arm existing was the only evidence that op was
+supported, and a match arm *not* existing looked identical to "this op
+legitimately never reaches this backend." That is a real gap, and it is not
+an ISA-differences problem — see Part 4.
+
+This gives a precise, non-analogical answer to question 1: **the codebase
+already has a two-level IR (lowering vs. scheduled-and-selected leaf
+emission) and the boundary is in the right place; the missing level is
+*inside* the leaf** — selection (which mnemonic does this op become) and
+encoding (which bytes does that mnemonic become) are conflated into one
+un-auditable match per backend, the same shape LLVM's SelectionDAG (op ->
+`MachineInstr`) and Cranelift's lowering pass (CLIF -> `VCode` instruction)
+keep as two explicit steps.
+
+## Part 2 — Is "3 backends of assembly" structural, irreducible, or a bug?
+
+All three, for three different pieces of code. Read `mod.rs`, `x86_64.rs`,
+`aarch64.rs`, `avx512.rs` end to end to separate them:
+
+### 2a. The AVX-512 op-coverage gap — a bug, now load-bearing-checked
+
+`avx512::emit_binary` supported Add/Sub/Mul/Div/Min/Max only; comparisons
+route through a separate `is_compare`/`emit_compare` pair (so they *were*
+covered, contrary to a first read of `emit_binary` alone) but `IAdd`/
+`BitAnd`/`BitOr` were not, and `ResolvedOp::ShiftImm` was an explicit,
+permanent `Err` ("EVEX integer shift not wired yet", `mod.rs:3720-3722`,
+pre-existing). Unary `Rsqrt`/`Recip`/`TruncToInt`/`IntToFloat` were also
+missing. Nothing enumerated the required set, so nothing could fail loudly
+when 9 ops were absent — the gap was discovered by accident (36 tests
+failing the first time someone compiled with `-C target-feature=+avx512f`).
+This is the completeness-check gap fixed in Part 5; it is a genuine
+structural absence (no contract existed to violate), not an irreducible ISA
+cost — EVEX integer shift and the three bit-manip ops are ordinary
+instructions, not missing hardware.
+
+### 2b. Three unrelated loop-emission strategies, none shared, none in
+production
+
+This is the direct answer to "make sure this is the only version of this."
+It is not.
+
+**(i) A Sethi-Ullman tree-walk emitter, x86-only, no spilling.**
+`needs_arena`/`emit_arena` (`mod.rs:387-588`) is a full second code
+generation strategy — recursive register-by-tree-position, not
+schedule+linear-scan — that exists *only* because the x86 scanline body
+predates (or was never migrated to) the shared driver. It is explicitly
+documented as the exception: "the per-batch path goes through the shared
+schedule/regalloc driver" (`mod.rs:3269`). Aarch64 has no equivalent — its
+scanline path uses the schedule+regalloc approach throughout. So this is one
+architecture (x86) carrying a whole second emitter alive for one call site.
+
+**(ii) Both scanline-hoisted paths reimplement `emit_dag_body`'s guard logic
+by hand, around a hand-rolled loop, calling neither `emit_dag_body` nor
+`IsaBackend`.** `compile_scanline_hoisted` (aarch64, `mod.rs:1022-1421`) is
+~250 lines that duplicate `emit_dag_body`'s Select short-circuit
+guard-branch bookkeeping (`branch_starts`/`branch_ends`/`pending_patches`,
+byte-for-byte the same algorithm as `mod.rs:2016-2043` and `2065-2172`) —
+but calls `aarch64::emit_umaxv`/`emit_cbz_w16`/`patch_cbz_cbnz` directly
+instead of `IsaBackend::emit_skip_if_all_false`/`patch_branch`, and does so
+*twice inline* (once for the setup phase, once for the loop phase — compare
+`mod.rs:1182-1213` against `1250-1281`, nearly identical). x86's
+`compile_arena_dag_scanline` (`mod.rs:3995-4068`) hand-encodes its loop
+control flow as raw opcode bytes (`0x31, 0xC0` for `xor eax, eax`, etc.) and
+`compile_collapse_avx512`'s `emit_avx512_collapse_loop`
+(`mod.rs:3923-3974`) does the same for AVX-512's zmm registers. Three
+architectures, three independent byte-level loop implementations, zero
+sharing, despite `emit_dag_body`'s own doc comment already stating the
+right shape: *"The body's branches are self-relative, so a caller may
+freely prepend a prologue / wrap it in a loop / append an epilogue. This is
+the seam that lets both the per-batch kernel and the internal-loop collapse
+driver share one body emitter"* (`mod.rs:1980-1982`). `compile_collapse_avx512`
+is the one place that actually uses that seam correctly — it calls
+`emit_dag_body` for the body — but even it abandons `IsaBackend::emit_jump`/
+`patch_branch` for the loop's own back-edge and hand-encodes the `cmp`/`jae`/
+`jmp` bytes instead, for no reason the code states (both `emit_jump` and
+`patch_branch` handle backward targets fine — see
+`x86_64.rs::patch_rel32` and `aarch64.rs::patch_b`/`patch_cbz_cbnz`, all of
+which compute `target - pos` and accept a negative result).
+
+**(iii) None of the above three are in the production render path.** Grep
+confirms: `compile_collapse_avx512`/`CollapseKernelFn` has exactly one
+caller anywhere in the workspace — its own test (`mod.rs:6098` in the
+`avx512_driver` test module). `ScanlineJitManifold` (the wrapper around both
+scanline paths) is used only by two benchmark binaries,
+`pixelflow-pipeline/src/bin/bench_scanline_jit.rs` and
+`bench_hoisted_scanline.rs` — never by `pixelflow-core` or
+`pixelflow-graphics`. The actual hot path,
+`pixelflow-core/src/lattice/mod.rs::Lattice::collapse` (and `fold_lanes`,
+`collapse_axis0/1`), is a plain Rust `for`/`while` nest
+(`lattice/mod.rs:338-403`) that calls `RealizedKernel::eval` once per
+SIMD-width batch, which crosses into JIT code via one `extern "C"` call per
+batch (`lattice/mod.rs:606-621`) — exactly the per-batch call boundary the
+internal-loop kernels exist to eliminate ("no per-batch Rust <-> JIT boundary
+crossing," `mod.rs:3878`). So the project paid for three hand-written,
+per-ISA internal loops, and the code that actually renders every frame
+still pays a Rust-loop-plus-extern-C-call per batch anyway.
+
+**(iv) Both scanline tiers skip Stage 1 lowering entirely — a second,
+independent completeness gap from 2a, on both architectures.** Neither
+`compile_arena_dag_scanline` (x86, tree-walk) nor
+`compile_arena_dag_scanline_hoisted`/`arena_to_hoisted_schedule` (aarch64)
+calls `lower_dwrt_owned`/`expand_reduce_owned`/`expand_gather_owned`/
+`expand_transcendentals_owned` before scheduling. This is stated outright in
+the aarch64 source: *"Both forms are checked: lowered `RawGather`
+(`ScheduledOp::Gather`) and the high-level ternary (this path runs no
+lowering passes)"* (`mod.rs:1004-1005`). Concretely: a scanline kernel
+containing `sin`, `Dwrt`, or a `Reduce` binder will panic or error on
+*either* architecture's scanline path, while the exact same expression
+compiles fine through the per-batch path on both. This was never caught
+because — see (iii) — nothing in production exercises the scanline tier.
+
+**Verdict on question 2:** genuine duplicate/competing machinery, but not of
+one kind. (i) and the byte-level halves of (ii) should go — they duplicate a
+capability (schedule + linear-scan + guarded body emission) that
+`emit_dag_body` already provides correctly and more completely (it runs
+lowering; the scanline paths don't). (iii)'s framing ("collapse loop") is
+the *right* shape and should stay and be finished, not deleted — it is an
+abandoned prototype of the correct pattern, not a competing one, and its
+only real defect is bypassing `IsaBackend`'s own branch primitives for no
+stated reason. None of this is an irreducible per-ISA cost; it is three
+uncoordinated one-off answers to "how do I emit a loop," each written when
+someone needed exactly one call site to go faster, never generalized,
+never connected to what ships.
+
+## Part 3 — Where the binder/scope belongs
+
+The reduction binder already has an ISA-agnostic front door and an
+ISA-agnostic lowering pass — `Kernel::over`/`sum_over`/`product_over`/...
+(`pixelflow-ir/src/kernel.rs:500-547`) build an `OpKind::Reduce` node, and
+`expand_reduce`/`unroll_reduce` (`lowering.rs:266-340`) is Stage 1, exactly
+where Part 1 says it should be: one pure, ISA-agnostic pass that every
+backend already runs. This part of the design (docs/designs/
+REDUCTIONS_AND_FOLDS.md, "the reduction is the operation that CROSSES a
+scope boundary") is fully realized in code today.
+
+**What is not realized: `unroll_reduce` never emits a loop. It always
+statically unrolls** (`lowering.rs:330-339`: `n` copies of the body chained
+by the combiner op, `n` read from a `Const`). This is correct and cheap for
+the binder's actual current uses — dot products, softmax over small
+extents, N ~ 3-64 — but it is not a substitute for a real loop, and it is
+the reason the lattice's coordinate nest was never expressed as `Reduce`:
+unrolling a 1920-pixel scanline into machine code is not a viable strategy,
+so the lattice loop stayed a separate, invisible-to-the-IR Rust `for` loop
+in `pixelflow-core`. **The binder was never missing a backend. It was
+missing a second lowering strategy for large extents — which is a Stage 1
+question, not a per-ISA one**, and answering it is most of what "unify the
+lattice nest into the binder" needs.
+
+Proposed placement, concretely:
+
+1. **Stage 1 gets a second reduction strategy, chosen by extent (or an
+   explicit hint), not by backend.** Small `n` keeps unrolling exactly as
+   today (`unroll_reduce`, unchanged). Large `n` — or a `Reduce` explicitly
+   tagged as a scope/coordinate binder rather than an arithmetic fold —
+   lowers instead to a new arena shape the scheduler understands as "emit
+   this body once, with a loop-carried index and accumulator, `n` times."
+   This is a **pure `ExprArena -> ExprArena` decision**, made once, in
+   `lowering.rs`, identically for every backend — the same place `Dwrt`,
+   `Gather`, and the small-`n` `Reduce` case are already decided.
+
+2. **Stage 2 gets the loop-control-flow mechanism once, in `emit_dag_body`/
+   `compile_dag_via_backend`, not per backend.** The body-with-a-loop-inside
+   is already proven sound by `compile_collapse_avx512`: call
+   `emit_dag_body` once for the loop body (it already returns
+   self-relative-branch bytes designed to be embeddable), then wrap it using
+   only `IsaBackend` primitives that already exist —
+   `backend.emit_jump()` / `backend.patch_branch()` for the backward
+   branch (both already handle negative/backward targets, per Part 2's
+   citation of `patch_rel32`/`patch_b`), `backend.emit_mov()` for handing
+   the accumulator/index across iterations. **Zero new per-backend assembly
+   is needed for the branch and move primitives** — they are exactly what
+   `IsaBackend` already declares.
+
+3. **One genuinely new per-backend primitive is needed, and it is small:
+   a scalar loop-counter compare-and-branch.** `IsaBackend` currently has
+   branch primitives for two things: SIMD mask guards
+   (`emit_skip_if_all_false`/`emit_skip_if_all_true`, for `Select`) and an
+   unconditional jump. It has nothing for "test an integer counter against
+   a bound and branch" — the one piece of control flow every hand-rolled
+   loop in Part 2(ii) had to invent for itself, three times, in three
+   different styles (x86 scanline: `cmp r8,rcx; jae`, forward-exit +
+   backward `jmp`; aarch64 scanline: `subs x21,x21,#1; b.ne`,
+   decrement-and-branch; AVX-512 collapse: identical shape to x86 scanline).
+   Promoting this to two new `IsaBackend` methods (e.g.
+   `emit_loop_init(code, counter_reg, bound_reg) -> Branch` for the
+   early-exit-if-zero check, `emit_loop_back_edge(code, counter_reg) ->
+   Branch` for the decrement/compare-and-branch) turns three ad hoc,
+   already-written encodings into three ~5-line trait impls, which is
+   *less* code than exists today, not more — this is "subtract before you
+   add" applied to the loop mechanism itself.
+
+4. **The one truly irreducible per-backend difference is what a
+   loop-invariant value is held in, not how the loop branches.** AAPCS64
+   gives 8 callee-saved NEON registers (v8-v15) free for hoisting values
+   across iterations at zero cost; SysV has *zero* callee-saved XMM/YMM
+   registers, so x86-64 hoisting is stack-slot-based, a different strategy,
+   not just different bytes (this is exactly why
+   `MAX_PERSISTENT_SLOTS` is 8 on aarch64 and 0, "not yet implemented," on
+   x86-64 today — `mod.rs:692-696`). This asymmetry is real, ABI-driven, and
+   will still require two different hoisting strategies after the binder
+   unification — but it is orthogonal to loop *control flow*, which the
+   proposal above makes fully shared. Do not let this one genuine ABI
+   difference justify duplicating the branch/jump machinery too, which is
+   what happened in Part 2(ii).
+
+Net effect once this lands: `Kernel::over` at pixel-coordinate scope
+*becomes* the lattice's coordinate loop — closing the "lattice dissolves
+into nested scope/binder nodes" idea from `docs/designs/
+lattice-scheduling-types.md` and `REDUCTIONS_AND_FOLDS.md` — and
+`Lattice::collapse` can finally call the internal-loop compile entry points
+that already exist (generalized beyond AVX-512-only) instead of paying a
+per-batch `extern "C"` call in a Rust loop on every frame, on every backend.
+That second effect is not a new task; it is 2b(iii)'s dangling wire finally
+getting connected, as a consequence of the binder unification rather than a
+separate project.
+
+## Part 4 — The Instruction/Assembler split (landed slice)
+
+Part 1 identified the real gap as *inside* the per-ISA leaf: selection and
+encoding conflated into one un-auditable match. `docs/function-namespace-audit.md`
+found the same family from a different angle — 152 flat `emit_*` free
+functions (87 `pub`) across `x86_64.rs`/`aarch64.rs`/`mod.rs`, no shared
+type, "an un-namespaced public assembler API." That audit's proposed fix
+(wrap `Vec<u8>` in an `Assembler` newtype) is necessary but not sufficient
+by itself — a newtype around the buffer does not make the *dispatch*
+exhaustive; only splitting selection from encoding does that.
+
+**Landed this session, one backend, one op family, as the pilot:**
+`x86_64.rs` gains `X86BinaryInsn` — a closed enum of the ten binary
+mnemonics this backend can emit (`AddPs`/`SubPs`/.../`CmpPs(pred)`/`PAddD`/
+`AndPs`/`OrPs`) — with two functions where there was one match:
+
+- `X86BinaryInsn::select(op: OpKind) -> Option<Self>` — still partial over
+  `OpKind` (most of its variants are unary, ternary, or eliminated by
+  lowering before reaching here), so it keeps a `_ => None`, but every op
+  this backend supports is now named exactly once, as data, in one place a
+  completeness test can enumerate directly.
+- `X86BinaryInsn::encode(self, code, dst, src2)` — exhaustive over the
+  *closed* `X86BinaryInsn` set, **no wildcard arm**. Adding a variant
+  without teaching `encode` how to emit it is now a `rustc` compile error,
+  not a missing case discovered at runtime — this is the actual mechanism
+  LLVM's `MachineInstr`/Cranelift's `VCode` gets from making "instruction"
+  a value instead of a function call.
+
+`emit_binary`'s behavior and byte output are unchanged (same
+`emit_addps`/`emit_vandps`/etc. calls, same argument order); confirmed by
+the pre-existing test suite staying green (`cargo test -p pixelflow-ir`, see
+Part 5).
+
+**Deliberately not done in this slice**, and why:
+
+- **Not extended to unary/ternary ops, or to `aarch64.rs`.** Same pattern
+  applies cleanly (`X86UnaryInsn`, `Aarch64BinaryInsn`, ...); this is
+  follow-up sized-to-review, not a research question.
+- **Not applied to `avx512.rs`, and not extended to a shared enum across
+  ISAs.** Two reasons. First, a shared `Instruction` enum across backends
+  would be the wrong abstraction — an ARM `fadd` and an x86 `vaddps` really
+  are different operations with different operand shapes (this is the one
+  piece of the owner's framing this doc pushes back on: leaf *encoding*
+  genuinely is per-ISA and no abstraction erases that; what was missing was
+  never a shared instruction set, it was exhaustiveness *within* each
+  backend's own closed set). Second, `avx512.rs` and the surrounding
+  `mod.rs` cfg/dispatch logic are being actively edited concurrently by a
+  separate agent doing the AVX2/AVX-512 op-coverage completion in a
+  different worktree; touching that file risked a real merge conflict for
+  no benefit this session, so it was left alone entirely. **The natural
+  place to apply this pattern next is exactly that AVX-512 completion
+  work** — filling in the missing 9 ops as new `Avx512BinaryInsn`/
+  `Avx512UnaryInsn` variants (with the required-op completeness test from
+  Part 5 as the acceptance check) rather than as new arms in the existing
+  flat match, so the fix and the structural improvement land together
+  instead of the structural improvement becoming a second migration later.
+
+## Part 5 — The completeness check (landed, verified)
+
+`pixelflow-ir/src/backend/emit/coverage.rs` (test-only, `#[cfg(test)]`) is
+the single enumeration that did not exist before: `REQUIRED_UNARY_OPS`
+(10 ops), `REQUIRED_BINARY_OPS` (15), `REQUIRED_SHIFT_OPS` (2), and
+`REQUIRED_TERNARY_OPS` (`MulAdd`, `Select`, documented but hand-checked
+rather than looped — each has a distinct `ResolvedOp` shape). Each list's
+doc comment cites exactly which `lowering.rs` pass removes everything *not*
+listed, so the contract is traceable back to Part 1's Stage 1/Stage 2 split,
+not an arbitrary list.
+
+`mod.rs`'s new `backend_op_coverage` test module sweeps these against a
+real backend via `IsaBackend::emit_plan` (not the raw per-op functions, so
+it doesn't care whether a given backend signals "unsupported" via `Err`
+(avx512) or `panic!` (x86-64/aarch64 today) — `catch_unwind` treats both as
+the same "not supported" signal) and collects every failure into one
+itemized list rather than stopping at the first:
+
+- `x86_backend_covers_required_ops` — `#[cfg(target_arch = "x86_64")]`,
+  always compiles and runs on x86-64. Currently green (`X86Backend`
+  already covers every required op).
+- `aarch64_backend_covers_required_ops` — `#[cfg(target_arch = "aarch64")]`,
+  same shape, for the architecture this session's host cannot even compile
+  (the struct itself is arch-gated), so it will run wherever `cargo test`
+  actually runs on aarch64 hardware.
+- `avx512_backend_covers_required_ops` — `#[cfg(all(target_arch = "x86_64",
+  target_feature = "avx512f"))]`, mirroring the exact cfg
+  `compile_arena_dag_with_ctx` uses to select `Avx512Backend` in production
+  (`mod.rs:3292-3299`). On this session's default build it does not compile
+  at all — not "skipped," genuinely absent from the build — so it makes no
+  claim about AVX-512 completeness today and does not block this worktree's
+  green build. The moment the concurrent multi-ISA work (or anyone) builds
+  with `+avx512f`, this same test starts running and will fail immediately
+  with an itemized list of every missing op, instead of the 36-unrelated-
+  test-failures discovery mode from before this session.
+
+`x86_64.rs` additionally gets `selects_every_required_binary_op`, a cheaper
+and more precise check specific to the Part 4 pattern: it calls
+`X86BinaryInsn::select` directly against `REQUIRED_BINARY_OPS` rather than
+emitting-and-catching, because once a backend adopts the selection/encoding
+split, checking selection is a pure function call, not a runtime
+capability probe.
+
+**Verified to actually catch a regression**, not just to pass today:
+commenting out the `OpKind::BitOr => Some(Self::OrPs)` arm in
+`X86BinaryInsn::select` and re-running the suite fails with
+
+```
+X86Backend (SSE2) is missing required ops: ["binary BitOr"] (see
+pixelflow-ir/src/backend/emit/coverage.rs for the full completeness
+contract)
+```
+
+— by name, at the completeness test, not as a panic three stack frames
+away inside an unrelated test that happened to construct a `BitOr` node.
+The stub was reverted immediately after confirming this; `git diff` on the
+worktree shows no trace of it.
+
+`cargo test -p pixelflow-ir --lib backend::emit` and `cargo test
+--workspace` (default build, no RUSTFLAGS) both stay green with the check
+added — see the commit history on this branch for the exact run.
+
+## What's landed vs. what's follow-up
+
+**Landed this session:**
+- This design doc.
+- `coverage.rs` — the required-op enumeration, the completeness contract.
+- `backend_op_coverage` test module (`mod.rs`) — sweeps `X86Backend` always,
+  `Aarch64Backend`/`Avx512Backend` when the build actually compiles them.
+- `X86BinaryInsn` selection/encoding split (`x86_64.rs`) — pilot of the
+  Instruction/Assembler pattern, one backend, one op family, zero behavior
+  change, plus its own unit test.
+
+**Explicit follow-up, not done here, and why:**
+- Extending the selection/encoding split to unary/ternary ops and to
+  `aarch64.rs` — same pattern, mechanical, no open design question.
+- Applying the pattern to `avx512.rs` as *how* the concurrent multi-ISA
+  work fills its 9 missing ops, rather than as new arms in the existing
+  flat match — a coordination point for the main session, not something to
+  do unilaterally into an actively-edited file.
+- The reduction-binder-as-loop lowering strategy from Part 3 (large-`n`
+  `Reduce` lowering to a real loop instead of unrolling) and the two new
+  `IsaBackend` loop-counter primitives it needs — a real, scoped
+  implementation task, larger and riskier than this session's slice, and
+  explicitly out of scope per the task brief ("do not implement the full
+  binder-in-IR migration").
+- Retiring the x86 Sethi-Ullman tree-walk emitter (`needs_arena`/
+  `emit_arena`) and both scanline-hoisted paths' hand-duplicated guard logic
+  in favor of routing everything through `emit_dag_body`, and running Stage
+  1 lowering on the scanline tier so it stops silently rejecting
+  transcendentals/`Dwrt`/`Reduce` that the per-batch tier accepts — real
+  bug fixes (2b-iv is a correctness gap, not just a cleanliness one) but a
+  separate, reviewable change from this one.
+- Wiring `Lattice::collapse` to the internal-loop compile entry points once
+  Part 3 lands, eliminating the per-batch `extern "C"` call boundary in
+  production — the payoff of Part 3, not a separate project.

--- a/pixelflow-core/src/lattice/mod.rs
+++ b/pixelflow-core/src/lattice/mod.rs
@@ -594,9 +594,20 @@ mod tests;
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 struct RealizedKernel(alloc::sync::Arc<pixelflow_ir::JitManifold>);
 
-/// The vector type of the JIT's call ABI on this build.
-#[cfg(all(target_arch = "x86_64", not(target_feature = "avx512f")))]
+/// The vector type of the JIT's call ABI on this build. Mirrors
+/// `pixelflow_ir::JIT_VECTOR_BYTES`'s 3-way split (SSE2/AVX2/AVX-512).
+#[cfg(all(
+    target_arch = "x86_64",
+    not(target_feature = "avx512f"),
+    not(target_feature = "avx2")
+))]
 type JitVec = core::arch::x86_64::__m128;
+#[cfg(all(
+    target_arch = "x86_64",
+    target_feature = "avx2",
+    not(target_feature = "avx512f")
+))]
+type JitVec = core::arch::x86_64::__m256;
 #[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
 type JitVec = core::arch::x86_64::__m512;
 #[cfg(target_arch = "aarch64")]

--- a/pixelflow-core/src/storage.rs
+++ b/pixelflow-core/src/storage.rs
@@ -81,16 +81,18 @@ impl FieldStorage for f32 {
 // Storage Implementation for bool (Mask)
 // ============================================================================
 
-/// Native SIMD mask storage type for the current platform.
-///
-/// This is the native mask type from the IR backend:
-/// - AVX-512: `Mask16` (k-register, runs on separate execution unit)
-/// - AVX2: `Mask8` (float-encoded in YMM registers)
-/// - SSE2: `Mask4` (float-encoded in XMM registers)
-/// - NEON: `Mask4`
-/// - Scalar: `MaskScalar`
-#[cfg(all(target_arch = "x86_64", target_feature = "avx512f", pixelflow_avx512f))]
+// Native SIMD mask storage type for the current platform — the native mask type
+// from the IR backend, one `cfg`'d alias per width:
+//   AVX-512: `Mask16` (k-register, runs on a separate execution unit)
+//   AVX2:    `Mask8`  (float-encoded in YMM registers)
+//   SSE2:    `Mask4`  (float-encoded in XMM registers)
+//   NEON:    `Mask4`
+// Deliberately a plain comment, not a doc comment: it describes the whole
+// family, but rustdoc would attach it to whichever single alias this build
+// enables and merge it with that alias's own `///` line.
+
 /// Native mask storage for AVX-512.
+#[cfg(all(target_arch = "x86_64", target_feature = "avx512f", pixelflow_avx512f))]
 pub type NativeMaskStorage = crate::backend::x86::Mask16;
 
 #[cfg(all(

--- a/pixelflow-graphics/src/render/rasterizer/parallel.rs
+++ b/pixelflow-graphics/src/render/rasterizer/parallel.rs
@@ -177,8 +177,29 @@ struct SendPtr<T>(*mut T);
 unsafe impl<T> Send for SendPtr<T> {}
 unsafe impl<T> Sync for SendPtr<T> {}
 
-// 2MB stack per thread (needed for deep 3D scene recursion)
-const STACK_SIZE: usize = 2 * 1024 * 1024;
+/// Stack per worker thread, scaled by SIMD width.
+///
+/// Deep 3D scene recursion needs a large stack (the dev profile runs
+/// `opt-level=1` precisely because these Manifold chains overflow without
+/// inlining — see CLAUDE.md). The frames are dominated by `Field` locals, so
+/// the requirement grows with the vector: a flat 2 MiB was sized when a
+/// `Field` was 4 lanes, and an 8-lane build overflowed it — `scene3d_test`
+/// aborted with "has overflowed its stack" on the AVX2 leg of
+/// `cargo xtask isa-matrix` while passing at SSE2.
+///
+/// `Builder::stack_size` overrides `RUST_MIN_STACK`, so no environment
+/// variable can rescue these threads; the number has to be right here. Scaling
+/// off `size_of::<Field>()` keeps 2 MiB at 16-byte vectors (SSE2, NEON) and
+/// grows to 4 MiB at AVX2 and 8 MiB at AVX-512. The reservation is virtual and
+/// committed lazily, so the wider figures cost nothing on the untaken paths.
+const STACK_SIZE: usize = 2 * 1024 * 1024 * lanes_scale();
+
+/// `size_of::<Field>() / 16`, floored at 1 — how much wider this build's
+/// vector is than the 128-bit baseline the 2 MiB figure was chosen for.
+const fn lanes_scale() -> usize {
+    let scale = core::mem::size_of::<pixelflow_core::Field>() / 16;
+    if scale < 1 { 1 } else { scale }
+}
 
 /// Render with parallel rasterization (spawns new threads).
 pub fn render_parallel<P, M>(manifold: &M, frame: &mut Frame<P>, options: RenderOptions)

--- a/pixelflow-ir/src/backend/emit/avx2.rs
+++ b/pixelflow-ir/src/backend/emit/avx2.rs
@@ -1,0 +1,572 @@
+//! x86-64 AVX2 (VEX.256) JIT encoder — 256-bit, 8-lane `ymm` kernels.
+//!
+//! The middle width between the SSE2 leaf encoders (`x86_64.rs`, 128-bit) and
+//! the AVX-512 EVEX encoders (`avx512.rs`, 512-bit). Register numbering is
+//! identical to SSE2 (ymm0-15, no extended file — AVX2 has no REX2/EVEX), so
+//! this backend reuses the exact register-role layout `X86Backend` already
+//! established (inputs 0-3, allocatable 4-9, fixed scratch 10, reload 11-12,
+//! builtin scratch 10/13-15): only the instruction *encoding* changes.
+//!
+//! Unlike legacy SSE2, VEX is 3-operand and non-destructive — same property
+//! AVX-512's EVEX has — so there is no two-operand hazard to route around
+//! (contrast `emit_binary_safe` in `mod.rs`, needed only by the SSE2 path).
+//! Comparisons are simpler here than on AVX-512: `vcmpps` writes an ordinary
+//! all-ones/all-zeros `ymm` directly (no k-register, no mask-to-vector
+//! conversion) — the same representation NEON and SSE2 already use.
+//!
+//! Spills use a real stack frame, not the red zone: mirrors `avx512.rs`'s
+//! reasoning (a `ymm` slot is 32 bytes; keeping the red-zone arithmetic exact
+//! for two different slot widths is not worth it for a bit of frame reuse on
+//! tiny kernels).
+//!
+//! Gather has no direct AVX2 hardware analogue reused here: `vgatherdps`'s
+//! VSIB + vector-mask-with-clearing semantics are a bigger lift than this
+//! backend's scope warrants, so — like `X86Backend` — a gather is assembled
+//! from scalar loads via the existing 128-bit lane-insert sequence
+//! (`x86_64::emit_gather_scalar`), run once per 128-bit half and combined
+//! with `vinsertf128`.
+
+use super::Reg;
+use super::x86_64;
+use crate::OpKind;
+use alloc::vec::Vec;
+
+// =============================================================================
+// VEX.256 encoder
+// =============================================================================
+
+/// Emit a VEX-encoded 3-operand instruction, 256-bit (`L=1`).
+/// `pp`: 0=none, 1=0x66, 2=0xF3, 3=0xF2. `mmmmm`: 1=0F, 2=0F38, 3=0F3A.
+fn vex256(
+    code: &mut Vec<u8>,
+    pp: u8,
+    mmmmm: u8,
+    w: u8,
+    opcode: u8,
+    dst: u8,
+    vvvv: u8,
+    rm: u8,
+) {
+    let rbit = if dst >= 8 { 0x00 } else { 0x80 };
+    let xbit = 0x40;
+    let bbit = if rm >= 8 { 0x00 } else { 0x20 };
+    code.push(0xC4);
+    code.push(rbit | xbit | bbit | mmmmm);
+    code.push((w << 7) | ((!vvvv & 0xF) << 3) | (1 << 2) | pp); // L=1
+    code.push(opcode);
+    code.push(0xC0 | ((dst & 7) << 3) | (rm & 7));
+}
+
+/// Like [`vex256`] but appends an `imm8` (for `vcmpps`, `vroundps`, shifts).
+#[allow(clippy::too_many_arguments)]
+fn vex256_imm(code: &mut Vec<u8>, pp: u8, mmmmm: u8, w: u8, opcode: u8, dst: u8, vvvv: u8, rm: u8, imm: u8) {
+    vex256(code, pp, mmmmm, w, opcode, dst, vvvv, rm);
+    code.push(imm);
+}
+
+/// Sentinel for an unused VEX.vvvv source (2-operand forms): index 0 inverts
+/// to `1111`, the required "unused" encoding.
+const UNUSED_VVVV: u8 = 0;
+
+/// `[rsp + disp32]` operand form for a VEX 256-bit load/store.
+fn vex256_rm_rsp(code: &mut Vec<u8>, pp: u8, mmmmm: u8, w: u8, opcode: u8, reg: u8, disp: i32) {
+    let rbit = if reg >= 8 { 0x00 } else { 0x80 };
+    code.push(0xC4);
+    code.push(rbit | 0x40 | 0x20 | mmmmm); // X=1 (unused), B=1 (rsp < 8)
+    code.push((w << 7) | (0xF << 3) | (1 << 2) | pp); // vvvv unused, L=1
+    code.push(opcode);
+    code.push(0x84 | ((reg & 7) << 3)); // mod=10, reg=reg, rm=100 (SIB)
+    code.push(0x24); // SIB: base=rsp, no index
+    code.extend_from_slice(&disp.to_le_bytes());
+}
+
+// --- packed-single arithmetic (0F, no prefix, W0) ---
+fn vaddps(c: &mut Vec<u8>, d: u8, s1: u8, s2: u8) {
+    vex256(c, 0, 1, 0, 0x58, d, s1, s2);
+}
+fn vsubps(c: &mut Vec<u8>, d: u8, s1: u8, s2: u8) {
+    vex256(c, 0, 1, 0, 0x5C, d, s1, s2);
+}
+fn vmulps(c: &mut Vec<u8>, d: u8, s1: u8, s2: u8) {
+    vex256(c, 0, 1, 0, 0x59, d, s1, s2);
+}
+fn vdivps(c: &mut Vec<u8>, d: u8, s1: u8, s2: u8) {
+    vex256(c, 0, 1, 0, 0x5E, d, s1, s2);
+}
+fn vminps(c: &mut Vec<u8>, d: u8, s1: u8, s2: u8) {
+    vex256(c, 0, 1, 0, 0x5D, d, s1, s2);
+}
+fn vmaxps(c: &mut Vec<u8>, d: u8, s1: u8, s2: u8) {
+    vex256(c, 0, 1, 0, 0x5F, d, s1, s2);
+}
+fn vsqrtps(c: &mut Vec<u8>, d: u8, s: u8) {
+    vex256(c, 0, 1, 0, 0x51, d, UNUSED_VVVV, s);
+}
+fn vrsqrtps(c: &mut Vec<u8>, d: u8, s: u8) {
+    vex256(c, 0, 1, 0, 0x52, d, UNUSED_VVVV, s);
+}
+fn vrcpps(c: &mut Vec<u8>, d: u8, s: u8) {
+    vex256(c, 0, 1, 0, 0x53, d, UNUSED_VVVV, s);
+}
+
+// --- bitwise (0F, no prefix, W0) ---
+fn vandps(c: &mut Vec<u8>, d: u8, s1: u8, s2: u8) {
+    vex256(c, 0, 1, 0, 0x54, d, s1, s2);
+}
+fn vandnps(c: &mut Vec<u8>, d: u8, s1: u8, s2: u8) {
+    vex256(c, 0, 1, 0, 0x55, d, s1, s2);
+}
+fn vorps(c: &mut Vec<u8>, d: u8, s1: u8, s2: u8) {
+    vex256(c, 0, 1, 0, 0x56, d, s1, s2);
+}
+fn vxorps(c: &mut Vec<u8>, d: u8, s1: u8, s2: u8) {
+    vex256(c, 0, 1, 0, 0x57, d, s1, s2);
+}
+
+// --- comparisons (0F, no prefix, W0; imm8 predicate) ---
+const CMP_EQ: u8 = 0;
+const CMP_LT: u8 = 1;
+const CMP_LE: u8 = 2;
+const CMP_NEQ: u8 = 4;
+const CMP_GE: u8 = 5;
+const CMP_NLE: u8 = 6; // > (unordered-safe "not less-or-equal")
+
+fn vcmpps(c: &mut Vec<u8>, d: u8, s1: u8, s2: u8, pred: u8) {
+    vex256_imm(c, 0, 1, 0, 0xC2, d, s1, s2, pred);
+}
+
+fn cmp_pred(op: OpKind) -> Option<u8> {
+    Some(match op {
+        OpKind::Eq => CMP_EQ,
+        OpKind::Ne => CMP_NEQ,
+        OpKind::Lt => CMP_LT,
+        OpKind::Le => CMP_LE,
+        OpKind::Gt => CMP_NLE,
+        OpKind::Ge => CMP_GE,
+        _ => return None,
+    })
+}
+
+/// Whether `op` is a comparison handled by [`emit_binary`].
+#[must_use]
+pub fn is_compare(op: OpKind) -> bool {
+    cmp_pred(op).is_some()
+}
+
+// --- rounding (0F3A, 66 prefix, W0; imm8) ---
+fn vroundps(c: &mut Vec<u8>, d: u8, s: u8, imm: u8) {
+    vex256_imm(c, 1, 3, 0, 0x08, d, UNUSED_VVVV, s, imm);
+}
+
+// --- int/float convert (0F, W0) ---
+fn vcvttps2dq(c: &mut Vec<u8>, d: u8, s: u8) {
+    vex256(c, 2, 1, 0, 0x5B, d, UNUSED_VVVV, s); // F3 prefix
+}
+fn vcvtdq2ps(c: &mut Vec<u8>, d: u8, s: u8) {
+    vex256(c, 0, 1, 0, 0x5B, d, UNUSED_VVVV, s); // no prefix
+}
+
+// --- integer-domain (66 prefix, 0F, W0) ---
+fn vpaddd(c: &mut Vec<u8>, d: u8, s1: u8, s2: u8) {
+    vex256(c, 1, 1, 0, 0xFE, d, s1, s2);
+}
+fn vpslld_imm(c: &mut Vec<u8>, d: u8, s: u8, imm: u8) {
+    vex256_imm(c, 1, 1, 0, 0x72, 6, d, s, imm); // /6, dst=vvvv, src=rm
+}
+fn vpsrld_imm(c: &mut Vec<u8>, d: u8, s: u8, imm: u8) {
+    vex256_imm(c, 1, 1, 0, 0x72, 2, d, s, imm); // /2
+}
+
+// --- lane insert/extract between 256-bit and 128-bit (0F3A, 66 prefix, W0) ---
+/// `vinsertf128 ymmDST, ymmSRC1, xmmSRC2, imm8[0]` — copy `src1`, then place
+/// `src2` into the low (`imm=0`) or high (`imm=1`) 128 bits.
+fn vinsertf128(c: &mut Vec<u8>, d: u8, s1: u8, s2: u8, imm: u8) {
+    vex256_imm(c, 1, 3, 0, 0x18, d, s1, s2, imm);
+}
+/// `vextractf128 xmmDST, ymmSRC, imm8[0]` — extract the low (`imm=0`) or high
+/// (`imm=1`) 128 bits of `src` into `dst`.
+fn vextractf128(c: &mut Vec<u8>, d: u8, s: u8, imm: u8) {
+    // VEX.256.66.0F3A.W0 19 /r ib — note dst is the ModRM.rm operand here
+    // (the reverse of the usual direction: register source, register/mem dest).
+    vex256_imm(c, 1, 3, 0, 0x19, s, UNUSED_VVVV, d, imm);
+}
+
+/// `vmovaps ymmDST, ymmSRC` — register copy.
+pub fn emit_mov(code: &mut Vec<u8>, dst: Reg, src: Reg) {
+    if dst.0 == src.0 {
+        return;
+    }
+    vex256(code, 0, 1, 0, 0x28, dst.0, UNUSED_VVVV, src.0);
+}
+
+/// `vmovups ymmDST, [rsp+disp32]` — 256-bit reload.
+pub fn emit_load_rsp(code: &mut Vec<u8>, dst: Reg, disp: i32) {
+    vex256_rm_rsp(code, 0, 1, 0, 0x10, dst.0, disp);
+}
+
+/// `vmovups [rsp+disp32], ymmSRC` — 256-bit spill store.
+pub fn emit_store_rsp(code: &mut Vec<u8>, src: Reg, disp: i32) {
+    vex256_rm_rsp(code, 0, 1, 0, 0x11, src.0, disp);
+}
+
+/// Broadcast an f32 constant to all 8 lanes of `dst` via the stack (red zone,
+/// `[rsp-4]`; never affected by a spill frame, which lives at `[rsp..rsp+N)`).
+pub fn emit_const(code: &mut Vec<u8>, dst: Reg, val: f32) {
+    let bits = val.to_bits();
+    if bits == 0 {
+        vxorps(code, dst.0, dst.0, dst.0);
+        return;
+    }
+    // mov dword [rsp-4], imm32
+    code.extend_from_slice(&[0xC7, 0x44, 0x24, 0xFC]);
+    code.extend_from_slice(&bits.to_le_bytes());
+    // vbroadcastss ymm, [rsp-4]  (VEX.256.66.0F38.W0 18 /r)
+    let rbit = if dst.0 >= 8 { 0x00 } else { 0x80 };
+    code.push(0xC4);
+    code.push(rbit | 0x40 | 0x20 | 2); // mmmmm = 0F38
+    code.push((0xF << 3) | (1 << 2) | 1); // vvvv unused, L=1, pp=66
+    code.push(0x18);
+    code.push(0x44 | ((dst.0 & 7) << 3)); // mod=01, reg=dst, rm=100 (SIB)
+    code.push(0x24);
+    code.push(0xFC_u8); // disp8 = -4
+}
+
+// =============================================================================
+// Stack frame (real frame; a ymm spill is 32 bytes)
+// =============================================================================
+
+pub fn emit_sub_rsp(code: &mut Vec<u8>, size: u32) {
+    code.extend_from_slice(&[0x48, 0x81, 0xEC]);
+    code.extend_from_slice(&size.to_le_bytes());
+}
+pub fn emit_add_rsp(code: &mut Vec<u8>, size: u32) {
+    code.extend_from_slice(&[0x48, 0x81, 0xC4]);
+    code.extend_from_slice(&size.to_le_bytes());
+}
+pub fn emit_ret(code: &mut Vec<u8>) {
+    code.push(0xC3);
+}
+
+// =============================================================================
+// Op dispatch
+// =============================================================================
+
+/// `dst = op(src1, src2)`. VEX is 3-operand/non-destructive: operands are
+/// never clobbered and may alias `dst`. Comparisons produce an ordinary
+/// all-ones/all-zeros vector directly (no k-register step, unlike AVX-512).
+pub fn emit_binary(code: &mut Vec<u8>, op: OpKind, dst: Reg, src1: Reg, src2: Reg) -> Result<(), &'static str> {
+    let (d, s1, s2) = (dst.0, src1.0, src2.0);
+    if let Some(pred) = cmp_pred(op) {
+        vcmpps(code, d, s1, s2, pred);
+        return Ok(());
+    }
+    match op {
+        OpKind::Add => vaddps(code, d, s1, s2),
+        OpKind::Sub => vsubps(code, d, s1, s2),
+        OpKind::Mul => vmulps(code, d, s1, s2),
+        OpKind::Div => vdivps(code, d, s1, s2),
+        OpKind::Min => vminps(code, d, s1, s2),
+        OpKind::Max => vmaxps(code, d, s1, s2),
+        OpKind::BitAnd => vandps(code, d, s1, s2),
+        OpKind::BitOr => vorps(code, d, s1, s2),
+        OpKind::IAdd => vpaddd(code, d, s1, s2),
+        _ => return Err("avx2: binary op not implemented"),
+    }
+    Ok(())
+}
+
+/// `dst = op(src)`.
+pub fn emit_unary(code: &mut Vec<u8>, op: OpKind, dst: Reg, src: Reg) -> Result<(), &'static str> {
+    match op {
+        OpKind::Sqrt => vsqrtps(code, dst.0, src.0),
+        OpKind::Rsqrt => vrsqrtps(code, dst.0, src.0),
+        OpKind::Recip => vrcpps(code, dst.0, src.0),
+        OpKind::Neg => {
+            emit_const(code, UNARY_SCRATCH, f32::from_bits(0x8000_0000));
+            vxorps(code, dst.0, src.0, UNARY_SCRATCH.0);
+        }
+        OpKind::Abs => {
+            emit_const(code, UNARY_SCRATCH, f32::from_bits(0x7FFF_FFFF));
+            vandps(code, dst.0, src.0, UNARY_SCRATCH.0);
+        }
+        // imm8: bits[3:0] = rounding mode (0=nearest, 1=floor, 2=ceil).
+        OpKind::Floor => vroundps(code, dst.0, src.0, 0x01),
+        OpKind::Ceil => vroundps(code, dst.0, src.0, 0x02),
+        OpKind::Round => vroundps(code, dst.0, src.0, 0x00),
+        OpKind::TruncToInt => vcvttps2dq(code, dst.0, src.0),
+        OpKind::IntToFloat => vcvtdq2ps(code, dst.0, src.0),
+        _ => return Err("avx2: unary op not implemented"),
+    }
+    Ok(())
+}
+
+/// Scratch register for unary mask materialization (neg/abs) and the select
+/// blend temp. ymm15 is outside the allocatable range (4-9), reload regs
+/// (11-12), and inputs (0-3).
+const UNARY_SCRATCH: Reg = Reg(15);
+
+/// Emit a shift of i32 lanes by a compile-time immediate.
+pub fn emit_shift_imm(code: &mut Vec<u8>, op: OpKind, dst: Reg, src: Reg, amount: u8) -> Result<(), &'static str> {
+    match op {
+        OpKind::Shl => vpslld_imm(code, dst.0, src.0, amount),
+        OpKind::Shr => vpsrld_imm(code, dst.0, src.0, amount),
+        _ => return Err("avx2: not a shift op"),
+    }
+    Ok(())
+}
+
+/// `dst = mask ? if_true : if_false` (bit-select; mask already in `dst`, same
+/// convention as SSE2/AVX-512). `tmp` differs from all of `dst`/`if_true`/`if_false`.
+pub fn emit_select(code: &mut Vec<u8>, dst: Reg, if_true: Reg, if_false: Reg) {
+    let tmp = UNARY_SCRATCH;
+    debug_assert!(tmp.0 != dst.0 && tmp.0 != if_true.0 && tmp.0 != if_false.0);
+    vandps(code, tmp.0, dst.0, if_true.0); // tmp = mask & if_true
+    vandnps(code, dst.0, dst.0, if_false.0); // dst = ~mask & if_false
+    vorps(code, dst.0, tmp.0, dst.0); // dst = blended
+}
+
+/// `vmovmskps eax, ymmSRC` — gather the 8 lane sign bits into eax[7:0].
+pub fn emit_movmskps_eax(code: &mut Vec<u8>, src: Reg) {
+    vex256(code, 0, 1, 0, 0x50, 0, UNUSED_VVVV, src.0);
+}
+
+/// `cmp al, imm8` — unlike `cmp eax, imm8` (sign-extending `0x83`), this
+/// compares the raw byte pattern, which is what an 8-lane all-true check
+/// (`eax == 0xFF`) needs (`0x83`'s sign-extension would compare against
+/// `0xFFFFFFFF`, which `vmovmskps`'s zero-extended result can never equal).
+pub fn emit_cmp_al_imm8(code: &mut Vec<u8>, imm: u8) {
+    code.push(0x3C);
+    code.push(imm);
+}
+
+/// Fused multiply-add via software mul+add (no hardware FMA dependency: this
+/// backend is gated on `avx2` alone, not `avx2,fma`, and VIA/older Zen
+/// chips have shipped AVX2 without FMA3). `dst` already holds `c`.
+pub fn emit_fmadd_c_in_dst(code: &mut Vec<u8>, dst: Reg, a: Reg, b: Reg) {
+    let tmp = UNARY_SCRATCH;
+    vmulps(code, tmp.0, a.0, b.0);
+    vaddps(code, dst.0, dst.0, tmp.0);
+}
+
+// =============================================================================
+// Bound-memory gather (RawGather lowering target)
+//
+// No native vgatherdps here (see the module doc): truncate all 8 lanes at
+// once, split into two 128-bit halves, run the existing SSE2/AVX scalar-load
+// sequence (`x86_64::emit_gather_scalar`) on each half (it only ever touches
+// the low 128 bits of whatever register it's given — ymm0's low 128 IS
+// xmm0), then recombine with vinsertf128.
+// =============================================================================
+
+/// `dst = buffer[slot][idx_lane]` for 8 lanes. `idx` holds FLOAT indices
+/// (already clamped in range by the `Gather` lowering — `x86_64::emit_gather_scalar`
+/// does its own float->int truncation per half, so `idx` must not be
+/// pre-truncated here). Clobbers the GPRs and vector scratch in `s`, plus
+/// `idx_hi`/`res_hi` (backend-reserved scratch distinct from `s`'s fields and
+/// from `dst`/`idx`).
+#[allow(clippy::too_many_arguments)]
+pub fn emit_gather_scalar(
+    code: &mut Vec<u8>,
+    dst: Reg,
+    idx: Reg,
+    slot: u16,
+    s: x86_64::GatherScratch,
+    idx_hi: Reg,
+    res_hi: Reg,
+) {
+    // idx's low 128 already holds lanes 0..4 (float); split off lanes 4..8
+    // into idx_hi before either gather call touches idx/dst (which may alias).
+    vextractf128(code, idx_hi.0, idx.0, 1);
+
+    // Low half: lanes 0..4. May write dst == idx (the callee handles that:
+    // it converts idx to int in scratch before ever writing dst).
+    x86_64::emit_gather_scalar(code, dst, idx, slot, s);
+    // High half: lanes 4..8, into res_hi (a 128-bit scratch distinct from dst).
+    x86_64::emit_gather_scalar(code, res_hi, idx_hi, slot, s);
+
+    // Recombine: dst[0..4] already holds the low half; splice in the high.
+    vinsertf128(code, dst.0, dst.0, res_hi.0, 1);
+}
+
+#[cfg(test)]
+mod tests {
+    //! Hardware validation, mirroring `avx512.rs`'s runtime test tier: JIT real
+    //! `ymm` kernels and execute them on the host.
+    #[cfg(all(target_feature = "avx2", not(target_feature = "avx512f")))]
+    mod runtime {
+        use super::super::*;
+        use crate::backend::emit::executable::ExecutableCode;
+        use core::arch::x86_64::*;
+
+        type K = unsafe extern "C" fn(__m256, __m256, __m256, __m256) -> __m256;
+
+        fn run(body: &[u8], xs: [f32; 8], ys: [f32; 8], zs: [f32; 8]) -> [f32; 8] {
+            let mut code = body.to_vec();
+            emit_ret(&mut code);
+            let exec = unsafe { ExecutableCode::from_code(&code).expect("mmap") };
+            unsafe {
+                let f: K = exec.as_fn();
+                let r = f(
+                    _mm256_loadu_ps(xs.as_ptr()),
+                    _mm256_loadu_ps(ys.as_ptr()),
+                    _mm256_loadu_ps(zs.as_ptr()),
+                    _mm256_setzero_ps(),
+                );
+                let mut out = [0.0f32; 8];
+                _mm256_storeu_ps(out.as_mut_ptr(), r);
+                out
+            }
+        }
+
+        fn lanes() -> ([f32; 8], [f32; 8], [f32; 8]) {
+            let mut xs = [0.0; 8];
+            let mut ys = [0.0; 8];
+            let mut zs = [0.0; 8];
+            for i in 0..8 {
+                xs[i] = i as f32 - 3.5;
+                ys[i] = (i as f32) * 0.5 + 1.0;
+                zs[i] = 3.0 - (i as f32) * 0.25;
+            }
+            (xs, ys, zs)
+        }
+
+        fn check(got: [f32; 8], want: impl Fn(usize) -> f32, tag: &str) {
+            for i in 0..8 {
+                let w = want(i);
+                assert!(
+                    (got[i] - w).abs() <= 1e-3,
+                    "{tag} lane {i}: got {} want {}",
+                    got[i],
+                    w
+                );
+            }
+        }
+
+        const X: Reg = Reg(0);
+        const Y: Reg = Reg(1);
+        const Z: Reg = Reg(2);
+
+        #[test]
+        fn binary_ops() {
+            let (xs, ys, zs) = lanes();
+            let cases: &[(OpKind, fn(f32, f32) -> f32)] = &[
+                (OpKind::Add, |a, b| a + b),
+                (OpKind::Sub, |a, b| a - b),
+                (OpKind::Mul, |a, b| a * b),
+                (OpKind::Div, |a, b| a / b),
+                (OpKind::Min, |a, b| a.min(b)),
+                (OpKind::Max, |a, b| a.max(b)),
+            ];
+            for &(op, f) in cases {
+                let mut c = Vec::new();
+                emit_binary(&mut c, op, X, X, Y).unwrap();
+                check(run(&c, xs, ys, zs), |i| f(xs[i], ys[i]), "binary");
+            }
+        }
+
+        #[test]
+        fn compare_lt() {
+            let (xs, ys, zs) = lanes();
+            let mut c = Vec::new();
+            emit_binary(&mut c, OpKind::Lt, X, X, Y).unwrap();
+            check(
+                run(&c, xs, ys, zs),
+                |i| if xs[i] < ys[i] { f32::from_bits(0xFFFF_FFFF) } else { 0.0 },
+                "lt mask",
+            );
+        }
+
+        #[test]
+        fn sqrt_and_neg_abs() {
+            let (xs, ys, zs) = lanes();
+            let mut c = Vec::new();
+            emit_unary(&mut c, OpKind::Sqrt, X, Y).unwrap();
+            check(run(&c, xs, ys, zs), |i| ys[i].sqrt(), "sqrt");
+
+            let mut c = Vec::new();
+            emit_unary(&mut c, OpKind::Neg, X, X).unwrap();
+            check(run(&c, xs, ys, zs), |i| -xs[i], "neg");
+
+            let mut c = Vec::new();
+            emit_unary(&mut c, OpKind::Abs, X, X).unwrap();
+            check(run(&c, xs, ys, zs), |i| xs[i].abs(), "abs");
+        }
+
+        #[test]
+        fn select_blend() {
+            let (xs, ys, zs) = lanes();
+            let mut c = Vec::new();
+            emit_binary(&mut c, OpKind::Lt, Reg(5), X, Y).unwrap(); // mask
+            emit_mov(&mut c, Reg(6), Reg(5));
+            emit_select(&mut c, Reg(6), X, Y); // dst = mask ? x : y
+            emit_mov(&mut c, X, Reg(6));
+            check(
+                run(&c, xs, ys, zs),
+                |i| if xs[i] < ys[i] { xs[i] } else { ys[i] },
+                "select",
+            );
+        }
+
+        #[test]
+        fn const_broadcast_and_fma() {
+            let (xs, ys, zs) = lanes();
+            let mut c = Vec::new();
+            emit_const(&mut c, Reg(5), 2.5);
+            emit_binary(&mut c, OpKind::Add, X, X, Reg(5)).unwrap();
+            check(run(&c, xs, ys, zs), |i| xs[i] + 2.5, "const+add");
+
+            let mut c = Vec::new();
+            emit_mov(&mut c, Reg(5), Z);
+            emit_fmadd_c_in_dst(&mut c, Reg(5), X, Y);
+            emit_mov(&mut c, X, Reg(5));
+            check(run(&c, xs, ys, zs), |i| xs[i] * ys[i] + zs[i], "fma sw");
+        }
+
+        #[test]
+        fn spill_frame_roundtrip() {
+            let (xs, ys, zs) = lanes();
+            let mut c = Vec::new();
+            emit_sub_rsp(&mut c, 32);
+            emit_binary(&mut c, OpKind::Mul, Reg(6), X, Y).unwrap();
+            emit_store_rsp(&mut c, Reg(6), 0);
+            emit_binary(&mut c, OpKind::Add, Reg(6), X, X).unwrap(); // clobber
+            emit_load_rsp(&mut c, X, 0);
+            emit_add_rsp(&mut c, 32);
+            check(run(&c, xs, ys, zs), |i| xs[i] * ys[i], "spill roundtrip");
+        }
+
+        #[test]
+        fn gather_from_buffer() {
+            type G = unsafe extern "C" fn(*const f32, __m256) -> __m256;
+
+            let mut c = Vec::new();
+            // idx (zmm/ymm0) -> int truncate happens inside emit_gather_scalar.
+            let s = x86_64::GatherScratch {
+                base_gpr: 0,  // rax
+                index_gpr: 1, // rcx
+                ctx_gpr: 7,   // rdi
+                idx_lanes: Reg(13),
+                value: Reg(14),
+            };
+            emit_gather_scalar(&mut c, Reg(0), Reg(0), 0, s, Reg(9), Reg(8));
+            emit_ret(&mut c);
+
+            let buf: Vec<f32> = (0..64).map(|i| (i as f32) * 1.5 + 0.25).collect();
+            let idx: [f32; 8] = [0.0, 63.0, 1.0, 2.0, 10.0, 5.0, 32.0, 7.0];
+
+            let exec = unsafe { ExecutableCode::from_code(&c).expect("mmap") };
+            let out = unsafe {
+                let f: G = exec.as_fn();
+                let r = f(buf.as_ptr(), _mm256_loadu_ps(idx.as_ptr()));
+                let mut out = [0.0f32; 8];
+                _mm256_storeu_ps(out.as_mut_ptr(), r);
+                out
+            };
+
+            for i in 0..8 {
+                let want = buf[idx[i] as usize];
+                assert_eq!(out[i], want, "gather lane {i}: idx {}", idx[i]);
+            }
+        }
+    }
+}

--- a/pixelflow-ir/src/backend/emit/avx2.rs
+++ b/pixelflow-ir/src/backend/emit/avx2.rs
@@ -35,92 +35,170 @@ use alloc::vec::Vec;
 // VEX.256 encoder
 // =============================================================================
 
-/// Emit a VEX-encoded 3-operand instruction, 256-bit (`L=1`).
-/// `pp`: 0=none, 1=0x66, 2=0xF3, 3=0xF2. `mmmmm`: 1=0F, 2=0F38, 3=0F3A.
-fn vex256(
-    code: &mut Vec<u8>,
-    pp: u8,
-    mmmmm: u8,
-    w: u8,
-    opcode: u8,
-    dst: u8,
-    vvvv: u8,
-    rm: u8,
-) {
-    let rbit = if dst >= 8 { 0x00 } else { 0x80 };
-    let xbit = 0x40;
-    let bbit = if rm >= 8 { 0x00 } else { 0x20 };
-    code.push(0xC4);
-    code.push(rbit | xbit | bbit | mmmmm);
-    code.push((w << 7) | ((!vvvv & 0xF) << 3) | (1 << 2) | pp); // L=1
-    code.push(opcode);
-    code.push(0xC0 | ((dst & 7) << 3) | (rm & 7));
+/// Which legacy-prefix byte the VEX prefix implies (the `pp` field).
+#[derive(Clone, Copy)]
+enum Pp {
+    /// No implied prefix.
+    None = 0,
+    /// `66`
+    P66 = 1,
+    /// `F3`
+    F3 = 2,
 }
 
-/// Like [`vex256`] but appends an `imm8` (for `vcmpps`, `vroundps`, shifts).
-#[allow(clippy::too_many_arguments)]
-fn vex256_imm(code: &mut Vec<u8>, pp: u8, mmmmm: u8, w: u8, opcode: u8, dst: u8, vvvv: u8, rm: u8, imm: u8) {
-    vex256(code, pp, mmmmm, w, opcode, dst, vvvv, rm);
-    code.push(imm);
+/// Which opcode map the instruction lives in (the field Intel calls
+/// `mmmmm` — a map *selector*, nothing more).
+#[derive(Clone, Copy)]
+enum Map {
+    /// `0F`
+    M0F = 1,
+    /// `0F38`
+    M0F38 = 2,
+    /// `0F3A`
+    M0F3A = 3,
+}
+
+/// The identity of one VEX-256 instruction: opcode map, implied legacy
+/// prefix, W bit, opcode byte. This quadruple is *which instruction* — it is
+/// constant per mnemonic, so each mnemonic below states it exactly once and
+/// the operand form (`rrr`/`imm`/`rm_rsp`) supplies the per-call parts.
+#[derive(Clone, Copy)]
+struct Vex {
+    map: Map,
+    pp: Pp,
+    w: bool,
+    opcode: u8,
 }
 
 /// Sentinel for an unused VEX.vvvv source (2-operand forms): index 0 inverts
 /// to `1111`, the required "unused" encoding.
 const UNUSED_VVVV: u8 = 0;
 
-/// `[rsp + disp32]` operand form for a VEX 256-bit load/store.
-fn vex256_rm_rsp(code: &mut Vec<u8>, pp: u8, mmmmm: u8, w: u8, opcode: u8, reg: u8, disp: i32) {
-    let rbit = if reg >= 8 { 0x00 } else { 0x80 };
-    code.push(0xC4);
-    code.push(rbit | 0x40 | 0x20 | mmmmm); // X=1 (unused), B=1 (rsp < 8)
-    code.push((w << 7) | (0xF << 3) | (1 << 2) | pp); // vvvv unused, L=1
-    code.push(opcode);
-    code.push(0x84 | ((reg & 7) << 3)); // mod=10, reg=reg, rm=100 (SIB)
-    code.push(0x24); // SIB: base=rsp, no index
-    code.extend_from_slice(&disp.to_le_bytes());
+impl Vex {
+    const fn new(map: Map, pp: Pp, opcode: u8) -> Self {
+        Self { map, pp, w: false, opcode }
+    }
+    /// Map `0F`, no prefix — the packed-single arithmetic family.
+    const fn m0f(opcode: u8) -> Self {
+        Self::new(Map::M0F, Pp::None, opcode)
+    }
+    /// Map `0F`, `66` — the integer-domain family.
+    const fn m0f_66(opcode: u8) -> Self {
+        Self::new(Map::M0F, Pp::P66, opcode)
+    }
+    /// Map `0F`, `F3`.
+    const fn m0f_f3(opcode: u8) -> Self {
+        Self::new(Map::M0F, Pp::F3, opcode)
+    }
+    /// Map `0F38`, `66`.
+    const fn m0f38_66(opcode: u8) -> Self {
+        Self::new(Map::M0F38, Pp::P66, opcode)
+    }
+    /// Map `0F3A`, `66` — the imm8 family (round, insert/extract).
+    const fn m0f3a_66(opcode: u8) -> Self {
+        Self::new(Map::M0F3A, Pp::P66, opcode)
+    }
+
+    /// Attach an imm8 (`vcmpps` predicate, rounding mode, shift count, lane
+    /// index); the returned value emits it after the instruction.
+    const fn imm(self, imm: u8) -> VexImm {
+        VexImm { vex: self, imm }
+    }
+
+    /// Register-register-register form: `op dst, vvvv, rm`.
+    fn rrr(self, code: &mut Vec<u8>, dst: u8, vvvv: u8, rm: u8) {
+        let rbit = if dst >= 8 { 0x00 } else { 0x80 };
+        let xbit = 0x40;
+        let bbit = if rm >= 8 { 0x00 } else { 0x20 };
+        code.push(0xC4);
+        code.push(rbit | xbit | bbit | self.map as u8);
+        code.push(((self.w as u8) << 7) | ((!vvvv & 0xF) << 3) | (1 << 2) | self.pp as u8); // L=1
+        code.push(self.opcode);
+        code.push(0xC0 | ((dst & 7) << 3) | (rm & 7));
+    }
+
+    /// `[rsp + disp32]` memory-operand form (spill loads/stores).
+    fn rm_rsp(self, code: &mut Vec<u8>, reg: u8, disp: i32) {
+        self.rm_rsp_prefix(code, reg);
+        code.push(0x84 | ((reg & 7) << 3)); // mod=10, reg=reg, rm=100 (SIB)
+        code.push(0x24); // SIB: base=rsp, no index
+        code.extend_from_slice(&disp.to_le_bytes());
+    }
+
+    /// `[rsp + disp8]` memory-operand form (red-zone constant broadcast).
+    fn rm_rsp8(self, code: &mut Vec<u8>, reg: u8, disp: i8) {
+        self.rm_rsp_prefix(code, reg);
+        code.push(0x44 | ((reg & 7) << 3)); // mod=01, reg=reg, rm=100 (SIB)
+        code.push(0x24);
+        code.push(disp as u8);
+    }
+
+    /// Shared VEX prefix + opcode for the rsp-based memory forms.
+    fn rm_rsp_prefix(self, code: &mut Vec<u8>, reg: u8) {
+        let rbit = if reg >= 8 { 0x00 } else { 0x80 };
+        code.push(0xC4);
+        code.push(rbit | 0x40 | 0x20 | self.map as u8); // X=1 (unused), B=1 (rsp < 8)
+        code.push(((self.w as u8) << 7) | (0xF << 3) | (1 << 2) | self.pp as u8); // vvvv unused, L=1
+        code.push(self.opcode);
+    }
+}
+
+/// A [`Vex`] instruction carrying its imm8.
+#[derive(Clone, Copy)]
+struct VexImm {
+    vex: Vex,
+    imm: u8,
+}
+
+impl VexImm {
+    /// Register form with the imm8 appended.
+    fn rrr(self, code: &mut Vec<u8>, dst: u8, vvvv: u8, rm: u8) {
+        self.vex.rrr(code, dst, vvvv, rm);
+        code.push(self.imm);
+    }
 }
 
 // --- packed-single arithmetic (0F, no prefix, W0) ---
 fn vaddps(c: &mut Vec<u8>, d: u8, s1: u8, s2: u8) {
-    vex256(c, 0, 1, 0, 0x58, d, s1, s2);
+    Vex::m0f(0x58).rrr(c, d, s1, s2);
 }
 fn vsubps(c: &mut Vec<u8>, d: u8, s1: u8, s2: u8) {
-    vex256(c, 0, 1, 0, 0x5C, d, s1, s2);
+    Vex::m0f(0x5C).rrr(c, d, s1, s2);
 }
 fn vmulps(c: &mut Vec<u8>, d: u8, s1: u8, s2: u8) {
-    vex256(c, 0, 1, 0, 0x59, d, s1, s2);
+    Vex::m0f(0x59).rrr(c, d, s1, s2);
 }
 fn vdivps(c: &mut Vec<u8>, d: u8, s1: u8, s2: u8) {
-    vex256(c, 0, 1, 0, 0x5E, d, s1, s2);
+    Vex::m0f(0x5E).rrr(c, d, s1, s2);
 }
 fn vminps(c: &mut Vec<u8>, d: u8, s1: u8, s2: u8) {
-    vex256(c, 0, 1, 0, 0x5D, d, s1, s2);
+    Vex::m0f(0x5D).rrr(c, d, s1, s2);
 }
 fn vmaxps(c: &mut Vec<u8>, d: u8, s1: u8, s2: u8) {
-    vex256(c, 0, 1, 0, 0x5F, d, s1, s2);
+    Vex::m0f(0x5F).rrr(c, d, s1, s2);
 }
 fn vsqrtps(c: &mut Vec<u8>, d: u8, s: u8) {
-    vex256(c, 0, 1, 0, 0x51, d, UNUSED_VVVV, s);
+    Vex::m0f(0x51).rrr(c, d, UNUSED_VVVV, s);
 }
 fn vrsqrtps(c: &mut Vec<u8>, d: u8, s: u8) {
-    vex256(c, 0, 1, 0, 0x52, d, UNUSED_VVVV, s);
+    Vex::m0f(0x52).rrr(c, d, UNUSED_VVVV, s);
 }
 fn vrcpps(c: &mut Vec<u8>, d: u8, s: u8) {
-    vex256(c, 0, 1, 0, 0x53, d, UNUSED_VVVV, s);
+    Vex::m0f(0x53).rrr(c, d, UNUSED_VVVV, s);
 }
 
 // --- bitwise (0F, no prefix, W0) ---
 fn vandps(c: &mut Vec<u8>, d: u8, s1: u8, s2: u8) {
-    vex256(c, 0, 1, 0, 0x54, d, s1, s2);
+    Vex::m0f(0x54).rrr(c, d, s1, s2);
 }
 fn vandnps(c: &mut Vec<u8>, d: u8, s1: u8, s2: u8) {
-    vex256(c, 0, 1, 0, 0x55, d, s1, s2);
+    Vex::m0f(0x55).rrr(c, d, s1, s2);
 }
 fn vorps(c: &mut Vec<u8>, d: u8, s1: u8, s2: u8) {
-    vex256(c, 0, 1, 0, 0x56, d, s1, s2);
+    Vex::m0f(0x56).rrr(c, d, s1, s2);
 }
 fn vxorps(c: &mut Vec<u8>, d: u8, s1: u8, s2: u8) {
-    vex256(c, 0, 1, 0, 0x57, d, s1, s2);
+    Vex::m0f(0x57).rrr(c, d, s1, s2);
 }
 
 // --- comparisons (0F, no prefix, W0; imm8 predicate) ---
@@ -132,7 +210,7 @@ const CMP_GE: u8 = 5;
 const CMP_NLE: u8 = 6; // > (unordered-safe "not less-or-equal")
 
 fn vcmpps(c: &mut Vec<u8>, d: u8, s1: u8, s2: u8, pred: u8) {
-    vex256_imm(c, 0, 1, 0, 0xC2, d, s1, s2, pred);
+    Vex::m0f(0xC2).imm(pred).rrr(c, d, s1, s2);
 }
 
 fn cmp_pred(op: OpKind) -> Option<u8> {
@@ -155,40 +233,40 @@ pub fn is_compare(op: OpKind) -> bool {
 
 // --- rounding (0F3A, 66 prefix, W0; imm8) ---
 fn vroundps(c: &mut Vec<u8>, d: u8, s: u8, imm: u8) {
-    vex256_imm(c, 1, 3, 0, 0x08, d, UNUSED_VVVV, s, imm);
+    Vex::m0f3a_66(0x08).imm(imm).rrr(c, d, UNUSED_VVVV, s);
 }
 
 // --- int/float convert (0F, W0) ---
 fn vcvttps2dq(c: &mut Vec<u8>, d: u8, s: u8) {
-    vex256(c, 2, 1, 0, 0x5B, d, UNUSED_VVVV, s); // F3 prefix
+    Vex::m0f_f3(0x5B).rrr(c, d, UNUSED_VVVV, s); // F3 prefix
 }
 fn vcvtdq2ps(c: &mut Vec<u8>, d: u8, s: u8) {
-    vex256(c, 0, 1, 0, 0x5B, d, UNUSED_VVVV, s); // no prefix
+    Vex::m0f(0x5B).rrr(c, d, UNUSED_VVVV, s); // no prefix
 }
 
 // --- integer-domain (66 prefix, 0F, W0) ---
 fn vpaddd(c: &mut Vec<u8>, d: u8, s1: u8, s2: u8) {
-    vex256(c, 1, 1, 0, 0xFE, d, s1, s2);
+    Vex::m0f_66(0xFE).rrr(c, d, s1, s2);
 }
 fn vpslld_imm(c: &mut Vec<u8>, d: u8, s: u8, imm: u8) {
-    vex256_imm(c, 1, 1, 0, 0x72, 6, d, s, imm); // /6, dst=vvvv, src=rm
+    Vex::m0f_66(0x72).imm(imm).rrr(c, 6, d, s); // /6, dst=vvvv, src=rm
 }
 fn vpsrld_imm(c: &mut Vec<u8>, d: u8, s: u8, imm: u8) {
-    vex256_imm(c, 1, 1, 0, 0x72, 2, d, s, imm); // /2
+    Vex::m0f_66(0x72).imm(imm).rrr(c, 2, d, s); // /2
 }
 
 // --- lane insert/extract between 256-bit and 128-bit (0F3A, 66 prefix, W0) ---
 /// `vinsertf128 ymmDST, ymmSRC1, xmmSRC2, imm8[0]` — copy `src1`, then place
 /// `src2` into the low (`imm=0`) or high (`imm=1`) 128 bits.
 fn vinsertf128(c: &mut Vec<u8>, d: u8, s1: u8, s2: u8, imm: u8) {
-    vex256_imm(c, 1, 3, 0, 0x18, d, s1, s2, imm);
+    Vex::m0f3a_66(0x18).imm(imm).rrr(c, d, s1, s2);
 }
 /// `vextractf128 xmmDST, ymmSRC, imm8[0]` — extract the low (`imm=0`) or high
 /// (`imm=1`) 128 bits of `src` into `dst`.
 fn vextractf128(c: &mut Vec<u8>, d: u8, s: u8, imm: u8) {
     // VEX.256.66.0F3A.W0 19 /r ib — note dst is the ModRM.rm operand here
     // (the reverse of the usual direction: register source, register/mem dest).
-    vex256_imm(c, 1, 3, 0, 0x19, s, UNUSED_VVVV, d, imm);
+    Vex::m0f3a_66(0x19).imm(imm).rrr(c, s, UNUSED_VVVV, d);
 }
 
 /// `vmovaps ymmDST, ymmSRC` — register copy.
@@ -196,17 +274,17 @@ pub fn emit_mov(code: &mut Vec<u8>, dst: Reg, src: Reg) {
     if dst.0 == src.0 {
         return;
     }
-    vex256(code, 0, 1, 0, 0x28, dst.0, UNUSED_VVVV, src.0);
+    Vex::m0f(0x28).rrr(code, dst.0, UNUSED_VVVV, src.0);
 }
 
 /// `vmovups ymmDST, [rsp+disp32]` — 256-bit reload.
 pub fn emit_load_rsp(code: &mut Vec<u8>, dst: Reg, disp: i32) {
-    vex256_rm_rsp(code, 0, 1, 0, 0x10, dst.0, disp);
+    Vex::m0f(0x10).rm_rsp(code, dst.0, disp);
 }
 
 /// `vmovups [rsp+disp32], ymmSRC` — 256-bit spill store.
 pub fn emit_store_rsp(code: &mut Vec<u8>, src: Reg, disp: i32) {
-    vex256_rm_rsp(code, 0, 1, 0, 0x11, src.0, disp);
+    Vex::m0f(0x11).rm_rsp(code, src.0, disp);
 }
 
 /// Broadcast an f32 constant to all 8 lanes of `dst` via the stack (red zone,
@@ -221,14 +299,7 @@ pub fn emit_const(code: &mut Vec<u8>, dst: Reg, val: f32) {
     code.extend_from_slice(&[0xC7, 0x44, 0x24, 0xFC]);
     code.extend_from_slice(&bits.to_le_bytes());
     // vbroadcastss ymm, [rsp-4]  (VEX.256.66.0F38.W0 18 /r)
-    let rbit = if dst.0 >= 8 { 0x00 } else { 0x80 };
-    code.push(0xC4);
-    code.push(rbit | 0x40 | 0x20 | 2); // mmmmm = 0F38
-    code.push((0xF << 3) | (1 << 2) | 1); // vvvv unused, L=1, pp=66
-    code.push(0x18);
-    code.push(0x44 | ((dst.0 & 7) << 3)); // mod=01, reg=dst, rm=100 (SIB)
-    code.push(0x24);
-    code.push(0xFC_u8); // disp8 = -4
+    Vex::m0f38_66(0x18).rm_rsp8(code, dst.0, -4);
 }
 
 // =============================================================================
@@ -327,7 +398,7 @@ pub fn emit_select(code: &mut Vec<u8>, dst: Reg, if_true: Reg, if_false: Reg) {
 
 /// `vmovmskps eax, ymmSRC` — gather the 8 lane sign bits into eax[7:0].
 pub fn emit_movmskps_eax(code: &mut Vec<u8>, src: Reg) {
-    vex256(code, 0, 1, 0, 0x50, 0, UNUSED_VVVV, src.0);
+    Vex::m0f(0x50).rrr(code, 0, UNUSED_VVVV, src.0);
 }
 
 /// `cmp al, imm8` — unlike `cmp eax, imm8` (sign-extending `0x83`), this
@@ -345,7 +416,7 @@ pub fn emit_cmp_al_imm8(code: &mut Vec<u8>, imm: u8) {
 /// `target_feature = "fma"` (FMA3) — not implied by `avx2` alone.
 #[cfg(target_feature = "fma")]
 fn vfmadd231ps(c: &mut Vec<u8>, d: u8, s1: u8, s2: u8) {
-    vex256(c, 1, 2, 0, 0xB8, d, s1, s2);
+    Vex::m0f38_66(0xB8).rrr(c, d, s1, s2);
 }
 
 /// Fused multiply-add: `dst` already holds `c`; computes `dst = a*b + dst`.
@@ -453,15 +524,13 @@ mod tests {
             (xs, ys, zs)
         }
 
+        /// One row of the binary-op table: the op and its scalar reference.
+        type BinaryCase = (OpKind, fn(f32, f32) -> f32);
+
         fn check(got: [f32; 8], want: impl Fn(usize) -> f32, tag: &str) {
-            for i in 0..8 {
+            for (i, &g) in got.iter().enumerate() {
                 let w = want(i);
-                assert!(
-                    (got[i] - w).abs() <= 1e-3,
-                    "{tag} lane {i}: got {} want {}",
-                    got[i],
-                    w
-                );
+                assert!((g - w).abs() <= 1e-3, "{tag} lane {i}: got {g} want {w}");
             }
         }
 
@@ -469,13 +538,13 @@ mod tests {
         /// NaN under float subtraction, so `check`'s epsilon comparison can't
         /// be used for compares/selects' underlying mask bit pattern.
         fn check_bits(got: [f32; 8], want: impl Fn(usize) -> u32, tag: &str) {
-            for i in 0..8 {
+            for (i, &g) in got.iter().enumerate() {
                 let w = want(i);
                 assert_eq!(
-                    got[i].to_bits(),
+                    g.to_bits(),
                     w,
                     "{tag} lane {i}: got {:#x} want {:#x}",
-                    got[i].to_bits(),
+                    g.to_bits(),
                     w
                 );
             }
@@ -488,7 +557,7 @@ mod tests {
         #[test]
         fn binary_ops() {
             let (xs, ys, zs) = lanes();
-            let cases: &[(OpKind, fn(f32, f32) -> f32)] = &[
+            let cases: &[BinaryCase] = &[
                 (OpKind::Add, |a, b| a + b),
                 (OpKind::Sub, |a, b| a - b),
                 (OpKind::Mul, |a, b| a * b),

--- a/pixelflow-ir/src/backend/emit/avx2.rs
+++ b/pixelflow-ir/src/backend/emit/avx2.rs
@@ -339,9 +339,31 @@ pub fn emit_cmp_al_imm8(code: &mut Vec<u8>, imm: u8) {
     code.push(imm);
 }
 
-/// Fused multiply-add via software mul+add (no hardware FMA dependency: this
-/// backend is gated on `avx2` alone, not `avx2,fma`, and VIA/older Zen
-/// chips have shipped AVX2 without FMA3). `dst` already holds `c`.
+/// `vfmadd231ps ymmD, ymmA, ymmB` — `dst = a*b + dst` (231 form: dst is the
+/// addend going in, `a`/`b` the product). VEX.256.66.0F38.W0 B8 /r, same
+/// opcode as `avx512.rs`'s EVEX form, just VEX-encoded at 256 bits. Requires
+/// `target_feature = "fma"` (FMA3) — not implied by `avx2` alone.
+#[cfg(target_feature = "fma")]
+fn vfmadd231ps(c: &mut Vec<u8>, d: u8, s1: u8, s2: u8) {
+    vex256(c, 1, 2, 0, 0xB8, d, s1, s2);
+}
+
+/// Fused multiply-add: `dst` already holds `c`; computes `dst = a*b + dst`.
+///
+/// Uses real hardware FMA when the build has `+fma` (rounds once, exactly
+/// matching the reference interpreter under `fp-contract=fast` — see the
+/// regression this fixed: `eval_scalar`'s scalar `a*b+c` gets contracted to
+/// an `fma` instruction by LLVM under `+fma` too, so a software two-step
+/// mul-then-add here would round twice and disagree in the last bit).
+/// Falls back to software mul+add otherwise (this backend is gated on `avx2`
+/// alone, not `avx2,fma` — VIA/older Zen chips shipped AVX2 without FMA3).
+#[cfg(target_feature = "fma")]
+pub fn emit_fmadd_c_in_dst(code: &mut Vec<u8>, dst: Reg, a: Reg, b: Reg) {
+    vfmadd231ps(code, dst.0, a.0, b.0);
+}
+
+/// See the `+fma` variant above.
+#[cfg(not(target_feature = "fma"))]
 pub fn emit_fmadd_c_in_dst(code: &mut Vec<u8>, dst: Reg, a: Reg, b: Reg) {
     let tmp = UNARY_SCRATCH;
     vmulps(code, tmp.0, a.0, b.0);
@@ -398,6 +420,7 @@ mod tests {
         use crate::backend::emit::executable::ExecutableCode;
         use core::arch::x86_64::*;
 
+        #[allow(improper_ctypes_definitions)]
         type K = unsafe extern "C" fn(__m256, __m256, __m256, __m256) -> __m256;
 
         fn run(body: &[u8], xs: [f32; 8], ys: [f32; 8], zs: [f32; 8]) -> [f32; 8] {
@@ -442,6 +465,22 @@ mod tests {
             }
         }
 
+        /// Bit-exact check for mask results: an all-ones/all-zeros lane is
+        /// NaN under float subtraction, so `check`'s epsilon comparison can't
+        /// be used for compares/selects' underlying mask bit pattern.
+        fn check_bits(got: [f32; 8], want: impl Fn(usize) -> u32, tag: &str) {
+            for i in 0..8 {
+                let w = want(i);
+                assert_eq!(
+                    got[i].to_bits(),
+                    w,
+                    "{tag} lane {i}: got {:#x} want {:#x}",
+                    got[i].to_bits(),
+                    w
+                );
+            }
+        }
+
         const X: Reg = Reg(0);
         const Y: Reg = Reg(1);
         const Z: Reg = Reg(2);
@@ -469,9 +508,9 @@ mod tests {
             let (xs, ys, zs) = lanes();
             let mut c = Vec::new();
             emit_binary(&mut c, OpKind::Lt, X, X, Y).unwrap();
-            check(
+            check_bits(
                 run(&c, xs, ys, zs),
-                |i| if xs[i] < ys[i] { f32::from_bits(0xFFFF_FFFF) } else { 0.0 },
+                |i| if xs[i] < ys[i] { 0xFFFF_FFFF } else { 0 },
                 "lt mask",
             );
         }
@@ -537,7 +576,13 @@ mod tests {
 
         #[test]
         fn gather_from_buffer() {
-            type G = unsafe extern "C" fn(*const f32, __m256) -> __m256;
+            // Matches the production ABI (mod.rs's ResolvedOp::Gather): the
+            // first arg is a context pointer to an ARRAY of buffer base
+            // pointers (one per slot), not a buffer pointer directly —
+            // `x86_64::emit_gather_scalar` loads `[ctx_gpr + slot*8]` to get
+            // the real base. `emit_load_ptr_from_ctx`'s doc calls this out.
+            #[allow(improper_ctypes_definitions)]
+            type G = unsafe extern "C" fn(*const *const f32, __m256) -> __m256;
 
             let mut c = Vec::new();
             // idx (zmm/ymm0) -> int truncate happens inside emit_gather_scalar.
@@ -553,11 +598,12 @@ mod tests {
 
             let buf: Vec<f32> = (0..64).map(|i| (i as f32) * 1.5 + 0.25).collect();
             let idx: [f32; 8] = [0.0, 63.0, 1.0, 2.0, 10.0, 5.0, 32.0, 7.0];
+            let ctx: [*const f32; 1] = [buf.as_ptr()];
 
             let exec = unsafe { ExecutableCode::from_code(&c).expect("mmap") };
             let out = unsafe {
                 let f: G = exec.as_fn();
-                let r = f(buf.as_ptr(), _mm256_loadu_ps(idx.as_ptr()));
+                let r = f(ctx.as_ptr(), _mm256_loadu_ps(idx.as_ptr()));
                 let mut out = [0.0f32; 8];
                 _mm256_storeu_ps(out.as_mut_ptr(), r);
                 out

--- a/pixelflow-ir/src/backend/emit/avx512.rs
+++ b/pixelflow-ir/src/backend/emit/avx512.rs
@@ -710,6 +710,9 @@ mod tests {
         use crate::backend::emit::executable::ExecutableCode;
         use core::arch::x86_64::*;
 
+        // Passing __m512 by value IS the emitted ABI (SysV: zmm0-7), so
+        // not-FFI-safe is a false positive here, as for `executable`'s aliases.
+        #[allow(improper_ctypes_definitions)]
         type K = unsafe extern "C" fn(__m512, __m512, __m512, __m512) -> __m512;
 
         fn run(body: &[u8], xs: [f32; 16], ys: [f32; 16], zs: [f32; 16]) -> [f32; 16] {
@@ -758,10 +761,13 @@ mod tests {
         const Y: Reg = Reg(1);
         const Z: Reg = Reg(2);
 
+        /// One row of the binary-op table: the op and its scalar reference.
+        type BinaryCase = (OpKind, fn(f32, f32) -> f32);
+
         #[test]
         fn binary_ops() {
             let (xs, ys, zs) = lanes();
-            let cases: &[(OpKind, fn(f32, f32) -> f32)] = &[
+            let cases: &[BinaryCase] = &[
                 (OpKind::Add, |a, b| a + b),
                 (OpKind::Sub, |a, b| a - b),
                 (OpKind::Mul, |a, b| a * b),
@@ -829,6 +835,9 @@ mod tests {
             // JIT a function: fn(*const f32 base [rdi], __m512 idx_float [zmm0]) -> __m512
             // that truncates the float indices, sets the mask, and gathers
             // base[idx] per lane. Validates the VSIB vgatherdps bytes on hardware.
+            // Passing __m512 by value IS the emitted ABI (SysV: zmm0-7), so
+            // not-FFI-safe is a false positive here, as for `executable`'s aliases.
+            #[allow(improper_ctypes_definitions)]
             type G = unsafe extern "C" fn(*const f32, __m512) -> __m512;
 
             let mut c = Vec::new();

--- a/pixelflow-ir/src/backend/emit/avx512.rs
+++ b/pixelflow-ir/src/backend/emit/avx512.rs
@@ -194,6 +194,37 @@ fn vrsqrt14ps(c: &mut Vec<u8>, d: u8, s: u8) {
     evex_rrr(c, Map::M0F38, Pp::P66, false, 0x4E, d, UNUSED_VVVV, s);
 }
 
+// --- integer-domain primitives (exp/log lowering) ---
+// Same opcodes as the AVX2 backend's VEX forms, EVEX-wrapped at 512 bits.
+
+/// vcvttps2dq zmmD, zmmS — EVEX.512.F3.0F.W0 5B /r ; vvvv unused.
+fn vcvttps2dq(c: &mut Vec<u8>, d: u8, s: u8) {
+    evex_rrr(c, Map::M0F, Pp::F3, false, 0x5B, d, UNUSED_VVVV, s);
+}
+
+/// vcvtdq2ps zmmD, zmmS — EVEX.512.0F.W0 5B /r ; vvvv unused.
+fn vcvtdq2ps(c: &mut Vec<u8>, d: u8, s: u8) {
+    evex_rrr(c, Map::M0F, Pp::None, false, 0x5B, d, UNUSED_VVVV, s);
+}
+
+/// vpaddd zmmD, zmmS1, zmmS2 — EVEX.512.66.0F.W0 FE /r.
+fn vpaddd(c: &mut Vec<u8>, d: u8, s1: u8, s2: u8) {
+    evex_rrr(c, Map::M0F, Pp::P66, false, 0xFE, d, s1, s2);
+}
+
+/// vpslld zmmD, zmmS, imm8 — EVEX.512.66.0F.W0 72 /6 ib. The shift-by-imm
+/// group encodes the operation in ModRM.reg (/6 = left) and the DESTINATION
+/// in vvvv, with the source in r/m — reg/vvvv swap roles vs. ordinary rrr.
+fn vpslld_imm(c: &mut Vec<u8>, d: u8, s: u8, imm: u8) {
+    evex_rrr_imm(c, Map::M0F, Pp::P66, false, 0x72, 6, d, s, imm);
+}
+
+/// vpsrld zmmD, zmmS, imm8 — EVEX.512.66.0F.W0 72 /2 ib (logical, zero-fill).
+fn vpsrld_imm(c: &mut Vec<u8>, d: u8, s: u8, imm: u8) {
+    evex_rrr_imm(c, Map::M0F, Pp::P66, false, 0x72, 2, d, s, imm);
+}
+
+
 // --- FMA (0F38, 66 prefix, W0). 213: dst = src1*dst + src2. ---
 fn vfmadd213ps(c: &mut Vec<u8>, d: u8, s1: u8, s2: u8) {
     evex_rrr(c, Map::M0F38, Pp::P66, false, 0xA8, d, s1, s2);
@@ -314,6 +345,8 @@ pub fn emit_binary(
         OpKind::Max => vmaxps(code, d, s1, s2),
         OpKind::BitAnd => vandps(code, d, s1, s2),
         OpKind::BitOr => vorps(code, d, s1, s2),
+        // Integer add on lane bit patterns (exp/log exponent arithmetic).
+        OpKind::IAdd => vpaddd(code, d, s1, s2),
         _ => return Err("avx512: binary op not in Stage-1 subset"),
     }
     Ok(())
@@ -456,6 +489,24 @@ pub fn emit_mask_flags(code: &mut Vec<u8>, mask: Reg) {
 }
 
 /// Emit `dst = op(src)` for a unary op (Stage-1 subset).
+/// Emit `dst = src << amount` / `dst = src >> amount` (logical, zero-fill)
+/// on lane bit patterns. The amount is a compile-time immediate — the
+/// schedule folds the `Const` RHS out (`ScheduledOp::ShiftImm`).
+pub fn emit_shift_imm(
+    code: &mut Vec<u8>,
+    op: OpKind,
+    dst: Reg,
+    src: Reg,
+    amount: u8,
+) -> Result<(), &'static str> {
+    match op {
+        OpKind::Shl => vpslld_imm(code, dst.0, src.0, amount),
+        OpKind::Shr => vpsrld_imm(code, dst.0, src.0, amount),
+        _ => return Err("avx512: emit_shift_imm requires Shl or Shr"),
+    }
+    Ok(())
+}
+
 pub fn emit_unary(code: &mut Vec<u8>, op: OpKind, dst: Reg, src: Reg) -> Result<(), &'static str> {
     match op {
         OpKind::Sqrt => vsqrtps(code, dst.0, src.0),
@@ -479,6 +530,10 @@ pub fn emit_unary(code: &mut Vec<u8>, op: OpKind, dst: Reg, src: Reg) -> Result<
         OpKind::Round => vrndscaleps(code, dst.0, src.0, 0x00),
         OpKind::Recip => vrcp14ps(code, dst.0, src.0),
         OpKind::Rsqrt => vrsqrt14ps(code, dst.0, src.0),
+        // Int/float domain crossings, exactly the hardware's cvttps2dq /
+        // cvtdq2ps — the primitives exp/log lower to.
+        OpKind::TruncToInt => vcvttps2dq(code, dst.0, src.0),
+        OpKind::IntToFloat => vcvtdq2ps(code, dst.0, src.0),
         _ => return Err("avx512: unary op not in Stage-1 subset"),
     }
     Ok(())

--- a/pixelflow-ir/src/backend/emit/avx512.rs
+++ b/pixelflow-ir/src/backend/emit/avx512.rs
@@ -4,11 +4,16 @@
 //! targets the full `zmm0..zmm31` register file via EVEX, so it can also use the
 //! extended registers (`zmm16..31`) that VEX cannot reach.
 //!
-//! Scope (Stage 1): arithmetic, FMA, sqrt/recip/rsqrt, min/max, bitwise, and
-//! constant broadcast — enough for the arithmetic core of a kernel. Comparison
-//! masks / select (the k-register class) and the transcendental polynomials are
-//! separate stages; the backend rejects those up front so nothing here is
-//! reached for an unsupported op.
+//! Scope (Stage 1): arithmetic, FMA, sqrt/recip/rsqrt, min/max, bitwise,
+//! comparisons, select, and constant broadcast — covers everything
+//! `Select`/`Clamp`/glyph coverage kernels need. Comparisons go through the
+//! k-register class (`vcmpps` -> `vpmovm2d`, see `emit_compare` below) so
+//! every downstream consumer still sees an ordinary all-ones/all-zeros
+//! vector, exactly like every other backend — the allocator never learns
+//! k-registers exist. The transcendental polynomials and the integer
+//! bit-shift lowering exp/log needs (`ShiftImm`) are still separate stages;
+//! the backend rejects those up front so nothing here is reached for an
+//! unsupported op.
 //!
 //! Spills use a real stack frame (a `zmm` is 64 bytes — far past the 128-byte
 //! red zone the SSE2 path relies on).
@@ -174,6 +179,21 @@ fn vrndscaleps(c: &mut Vec<u8>, d: u8, s: u8, imm: u8) {
     evex_rrr_imm(c, Map::M0F3A, Pp::P66, false, 0x08, d, UNUSED_VVVV, s, imm);
 }
 
+/// vrcp14ps zmmD, zmmS — EVEX.512.66.0F38.W0 4C /r ; vvvv unused. AVX-512F's
+/// replacement for AVX's `vrcpps` (EVEX has no `0F 53` form); ~2^-14 relative
+/// error, matching `Recip`'s existing "approximate reciprocal" contract on
+/// every other backend (SSE2's `rcpps`, AVX2's `vrcpps`).
+fn vrcp14ps(c: &mut Vec<u8>, d: u8, s: u8) {
+    evex_rrr(c, Map::M0F38, Pp::P66, false, 0x4C, d, UNUSED_VVVV, s);
+}
+
+/// vrsqrt14ps zmmD, zmmS — EVEX.512.66.0F38.W0 4E /r ; vvvv unused.
+/// AVX-512F's replacement for AVX's `vrsqrtps`, same accuracy tier as
+/// `vrcp14ps` above.
+fn vrsqrt14ps(c: &mut Vec<u8>, d: u8, s: u8) {
+    evex_rrr(c, Map::M0F38, Pp::P66, false, 0x4E, d, UNUSED_VVVV, s);
+}
+
 // --- FMA (0F38, 66 prefix, W0). 213: dst = src1*dst + src2. ---
 fn vfmadd213ps(c: &mut Vec<u8>, d: u8, s1: u8, s2: u8) {
     evex_rrr(c, Map::M0F38, Pp::P66, false, 0xA8, d, s1, s2);
@@ -292,6 +312,8 @@ pub fn emit_binary(
         OpKind::Div => vdivps(code, d, s1, s2),
         OpKind::Min => vminps(code, d, s1, s2),
         OpKind::Max => vmaxps(code, d, s1, s2),
+        OpKind::BitAnd => vandps(code, d, s1, s2),
+        OpKind::BitOr => vorps(code, d, s1, s2),
         _ => return Err("avx512: binary op not in Stage-1 subset"),
     }
     Ok(())
@@ -455,6 +477,8 @@ pub fn emit_unary(code: &mut Vec<u8>, op: OpKind, dst: Reg, src: Reg) -> Result<
         OpKind::Floor => vrndscaleps(code, dst.0, src.0, 0x01),
         OpKind::Ceil => vrndscaleps(code, dst.0, src.0, 0x02),
         OpKind::Round => vrndscaleps(code, dst.0, src.0, 0x00),
+        OpKind::Recip => vrcp14ps(code, dst.0, src.0),
+        OpKind::Rsqrt => vrsqrt14ps(code, dst.0, src.0),
         _ => return Err("avx512: unary op not in Stage-1 subset"),
     }
     Ok(())

--- a/pixelflow-ir/src/backend/emit/coverage.rs
+++ b/pixelflow-ir/src/backend/emit/coverage.rs
@@ -1,0 +1,77 @@
+//! The op-coverage completeness contract every [`super::IsaBackend`] must satisfy.
+//!
+//! This is test-only infrastructure (see `emit/mod.rs`'s `backend_op_coverage`
+//! tests, and `x86_64.rs`'s `X86BinaryInsn::select` coverage test), not a
+//! production API. It exists because nothing previously enumerated "the ops a
+//! backend must support" anywhere: AVX-512's binary-op dispatch
+//! (`avx512::emit_binary`) implemented 6 of the 15 required ops and nothing
+//! caught the gap until 36 tests failed by accident the first time someone
+//! actually compiled with `-C target-feature=+avx512f`. These lists turn that
+//! into a named, itemized test failure instead of a silent hole.
+//!
+//! Every `OpKind` an `IsaBackend` might see falls into exactly one bucket:
+//!
+//! - Reaches `IsaBackend::emit_plan` as `ResolvedOp::Unary` — [`REQUIRED_UNARY_OPS`].
+//! - Reaches it as `ResolvedOp::Binary` — [`REQUIRED_BINARY_OPS`].
+//! - Reaches it as `ResolvedOp::ShiftImm` (the RHS `Const` shift amount is
+//!   folded to an immediate by `arena_to_schedule`, so only the op + LHS
+//!   survive to codegen) — [`REQUIRED_SHIFT_OPS`].
+//! - Reaches it as `ResolvedOp::FusedMulAdd`/`DecomposedMulAdd` or
+//!   `ResolvedOp::Select` — [`REQUIRED_TERNARY_OPS`]. Not swept generically
+//!   like the arrays above (each has a distinct `ResolvedOp` shape and
+//!   `setup_mov` convention), so the per-backend tests construct these two
+//!   explicitly instead of looping.
+//! - Is eliminated by a `lowering` pass before any backend sees it
+//!   (transcendentals by `expand_transcendentals`, `Dwrt` by `lower_dwrt`,
+//!   `Reduce` by `expand_reduce`, the ternary `Gather` op by `expand_gather`
+//!   — see `lowering.rs`) — absent from every list here on purpose.
+//! - Is structural and never becomes a `ScheduledOp` at all (`Var`, `Const`,
+//!   `Tuple`, `Buffer`) — likewise absent.
+//! - `RawGather` (bound-memory read) reaches `ResolvedOp::Gather`, but is
+//!   intentionally backend-asymmetric today (native `vgatherdps` on AVX-512;
+//!   a four-lane scalar-load sequence on SSE2/aarch64) — deliberately NOT
+//!   included in a "every backend must support this" list; its own test
+//!   coverage lives with the gather-specific tests.
+
+use crate::kind::OpKind;
+
+/// Ops that reach `IsaBackend::emit_plan` as `ResolvedOp::Unary { op, .. }`.
+pub(crate) const REQUIRED_UNARY_OPS: &[OpKind] = &[
+    OpKind::Neg,
+    OpKind::Sqrt,
+    OpKind::Rsqrt,
+    OpKind::Abs,
+    OpKind::Recip,
+    OpKind::Floor,
+    OpKind::Ceil,
+    OpKind::Round,
+    OpKind::TruncToInt,
+    OpKind::IntToFloat,
+];
+
+/// Ops that reach `IsaBackend::emit_plan` as `ResolvedOp::Binary { op, .. }`.
+pub(crate) const REQUIRED_BINARY_OPS: &[OpKind] = &[
+    OpKind::Add,
+    OpKind::Sub,
+    OpKind::Mul,
+    OpKind::Div,
+    OpKind::Min,
+    OpKind::Max,
+    OpKind::Lt,
+    OpKind::Le,
+    OpKind::Gt,
+    OpKind::Ge,
+    OpKind::Eq,
+    OpKind::Ne,
+    OpKind::IAdd,
+    OpKind::BitAnd,
+    OpKind::BitOr,
+];
+
+/// Ops that reach `IsaBackend::emit_plan` as `ResolvedOp::ShiftImm { op, .. }`.
+pub(crate) const REQUIRED_SHIFT_OPS: &[OpKind] = &[OpKind::Shl, OpKind::Shr];
+
+/// Ops with a bespoke `ResolvedOp` shape (`FusedMulAdd`/`DecomposedMulAdd` for
+/// `MulAdd`, `Select` for `Select`). Listed for documentation; the per-backend
+/// tests build these two plans explicitly rather than looping generically.
+pub(crate) const REQUIRED_TERNARY_OPS: &[OpKind] = &[OpKind::MulAdd, OpKind::Select];

--- a/pixelflow-ir/src/backend/emit/executable.rs
+++ b/pixelflow-ir/src/backend/emit/executable.rs
@@ -379,6 +379,12 @@ use core::arch::aarch64::float32x4_t;
 
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::__m128;
+#[cfg(all(
+    target_arch = "x86_64",
+    target_feature = "avx2",
+    not(target_feature = "avx512f")
+))]
+use core::arch::x86_64::__m256;
 #[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
 use core::arch::x86_64::__m512;
 
@@ -439,9 +445,10 @@ pub type ScanlineKernelFn = extern "C" fn(
 /// Args: X/Y/Z/W in the first four vector registers; returns the result in the
 /// first. One call computes one pixel per lane; the caller loops.
 ///
-/// The width tracks the build's selected SIMD: 512-bit `__m512` (16 lanes) when
-/// compiled with AVX-512, else 128-bit `__m128` (4 lanes, SSE2). This MUST match
-/// `pixelflow-core`'s `Field`; the `kernel_jit!` wrapper const-asserts
+/// The width tracks the build's selected SIMD: 512-bit `__m512` (16 lanes) with
+/// AVX-512, 256-bit `__m256` (8 lanes) with AVX2 (and not AVX-512), else
+/// 128-bit `__m128` (4 lanes, SSE2). This MUST match `pixelflow-core`'s
+/// `Field`; the `kernel_jit!` wrapper const-asserts
 /// `size_of::<Field>() == JIT_VECTOR_BYTES`. The looping variant is
 /// `ScanlineKernelFn`, which stays 128-bit (the scanline emitter is still SSE2).
 #[allow(improper_ctypes_definitions)]
@@ -473,8 +480,35 @@ pub type CtxKernelFn = extern "C" fn(*const *const f32, __m512, __m512, __m512, 
 #[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
 pub type CollapseKernelFn = extern "C" fn(*const *const f32, *const f32, *mut f32, usize);
 
+/// JIT-compiled per-batch kernel signature for x86-64 AVX2 (256-bit, 8 lanes).
+/// See [`KernelFn`] (the AVX-512 variant) for the ABI contract; this is the
+/// same shape at the AVX2 width, selected when the build has `avx2` but not
+/// `avx512f`.
 #[allow(improper_ctypes_definitions)]
-#[cfg(all(target_arch = "x86_64", not(target_feature = "avx512f")))]
+#[cfg(all(
+    target_arch = "x86_64",
+    target_feature = "avx2",
+    not(target_feature = "avx512f")
+))]
+pub type KernelFn = extern "C" fn(__m256, __m256, __m256, __m256) -> __m256;
+
+/// JIT-compiled kernel that reads bound memory (x86-64 AVX2). See the
+/// AVX-512 [`CtxKernelFn`] doc for the context-pointer contract; `rdi` is
+/// still disjoint from the coordinate vectors (now `ymm0..3`).
+#[allow(improper_ctypes_definitions)]
+#[cfg(all(
+    target_arch = "x86_64",
+    target_feature = "avx2",
+    not(target_feature = "avx512f")
+))]
+pub type CtxKernelFn = extern "C" fn(*const *const f32, __m256, __m256, __m256, __m256) -> __m256;
+
+#[allow(improper_ctypes_definitions)]
+#[cfg(all(
+    target_arch = "x86_64",
+    not(target_feature = "avx512f"),
+    not(target_feature = "avx2")
+))]
 pub type KernelFn = extern "C" fn(__m128, __m128, __m128, __m128) -> __m128;
 
 /// JIT-compiled kernel that reads bound memory (x86-64, 128-bit).
@@ -486,7 +520,11 @@ pub type KernelFn = extern "C" fn(__m128, __m128, __m128, __m128) -> __m128;
 /// same as a `KernelFn` — only kernels containing a `Gather` read `rdi`. The
 /// caller picks this type iff the arena declared buffers.
 #[allow(improper_ctypes_definitions)]
-#[cfg(all(target_arch = "x86_64", not(target_feature = "avx512f")))]
+#[cfg(all(
+    target_arch = "x86_64",
+    not(target_feature = "avx512f"),
+    not(target_feature = "avx2")
+))]
 pub type CtxKernelFn = extern "C" fn(*const *const f32, __m128, __m128, __m128, __m128) -> __m128;
 
 /// JIT-compiled scanline kernel signature for x86-64 (128-bit; the scanline
@@ -507,10 +545,15 @@ pub type ScanlineKernelFn = extern "C" fn(
 // =============================================================================
 
 // These tests hand-assemble SSE2 byte sequences and call them through the
-// 128-bit `KernelFn`, so they are specific to the non-AVX-512 ABI. Under
-// `+avx512f`, `KernelFn` is `__m512` and these `__m128` call sites don't type
-// check; the AVX-512 path is covered by the `avx512` tests in `mod.rs`.
-#[cfg(all(test, not(target_feature = "avx512f")))]
+// 128-bit `KernelFn`, so they are specific to the SSE2 (no AVX2, no AVX-512)
+// ABI. Under `+avx512f` or `+avx2`, `KernelFn` is `__m512`/`__m256` and these
+// `__m128` call sites don't type check; those paths are covered by the
+// `avx512`/`avx2` tests in `mod.rs`.
+#[cfg(all(
+    test,
+    not(target_feature = "avx512f"),
+    not(target_feature = "avx2")
+))]
 mod tests {
     // These tests hand-assemble instruction words as `base | Rd | (Rn << 5) | ...`;
     // the `| 0` / `(0 << 5)` terms document zero register fields on purpose.

--- a/pixelflow-ir/src/backend/emit/mod.rs
+++ b/pixelflow-ir/src/backend/emit/mod.rs
@@ -3758,10 +3758,13 @@ impl IsaBackend for Avx512Backend {
             ResolvedOp::Unary { op, dst, src } => {
                 avx512::emit_unary(code, *op, *dst, *src)?;
             }
-            ResolvedOp::ShiftImm { .. } => {
-                // EVEX integer shift not wired yet -> exp/log don't lower on the
-                // AVX-512 path. Reject loudly rather than miscompile.
-                return Err("avx512: bit-shift (exp/log lowering) not yet supported");
+            ResolvedOp::ShiftImm {
+                op,
+                dst,
+                src,
+                amount,
+            } => {
+                avx512::emit_shift_imm(code, *op, *dst, *src, *amount)?;
             }
             ResolvedOp::Gather { dst, idx, slot } => {
                 // dst = buffer[slot][idx]. The context pointer (array of buffer
@@ -6746,7 +6749,15 @@ mod tests {
             );
         }
 
-        #[cfg(target_arch = "x86_64")]
+        // Same gate as the struct itself: the SSE2 backend only exists on the
+        // baseline build (the wide builds compile it out entirely), so this
+        // sweep runs exactly when there is a backend to sweep. The default
+        // build is the baseline, so CI's default job always runs it.
+        #[cfg(all(
+            target_arch = "x86_64",
+            not(target_feature = "avx2"),
+            not(target_feature = "avx512f")
+        ))]
         #[test]
         fn x86_backend_covers_required_ops() {
             assert_covers_required_ops("X86Backend (SSE2)", &mut X86Backend::default());

--- a/pixelflow-ir/src/backend/emit/mod.rs
+++ b/pixelflow-ir/src/backend/emit/mod.rs
@@ -6752,6 +6752,17 @@ mod tests {
             assert_covers_required_ops("X86Backend (SSE2)", &mut X86Backend::default());
         }
 
+        // Gated on arch alone, not `target_feature = "avx2"`: the sweep only
+        // *encodes* — bytes into a Vec, never executed — so it needs no AVX2
+        // hardware or build flags. Running it on every x86-64 build means a
+        // coverage gap in the AVX2 backend fails the default CI job, not just
+        // the one ISA-matrix leg that selects it.
+        #[cfg(target_arch = "x86_64")]
+        #[test]
+        fn avx2_backend_covers_required_ops() {
+            assert_covers_required_ops("Avx2Backend", &mut Avx2Backend);
+        }
+
         #[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
         #[test]
         fn avx512_backend_covers_required_ops() {

--- a/pixelflow-ir/src/backend/emit/mod.rs
+++ b/pixelflow-ir/src/backend/emit/mod.rs
@@ -30,6 +30,7 @@
 //! - This lets ML models learn register pressure vs spill tradeoffs
 
 pub mod aarch64;
+pub mod avx2;
 pub mod avx512;
 pub mod executable;
 pub mod lowering;
@@ -3289,11 +3290,17 @@ pub fn compile_arena_dag_with_ctx(
     let arena = &arena;
     let schedule = arena_to_schedule(arena, root);
     let uses = arena_to_uses(&schedule);
+    // Three-way build-width split, matching `pixelflow_ir::JIT_VECTOR_BYTES`
+    // and `pixelflow-core`'s `Field` storage: AVX-512 > AVX2 > SSE2.
     #[cfg(target_feature = "avx512f")]
     {
         compile_dag_via_backend(schedule, uses, &mut Avx512Backend)
     }
-    #[cfg(not(target_feature = "avx512f"))]
+    #[cfg(all(target_feature = "avx2", not(target_feature = "avx512f")))]
+    {
+        compile_dag_via_backend(schedule, uses, &mut Avx2Backend)
+    }
+    #[cfg(not(any(target_feature = "avx512f", target_feature = "avx2")))]
     {
         compile_dag_via_backend(schedule, uses, &mut X86Backend::default())
     }
@@ -3324,18 +3331,36 @@ const X86_SCHED_NUM_REGS: u8 = 6;
 
 /// Fixed scratch outside the allocatable range / reload regs: used for the
 /// binary two-operand hazard and as the select blend temp.
-#[cfg(target_arch = "x86_64")]
+///
+/// SSE2-only (like the rest of this section down to `X86Backend`): dead under
+/// a build that selects `Avx2Backend`/`Avx512Backend` instead, so gated off
+/// those widths — otherwise it (and `X86Backend`) would be unreachable dead
+/// code under `+avx2`/`+avx512f`, which the test-matrix's per-ISA clippy pass
+/// would then flag as a *new* failure on those levels only.
+#[cfg(all(
+    target_arch = "x86_64",
+    not(target_feature = "avx512f"),
+    not(target_feature = "avx2")
+))]
 const X86_SCRATCH: Reg = Reg(10);
 
 /// Scratch quad for builtins (sin/cos/exp/atan2/...), which need FOUR distinct
 /// scratch registers. Clear of the allocatable range (4-9) and the reload regs
 /// (11,12). Includes `X86_SCRATCH` (xmm10): builtins don't use it for the
 /// hazard/select roles, so it is free as a fourth scratch here.
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(
+    target_arch = "x86_64",
+    not(target_feature = "avx512f"),
+    not(target_feature = "avx2")
+))]
 const X86_BUILTIN_SCRATCH: [Reg; 4] = [Reg(10), Reg(13), Reg(14), Reg(15)];
 
 /// Map a `FrameLayout` spill offset to a red-zone `[rsp+disp8]` displacement.
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(
+    target_arch = "x86_64",
+    not(target_feature = "avx512f"),
+    not(target_feature = "avx2")
+))]
 fn x86_redzone_disp(offset: u32) -> Result<i8, &'static str> {
     // Slots live below rsp: offset 0 -> [rsp-16], 16 -> [rsp-32], ...
     // Only called in red-zone mode (the prologue switches to an allocated
@@ -3355,7 +3380,11 @@ fn x86_redzone_disp(offset: u32) -> Result<i8, &'static str> {
 /// when `dst == right` and `dst != left`. The allocator may assign `dst ==
 /// right`, so handle it: swap for commutative ops, otherwise stash `right` in
 /// the fixed scratch.
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(
+    target_arch = "x86_64",
+    not(target_feature = "avx512f"),
+    not(target_feature = "avx2")
+))]
 fn emit_binary_safe(code: &mut Vec<u8>, op: OpKind, dst: Reg, left: Reg, right: Reg) {
     use x86_64::*;
     let commutative = matches!(
@@ -3378,13 +3407,21 @@ fn emit_binary_safe(code: &mut Vec<u8>, op: OpKind, dst: Reg, left: Reg, right: 
 /// `frame_bytes` is set by `prologue`: 0 = spills fit the 128-byte red zone
 /// (no frame is allocated), otherwise the size of the allocated frame and
 /// spill slots are `[rsp + offset]`.
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(
+    target_arch = "x86_64",
+    not(target_feature = "avx512f"),
+    not(target_feature = "avx2")
+))]
 #[derive(Default)]
 struct X86Backend {
     frame_bytes: u32,
 }
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(
+    target_arch = "x86_64",
+    not(target_feature = "avx512f"),
+    not(target_feature = "avx2")
+))]
 impl X86Backend {
     fn spill_store(&self, code: &mut Vec<u8>, src: Reg, offset: u32) {
         if self.frame_bytes == 0 {
@@ -3405,7 +3442,11 @@ impl X86Backend {
     }
 }
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(
+    target_arch = "x86_64",
+    not(target_feature = "avx512f"),
+    not(target_feature = "avx2")
+))]
 impl IsaBackend for X86Backend {
     /// rel32 field offset of the branch (uniform for jcc/jmp on x86).
     type Branch = usize;
@@ -3856,6 +3897,255 @@ impl IsaBackend for Avx512Backend {
         }
         avx512::emit_ret(code);
     }
+}
+
+// =============================================================================
+// AVX2 backend: the leaf emit for the SHARED driver, 256-bit (ymm) kernels.
+// =============================================================================
+//
+// The middle width between `X86Backend` (128-bit) and `Avx512Backend`
+// (512-bit). Register roles are IDENTICAL to `X86Backend` — same input/
+// allocatable/scratch/reload layout (ymm0-15 is the same physical file as
+// xmm0-15) — only the leaf encodings differ (VEX.256 instead of legacy SSE).
+// VEX is 3-operand like EVEX, so — like `Avx512Backend` — there is no
+// two-operand hazard to route around.
+//
+// Spills use a real stack frame (mirrors `Avx512Backend`'s reasoning): a ymm
+// slot is 32 bytes, so `FrameLayout`'s 16-byte-unit offsets are scaled ×2.
+
+/// Scale a `FrameLayout` 16-byte slot offset to a 32-byte ymm frame offset.
+#[cfg(target_arch = "x86_64")]
+fn avx2_slot_disp(offset: u32) -> i32 {
+    (offset as i32 / 16) * 32
+}
+
+/// Total ymm frame bytes for a `FrameLayout.frame_size` (16-byte units).
+#[cfg(target_arch = "x86_64")]
+fn avx2_frame_bytes(frame_size: u32) -> u32 {
+    (frame_size / 16) * 32
+}
+
+/// AVX2 implementation of the shared driver's leaf operations.
+#[cfg(target_arch = "x86_64")]
+struct Avx2Backend;
+
+#[cfg(target_arch = "x86_64")]
+impl Avx2Backend {
+    fn reload(code: &mut Vec<u8>, reload: &Reload) {
+        match reload {
+            Reload::FromStack { target, offset } => {
+                avx2::emit_load_rsp(code, *target, avx2_slot_disp(*offset));
+            }
+            Reload::Const { target, val_bits } => {
+                avx2::emit_const(code, *target, f32::from_bits(*val_bits));
+            }
+        }
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+impl IsaBackend for Avx2Backend {
+    type Branch = usize;
+
+    fn num_regs(&self) -> u8 {
+        X86_SCHED_NUM_REGS // same 6 allocatable (ymm4-9)
+    }
+
+    fn begin(
+        &mut self,
+        _schedule: &[(regalloc::ValueId, ScheduledOp)],
+    ) -> Result<(), &'static str> {
+        Ok(()) // const broadcast is self-contained; no pool.
+    }
+
+    fn prologue(&mut self, code: &mut Vec<u8>, frame_size: u32) {
+        let bytes = avx2_frame_bytes(frame_size);
+        if bytes > 0 {
+            avx2::emit_sub_rsp(code, bytes);
+        }
+    }
+
+    fn emit_plan(
+        &mut self,
+        code: &mut Vec<u8>,
+        plan: &InstructionPlan,
+    ) -> Result<(), &'static str> {
+        for r in &plan.reloads {
+            Self::reload(code, r);
+        }
+        if let Some((dst, src)) = plan.setup_mov {
+            avx2::emit_mov(code, dst, src);
+        }
+        match &plan.op {
+            ResolvedOp::Nop => {}
+            ResolvedOp::LoadConst { dst, val_bits } => {
+                avx2::emit_const(code, *dst, f32::from_bits(*val_bits));
+            }
+            ResolvedOp::Unary { op, dst, src } => {
+                avx2::emit_unary(code, *op, *dst, *src)?;
+            }
+            ResolvedOp::ShiftImm {
+                op,
+                dst,
+                src,
+                amount,
+            } => {
+                avx2::emit_shift_imm(code, *op, *dst, *src, *amount)?;
+            }
+            ResolvedOp::Gather { dst, idx, slot } => {
+                // Context pointer (array of buffer base pointers) arrives in
+                // rdi; arithmetic/const emit never touches rdi, so it
+                // survives to here. ymm13/14 mirror X86Backend's gather
+                // scratch; ymm8/9 are the AVX2-only high-half scratch this
+                // two-half gather needs (see `avx2::emit_gather_scalar`).
+                avx2::emit_gather_scalar(
+                    code,
+                    *dst,
+                    *idx,
+                    *slot,
+                    x86_64::GatherScratch {
+                        base_gpr: 0,  // rax
+                        index_gpr: 1, // rcx
+                        ctx_gpr: 7,   // rdi
+                        idx_lanes: Reg(13),
+                        value: Reg(14),
+                    },
+                    Reg(9),
+                    Reg(8),
+                );
+            }
+            ResolvedOp::Binary {
+                op,
+                dst,
+                left,
+                right,
+            } => {
+                // VEX 3-operand: no two-operand hazard, emit directly.
+                avx2::emit_binary(code, *op, *dst, *left, *right)?;
+            }
+            ResolvedOp::FusedMulAdd { dst, a, b } => {
+                avx2::emit_fmadd_c_in_dst(code, *dst, *a, *b);
+            }
+            ResolvedOp::DecomposedMulAdd {
+                dst,
+                a,
+                b,
+                c,
+                c_deferred,
+            } => {
+                avx2::emit_binary(code, OpKind::Mul, *dst, *a, *b)?;
+                match c_deferred {
+                    Some(DeferredReload::FromStack(off)) => {
+                        avx2::emit_load_rsp(code, *c, avx2_slot_disp(*off));
+                    }
+                    Some(DeferredReload::Const(bits)) => {
+                        avx2::emit_const(code, *c, f32::from_bits(*bits));
+                    }
+                    None => {}
+                }
+                avx2::emit_binary(code, OpKind::Add, *dst, *dst, *c)?;
+            }
+            ResolvedOp::Select {
+                dst,
+                if_true,
+                if_false,
+            } => {
+                // setup_mov already placed the vector mask in dst.
+                avx2::emit_select(code, *dst, *if_true, *if_false);
+            }
+        }
+        if let Some(store) = &plan.store {
+            avx2::emit_store_rsp(code, store.src, avx2_slot_disp(store.offset));
+        }
+        Ok(())
+    }
+
+    fn emit_mov(&mut self, code: &mut Vec<u8>, dst: Reg, src: Reg) {
+        avx2::emit_mov(code, dst, src);
+    }
+
+    fn emit_store(
+        &mut self,
+        code: &mut Vec<u8>,
+        src: Reg,
+        offset: u32,
+    ) -> Result<(), &'static str> {
+        avx2::emit_store_rsp(code, src, avx2_slot_disp(offset));
+        Ok(())
+    }
+
+    fn emit_resolve(
+        &mut self,
+        code: &mut Vec<u8>,
+        vid: regalloc::ValueId,
+        target: Reg,
+        reg_for: &[Option<Reg>],
+        spill_for: &[Option<u32>],
+        remat_for: &[Option<u32>],
+    ) -> Reg {
+        let idx = vid.0 as usize;
+        if let Some(Some(reg)) = reg_for.get(idx) {
+            *reg
+        } else if let Some(Some(bits)) = remat_for.get(idx) {
+            avx2::emit_const(code, target, f32::from_bits(*bits));
+            target
+        } else if let Some(Some(offset)) = spill_for.get(idx) {
+            avx2::emit_load_rsp(code, target, avx2_slot_disp(*offset));
+            target
+        } else {
+            panic!(
+                "value {:?} has no register, spill slot, or rematerialize entry",
+                vid
+            );
+        }
+    }
+
+    // Select short-circuit guards: vmovmskps -> eax[7:0], same shape as
+    // X86Backend's MOVMSKPS guards but 8 lanes wide (al == 0xFF for
+    // all-true, not 0x0F — see `avx2::emit_cmp_al_imm8`'s doc for why the
+    // sign-extending `cmp eax, imm8` X86Backend uses doesn't work here).
+    fn emit_skip_if_all_false(&mut self, code: &mut Vec<u8>, mask_reg: Reg) -> usize {
+        avx2::emit_movmskps_eax(code, mask_reg);
+        x86_64::emit_test_eax(code);
+        x86_64::emit_jcc_rel32(code, 0x84) // jz: taken when eax == 0 (all lanes false)
+    }
+
+    fn emit_skip_if_all_true(&mut self, code: &mut Vec<u8>, mask_reg: Reg) -> usize {
+        avx2::emit_movmskps_eax(code, mask_reg);
+        avx2::emit_cmp_al_imm8(code, 0xFF);
+        x86_64::emit_jcc_rel32(code, 0x84) // je: taken when al == 0xFF (all lanes true)
+    }
+
+    fn emit_jump(&mut self, code: &mut Vec<u8>) -> usize {
+        x86_64::emit_jmp_rel32(code)
+    }
+    fn patch_branch(&mut self, code: &mut Vec<u8>, branch: usize, target: usize) {
+        x86_64::patch_rel32(code, branch, target);
+    }
+
+    fn epilogue(&mut self, code: &mut Vec<u8>, result_reg: Reg, frame_size: u32) {
+        if result_reg.0 != 0 {
+            avx2::emit_mov(code, Reg(0), result_reg);
+        }
+        let bytes = avx2_frame_bytes(frame_size);
+        if bytes > 0 {
+            avx2::emit_add_rsp(code, bytes);
+        }
+        avx2::emit_ret(code);
+    }
+}
+
+/// Compile an arena DAG to an AVX2 (256-bit, 8-lane ymm) kernel via the shared
+/// driver. Same arg shape as [`compile_arena_dag`] but the kernel's ABI is
+/// `__m256` (one pixel per lane, 8 pixels per call).
+#[cfg(target_arch = "x86_64")]
+pub fn compile_arena_dag_avx2(
+    arena: &ExprArena,
+    root: ExprId,
+) -> Result<CompileResult, &'static str> {
+    let schedule = arena_to_schedule(arena, root);
+    let uses = arena_to_uses(&schedule);
+    compile_dag_via_backend(schedule, uses, &mut Avx2Backend)
 }
 
 /// Compile an arena DAG to an AVX-512 (512-bit, 16-lane zmm) kernel via the

--- a/pixelflow-ir/src/backend/emit/mod.rs
+++ b/pixelflow-ir/src/backend/emit/mod.rs
@@ -5189,7 +5189,11 @@ mod tests {
     // 128-bit under the default build; gated off `+avx512f` where `KernelFn` is
     // `__m512` (the AVX-512 per-batch path is covered by the `avx512` tests).
     #[test]
-    #[cfg(all(target_arch = "x86_64", not(target_feature = "avx512f")))]
+    #[cfg(all(
+        target_arch = "x86_64",
+        not(target_feature = "avx512f"),
+        not(target_feature = "avx2")
+    ))]
     fn scanline_matches_per_batch_x86() {
         use core::arch::x86_64::*;
 
@@ -5254,7 +5258,11 @@ mod tests {
     /// Run a per-batch arena kernel at `x` (Y/Z/W = 0) and return lane 0.
     /// 128-bit `KernelFn`; the builtin-parity tests below use it. Gated off
     /// `+avx512f` (those builtins aren't in the AVX-512 op set yet anyway).
-    #[cfg(all(target_arch = "x86_64", not(target_feature = "avx512f")))]
+    #[cfg(all(
+        target_arch = "x86_64",
+        not(target_feature = "avx512f"),
+        not(target_feature = "avx2")
+    ))]
     fn run1(arena: &ExprArena, root: ExprId, x: f32) -> f32 {
         use core::arch::x86_64::*;
         let r = compile_arena_dag(arena, root).expect("compile failed");
@@ -5267,7 +5275,11 @@ mod tests {
 
     /// Per-batch eval at (X=x, Y=y, Z=W=0), lane 0. 128-bit `KernelFn`, so gated
     /// off `+avx512f` like `run1`.
-    #[cfg(all(target_arch = "x86_64", not(target_feature = "avx512f")))]
+    #[cfg(all(
+        target_arch = "x86_64",
+        not(target_feature = "avx512f"),
+        not(target_feature = "avx2")
+    ))]
     fn run_xy(arena: &ExprArena, root: ExprId, x: f32, y: f32) -> f32 {
         use core::arch::x86_64::*;
         let r = compile_arena_dag(arena, root).expect("compile failed");
@@ -5282,7 +5294,11 @@ mod tests {
     /// runs `lower_dwrt`, so `D(√(x²+y²), x)` compiles to `x / √(x²+y²)`
     /// without the caller ever seeing the derivative machinery.
     #[test]
-    #[cfg(all(target_arch = "x86_64", not(target_feature = "avx512f")))]
+    #[cfg(all(
+        target_arch = "x86_64",
+        not(target_feature = "avx512f"),
+        not(target_feature = "avx2")
+    ))]
     fn dwrt_compiles_to_analytic_derivative() {
         let mut a = ExprArena::new();
         let x = a.push_var(0);
@@ -5330,7 +5346,11 @@ mod tests {
     /// all pushed before any is consumed, so dozens are simultaneously live
     /// against 6 allocatable registers.
     #[test]
-    #[cfg(all(target_arch = "x86_64", not(target_feature = "avx512f")))]
+    #[cfg(all(
+        target_arch = "x86_64",
+        not(target_feature = "avx512f"),
+        not(target_feature = "avx2")
+    ))]
     fn spill_frame_beyond_red_zone_compiles_correctly() {
         let mut a = ExprArena::new();
         let x = a.push_var(0);
@@ -5371,7 +5391,11 @@ mod tests {
     /// reference across a range of inputs — these exercise `emit_arena` →
     /// `emit_unary` directly (not the compiler's lowering).
     #[test]
-    #[cfg(all(target_arch = "x86_64", not(target_feature = "avx512f")))]
+    #[cfg(all(
+        target_arch = "x86_64",
+        not(target_feature = "avx512f"),
+        not(target_feature = "avx2")
+    ))]
     fn x86_unary_builtins_match_scalar() {
         // Tolerances reflect the shared (with aarch64) minimax-polynomial
         // accuracy over a sensible input range; exact ops use tight bounds.
@@ -5485,7 +5509,11 @@ mod tests {
 
     /// Binary transcendentals + comparisons + ternaries, JIT vs scalar.
     #[test]
-    #[cfg(all(target_arch = "x86_64", not(target_feature = "avx512f")))]
+    #[cfg(all(
+        target_arch = "x86_64",
+        not(target_feature = "avx512f"),
+        not(target_feature = "avx2")
+    ))]
     fn x86_binary_ternary_builtins_match_scalar() {
         use core::arch::x86_64::*;
         // Helper: compile f(X, Y) and eval at (x, y).
@@ -5606,7 +5634,11 @@ mod tests {
     /// Transcendental lowering: sin/cos/tan JIT through the per-batch path with
     /// no backend ever emitting a transcendental (they expand to arithmetic in
     /// `lowering`). Validated against `f32` on the default (128-bit) build.
-    #[cfg(all(target_arch = "x86_64", not(target_feature = "avx512f")))]
+    #[cfg(all(
+        target_arch = "x86_64",
+        not(target_feature = "avx512f"),
+        not(target_feature = "avx2")
+    ))]
     mod lowering_tests {
         use super::*;
         use crate::arena::ExprArena;
@@ -5766,7 +5798,11 @@ mod tests {
     // =========================================================================
     // Calls kernels through the per-batch `KernelFn` (128-bit here); gated off
     // `+avx512f` where that ABI is `__m512` (AVX-512 covered by `avx512_driver`).
-    #[cfg(all(target_arch = "x86_64", not(target_feature = "avx512f")))]
+    #[cfg(all(
+        target_arch = "x86_64",
+        not(target_feature = "avx512f"),
+        not(target_feature = "avx2")
+    ))]
     mod sched {
         use super::*;
         use crate::arena::ExprArena;
@@ -5916,7 +5952,11 @@ mod tests {
     // =========================================================================
     #[cfg(any(
         target_arch = "aarch64",
-        all(target_arch = "x86_64", not(target_feature = "avx512f"))
+        all(
+            target_arch = "x86_64",
+            not(target_feature = "avx512f"),
+            not(target_feature = "avx2")
+        )
     ))]
     mod gather_driver_128 {
         use super::*;

--- a/pixelflow-ir/src/backend/emit/mod.rs
+++ b/pixelflow-ir/src/backend/emit/mod.rs
@@ -31,6 +31,8 @@
 
 pub mod aarch64;
 pub mod avx512;
+#[cfg(test)]
+pub(crate) mod coverage;
 pub mod executable;
 pub mod lowering;
 pub mod regalloc;
@@ -6306,6 +6308,135 @@ mod tests {
                 let res = compile_arena_dag_avx512(&a, root).expect("avx512 compile");
                 check(run16(&res, xs, ones, ones), |i| f(xs[i]), tag);
             }
+        }
+    }
+
+    // =========================================================================
+    // Backend op-coverage completeness (docs/designs/2026-07-25-two-level-ir-
+    // and-backend-completeness.md)
+    // =========================================================================
+    //
+    // Turns "backend X silently doesn't support op Y" into a named, itemized
+    // test failure instead of a gap nobody notices until something happens to
+    // exercise it (this is exactly how AVX-512's binary-op dispatch sat at
+    // 6-of-15 required ops — nothing enumerated "the ops every backend must
+    // support" anywhere, so the hole was invisible until 36 tests failed by
+    // accident the first time someone compiled with `-C target-feature=
+    // +avx512f`).
+    //
+    // Each test below is scoped to a backend this build ACTUALLY compiles —
+    // `x86_backend_covers_required_ops` always runs on x86-64,
+    // `aarch64_backend_covers_required_ops` always runs on aarch64, and
+    // `avx512_backend_covers_required_ops` only compiles (and only needs to
+    // pass) when built with `avx512f` — the same feature gate
+    // `compile_arena_dag_with_ctx` uses to select `Avx512Backend` in
+    // production. On a default `cargo test --workspace` (no RUSTFLAGS) on
+    // this x86-64 host, that means: the SSE2 test runs and must be green
+    // (it is: X86Backend already covers every required op), and the AVX-512
+    // test does not even compile — it isn't lying about passing, it simply
+    // isn't part of this build. The moment someone builds with
+    // `+avx512f` (exactly the multi-ISA completion work tracked separately),
+    // this same test starts running and will fail loudly, by name, for every
+    // op `avx512::emit_unary`/`emit_binary`/`emit_plan` doesn't yet cover —
+    // rather than waiting for an unrelated test to trip over the gap.
+    mod backend_op_coverage {
+        use super::super::coverage::*;
+        use super::*;
+
+        /// Run one `ResolvedOp` through a backend and report whether it
+        /// emitted without error. Backends disagree on failure signaling
+        /// today (avx512 returns `Err`; x86-64/aarch64's leaf encoders
+        /// `panic!` on an unhandled op) — `catch_unwind` treats both as the
+        /// same "not supported" signal so this test doesn't have to care
+        /// which convention a given backend uses.
+        fn try_emit<B: IsaBackend>(backend: &mut B, op: ResolvedOp) -> bool {
+            let plan = InstructionPlan {
+                reloads: alloc::vec::Vec::new(),
+                op,
+                setup_mov: None,
+                store: None,
+            };
+            let mut code = alloc::vec::Vec::new();
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                backend.emit_plan(&mut code, &plan)
+            }))
+            .map(|r| r.is_ok())
+            .unwrap_or(false)
+        }
+
+        /// Sweep the required unary/binary/shift op lists plus the two
+        /// bespoke ternary shapes (`MulAdd`, `Select`) against `backend`,
+        /// collecting every failure instead of stopping at the first one —
+        /// a completeness gap is much cheaper to fix as an itemized list
+        /// than rediscovered one `cargo test` run per missing op.
+        fn assert_covers_required_ops<B: IsaBackend>(backend_name: &str, backend: &mut B) {
+            // The two explicit `try_emit` calls below for MulAdd/Select are
+            // this constant, unrolled by hand (each needs its own
+            // `ResolvedOp` shape, so they aren't worth a generic loop) — kept
+            // in sync deliberately rather than by a shared loop.
+            debug_assert_eq!(REQUIRED_TERNARY_OPS, &[OpKind::MulAdd, OpKind::Select]);
+            let mut missing = alloc::vec::Vec::new();
+
+            for &op in REQUIRED_UNARY_OPS {
+                if !try_emit(backend, ResolvedOp::Unary { op, dst: Reg(4), src: Reg(5) }) {
+                    missing.push(alloc::format!("unary {:?}", op));
+                }
+            }
+            for &op in REQUIRED_BINARY_OPS {
+                if !try_emit(
+                    backend,
+                    ResolvedOp::Binary { op, dst: Reg(4), left: Reg(4), right: Reg(5) },
+                ) {
+                    missing.push(alloc::format!("binary {:?}", op));
+                }
+            }
+            for &op in REQUIRED_SHIFT_OPS {
+                if !try_emit(
+                    backend,
+                    ResolvedOp::ShiftImm { op, dst: Reg(4), src: Reg(4), amount: 1 },
+                ) {
+                    missing.push(alloc::format!("shift {:?}", op));
+                }
+            }
+            if !try_emit(backend, ResolvedOp::FusedMulAdd { dst: Reg(4), a: Reg(5), b: Reg(6) }) {
+                missing.push(alloc::string::String::from("ternary MulAdd"));
+            }
+            if !try_emit(
+                backend,
+                ResolvedOp::Select { dst: Reg(4), if_true: Reg(5), if_false: Reg(6) },
+            ) {
+                missing.push(alloc::string::String::from("ternary Select"));
+            }
+
+            assert!(
+                missing.is_empty(),
+                "{backend_name} is missing required ops: {missing:?} (see \
+                 pixelflow-ir/src/backend/emit/coverage.rs for the full \
+                 completeness contract)"
+            );
+        }
+
+        #[cfg(target_arch = "x86_64")]
+        #[test]
+        fn x86_backend_covers_required_ops() {
+            assert_covers_required_ops("X86Backend (SSE2)", &mut X86Backend::default());
+        }
+
+        #[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
+        #[test]
+        fn avx512_backend_covers_required_ops() {
+            assert_covers_required_ops("Avx512Backend", &mut Avx512Backend);
+        }
+
+        #[cfg(target_arch = "aarch64")]
+        #[test]
+        fn aarch64_backend_covers_required_ops() {
+            let mut backend = Aarch64Backend {
+                pool: ConstPool::new(),
+                adr_patch_pos: 0,
+                max_regs: EmitCtx::default().max_regs,
+            };
+            assert_covers_required_ops("Aarch64Backend", &mut backend);
         }
     }
 }

--- a/pixelflow-ir/src/backend/emit/mod.rs
+++ b/pixelflow-ir/src/backend/emit/mod.rs
@@ -3331,6 +3331,23 @@ pub fn compile_arena_dag_with_ctx(
 #[cfg(target_arch = "x86_64")]
 const X86_SCHED_NUM_REGS: u8 = 6;
 
+/// Allocatable scratch register count handed to `linear_scan` on AVX2 (ymm4-7).
+///
+/// Two fewer than SSE2's six. AVX2's gather splits into 128-bit halves and so
+/// needs two scratch registers beyond the pair SSE2 uses (ymm13/14) to hold the
+/// high-half indices and the high-half result across the recombine. Those live
+/// in ymm8/ymm9, which must therefore sit OUTSIDE the allocator's range: with
+/// six allocatable (ymm4-9) the allocator could hand `dst` or `idx` an ymm8/9
+/// that the gather then overwrites mid-sequence, silently returning wrong
+/// lanes — reachable whenever five values stay live across a gather.
+///
+/// The cost is more spilling in AVX2 kernels generally, to fix a bug on the
+/// gather path specifically. Spilling the two half-temporaries to the red zone
+/// instead would restore the sixth register; that is a contained change to
+/// `avx2::emit_gather_scalar` and is the better long-term fix.
+#[cfg(target_arch = "x86_64")]
+const AVX2_SCHED_NUM_REGS: u8 = 4;
+
 /// Fixed scratch outside the allocatable range / reload regs: used for the
 /// binary two-operand hazard and as the select blend temp.
 ///
@@ -3953,7 +3970,7 @@ impl IsaBackend for Avx2Backend {
     type Branch = usize;
 
     fn num_regs(&self) -> u8 {
-        X86_SCHED_NUM_REGS // same 6 allocatable (ymm4-9)
+        AVX2_SCHED_NUM_REGS
     }
 
     fn begin(
@@ -4003,6 +4020,9 @@ impl IsaBackend for Avx2Backend {
                 // survives to here. ymm13/14 mirror X86Backend's gather
                 // scratch; ymm8/9 are the AVX2-only high-half scratch this
                 // two-half gather needs (see `avx2::emit_gather_scalar`).
+                // ymm8/9 are non-allocatable by construction — see
+                // `AVX2_SCHED_NUM_REGS`, which caps the pool at ymm4-7 so the
+                // allocator can never place `dst`/`idx` where this clobbers.
                 avx2::emit_gather_scalar(
                     code,
                     *dst,
@@ -6212,6 +6232,9 @@ mod tests {
         use super::*;
         use crate::arena::ExprArena;
 
+        // Passing __m512 by value IS the emitted ABI (SysV: zmm0-7), so
+        // not-FFI-safe is a false positive here, as for `executable`'s aliases.
+        #[allow(improper_ctypes_definitions)]
         type K = unsafe extern "C" fn(
             core::arch::x86_64::__m512,
             core::arch::x86_64::__m512,
@@ -6249,12 +6272,12 @@ mod tests {
         }
 
         fn check(got: [f32; 16], want: impl Fn(usize) -> f32, tag: &str) {
-            for i in 0..16 {
+            for (i, &g) in got.iter().enumerate() {
                 let w = want(i);
                 assert!(
-                    (got[i] - w).abs() <= 1e-3,
+                    (g - w).abs() <= 1e-3,
                     "{tag} lane {i}: got {} want {}",
-                    got[i],
+                    g,
                     w
                 );
             }
@@ -6262,6 +6285,9 @@ mod tests {
 
         // ---- Bound-memory gather: JIT vs reference interpreter ----
 
+        // Passing __m512 by value IS the emitted ABI (SysV: zmm0-7), so
+        // not-FFI-safe is a false positive here, as for `executable`'s aliases.
+        #[allow(improper_ctypes_definitions)]
         type CtxK = unsafe extern "C" fn(
             *const *const f32,
             core::arch::x86_64::__m512,
@@ -6310,10 +6336,10 @@ mod tests {
             let got = run16_ctx(&res, &ctx, xs, ys);
 
             let bindings = crate::binding::BindingTable::bind(arena, buffers).unwrap();
-            for i in 0..16 {
+            for (i, &g) in got.iter().enumerate() {
                 let want =
                     crate::eval::eval_scalar(arena, root, &[xs[i], ys[i], 0.0, 0.0], &bindings);
-                assert_eq!(got[i], want, "{tag} lane {i} (x={}, y={})", xs[i], ys[i]);
+                assert_eq!(g, want, "{tag} lane {i} (x={}, y={})", xs[i], ys[i]);
             }
         }
 
@@ -6444,10 +6470,10 @@ mod tests {
             // Compare every output lane to the reference interpreter.
             let bindings =
                 crate::binding::BindingTable::bind(&a, &[w.as_slice(), input.as_slice()]).unwrap();
-            for jj in 0..out_dim {
+            for (jj, &got) in out.iter().enumerate().take(out_dim) {
                 let want =
                     crate::eval::eval_scalar(&a, root, &[jj as f32, 0.0, 0.0, 0.0], &bindings);
-                assert_eq!(out[jj], want, "collapse out[{jj}]");
+                assert_eq!(got, want, "collapse out[{jj}]");
             }
         }
 

--- a/pixelflow-ir/src/backend/emit/mod.rs
+++ b/pixelflow-ir/src/backend/emit/mod.rs
@@ -1928,6 +1928,18 @@ trait IsaBackend {
     /// after the body is produced and can only prepend bytes.
     fn frame_ready(&mut self, _frame_size: u32) {}
 
+    /// Bytes actually reserved on the stack for a `frame_size`-byte *logical*
+    /// spill frame.
+    ///
+    /// `FrameLayout` counts 16-byte slots because that is the narrowest vector
+    /// any backend spills; a backend whose vector is wider reserves
+    /// proportionally more in its prologue, and must report the real figure so
+    /// `CompileResult::spill_bytes` describes the code that was actually
+    /// emitted. Identity for the 16-byte backends (SSE2, NEON).
+    fn frame_bytes(&self, frame_size: u32) -> u32 {
+        frame_size
+    }
+
     /// Function prologue (allocate the spill frame, set up any pool anchor).
     fn prologue(&mut self, code: &mut Vec<u8>, frame_size: u32);
 
@@ -2206,7 +2218,12 @@ fn compile_dag_via_backend<B: IsaBackend>(
     Ok(CompileResult {
         code: exec,
         spill_count,
-        spill_bytes: frame_size,
+        // The backend's own figure, not the logical one: an AVX2 slot is 32
+        // bytes and an AVX-512 slot 64, so reporting `frame_size` here claimed
+        // 16 bytes per spill while the prologue reserved 2x/4x that. The
+        // number feeds the cost model's training metadata and frame-size
+        // thresholds, so the discrepancy was silently mistraining them.
+        spill_bytes: backend.frame_bytes(frame_size),
         max_regs: backend.num_regs(),
     })
 }
@@ -3742,6 +3759,10 @@ impl IsaBackend for Avx512Backend {
         X86_SCHED_NUM_REGS // same 6 allocatable (zmm4-9)
     }
 
+    fn frame_bytes(&self, frame_size: u32) -> u32 {
+        avx512_frame_bytes(frame_size)
+    }
+
     fn begin(
         &mut self,
         _schedule: &[(regalloc::ValueId, ScheduledOp)],
@@ -3971,6 +3992,10 @@ impl IsaBackend for Avx2Backend {
 
     fn num_regs(&self) -> u8 {
         AVX2_SCHED_NUM_REGS
+    }
+
+    fn frame_bytes(&self, frame_size: u32) -> u32 {
+        avx2_frame_bytes(frame_size)
     }
 
     fn begin(

--- a/pixelflow-ir/src/backend/emit/x86_64.rs
+++ b/pixelflow-ir/src/backend/emit/x86_64.rs
@@ -609,6 +609,105 @@ pub fn emit_shift_imm(code: &mut Vec<u8>, op: OpKind, dst: Reg, src: Reg, amount
     }
 }
 
+// =============================================================================
+// Instruction selection: OpKind -> a closed set of binary-op mnemonics
+// =============================================================================
+//
+// This used to be one flat `match OpKind { Add => emit_addps(...), ...,
+// _ => panic!() }`: "which ops exist" and "how do I encode this op" were the
+// same match, so a missing arm only showed up as a runtime panic on whatever
+// input happened to exercise it — exactly how AVX-512's binary-op match sat
+// at 6-of-15 ops for a release (see avx512.rs `emit_binary`, and
+// docs/designs/2026-07-25-two-level-ir-and-backend-completeness.md).
+// Splitting selection from encoding makes "does this backend support op Y"
+// a question with one authoritative answer, not an emergent property of a
+// match arm nobody re-checked:
+//
+//   1. **Selection** (`X86BinaryInsn::select`): OpKind -> Option<X86BinaryInsn>.
+//      Still partial over the full `OpKind` (most of its variants are unary,
+//      ternary, or eliminated by `lowering` before they ever reach a backend
+//      — see `lowering.rs`), so this keeps a `_ => None`. But every op this
+//      backend claims to encode is named exactly once, here, as data — a
+//      completeness test enumerates against this function directly instead
+//      of poking the flat dispatch and hoping to hit every case.
+//   2. **Encoding** (`X86BinaryInsn::encode`): X86BinaryInsn -> bytes. This
+//      match has NO wildcard: it is exhaustive over the closed mnemonic
+//      enum, so adding a variant without teaching `encode` how to emit it is
+//      a compile error, not a silently-missing arm.
+//
+// An instruction is a value, not a function call: constructing
+// `X86BinaryInsn::AddPs` and encoding it are two separate steps, so
+// selection (which op maps to which mnemonic) is testable independently of
+// encoding (which mnemonic maps to which bytes).
+
+/// A binary SSE mnemonic this backend knows how to encode.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum X86BinaryInsn {
+    AddPs,
+    SubPs,
+    MulPs,
+    DivPs,
+    MinPs,
+    MaxPs,
+    /// `vcmpps` ordered predicate immediate (`CMP_EQ`/`CMP_LT`/...).
+    CmpPs(u8),
+    /// Packed i32 lane add (`IAdd`).
+    PAddD,
+    AndPs,
+    OrPs,
+}
+
+impl X86BinaryInsn {
+    /// Select the mnemonic for `op`, or `None` if this backend has no binary
+    /// encoding for it. `None` covers every non-binary `OpKind` (unary,
+    /// ternary, structural) as well as ops eliminated by `lowering` before
+    /// scheduling (transcendentals, `Dwrt`, `Reduce`, `Gather`) — none of
+    /// those can reach `emit_binary` from a correctly-lowered arena, so
+    /// `None` reaching a caller is an upstream invariant violation, not a
+    /// missing feature.
+    pub(crate) const fn select(op: OpKind) -> Option<Self> {
+        match op {
+            OpKind::Add => Some(Self::AddPs),
+            OpKind::Sub => Some(Self::SubPs),
+            OpKind::Mul => Some(Self::MulPs),
+            OpKind::Div => Some(Self::DivPs),
+            OpKind::Min => Some(Self::MinPs),
+            OpKind::Max => Some(Self::MaxPs),
+            OpKind::Eq => Some(Self::CmpPs(CMP_EQ)),
+            OpKind::Ne => Some(Self::CmpPs(CMP_NEQ)),
+            OpKind::Lt => Some(Self::CmpPs(CMP_LT)),
+            OpKind::Le => Some(Self::CmpPs(CMP_LE)),
+            OpKind::Gt => Some(Self::CmpPs(CMP_NLE)),
+            OpKind::Ge => Some(Self::CmpPs(CMP_GE)),
+            OpKind::IAdd => Some(Self::PAddD),
+            OpKind::BitAnd => Some(Self::AndPs),
+            OpKind::BitOr => Some(Self::OrPs),
+            _ => None,
+        }
+    }
+
+    /// Encode `dst = dst <mnemonic> src2` (the two-operand SSE setup —
+    /// `dst` already holding `src1` — runs in the caller, `emit_binary`).
+    /// Exhaustive over the closed `X86BinaryInsn` set: no wildcard arm.
+    fn encode(self, code: &mut Vec<u8>, dst: Reg, src2: Reg) {
+        match self {
+            Self::AddPs => emit_addps(code, dst, src2),
+            Self::SubPs => emit_subps(code, dst, src2),
+            Self::MulPs => emit_mulps(code, dst, src2),
+            Self::DivPs => emit_divps(code, dst, src2),
+            Self::MinPs => emit_minps(code, dst, src2),
+            Self::MaxPs => emit_maxps(code, dst, src2),
+            // Comparisons -> all-ones / all-zeros mask (ordered predicates).
+            Self::CmpPs(pred) => emit_cmp_tail(code, dst, src2, pred),
+            // Bit-manip primitives: the VEX 3-operand encoders take `dst` as
+            // the vvvv source, so this is in-place (dst already holds src1).
+            Self::PAddD => emit_vpaddd(code, dst, dst, src2),
+            Self::AndPs => emit_vandps(code, dst, dst, src2),
+            Self::OrPs => emit_vorps(code, dst, dst, src2),
+        }
+    }
+}
+
 /// Emit binary operation
 pub fn emit_binary(code: &mut Vec<u8>, op: OpKind, dst: Reg, src1: Reg, src2: Reg) {
     // SSE is 2-operand, so we may need to move first
@@ -616,30 +715,9 @@ pub fn emit_binary(code: &mut Vec<u8>, op: OpKind, dst: Reg, src1: Reg, src2: Re
         emit_sse_rr(code, None, &[0x0F, 0x28], dst, src1); // MOVAPS dst, src1
     }
 
-    match op {
-        OpKind::Add => emit_addps(code, dst, src2),
-        OpKind::Sub => emit_subps(code, dst, src2),
-        OpKind::Mul => emit_mulps(code, dst, src2),
-        OpKind::Div => emit_divps(code, dst, src2),
-        OpKind::Min => emit_minps(code, dst, src2),
-        OpKind::Max => emit_maxps(code, dst, src2),
-
-        // Comparisons → all-ones / all-zeros mask (ordered predicates).
-        // `dst` already holds src1 (moved above), so compare in place.
-        OpKind::Eq => emit_cmp_tail(code, dst, src2, CMP_EQ),
-        OpKind::Ne => emit_cmp_tail(code, dst, src2, CMP_NEQ),
-        OpKind::Lt => emit_cmp_tail(code, dst, src2, CMP_LT),
-        OpKind::Le => emit_cmp_tail(code, dst, src2, CMP_LE),
-        OpKind::Gt => emit_cmp_tail(code, dst, src2, CMP_NLE),
-        OpKind::Ge => emit_cmp_tail(code, dst, src2, CMP_GE),
-
-        // Bit-manip primitives. `dst` already holds src1 (moved above); the VEX
-        // 3-operand encoders take it as the vvvv source so this is in-place.
-        OpKind::IAdd => emit_vpaddd(code, dst, dst, src2),
-        OpKind::BitAnd => emit_vandps(code, dst, dst, src2),
-        OpKind::BitOr => emit_vorps(code, dst, dst, src2),
-
-        _ => panic!("x86_64 binary emit not implemented for {:?}", op),
+    match X86BinaryInsn::select(op) {
+        Some(insn) => insn.encode(code, dst, src2),
+        None => panic!("x86_64 binary emit not implemented for {:?}", op),
     }
 }
 
@@ -743,4 +821,32 @@ pub fn emit_test_eax(code: &mut Vec<u8>) {
 /// CMP eax, imm8 (sign-extended).
 pub fn emit_cmp_eax_imm8(code: &mut Vec<u8>, imm: u8) {
     code.extend_from_slice(&[0x83, 0xF8, imm]);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `X86BinaryInsn::select` is `emit_binary`'s completeness contract made
+    /// checkable: every op `pixelflow_ir::backend::emit::coverage::
+    /// REQUIRED_BINARY_OPS` lists must select `Some`, or this backend would
+    /// panic the moment the scheduler handed it that op. Cheaper and more
+    /// precise than the emit-and-catch-panic sweep in `emit/mod.rs`'s
+    /// `backend_op_coverage` tests, because it checks the *selection* step
+    /// directly instead of inferring "not supported" from a caught panic.
+    #[test]
+    fn selects_every_required_binary_op() {
+        use crate::backend::emit::coverage::REQUIRED_BINARY_OPS;
+
+        let unselected: alloc::vec::Vec<OpKind> = REQUIRED_BINARY_OPS
+            .iter()
+            .copied()
+            .filter(|&op| X86BinaryInsn::select(op).is_none())
+            .collect();
+
+        assert!(
+            unselected.is_empty(),
+            "X86BinaryInsn::select has no mnemonic for: {unselected:?}"
+        );
+    }
 }

--- a/pixelflow-ir/src/backend/x86.rs
+++ b/pixelflow-ir/src/backend/x86.rs
@@ -1417,6 +1417,7 @@ impl U32x8 {
     /// Pack 8 f32 Fields (RGBA) into packed u32 pixels.
     #[allow(dead_code)]
     #[inline(always)]
+    #[must_use]
     pub fn pack_rgba(r: F32x8, g: F32x8, b: F32x8, a: F32x8) -> Self {
         unsafe {
             let scale = _mm256_set1_ps(255.0);
@@ -2109,6 +2110,7 @@ impl U32x16 {
     /// Pack 16 f32 Fields (RGBA) into packed u32 pixels.
     #[allow(dead_code)]
     #[inline(always)]
+    #[must_use]
     pub fn pack_rgba(r: F32x16, g: F32x16, b: F32x16, a: F32x16) -> Self {
         unsafe {
             let scale = _mm512_set1_ps(255.0);

--- a/pixelflow-ir/src/jit_manifold.rs
+++ b/pixelflow-ir/src/jit_manifold.rs
@@ -45,7 +45,11 @@ impl JitManifold {
     }
 }
 
-#[cfg(all(target_arch = "x86_64", not(target_feature = "avx512f")))]
+#[cfg(all(
+    target_arch = "x86_64",
+    not(target_feature = "avx512f"),
+    not(target_feature = "avx2")
+))]
 impl JitManifold {
     /// Evaluate the kernel at the given coordinates (SSE2, 128-bit, 4 lanes).
     ///
@@ -62,6 +66,34 @@ impl JitManifold {
         z: core::arch::x86_64::__m128,
         w: core::arch::x86_64::__m128,
     ) -> core::arch::x86_64::__m128 {
+        // SAFETY: The ExecutableCode was produced by our JIT compiler which
+        // emits code matching the KernelFn signature.
+        let func: KernelFn = unsafe { self.code.as_fn() };
+        func(x, y, z, w)
+    }
+}
+
+#[cfg(all(
+    target_arch = "x86_64",
+    target_feature = "avx2",
+    not(target_feature = "avx512f")
+))]
+impl JitManifold {
+    /// Evaluate the kernel at the given coordinates (AVX2, 256-bit, 8 lanes).
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure the SIMD types match the platform ABI the emitter
+    /// generated code for (x86-64 AVX2: `__m256`).
+    #[inline(always)]
+    #[must_use]
+    pub unsafe fn call(
+        &self,
+        x: core::arch::x86_64::__m256,
+        y: core::arch::x86_64::__m256,
+        z: core::arch::x86_64::__m256,
+        w: core::arch::x86_64::__m256,
+    ) -> core::arch::x86_64::__m256 {
         // SAFETY: The ExecutableCode was produced by our JIT compiler which
         // emits code matching the KernelFn signature.
         let func: KernelFn = unsafe { self.code.as_fn() };

--- a/pixelflow-ir/src/jit_manifold.rs
+++ b/pixelflow-ir/src/jit_manifold.rs
@@ -110,6 +110,7 @@ impl JitManifold {
     /// The caller must ensure the SIMD types match the platform ABI the emitter
     /// generated code for (x86-64 AVX-512: `__m512`).
     #[inline(always)]
+    #[must_use]
     pub unsafe fn call(
         &self,
         x: core::arch::x86_64::__m512,

--- a/pixelflow-ir/src/lib.rs
+++ b/pixelflow-ir/src/lib.rs
@@ -61,12 +61,42 @@ pub use traits::{EmitStyle, Op, OpMeta};
 /// at compile time, turning any width disagreement into a clear build error
 /// rather than a raw `transmute` size error (or, worse, a silent miscompile).
 ///
-/// 64 (512-bit, AVX-512) when compiled with `target_feature = "avx512f"`, where
-/// `compile_arena_dag` routes to `Avx512Backend` and `KernelFn` is `__m512`;
-/// otherwise 16 (128-bit, SSE2/NEON). This matches `pixelflow-core`'s `Field`
-/// width under the same build flags, so the `kernel_jit!` assert holds.
+/// A genuine 3-way split, checked only against `target_feature` (the flag
+/// that actually governs what the compiler may emit into this crate) — NOT
+/// ANDed against a build.rs host-detected cfg the way `pixelflow-core`'s
+/// `storage.rs` gates `NativeF32Storage`. That AND is a real safety net over
+/// there (see its comment): it guards against a build host whose CPU lacks
+/// the feature it was explicitly told to target, which would emit
+/// AVX-512/AVX2 instructions the box running the build can't execute. This
+/// crate has no build script of its own to reproduce that host probe — it is
+/// `no_std`-first and carries no `is_x86_feature_detected!` machinery — and
+/// duplicating pixelflow-core's `pixelflow_avx512f`/`pixelflow_avx2` cfg here
+/// would only recreate the mismatch it's meant to catch (a build script is
+/// per-crate; a cfg it emits does not cross a crate boundary). Every other
+/// `target_feature = "avx512f"` gate already in this crate (`x86.rs`,
+/// `emit/mod.rs`, `emit/executable.rs`, `jit_manifold.rs`) is bare
+/// `target_feature`, so this stays consistent with the rest of the crate
+/// rather than inventing a second rule for one const.
+///
+/// 64 (512-bit, AVX-512) when compiled with `target_feature = "avx512f"`,
+/// where `compile_arena_dag` routes to `Avx512Backend` and `KernelFn` is
+/// `__m512`; 32 (256-bit, AVX2) when compiled with `target_feature = "avx2"`
+/// and not `"avx512f"`, routing to `Avx2Backend` (`KernelFn` = `__m256`);
+/// otherwise 16 (128-bit, SSE2/NEON). This matches `pixelflow-core`'s
+/// `Field` width under the same build flags, so the `kernel_jit!` assert
+/// holds.
 #[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
 pub const JIT_VECTOR_BYTES: usize = 64;
 /// See the AVX-512 variant above.
-#[cfg(not(all(target_arch = "x86_64", target_feature = "avx512f")))]
+#[cfg(all(
+    target_arch = "x86_64",
+    target_feature = "avx2",
+    not(target_feature = "avx512f")
+))]
+pub const JIT_VECTOR_BYTES: usize = 32;
+/// See the AVX-512 variant above.
+#[cfg(not(any(
+    all(target_arch = "x86_64", target_feature = "avx512f"),
+    all(target_arch = "x86_64", target_feature = "avx2")
+)))]
 pub const JIT_VECTOR_BYTES: usize = 16;

--- a/pixelflow-ir/tests/avx512_evex_proof.rs
+++ b/pixelflow-ir/tests/avx512_evex_proof.rs
@@ -132,6 +132,10 @@ fn evex_runtime_16_lanes() {
     use core::arch::x86_64::*;
 
     // System V passes/returns __m512 in zmm0-7: X=zmm0, Y=zmm1, Z=zmm2.
+    // Passing __m512 by value IS the emitted ABI (SysV: zmm0-7), so the
+    // not-FFI-safe warning is a false positive here — same reason
+    // `backend::emit::executable`'s KernelFn aliases carry this allow.
+    #[allow(improper_ctypes_definitions)]
     type Kernel = unsafe extern "C" fn(__m512, __m512, __m512, __m512) -> __m512;
 
     // Kernel A: (X + Y) * Z

--- a/pixelflow-ir/tests/reduction_binder.rs
+++ b/pixelflow-ir/tests/reduction_binder.rs
@@ -276,6 +276,26 @@ mod jit {
     use pixelflow_ir::backend::emit::compile_arena_dag;
     use pixelflow_ir::jit_manifold::JitManifold;
 
+    // JitManifold::call's ABI tracks the build's selected width (SSE2/AVX2;
+    // this module is gated off avx512f above), so the splat/extract pair must
+    // match: __m256 under +avx2, else __m128.
+    #[cfg(target_feature = "avx2")]
+    fn jit_eval(k: &Kernel, x: f32, y: f32) -> f32 {
+        use core::arch::x86_64::*;
+        let (arena, root) = k.parts();
+        let compiled = compile_arena_dag(arena, root).expect("reduction JIT compile");
+        let jit = JitManifold::new(compiled.code);
+        unsafe {
+            _mm256_cvtss_f32(jit.call(
+                _mm256_set1_ps(x),
+                _mm256_set1_ps(y),
+                _mm256_set1_ps(0.0),
+                _mm256_set1_ps(0.0),
+            ))
+        }
+    }
+
+    #[cfg(not(target_feature = "avx2"))]
     fn jit_eval(k: &Kernel, x: f32, y: f32) -> f32 {
         use core::arch::x86_64::*;
         let (arena, root) = k.parts();

--- a/pixelflow-ir/tests/spill_pressure.rs
+++ b/pixelflow-ir/tests/spill_pressure.rs
@@ -66,12 +66,31 @@ fn assert_jit_matches_interp(arena: &ExprArena, root: ExprId, label: &str) -> u3
             let want = eval_scalar(arena, root, &[x, y, 0.1, 0.9], &BindingTable::empty());
             let got = jit_eval(&jit, x, y, 0.1, 0.9);
             assert!(
-                (want.is_nan() && got.is_nan()) || want == got,
+                (want.is_nan() && got.is_nan()) || floats_agree(want, got),
                 "{label}: JIT {got} != interp {want} at ({x}, {y}) [spills={spills}]"
             );
         }
     }
     spills
+}
+
+/// Bit-exact under every build this file was originally tested with (no
+/// hardware FMA target feature => `fp-contract=fast` has nothing to contract
+/// into, so both tiers round identically). Under `+avx2,+fma`, `eval_scalar`'s
+/// scalar `a*b+c` gets contracted by LLVM into one rounding (a real `fma`
+/// instruction); a `DecomposedMulAdd` (register pressure forced `a`/`b` apart
+/// from `c` — see `muladd_and_clamp_spilled`, which deliberately builds
+/// operands deeper than the register budget) is architecturally a two-step
+/// mul-then-add and rounds twice, regardless of backend. That is a genuine
+/// last-bit IEEE-754 rounding difference, not a miscompile, so this tolerates
+/// a few ULPs of f32 relative error instead of weakening to a coarse epsilon
+/// that would also hide a real one.
+fn floats_agree(want: f32, got: f32) -> bool {
+    if want == got {
+        return true;
+    }
+    let ulp = f32::EPSILON * want.abs().max(f32::MIN_POSITIVE);
+    (want - got).abs() <= 4.0 * ulp
 }
 
 /// A "wide" balanced expression tree: needs ~depth registers transiently, so a

--- a/pixelflow-ir/tests/spill_pressure.rs
+++ b/pixelflow-ir/tests/spill_pressure.rs
@@ -23,6 +23,23 @@ use pixelflow_ir::binding::BindingTable;
 use pixelflow_ir::eval_scalar;
 use pixelflow_ir::jit_manifold::JitManifold;
 
+// JitManifold::call's ABI tracks the build's selected width (SSE2/AVX2; this
+// file is gated off avx512f above), so the splat/extract pair must match:
+// __m256 under +avx2, else __m128.
+#[cfg(target_feature = "avx2")]
+fn jit_eval(jit: &JitManifold, x: f32, y: f32, z: f32, w: f32) -> f32 {
+    use core::arch::x86_64::*;
+    unsafe {
+        _mm256_cvtss_f32(jit.call(
+            _mm256_set1_ps(x),
+            _mm256_set1_ps(y),
+            _mm256_set1_ps(z),
+            _mm256_set1_ps(w),
+        ))
+    }
+}
+
+#[cfg(not(target_feature = "avx2"))]
 fn jit_eval(jit: &JitManifold, x: f32, y: f32, z: f32, w: f32) -> f32 {
     use core::arch::x86_64::*;
     unsafe {

--- a/pixelflow-ir/tests/transcendental_jit.rs
+++ b/pixelflow-ir/tests/transcendental_jit.rs
@@ -1,0 +1,87 @@
+//! exp/log kernels through the JIT, checked numerically at this build's width.
+//!
+//! These lower (`expand_transcendentals`) to the integer-domain primitives
+//! TruncToInt/IntToFloat/IAdd/Shl/Shr — ops a backend can silently lack while
+//! every other test stays green, because `Field`'s combinator tier computes
+//! its own log2/exp via native intrinsics and never consults the JIT. That is
+//! exactly how Avx512Backend shipped refusing `ShiftImm`: `test_log2` passed
+//! (combinator tier), the full workspace passed under `+avx512f`, and a
+//! `Kernel::log2` still failed to compile. The completeness sweep catches the
+//! emission gap; this catches the semantics — the bytes must also be right.
+
+use pixelflow_ir::{Kernel, jit_cache};
+
+#[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
+fn call_x(jit: &pixelflow_ir::JitManifold, x: f32) -> f32 {
+    use core::arch::x86_64::*;
+    unsafe {
+        let v = _mm512_set1_ps(x);
+        let z = _mm512_setzero_ps();
+        _mm512_cvtss_f32(jit.call(v, z, z, z))
+    }
+}
+#[cfg(all(
+    target_arch = "x86_64",
+    target_feature = "avx2",
+    not(target_feature = "avx512f")
+))]
+fn call_x(jit: &pixelflow_ir::JitManifold, x: f32) -> f32 {
+    use core::arch::x86_64::*;
+    unsafe {
+        let v = _mm256_set1_ps(x);
+        let z = _mm256_setzero_ps();
+        _mm256_cvtss_f32(jit.call(v, z, z, z))
+    }
+}
+#[cfg(all(
+    target_arch = "x86_64",
+    not(target_feature = "avx2"),
+    not(target_feature = "avx512f")
+))]
+fn call_x(jit: &pixelflow_ir::JitManifold, x: f32) -> f32 {
+    use core::arch::x86_64::*;
+    unsafe {
+        let v = _mm_set1_ps(x);
+        let z = _mm_setzero_ps();
+        _mm_cvtss_f32(jit.call(v, z, z, z))
+    }
+}
+#[cfg(target_arch = "aarch64")]
+fn call_x(jit: &pixelflow_ir::JitManifold, x: f32) -> f32 {
+    use core::arch::aarch64::*;
+    unsafe {
+        let v = vdupq_n_f32(x);
+        let z = vdupq_n_f32(0.0);
+        vgetq_lane_f32::<0>(jit.call(v, z, z, z))
+    }
+}
+
+fn check(name: &str, k: &Kernel, inputs: &[f32], reference: impl Fn(f32) -> f32) {
+    let (arena, root) = k.parts();
+    let jit = jit_cache::compile_cached(arena, root)
+        .unwrap_or_else(|e| panic!("{name}: kernel failed to compile on this backend: {e}"));
+    for &x in inputs {
+        let got = call_x(&jit, x);
+        let want = reference(x);
+        let rel = ((got - want) / want.abs().max(1e-6)).abs();
+        assert!(
+            rel <= 1e-3 || (got - want).abs() <= 1e-4,
+            "{name}({x}): got {got}, want {want} (rel {rel:.2e})"
+        );
+    }
+}
+
+#[test]
+fn exp_log_kernels_compile_and_agree_with_std() {
+    // Log domains can range wide; exp inputs stay where e^x is a finite f32.
+    // The expansion clamps its exponent to ±126 by design (expand_exp2,
+    // lowering.rs) — the JIT saturates where std overflows to inf, so inputs
+    // past ~88.7 (ln(f32::MAX)) compare a clamp against an inf, which is a
+    // contract difference, not an encoding bug.
+    let logs = [0.5f32, 1.0, 2.0, 8.0, 100.0, 4096.0];
+    let exps = [-10.0f32, -1.0, 0.0, 0.5, 1.0, 8.0, 80.0];
+    check("log2", &Kernel::x().log2(), &logs, f32::log2);
+    check("ln", &Kernel::x().ln(), &logs, f32::ln);
+    check("exp", &Kernel::x().exp(), &exps, f32::exp);
+    check("exp2", &Kernel::x().exp2(), &exps, f32::exp2);
+}

--- a/pixelflow-pipeline/src/bin/bench_extraction_3way.rs
+++ b/pixelflow-pipeline/src/bin/bench_extraction_3way.rs
@@ -181,7 +181,11 @@ fn named_kernels() -> Vec<(&'static str, ExprArena, ExprId)> {
 // Broadcasts one coordinate to all lanes, reads lane 0.
 // ---------------------------------------------------------------------------
 
-#[cfg(all(target_arch = "x86_64", not(target_feature = "avx512f")))]
+#[cfg(all(
+    target_arch = "x86_64",
+    not(target_feature = "avx512f"),
+    not(target_feature = "avx2")
+))]
 fn run_scalar(code: &ExecutableCode, x: f32, y: f32, z: f32, w: f32) -> f32 {
     use core::arch::x86_64::{_mm_cvtss_f32, _mm_set1_ps};
     // SAFETY: SSE2 is the baseline on x86-64; the JIT emitted `__m128` ABI.
@@ -194,6 +198,27 @@ fn run_scalar(code: &ExecutableCode, x: f32, y: f32, z: f32, w: f32) -> f32 {
             _mm_set1_ps(w),
         );
         _mm_cvtss_f32(r)
+    }
+}
+
+#[cfg(all(
+    target_arch = "x86_64",
+    target_feature = "avx2",
+    not(target_feature = "avx512f")
+))]
+fn run_scalar(code: &ExecutableCode, x: f32, y: f32, z: f32, w: f32) -> f32 {
+    use core::arch::x86_64::{_mm256_cvtss_f32, _mm256_set1_ps};
+    // SAFETY: built with +avx2 (not +avx512f), so the JIT emitted the
+    // `__m256` ABI.
+    unsafe {
+        let f: KernelFn = code.as_fn();
+        let r = f(
+            _mm256_set1_ps(x),
+            _mm256_set1_ps(y),
+            _mm256_set1_ps(z),
+            _mm256_set1_ps(w),
+        );
+        _mm256_cvtss_f32(r)
     }
 }
 

--- a/pixelflow-pipeline/src/bin/bench_hoisted_scanline.rs
+++ b/pixelflow-pipeline/src/bin/bench_hoisted_scanline.rs
@@ -87,9 +87,19 @@ struct JitWrapper(pixelflow_ir::JitManifold);
 // The vector type of the JIT's call ABI on *this build*, which must track the
 // emitted width rather than assume one. Hard-coding `__m128` pinned this
 // benchmark to SSE2, so it stopped compiling on any build wide enough to be
-// worth benchmarking.
-#[cfg(all(target_arch = "x86_64", not(target_feature = "avx512f")))]
+// worth benchmarking. Mirrors `pixelflow_ir::JIT_VECTOR_BYTES`'s 3-way split.
+#[cfg(all(
+    target_arch = "x86_64",
+    not(target_feature = "avx512f"),
+    not(target_feature = "avx2")
+))]
 type JitLane = core::arch::x86_64::__m128;
+#[cfg(all(
+    target_arch = "x86_64",
+    target_feature = "avx2",
+    not(target_feature = "avx512f")
+))]
+type JitLane = core::arch::x86_64::__m256;
 #[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
 type JitLane = core::arch::x86_64::__m512;
 #[cfg(target_arch = "aarch64")]

--- a/pixelflow-pipeline/src/jit_bench.rs
+++ b/pixelflow-pipeline/src/jit_bench.rs
@@ -316,8 +316,9 @@ fn benchmark_exec_code(
             use pixelflow_ir::backend::emit::executable::KernelFn;
             let func: KernelFn = exec_code.as_fn();
 
-            // Inputs at the KernelFn's SIMD width: __m512 under +avx512f, else
-            // __m128 (SSE2). eval100! is width-agnostic (just calls func).
+            // Inputs at the KernelFn's SIMD width: __m512 under +avx512f, __m256
+            // under +avx2 (and not +avx512f), else __m128 (SSE2). eval100! is
+            // width-agnostic (just calls func).
             #[cfg(target_feature = "avx512f")]
             let (x, y, z, w) = (
                 _mm512_set1_ps(0.5),
@@ -325,7 +326,14 @@ fn benchmark_exec_code(
                 _mm512_set1_ps(1.3),
                 _mm512_set1_ps(-0.2),
             );
-            #[cfg(not(target_feature = "avx512f"))]
+            #[cfg(all(target_feature = "avx2", not(target_feature = "avx512f")))]
+            let (x, y, z, w) = (
+                _mm256_set1_ps(0.5),
+                _mm256_set1_ps(0.7),
+                _mm256_set1_ps(1.3),
+                _mm256_set1_ps(-0.2),
+            );
+            #[cfg(not(any(target_feature = "avx512f", target_feature = "avx2")))]
             let (x, y, z, w) = (
                 _mm_set1_ps(0.5),
                 _mm_set1_ps(0.7),
@@ -346,7 +354,13 @@ fn benchmark_exec_code(
                 _mm512_storeu_ps(wide.as_mut_ptr(), out);
                 output.copy_from_slice(&wide[..4]);
             }
-            #[cfg(not(target_feature = "avx512f"))]
+            #[cfg(all(target_feature = "avx2", not(target_feature = "avx512f")))]
+            {
+                let mut wide = [0.0f32; 8];
+                _mm256_storeu_ps(wide.as_mut_ptr(), out);
+                output.copy_from_slice(&wide[..4]);
+            }
+            #[cfg(not(any(target_feature = "avx512f", target_feature = "avx2")))]
             _mm_storeu_ps(output.as_mut_ptr(), out);
 
             let mut times = [0u64; TIMED_RUNS];

--- a/pixelflow-search/tests/prod_kernel_jit.rs
+++ b/pixelflow-search/tests/prod_kernel_jit.rs
@@ -79,7 +79,11 @@ fn optimize(arena: &ExprArena, root: ExprId, tag: &str) -> (ExprArena, ExprId) {
 
 use pixelflow_ir::backend::emit::executable::{ExecutableCode, KernelFn};
 
-#[cfg(all(target_arch = "x86_64", not(target_feature = "avx512f")))]
+#[cfg(all(
+    target_arch = "x86_64",
+    not(target_feature = "avx512f"),
+    not(target_feature = "avx2")
+))]
 fn run_scalar(code: &ExecutableCode, x: f32, y: f32, z: f32, w: f32) -> f32 {
     use core::arch::x86_64::{_mm_cvtss_f32, _mm_set1_ps};
     // SAFETY: SSE2 is the baseline on x86-64; the JIT emitted `__m128` ABI.
@@ -92,6 +96,27 @@ fn run_scalar(code: &ExecutableCode, x: f32, y: f32, z: f32, w: f32) -> f32 {
             _mm_set1_ps(w),
         );
         _mm_cvtss_f32(r)
+    }
+}
+
+#[cfg(all(
+    target_arch = "x86_64",
+    target_feature = "avx2",
+    not(target_feature = "avx512f")
+))]
+fn run_scalar(code: &ExecutableCode, x: f32, y: f32, z: f32, w: f32) -> f32 {
+    use core::arch::x86_64::{_mm256_cvtss_f32, _mm256_set1_ps};
+    // SAFETY: built with +avx2 (not +avx512f), so the JIT emitted the
+    // `__m256` ABI.
+    unsafe {
+        let f: KernelFn = code.as_fn();
+        let r = f(
+            _mm256_set1_ps(x),
+            _mm256_set1_ps(y),
+            _mm256_set1_ps(z),
+            _mm256_set1_ps(w),
+        );
+        _mm256_cvtss_f32(r)
     }
 }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -413,11 +413,12 @@ fn run_with_rustflags(
         .args(args)
         .env("RUSTFLAGS", rustflags)
         .env("CARGO_TARGET_DIR", target_dir)
-        // Deep-Manifold tests (raymarch_sphere, scene3d) recurse near the
-        // stack limit by design (see CLAUDE.md's dev-profile note); 8- and
-        // 16-lane builds have 2-4x larger frames and overflowed the default
-        // 2 MiB test-thread stack on GitHub runners while passing locally.
-        // Pin the floor so the matrix behaves identically everywhere.
+        // Deep-Manifold tests recurse near the stack limit by design (see
+        // CLAUDE.md's dev-profile note), and 8-/16-lane builds have
+        // proportionally larger frames. This raises the floor for libtest's
+        // own threads; worker threads that set `stack_size` explicitly are
+        // NOT covered by it and must size themselves (see
+        // `rasterizer::parallel::STACK_SIZE`).
         .env("RUST_MIN_STACK", "16777216")
         .status()
         .map(|s| s.success())

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -218,6 +218,16 @@ const ISA_LEVELS: &[IsaLevel] = &[
         target_feature: "",
         requires: &[],
     },
+    // Two AVX2 rows, because `Avx2Backend` is gated on `avx2` ALONE and carries
+    // a documented software mul+add fallback for parts that shipped AVX2
+    // without FMA3 (VIA, early Zen). Requiring both features would skip this
+    // configuration entirely on such a host and never exercise that fallback —
+    // so the matrix would not, in fact, cover every level the host supports.
+    IsaLevel {
+        name: "avx2 (no fma)",
+        target_feature: "+avx2",
+        requires: &["avx2"],
+    },
     IsaLevel {
         name: "avx2+fma",
         target_feature: "+avx2,+fma",

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -307,8 +307,27 @@ fn isa_matrix(with_clippy: bool) {
             };
             println!("isa-matrix: RUSTFLAGS=\"{rustflags}\"");
 
+            // Each level's RUSTFLAGS produce a disjoint artifact set (the
+            // flags feed -C metadata), so levels sharing a target dir
+            // accumulate ~one full workspace build EACH — three levels
+            // exhausted a 21 GB disk the first time this ran for real.
+            // Every level therefore builds in one dedicated dir, wiped
+            // before each level: peak disk is a single artifact set, and
+            // the developer's own target/ (their incremental cache) is
+            // never touched.
+            let matrix_target = workspace_root.join("target/isa-matrix");
+            if matrix_target.exists() {
+                if let Err(e) = std::fs::remove_dir_all(&matrix_target) {
+                    panic!(
+                        "isa-matrix: could not clear {}: {e}",
+                        matrix_target.display()
+                    );
+                }
+            }
+
             let test_ok = run_with_rustflags(
                 &workspace_root,
+                &matrix_target,
                 &rustflags,
                 &["test", "--workspace", "--no-fail-fast"],
             );
@@ -322,6 +341,7 @@ fn isa_matrix(with_clippy: bool) {
             if with_clippy {
                 let clippy_ok = run_with_rustflags(
                     &workspace_root,
+                    &matrix_target,
                     &rustflags,
                     &["clippy", "--workspace", "--all-targets", "--", "-D", "warnings"],
                 );
@@ -363,14 +383,20 @@ fn isa_matrix(with_clippy: bool) {
 }
 
 /// Run `cargo <args>` from the workspace root with `RUSTFLAGS` set to
-/// `rustflags`, streaming output straight through. Returns whether it
-/// succeeded.
+/// `rustflags` and artifacts confined to `target_dir`, streaming output
+/// straight through. Returns whether it succeeded.
 #[cfg(target_arch = "x86_64")]
-fn run_with_rustflags(workspace_root: &std::path::Path, rustflags: &str, args: &[&str]) -> bool {
+fn run_with_rustflags(
+    workspace_root: &std::path::Path,
+    target_dir: &std::path::Path,
+    rustflags: &str,
+    args: &[&str],
+) -> bool {
     Command::new("cargo")
         .current_dir(workspace_root)
         .args(args)
         .env("RUSTFLAGS", rustflags)
+        .env("CARGO_TARGET_DIR", target_dir)
         .status()
         .map(|s| s.success())
         .unwrap_or(false)

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -19,6 +19,9 @@ fn main() {
         eprintln!("Commands:");
         eprintln!("  bundle-run    Build and run the bundled macOS app");
         eprintln!("  bake-eigen    Parse Stam's eigenstructure binary → Rust consts");
+        eprintln!("  isa-matrix    Run the workspace test suite at every x86-64 ISA");
+        eprintln!("                level this host actually supports (SSE2/AVX2/AVX-512)");
+        eprintln!("                [--clippy to also run clippy per level]");
         std::process::exit(1);
     }
 
@@ -30,6 +33,10 @@ fn main() {
         }
         "bake-eigen" => {
             bake_eigen();
+        }
+        "isa-matrix" => {
+            let with_clippy = args[2..].iter().any(|a| a == "--clippy");
+            isa_matrix(with_clippy);
         }
         _ => {
             eprintln!("Unknown command: {}", args[1]);

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -224,9 +224,14 @@ const ISA_LEVELS: &[IsaLevel] = &[
         requires: &["avx2", "fma"],
     },
     IsaLevel {
-        name: "avx512f",
-        target_feature: "+avx512f",
-        requires: &["avx512f"],
+        // DQ, not just F: `avx512::emit_compare` materializes a mask with
+        // `vpmovm2d`, which is AVX-512DQ. An AVX-512F-only part (Knights
+        // Landing) would take an illegal-instruction fault on any kernel
+        // containing a comparison, so probing for F alone would "support" a
+        // level that cannot run.
+        name: "avx512f+dq",
+        target_feature: "+avx512f,+avx512dq",
+        requires: &["avx512f", "avx512dq"],
     },
 ];
 
@@ -240,6 +245,7 @@ fn host_has_feature(feature: &str) -> bool {
         "avx2" => std::is_x86_feature_detected!("avx2"),
         "fma" => std::is_x86_feature_detected!("fma"),
         "avx512f" => std::is_x86_feature_detected!("avx512f"),
+        "avx512dq" => std::is_x86_feature_detected!("avx512dq"),
         other => panic!("isa-matrix: unknown feature {other:?} in ISA_LEVELS::requires"),
     }
 }
@@ -397,6 +403,12 @@ fn run_with_rustflags(
         .args(args)
         .env("RUSTFLAGS", rustflags)
         .env("CARGO_TARGET_DIR", target_dir)
+        // Deep-Manifold tests (raymarch_sphere, scene3d) recurse near the
+        // stack limit by design (see CLAUDE.md's dev-profile note); 8- and
+        // 16-lane builds have 2-4x larger frames and overflowed the default
+        // 2 MiB test-thread stack on GitHub runners while passing locally.
+        // Pin the floor so the matrix behaves identically everywhere.
+        .env("RUST_MIN_STACK", "16777216")
         .status()
         .map(|s| s.success())
         .unwrap_or(false)

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -190,6 +190,193 @@ fn bundle_run(extra_args: &[String]) {
 }
 
 // ============================================================================
+// ISA test matrix
+// ============================================================================
+//
+// `.cargo/config.toml` sets no `target-cpu`/`target-feature`, so a plain
+// `cargo build`/`cargo test` always produces SSE2 code on x86-64 — even on a
+// machine with AVX2 or AVX-512 available. Nothing in the default CI pipeline
+// ever exercised the wider JIT backends. This runs the workspace test suite
+// (and optionally clippy) once per x86-64 ISA level the CURRENT HOST actually
+// supports, via explicit `-C target-feature` flags rather than
+// `-C target-cpu=native` (which bakes in whatever the build machine happens
+// to be and isn't reproducible across machines/CI runners).
+
+/// One row of the ISA test matrix: a human-readable name, the
+/// `-C target-feature` value to pass (empty = the SSE2 baseline, no flag),
+/// and the `is_x86_feature_detected!` names that must all be present on this
+/// host to attempt the level at all.
+struct IsaLevel {
+    name: &'static str,
+    target_feature: &'static str,
+    requires: &'static [&'static str],
+}
+
+const ISA_LEVELS: &[IsaLevel] = &[
+    IsaLevel {
+        name: "sse2 (baseline)",
+        target_feature: "",
+        requires: &[],
+    },
+    IsaLevel {
+        name: "avx2+fma",
+        target_feature: "+avx2,+fma",
+        requires: &["avx2", "fma"],
+    },
+    IsaLevel {
+        name: "avx512f",
+        target_feature: "+avx512f",
+        requires: &["avx512f"],
+    },
+];
+
+/// Whether the host CPU has all the features an [`IsaLevel`] requires.
+/// `is_x86_feature_detected!` only accepts a literal feature name, so this is
+/// a fixed match rather than a generic lookup — extend it if `ISA_LEVELS`
+/// grows a level needing a feature not listed here.
+#[cfg(target_arch = "x86_64")]
+fn host_has_feature(feature: &str) -> bool {
+    match feature {
+        "avx2" => std::is_x86_feature_detected!("avx2"),
+        "fma" => std::is_x86_feature_detected!("fma"),
+        "avx512f" => std::is_x86_feature_detected!("avx512f"),
+        other => panic!("isa-matrix: unknown feature {other:?} in ISA_LEVELS::requires"),
+    }
+}
+
+/// Outcome of attempting one [`IsaLevel`].
+enum LevelResult {
+    /// Test suite (and clippy, if requested) both succeeded.
+    Passed,
+    /// A command ran and failed; the bool distinguishes which one for the summary.
+    Failed { clippy: bool },
+    /// Host lacks a required CPU feature; skipped cleanly, not a failure.
+    Skipped { missing: &'static str },
+}
+
+/// Run the workspace test suite (`cargo test --workspace`), and optionally
+/// `cargo clippy --workspace --all-targets -- -D warnings`, at every x86-64
+/// ISA level this host supports. Non-x86-64 hosts (aarch64/NEON) have a
+/// single ISA level already, so there is nothing to matrix — this prints a
+/// note and exits 0 rather than silently doing nothing.
+fn isa_matrix(with_clippy: bool) {
+    let workspace_root = find_workspace_root();
+
+    #[cfg(not(target_arch = "x86_64"))]
+    {
+        let _ = workspace_root;
+        println!(
+            "isa-matrix: host is not x86-64 (no SSE2/AVX2/AVX-512 split to test here — \
+             e.g. aarch64/NEON has one ISA level already)."
+        );
+        return;
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    {
+        println!("isa-matrix: workspace root {}", workspace_root.display());
+        // The base flag every build in this repo already gets from
+        // `.cargo/config.toml`'s `[build] rustflags`. Setting RUSTFLAGS in the
+        // environment REPLACES (does not merge with) that config-file value,
+        // so every level below must repeat it explicitly.
+        const FP_CONTRACT: &str = "-C llvm-args=-fp-contract=fast";
+
+        let mut results: Vec<(&str, LevelResult)> = Vec::new();
+
+        for level in ISA_LEVELS {
+            println!("\n=== ISA level: {} ===", level.name);
+
+            let missing = level
+                .requires
+                .iter()
+                .find(|&&feat| !host_has_feature(feat));
+            if let Some(&feat) = missing {
+                println!(
+                    "isa-matrix: skipping {} — host CPU lacks {feat} \
+                     (checked via is_x86_feature_detected!)",
+                    level.name
+                );
+                results.push((level.name, LevelResult::Skipped { missing: feat }));
+                continue;
+            }
+
+            let rustflags = if level.target_feature.is_empty() {
+                FP_CONTRACT.to_string()
+            } else {
+                format!("{FP_CONTRACT} -C target-feature={}", level.target_feature)
+            };
+            println!("isa-matrix: RUSTFLAGS=\"{rustflags}\"");
+
+            let test_ok = run_with_rustflags(
+                &workspace_root,
+                &rustflags,
+                &["test", "--workspace", "--no-fail-fast"],
+            );
+            if !test_ok {
+                println!("isa-matrix: {} — cargo test FAILED", level.name);
+                results.push((level.name, LevelResult::Failed { clippy: false }));
+                continue;
+            }
+            println!("isa-matrix: {} — cargo test passed", level.name);
+
+            if with_clippy {
+                let clippy_ok = run_with_rustflags(
+                    &workspace_root,
+                    &rustflags,
+                    &["clippy", "--workspace", "--all-targets", "--", "-D", "warnings"],
+                );
+                if !clippy_ok {
+                    println!("isa-matrix: {} — cargo clippy FAILED", level.name);
+                    results.push((level.name, LevelResult::Failed { clippy: true }));
+                    continue;
+                }
+                println!("isa-matrix: {} — cargo clippy passed", level.name);
+            }
+
+            results.push((level.name, LevelResult::Passed));
+        }
+
+        println!("\n=== ISA matrix summary ===");
+        let mut any_failed = false;
+        for (name, result) in &results {
+            let line = match result {
+                LevelResult::Passed => "PASS".to_string(),
+                LevelResult::Failed { clippy } => {
+                    any_failed = true;
+                    if *clippy {
+                        "FAIL (clippy)".to_string()
+                    } else {
+                        "FAIL (test)".to_string()
+                    }
+                }
+                LevelResult::Skipped { missing } => {
+                    format!("SKIP (host lacks {missing})")
+                }
+            };
+            println!("  {name:<20} {line}");
+        }
+
+        if any_failed {
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Run `cargo <args>` from the workspace root with `RUSTFLAGS` set to
+/// `rustflags`, streaming output straight through. Returns whether it
+/// succeeded.
+#[cfg(target_arch = "x86_64")]
+fn run_with_rustflags(workspace_root: &std::path::Path, rustflags: &str, args: &[&str]) -> bool {
+    Command::new("cargo")
+        .current_dir(workspace_root)
+        .args(args)
+        .env("RUSTFLAGS", rustflags)
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+// ============================================================================
 // Eigenstructure Baking
 // ============================================================================
 


### PR DESCRIPTION
Two concurrent workstreams merged, plus the fallout their meeting exposed.

## Multi-ISA testing story

`cargo test` only ever exercised whichever ISA the default flags select — SSE2 on every x86-64 machine, including AVX-512 hardware.

- **`JIT_VECTOR_BYTES` widened to a genuine 3-way split** (16/32/64) matching `Field`'s existing storage selection; previously a hardcoded avx512f-or-16 binary that made AVX2-only builds fail to compile (`E0512` transmute mismatch).
- **New `Avx2Backend`** (VEX-256, ymm0-15) mirroring SSE2's op coverage exactly, wired into the 3-way backend selection.
- **AVX-512 Stage-1 gap filled**: comparisons/bitwise (compare-to-k then convert back to a plain vector mask — no k-registers in the allocator), recip/rsqrt, and the exp/log integer primitives (see below).
- **`cargo xtask isa-matrix`**: runs the workspace suite at every x86-64 ISA level the host supports, via explicit reproducible `-C target-feature` flags. Builds each level in a dedicated `target/isa-matrix` dir wiped between levels — peak disk is one artifact set, and the developer's own `target/` (incremental cache) is never touched. Wired into CI on every PR.

## Backend completeness contract

The AVX-512 gaps sat undetected because nothing enumerated "the ops every backend must support" — a missing match arm was indistinguishable from an op that legitimately never reaches that backend.

- **`coverage.rs`**: `REQUIRED_{UNARY,BINARY,SHIFT,TERNARY}_OPS`, derived from what survives the shared lowering pipeline. Sweep tests run against whichever backends the current build compiles; failures are itemized by name.
- **`X86BinaryInsn` selection/encoding split** (pilot, zero behavior change): `select(OpKind) -> Option<Insn>` names every supported op once as data; `encode` is exhaustive with no wildcard, so adding a variant without an encoding is a compile error.
- **Design doc** (`docs/designs/2026-07-25-two-level-ir-and-backend-completeness.md`): the two-level-IR answer (staging already exists; the missing level was selection-vs-encoding inside the leaf), the three-unshared-loop-emitters inventory, and where the reduction binder's loop emission belongs.

## What the contract caught on first contact

With a real `+avx512f` build, the sweep named five missing ops (`TruncToInt`/`IntToFloat`/`IAdd`/`Shl`/`Shr`) while the full suite sat green at 1515/0 — `test_log2` exercises the combinator tier's native intrinsics, and nothing anywhere compiled an exp/log *kernel* through the AVX-512 JIT. `Kernel::x().log2()` failed to compile on hardware where everything looked green. Fixed with five EVEX encodings; `tests/transcendental_jit.rs` now checks exp/log kernels numerically against std at all four ABI widths (SSE2/AVX2/AVX-512/NEON) so a green suite can never again stand in for "the JIT can compile a logarithm."

## Test status

- Coverage sweep, transcendental parity, reduction_binder: green at all three x86 widths.
- Per-level full-workspace runs during development: SSE2 1507/0 · AVX2 1518/0 · AVX-512 1515/0 (pre-merge worktrees); final merged-tree `isa-matrix` run in flight at PR time — will report on this PR when it lands.
- aarch64/NEON: covered by the existing macos-latest CI job; the new parity test and coverage sweep have NEON/aarch64 arms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWyemrN5XvyS5kcXw8vYVL

---
_Generated by [Claude Code](https://claude.ai/code/session_01WWyemrN5XvyS5kcXw8vYVL)_