### PR TITLE
The FP contract: you get the instruction, and folds must not lie about the target

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,18 @@ Behavior every target agrees on, pinned by
 |---|---|
 | `Lt`, `Le` | ordered — false for NaN |
 | `Eq`, `Ne` | **exact** comparison; NaN never equal, always unequal |
+| every comparison's *result* | an **all-ones** lane for true, all-zero for false — a mask, never `1.0` |
 | `exp`, `exp2` | saturate past ±126 exponents rather than overflowing to `inf` |
+
+A mask is a bit pattern, not a number, and that is a load-bearing distinction:
+`Select` is a bitwise blend on every backend (`andps`/`andnps`/`orps`,
+`vpternlogd 0xCA`, `BSL`) and `BitAnd`/`BitOr` are literal bitwise ops. Spell a
+true mask `1.0` and `mask & 1.0` is `0x3f800000`, which blends `7.0` against
+`9.0` into `4.5` — a value neither branch held. `OpKind::mask(bool)` is the only
+constructor, `OpKind::is_bitwise_domain()` marks the ops whose results are
+patterns, and the folder's "refuse non-finite results" guard exempts them —
+otherwise an all-ones mask reads as NaN and comparison folding switches itself
+off while looking like a safety check.
 
 Behavior that differs by target, because the instructions do:
 
@@ -52,6 +63,16 @@ Behavior that differs by target, because the instructions do:
 | `Gt`, `Ge` (NaN operand) | unordered (imm8 6/5) — **true** | `FCMGT`/`FCMGE` ordered — **false** | ordered — **false** |
 | `Round` (exact tie) | nearest-**even** (imm 0x00) → `round(2.5) == 2` | `FRINTA` ties-**away** → `3` | `(x+0.5).floor()` → `3` |
 | `Round` (`-0.5 ≤ x ≤ -0.0`) | `-0.0` (sign preserved) | `-0.0` | `+0.0` |
+| `Recip`, `Rsqrt` | `rcpps` ~12 bits; `vrcp14ps` ~14 | `FRECPE` + one `FRECPS` step | estimate + NR |
+| `MulAdd` | **one** rounding with `+fma`, **two** without (`mulps`+`addps`) | one (`FMLA`) | one |
+
+The last two rows are the reminder that "target" is finer than "architecture":
+`Recip` and `MulAdd` differ between *ISA levels of the same machine*, which is
+what `cargo xtask isa-matrix` exists to keep honest. `Recip`/`Rsqrt` are
+estimates — only ever guaranteed close, never equal — so no argument to them is
+ever foldable; `MulAdd` is value-aware, since one rounding and two agree on most
+inputs (`mul_add(1.0000001, 4097.0, 4097.0)` is one of the inputs where they
+don't).
 
 Unifying any row costs instructions — x86 has no ties-away rounding mode, and
 NaN or signed-zero blending is a compare plus a select — so none of them are

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,15 +46,24 @@ on every target actually does:
 | Op | x86 | aarch64 | combinator tier |
 |---|---|---|---|
 | `Min`, `Max` (NaN operand) | `(a OP b) ? a : b` → the **second** operand | `FMIN`/`FMAX` **propagate** NaN | — |
+| `Min`, `Max` (opposite-signed zeros) | operand order → the **second** zero | `FMIN` picks `-0.0`, `FMAX` picks `+0.0` | — |
 | `Gt`, `Ge` (NaN operand) | unordered (imm8 6/5) — **true** | `FCMGT`/`FCMGE` ordered — **false** | ordered — **false** |
 | `Round` (exact tie) | nearest-**even** (imm 0x00) → `round(2.5) == 2` | `FRINTA` ties-**away** → `3` | `(x+0.5).floor()` → `3`, but `round(-1.5) == -1` |
 
 `min(NaN, 1.0)` is `1.0` on x86 and `NaN` on aarch64. x86 has no ties-away
 rounding mode, so unifying `Round` costs extra instructions in the hot path.
 "Hardware semantics" is not one answer when the hardware differs — so the
-language promises none, marked by `OpKind::nan_result_is_platform_specific` and
-`tie_result_is_platform_specific`. Do not write a test, a rewrite rule, or a
-fold that depends on one target's answer.
+language promises none, marked by `OpKind::fold_is_platform_specific(args)`,
+which is value-aware because the divergence is: `min(1.0, 2.0)` is perfectly
+foldable, `min(-0.0, 0.0)` is not. Do not write a test, a rewrite rule, or a
+fold that depends on one target's answer — and note that `==` cannot see the
+signed-zero case (`-0.0 == 0.0`), so compare bit patterns; `1.0 / x` turns it
+into `+inf` versus `-inf`.
+
+Constant folding must **decline** for these, and the reason is sharper than
+optimizer consistency: the folder runs on the *build host* at macro-expansion
+time while the constant executes on the *target*, so folding bakes the build
+machine's arithmetic into a binary that may run elsewhere.
 
 Corollary worth stating because it is easy to get wrong: **unspecified means the
 optimizer may legitimately produce a different answer than the unoptimized code.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,36 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Minimal public API** - Do NOT change visibility of internal APIs without explicit permission. Keep `pub(crate)` and private items encapsulated. Use Manifold composition instead of exposing internals.
 - **Subtract before you add.** The good version of a primitive is reached by removing machinery, not stacking it. If a type's signature already refuses the wrong shape, you don't need a macro, a lint, or a doc to forbid it — the opinion lives in the types. Reach for a new dependency or a new abstraction only after subtraction has failed.
 
+### Floating point at the edges
+
+**The contract is hardware semantics, not IEEE-754 conformance.** Floating point
+should behave the way someone who is not a computer scientist would expect;
+IEEE is over-specified for a renderer, and matching it exactly costs
+instructions in the hot path for cases the language does not promise. So where
+a SIMD instruction and scalar Rust disagree at the edges, **the instruction
+wins** and the reference semantics are written to match it — never the reverse.
+
+Consequences, all pinned by `pixelflow-ir/tests/transcendental_jit.rs`:
+
+| Op | Behavior | Not |
+|---|---|---|
+| `Gt`, `Ge` | unordered — **true** if either operand is NaN (imm8 6/5 = `NLE_US`/`NLT_US`) | scalar `>`/`>=`, false for NaN |
+| `Lt`, `Le`, `Eq` | ordered — false for NaN | — |
+| `Ne` | true for NaN | — |
+| `Min`, `Max` | `(a OP b) ? a : b`, so NaN in *either* operand yields the second | `f32::min`/`max`, which return the numeric operand |
+| `Round` | nearest-**even**, so `round(2.5) == 2` | `f32::round`, ties away from zero |
+| `exp`, `exp2` | saturate past ±126 exponents | overflow to `inf` |
+
+The asymmetry (`Gt` unordered while `Lt` ordered) is the hardware's, not a
+choice — it is what a single `cmpps` gives for free.
+
+**What this does NOT license: the two tiers disagreeing.** `OpKind::eval_unary`
+/ `eval_binary` are the differential oracle *and* the e-graph's constant
+folder, so if they diverge from the emitted code, a folded expression computes
+differently from the same expression at runtime — a miscompile, not an edge
+case. When you touch either an encoder or the oracle, change both and extend
+the tests above.
+
 ### Philosophy
 
 - **Pull-based rendering**: Pixels are sampled, not pushed. Nothing computes until coordinates arrive.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,63 +21,65 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ### Floating point at the edges
 
-**The contract is hardware semantics, not IEEE-754 conformance.** Floating point
-should behave the way someone who is not a computer scientist would expect;
-IEEE is over-specified for a renderer, and matching it exactly costs
-instructions in the hot path for cases the language does not promise. So where
-a SIMD instruction and scalar Rust disagree at the edges, **the instruction
-wins** and the reference semantics are written to match it — never the reverse.
+**Rust already ships reasonably fast IEEE-754 arithmetic.** `f32::min`,
+`f32::round`, ordered comparisons — correct, conformant, and quick enough for
+almost everything. Reaching for pixelflow *is* the decision that "almost
+everything" excludes you: the library exists because conformant-and-quick was
+judged inadequate on performance grounds. So the trade is made deliberately and
+in one direction — **the language gives you the instruction.** Edge-case IEEE
+conformance is not on offer, and code that needs it should compute that part in
+scalar `f32` where it is already available and already fast.
 
-Consequences, all pinned by `pixelflow-ir/tests/transcendental_jit.rs`:
+That is the whole contract. The tables below are reference material for what the
+instructions do, not a list of defects, and nothing here should be "fixed" by
+spending hot-path instructions to match scalar Rust.
 
-There are **three** evaluation tiers — the combinator `Field` ops, the JIT, and
-`OpKind::eval_*` (the differential oracle *and* the e-graph's constant folder) —
-and they do not all agree at the edges. What is promised is only what every tier
-on every target actually does:
+Behavior every target agrees on, pinned by
+`pixelflow-ir/tests/transcendental_jit.rs`:
 
 | Op | Behavior |
 |---|---|
 | `Lt`, `Le` | ordered — false for NaN |
-| `Eq`, `Ne` | **exact** comparison (not epsilon); NaN never equal, always unequal |
+| `Eq`, `Ne` | **exact** comparison; NaN never equal, always unequal |
 | `exp`, `exp2` | saturate past ±126 exponents rather than overflowing to `inf` |
 
-**Unspecified — the targets disagree, so rely on neither:**
+Behavior that differs by target, because the instructions do:
 
 | Op | x86 | aarch64 | combinator tier |
 |---|---|---|---|
 | `Min`, `Max` (NaN operand) | `(a OP b) ? a : b` → the **second** operand | `FMIN`/`FMAX` **propagate** NaN | — |
 | `Min`, `Max` (opposite-signed zeros) | operand order → the **second** zero | `FMIN` picks `-0.0`, `FMAX` picks `+0.0` | — |
 | `Gt`, `Ge` (NaN operand) | unordered (imm8 6/5) — **true** | `FCMGT`/`FCMGE` ordered — **false** | ordered — **false** |
-| `Round` (exact tie) | nearest-**even** (imm 0x00) → `round(2.5) == 2` | `FRINTA` ties-**away** → `3` | `(x+0.5).floor()` → `3`, but `round(-1.5) == -1` |
+| `Round` (exact tie) | nearest-**even** (imm 0x00) → `round(2.5) == 2` | `FRINTA` ties-**away** → `3` | `(x+0.5).floor()` → `3` |
+| `Round` (`-0.5 ≤ x ≤ -0.0`) | `-0.0` (sign preserved) | `-0.0` | `+0.0` |
 
-`min(NaN, 1.0)` is `1.0` on x86 and `NaN` on aarch64. x86 has no ties-away
-rounding mode, so unifying `Round` costs extra instructions in the hot path.
-"Hardware semantics" is not one answer when the hardware differs — so the
-language promises none, marked by `OpKind::fold_is_platform_specific(args)`,
-which is value-aware because the divergence is: `min(1.0, 2.0)` is perfectly
-foldable, `min(-0.0, 0.0)` is not. Do not write a test, a rewrite rule, or a
-fold that depends on one target's answer — and note that `==` cannot see the
-signed-zero case (`-0.0 == 0.0`), so compare bit patterns; `1.0 / x` turns it
-into `+inf` versus `-inf`.
+Unifying any row costs instructions — x86 has no ties-away rounding mode, and
+NaN or signed-zero blending is a compare plus a select — so none of them are
+unified. Portable code should not depend on a single row's answer;
+`OpKind::fold_is_platform_specific(args)` marks them, and is value-aware because
+the divergence is: `min(1.0, 2.0)` is perfectly foldable, `min(-0.0, 0.0)` is
+not. Note `==` cannot see the signed-zero case (`-0.0 == 0.0`), so compare bit
+patterns — `1.0 / x` turns it into `+inf` versus `-inf`.
 
-Constant folding must **decline** for these, and the reason is sharper than
-optimizer consistency: the folder runs on the *build host* at macro-expansion
-time while the constant executes on the *target*, so folding bakes the build
-machine's arithmetic into a binary that may run elsewhere.
+**The one thing this does not license: folding on the wrong machine.** Constant
+folding runs on the *build host* at macro-expansion time while the constant
+executes on the *target*, so folding a row from the second table bakes the build
+machine's answer into a binary that runs somewhere else. That is not a
+speed-for-conformance trade — it is simply the wrong value for that target — so
+`ConstantFold` declines those cases. Everything else folds.
 
-Corollary worth stating because it is easy to get wrong: **unspecified means the
-optimizer may legitimately produce a different answer than the unoptimized code.**
-`Min`/`Max` are not commutative on NaN (`min(1.0, NaN)` vs `min(NaN, 1.0)`
-differ on x86), yet the e-graph installs commutativity for them. That is sound
-only because the result is unspecified; it would be a miscompile the moment
-anything promised a value.
+Corollary, easy to get wrong: **within a target, the optimizer may still produce
+a different answer than the unoptimized code.** `Min`/`Max` are not commutative
+on NaN (`min(1.0, NaN)` vs `min(NaN, 1.0)` differ on x86), yet the e-graph
+installs commutativity for them. That is sound precisely because no value was
+promised; it would be a miscompile the moment anything promised one.
 
-**What this does NOT license: the two tiers disagreeing.** `OpKind::eval_unary`
-/ `eval_binary` are the differential oracle *and* the e-graph's constant
-folder, so if they diverge from the emitted code, a folded expression computes
-differently from the same expression at runtime — a miscompile, not an edge
-case. When you touch either an encoder or the oracle, change both and extend
-the tests above.
+The combinator tier's `Round` is a genuine bug rather than an instance of this
+trade: `(x + 0.5).floor()` is two instructions where `roundps` is one, and it is
+not any IEEE rounding mode (`round(-1.5)` is -1 there, -2 everywhere else). It
+is slower *and* wrong, so it should be replaced with the target's rounding
+instruction — the trade only ever justifies taking what the hardware gives, never
+hand-rolling something worse.
 
 ### Philosophy
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,17 +30,38 @@ wins** and the reference semantics are written to match it — never the reverse
 
 Consequences, all pinned by `pixelflow-ir/tests/transcendental_jit.rs`:
 
-| Op | Behavior | Not |
-|---|---|---|
-| `Gt`, `Ge` | unordered — **true** if either operand is NaN (imm8 6/5 = `NLE_US`/`NLT_US`) | scalar `>`/`>=`, false for NaN |
-| `Lt`, `Le`, `Eq` | ordered — false for NaN | — |
-| `Ne` | true for NaN | — |
-| `Min`, `Max` | `(a OP b) ? a : b`, so NaN in *either* operand yields the second | `f32::min`/`max`, which return the numeric operand |
-| `Round` | nearest-**even**, so `round(2.5) == 2` | `f32::round`, ties away from zero |
-| `exp`, `exp2` | saturate past ±126 exponents | overflow to `inf` |
+There are **three** evaluation tiers — the combinator `Field` ops, the JIT, and
+`OpKind::eval_*` (the differential oracle *and* the e-graph's constant folder) —
+and they do not all agree at the edges. What is promised is only what every tier
+on every target actually does:
 
-The asymmetry (`Gt` unordered while `Lt` ordered) is the hardware's, not a
-choice — it is what a single `cmpps` gives for free.
+| Op | Behavior |
+|---|---|
+| `Lt`, `Le` | ordered — false for NaN |
+| `Eq`, `Ne` | **exact** comparison (not epsilon); NaN never equal, always unequal |
+| `exp`, `exp2` | saturate past ±126 exponents rather than overflowing to `inf` |
+
+**Unspecified — the targets disagree, so rely on neither:**
+
+| Op | x86 | aarch64 | combinator tier |
+|---|---|---|---|
+| `Min`, `Max` (NaN operand) | `(a OP b) ? a : b` → the **second** operand | `FMIN`/`FMAX` **propagate** NaN | — |
+| `Gt`, `Ge` (NaN operand) | unordered (imm8 6/5) — **true** | `FCMGT`/`FCMGE` ordered — **false** | ordered — **false** |
+| `Round` (exact tie) | nearest-**even** (imm 0x00) → `round(2.5) == 2` | `FRINTA` ties-**away** → `3` | `(x+0.5).floor()` → `3`, but `round(-1.5) == -1` |
+
+`min(NaN, 1.0)` is `1.0` on x86 and `NaN` on aarch64. x86 has no ties-away
+rounding mode, so unifying `Round` costs extra instructions in the hot path.
+"Hardware semantics" is not one answer when the hardware differs — so the
+language promises none, marked by `OpKind::nan_result_is_platform_specific` and
+`tie_result_is_platform_specific`. Do not write a test, a rewrite rule, or a
+fold that depends on one target's answer.
+
+Corollary worth stating because it is easy to get wrong: **unspecified means the
+optimizer may legitimately produce a different answer than the unoptimized code.**
+`Min`/`Max` are not commutative on NaN (`min(1.0, NaN)` vs `min(NaN, 1.0)`
+differ on x86), yet the e-graph installs commutativity for them. That is sound
+only because the result is unspecified; it would be a miscompile the moment
+anything promised a value.
 
 **What this does NOT license: the two tiers disagreeing.** `OpKind::eval_unary`
 / `eval_binary` are the differential oracle *and* the e-graph's constant

--- a/pixelflow-compiler/src/ir_bridge.rs
+++ b/pixelflow-compiler/src/ir_bridge.rs
@@ -493,8 +493,16 @@ pub fn ast_to_runtime_arena(
             pixelflow_ir::arena::ExprNode::Var(i) => {
                 quote! { ::pixelflow_core::__ir::arena::ExprNode::Var(#i) }
             }
+            // By bit pattern, not as a decimal literal: `quote`'s `f32`
+            // impl goes through `Literal::f32_suffixed`, which asserts
+            // `is_finite()` — and non-finite constants are ordinary here. A
+            // true comparison mask is all-ones (`OpKind::mask`), which is
+            // `BitAnd`'s monoid identity and therefore `all_over`'s seed, and
+            // the folder now produces those. Bits also roundtrip exactly, with
+            // no decimal-formatting question to get wrong.
             pixelflow_ir::arena::ExprNode::Const(v) => {
-                quote! { ::pixelflow_core::__ir::arena::ExprNode::Const(#v) }
+                let bits = v.to_bits();
+                quote! { ::pixelflow_core::__ir::arena::ExprNode::Const(f32::from_bits(#bits)) }
             }
             pixelflow_ir::arena::ExprNode::Param(i) => {
                 quote! { ::pixelflow_core::__ir::arena::ExprNode::Param(#i) }

--- a/pixelflow-ir/src/kind.rs
+++ b/pixelflow-ir/src/kind.rs
@@ -142,6 +142,48 @@ impl OpKind {
         }
     }
 
+    /// Whether this op's result is **platform-specific when an operand is NaN**.
+    ///
+    /// The FP contract (CLAUDE.md, "Floating point at the edges") is hardware
+    /// semantics — but the hardwares themselves disagree here, so for these ops
+    /// with a NaN operand the language promises *nothing*:
+    ///
+    /// - `Min`/`Max`: x86 `minps`/`maxps` compute `(a OP b) ? a : b`, yielding
+    ///   the SECOND operand when either is NaN; ARM `FMIN`/`FMAX` propagate the
+    ///   NaN. `min(NaN, 1.0)` is therefore `1.0` on x86 and `NaN` on aarch64.
+    /// - `Gt`/`Ge`: x86 uses the unordered predicates (imm8 6/5), TRUE for NaN;
+    ///   ARM `FCMGT`/`FCMGE` are ordered, FALSE for NaN.
+    ///
+    /// `Lt`/`Le`/`Eq` are ordered on both, `Ne` unordered on both, and `Round`
+    /// is nearest-even on both — those agree and are pinned by tests.
+    ///
+    /// Callers that must produce one answer for all targets (constant folding
+    /// above all: a folded result that differs from the runtime one is a
+    /// miscompile) have to DECLINE rather than pick a platform's answer. That
+    /// is what this predicate is for; `eval_binary` still returns a value,
+    /// which is this build's behavior and no promise about any other.
+    #[must_use]
+    pub const fn nan_result_is_platform_specific(self) -> bool {
+        matches!(self, Self::Min | Self::Max | Self::Gt | Self::Ge)
+    }
+
+    /// Whether this op's result is **platform-specific on an exact tie**
+    /// (a half-integer input), independently of NaN.
+    ///
+    /// `Round` is: nearest-even on x86 (`vroundps`/`vrndscaleps` imm 0x00),
+    /// ties-away on aarch64 (`FRINTA`), and `(x + 0.5).floor()` in the
+    /// combinator tier (`SimdVector::round`) — three behaviors, disagreeing at
+    /// `±n.5`. `round(2.5)` is 2, 3 and 3 respectively; `round(-1.5)` is -2, -2
+    /// and -1.
+    ///
+    /// x86 has no ties-away rounding mode, so unifying them costs extra
+    /// instructions in the hot path — which the FP contract declines to spend.
+    /// The result at a tie is therefore unspecified.
+    #[must_use]
+    pub const fn tie_result_is_platform_specific(self) -> bool {
+        matches!(self, Self::Round)
+    }
+
     /// Whether `self` is a valid reduction combiner (an associative monoid op
     /// with an identity).
     #[must_use]
@@ -550,10 +592,10 @@ impl OpKind {
             Self::Recip => Some(1.0 / x),
             Self::Floor => Some(x.floor()),
             Self::Ceil => Some(x.ceil()),
-            // Nearest-EVEN, not ties-away: this is what `vroundps`/`vrndscaleps`
-            // imm 0x00 does on every backend, and the folder must agree with the
-            // code it folds. `f32::round` (ties-away) would make `round(2.5)`
-            // fold to 3 and compute to 2. See the FP contract in CLAUDE.md.
+            // x86's answer (`vroundps` imm 0x00 is nearest-even). aarch64
+            // `FRINTA` is ties-away and the combinator tier is
+            // `(x + 0.5).floor()`, so at a tie this is one of three behaviors
+            // and no promise — see `tie_result_is_platform_specific`.
             Self::Round => Some(x.round_ties_even()),
             // Integer-domain primitives. A lane holds an f32 bit pattern; these
             // reinterpret it as i32, exactly as the hardware instructions do
@@ -584,29 +626,29 @@ impl OpKind {
             Self::Sub => Some(x - y),
             Self::Mul => Some(x * y),
             Self::Div => Some(x / y),
-            // `minps`/`maxps` semantics, NOT `f32::min`/`f32::max`: the hardware
-            // computes `(a OP b) ? a : b`, so a NaN in EITHER operand yields the
-            // second one. `f32::min` instead returns the numeric operand, which
-            // would make `min(1.0, NaN)` fold to 1.0 and compute to NaN.
+            // `minps`/`maxps` semantics on x86: `(a OP b) ? a : b`, so a NaN in
+            // EITHER operand yields the second. aarch64 `FMIN`/`FMAX` propagate
+            // the NaN instead — see `nan_result_is_platform_specific`. This arm
+            // is x86's answer and is not a promise for other targets.
             Self::Min => Some(if x < y { x } else { y }),
             Self::Max => Some(if x > y { x } else { y }),
             Self::Lt => Some(if x < y { 1.0 } else { 0.0 }),
             Self::Le => Some(if x <= y { 1.0 } else { 0.0 }),
-            // Gt/Ge are the UNORDERED predicates (imm8 6 = NLE_US, 5 = NLT_US),
-            // so unlike Lt/Le they are TRUE when either operand is NaN. Written
-            // as the negations the hardware actually evaluates.
+            // Gt/Ge are x86's UNORDERED predicates (imm8 6 = NLE_US, 5 =
+            // NLT_US), so unlike Lt/Le they are TRUE when either operand is
+            // NaN. ARM's FCMGT/FCMGE are ordered and give FALSE — see
+            // `nan_result_is_platform_specific`.
             Self::Gt => Some(if x <= y { 0.0 } else { 1.0 }),
             Self::Ge => Some(if x < y { 0.0 } else { 1.0 }),
-            Self::Eq => Some(if (x - y).abs() < f32::EPSILON {
-                1.0
-            } else {
-                0.0
-            }),
-            Self::Ne => Some(if (x - y).abs() >= f32::EPSILON {
-                1.0
-            } else {
-                0.0
-            }),
+            // Exact, as every emitter compares. The old `(x-y).abs() < EPSILON`
+            // made the folder disagree with the JIT for ordinary finite values:
+            // 0.5 and its next representable neighbour differ by less than
+            // EPSILON, so folding said "equal" where the hardware says "not".
+            // NaN is false here and in `cmpps`/`FCMEQ` alike.
+            Self::Eq => Some(if x == y { 1.0 } else { 0.0 }),
+            // Exact, and true for NaN — matching `NEQ_UQ` and an inverted
+            // `FCMEQ`. Same epsilon bug as `Eq` above.
+            Self::Ne => Some(if x == y { 0.0 } else { 1.0 }),
             // Integer-domain binaries on lane bit patterns. The shift count is
             // the RHS `Const`'s numeric value (the schedule reads it as
             // `*v as u32 as u8`), and both shifts are logical — `vpslld` /

--- a/pixelflow-ir/src/kind.rs
+++ b/pixelflow-ir/src/kind.rs
@@ -161,6 +161,11 @@ impl OpKind {
     /// - `Round` at an exact tie: nearest-even on x86 (`vroundps` imm 0x00),
     ///   ties-away on aarch64 (`FRINTA`), and `(x + 0.5).floor()` in the
     ///   combinator tier — three answers at `±n.5`.
+    /// - `Round` on `-0.5 <= x <= -0.0`: both JIT tiers round to `-0.0`,
+    ///   preserving the sign, while the combinator formula yields `+0.0`.
+    ///   Not a tie, so it needs its own condition. `(x + 0.5).floor()` is not
+    ///   any IEEE rounding mode — `round(-1.5)` is -1 there against -2
+    ///   everywhere else — so the real repair is in that tier, not here.
     ///
     /// x86 has no ties-away rounding mode and NaN/zero blending costs extra
     /// instructions, so unifying any of these would spend hot-path work on
@@ -184,7 +189,15 @@ impl OpKind {
                 _ => false,
             },
             Self::Gt | Self::Ge => args.iter().any(|a| a.is_nan()),
-            Self::Round => args.iter().any(|a| a.fract().abs() == 0.5),
+            // Ties (x86 nearest-even vs aarch64 ties-away), plus the interval
+            // where the combinator formula loses the sign of zero: for
+            // `-0.5 <= x <= -0.0` both JIT tiers round to `-0.0` (sign
+            // preserved) while `(x + 0.5).floor()` gives `+0.0`. `1.0 / x`
+            // makes that `-inf` versus `+inf`. `-0.5` is already covered as a
+            // tie; the rest of the interval is not.
+            Self::Round => args
+                .iter()
+                .any(|a| a.fract().abs() == 0.5 || (a.is_sign_negative() && *a > -0.5)),
             _ => false,
         }
     }

--- a/pixelflow-ir/src/kind.rs
+++ b/pixelflow-ir/src/kind.rs
@@ -166,6 +166,14 @@ impl OpKind {
     ///   Not a tie, so it needs its own condition. `(x + 0.5).floor()` is not
     ///   any IEEE rounding mode — `round(-1.5)` is -1 there against -2
     ///   everywhere else — so the real repair is in that tier, not here.
+    /// - `Recip`/`Rsqrt` **always**: these are estimate instructions and the
+    ///   estimates differ — `rcpps` ~12 bits, `vrcp14ps` ~14, aarch64
+    ///   `FRECPE` + one `FRECPS` refinement. The exact `1.0 / x` the folder
+    ///   computes is not any of those answers.
+    /// - `MulAdd` where one rounding differs from two: `vfmadd`/`FMLA` round
+    ///   the product and sum together, SSE2's `mulps`+`addps` rounds twice.
+    ///   `mul_add(1.0000001, 4097.0, 4097.0)` is `8194.001` fused, `8194.0`
+    ///   split.
     ///
     /// x86 has no ties-away rounding mode and NaN/zero blending costs extra
     /// instructions, so unifying any of these would spend hot-path work on
@@ -198,6 +206,21 @@ impl OpKind {
             Self::Round => args
                 .iter()
                 .any(|a| a.fract().abs() == 0.5 || (a.is_sign_negative() && *a > -0.5)),
+            // Reciprocal ESTIMATES, and every target estimates differently:
+            // SSE2/AVX2 `rcpps`/`vrcpps` give ~12 bits, AVX-512 `vrcp14ps`
+            // ~14, and aarch64 emits `FRECPE` plus one `FRECPS` Newton step.
+            // `eval_unary`'s exact `1.0 / x` matches none of them, so there is
+            // no host whose answer is worth baking. Unconditional: an estimate
+            // is only guaranteed close, never equal, so no argument is safe.
+            Self::Recip | Self::Rsqrt => true,
+            // One rounding or two. `mul_add` is the single-rounding FMA every
+            // first-class target has (`vfmadd`, `FMLA`); `x * y + z` is what
+            // SSE2 emits without one. Value-aware, because they agree for most
+            // inputs and folding is worth keeping where they do.
+            Self::MulAdd => match args {
+                [x, y, z] => x.mul_add(*y, *z).to_bits() != (x * y + z).to_bits(),
+                _ => false,
+            },
             _ => false,
         }
     }
@@ -634,6 +657,55 @@ impl OpKind {
         }
     }
 
+    /// A comparison lane: all bits set for true, all clear for false.
+    ///
+    /// This is not a stylistic choice about how to spell a boolean — it is the
+    /// only representation the consumers accept. `Select` is a *bitwise* blend
+    /// on every backend (`andps`/`andnps`/`orps` on SSE2 and AVX2, one
+    /// `vpternlogd 0xCA` on AVX-512, `BSL` on aarch64), and `BitAnd`/`BitOr`
+    /// are literal bitwise ops, so a mask lane's job is to be a per-bit
+    /// stencil. `1.0` is not one: `0xFFFFFFFF & 0x3f800000` is `0x3f800000`,
+    /// and blending `7.0` against `9.0` through that pattern gives `4.5` — a
+    /// value neither branch ever held.
+    ///
+    /// Every tier that *executes* a comparison already writes all-ones —
+    /// `cmpps`, `FCMEQ`, and the combinator tier's SIMD compares alike. Folding
+    /// in the same representation is what makes a folded comparison and an
+    /// executed one interchangeable as operands.
+    #[must_use]
+    pub const fn mask(condition: bool) -> f32 {
+        if condition { f32::from_bits(u32::MAX) } else { 0.0 }
+    }
+
+    /// Whether this op's result is a lane **bit pattern** rather than a number.
+    ///
+    /// Comparisons produce masks ([`Self::mask`] — all-ones, which reads as
+    /// NaN); the integer-domain primitives reinterpret lanes as `i32` and are
+    /// how exp/log lower to arithmetic; `Select`/`BitAnd`/`BitOr` pass patterns
+    /// through. For all of them a non-finite float reading is the intended
+    /// output rather than an overflow, which is what separates them from
+    /// `1e38 * 1e38` — the case a folder is right to refuse.
+    #[must_use]
+    pub const fn is_bitwise_domain(self) -> bool {
+        matches!(
+            self,
+            Self::Lt
+                | Self::Le
+                | Self::Gt
+                | Self::Ge
+                | Self::Eq
+                | Self::Ne
+                | Self::Select
+                | Self::BitAnd
+                | Self::BitOr
+                | Self::TruncToInt
+                | Self::IntToFloat
+                | Self::IAdd
+                | Self::Shl
+                | Self::Shr
+        )
+    }
+
     /// Evaluate a binary operation on constant arguments.
     ///
     /// Returns `None` for non-binary operations.
@@ -650,23 +722,26 @@ impl OpKind {
             // is x86's answer and is not a promise for other targets.
             Self::Min => Some(if x < y { x } else { y }),
             Self::Max => Some(if x > y { x } else { y }),
-            Self::Lt => Some(if x < y { 1.0 } else { 0.0 }),
-            Self::Le => Some(if x <= y { 1.0 } else { 0.0 }),
+            Self::Lt => Some(Self::mask(x < y)),
+            Self::Le => Some(Self::mask(x <= y)),
             // Gt/Ge are x86's UNORDERED predicates (imm8 6 = NLE_US, 5 =
             // NLT_US), so unlike Lt/Le they are TRUE when either operand is
             // NaN. ARM's FCMGT/FCMGE are ordered and give FALSE — see
             // `fold_is_platform_specific`.
-            Self::Gt => Some(if x <= y { 0.0 } else { 1.0 }),
-            Self::Ge => Some(if x < y { 0.0 } else { 1.0 }),
+            // Spelled as the ordered comparison plus the unordered case rather
+            // than as `!(x <= y)`: same answer, but it says which part is the
+            // NaN behavior instead of hiding it inside a negation.
+            Self::Gt => Some(Self::mask(x > y || x.is_nan() || y.is_nan())),
+            Self::Ge => Some(Self::mask(x >= y || x.is_nan() || y.is_nan())),
             // Exact, as every emitter compares. The old `(x-y).abs() < EPSILON`
             // made the folder disagree with the JIT for ordinary finite values:
             // 0.5 and its next representable neighbour differ by less than
             // EPSILON, so folding said "equal" where the hardware says "not".
             // NaN is false here and in `cmpps`/`FCMEQ` alike.
-            Self::Eq => Some(if x == y { 1.0 } else { 0.0 }),
+            Self::Eq => Some(Self::mask(x == y)),
             // Exact, and true for NaN — matching `NEQ_UQ` and an inverted
             // `FCMEQ`. Same epsilon bug as `Eq` above.
-            Self::Ne => Some(if x == y { 0.0 } else { 1.0 }),
+            Self::Ne => Some(Self::mask(x != y)),
             // Integer-domain binaries on lane bit patterns. The shift count is
             // the RHS `Const`'s numeric value (the schedule reads it as
             // `*v as u32 as u8`), and both shifts are logical — `vpslld` /
@@ -689,8 +764,18 @@ impl OpKind {
     #[must_use]
     pub fn eval_ternary(self, x: f32, y: f32, z: f32) -> Option<f32> {
         match self {
+            // Two roundings, which is what a target without FMA emits (SSE2:
+            // `mulps` then `addps`). AVX2+FMA, AVX-512 and aarch64 all round
+            // once (`vfmadd`, `FMLA`), so the answers differ by target and
+            // `fold_is_platform_specific` declines exactly where they do.
             Self::MulAdd => Some(x * y + z),
-            Self::Select => Some(if x != 0.0 { y } else { z }),
+            // The bitwise blend every backend emits — `andps`/`andnps`/`orps`
+            // on SSE2 and AVX2, one `vpternlogd 0xCA` on AVX-512, `BSL` on
+            // aarch64. Spelling it `if x != 0.0` would be right only for a
+            // canonical [`Self::mask`] and silently wrong for anything else.
+            Self::Select => Some(f32::from_bits(
+                (x.to_bits() & y.to_bits()) | (!x.to_bits() & z.to_bits()),
+            )),
             _ => None,
         }
     }

--- a/pixelflow-ir/src/kind.rs
+++ b/pixelflow-ir/src/kind.rs
@@ -142,46 +142,51 @@ impl OpKind {
         }
     }
 
-    /// Whether this op's result is **platform-specific when an operand is NaN**.
+    /// Whether folding this op on `args` would bake in a **platform-specific**
+    /// answer.
     ///
     /// The FP contract (CLAUDE.md, "Floating point at the edges") is hardware
-    /// semantics — but the hardwares themselves disagree here, so for these ops
-    /// with a NaN operand the language promises *nothing*:
+    /// semantics — but the hardwares disagree in specific places, so for these
+    /// (op, operand) combinations the language promises nothing:
     ///
-    /// - `Min`/`Max`: x86 `minps`/`maxps` compute `(a OP b) ? a : b`, yielding
-    ///   the SECOND operand when either is NaN; ARM `FMIN`/`FMAX` propagate the
-    ///   NaN. `min(NaN, 1.0)` is therefore `1.0` on x86 and `NaN` on aarch64.
-    /// - `Gt`/`Ge`: x86 uses the unordered predicates (imm8 6/5), TRUE for NaN;
-    ///   ARM `FCMGT`/`FCMGE` are ordered, FALSE for NaN.
+    /// - `Min`/`Max` with a NaN operand: x86 `minps`/`maxps` compute
+    ///   `(a OP b) ? a : b`, yielding the SECOND operand; aarch64 `FMIN`/`FMAX`
+    ///   propagate the NaN. `min(NaN, 1.0)` is `1.0` on x86, `NaN` on aarch64.
+    /// - `Min`/`Max` on **opposite-signed zeros**: the same operand-order rule
+    ///   returns the second zero on x86 (since `-0.0 < 0.0` is false), while
+    ///   `FMIN` selects `-0.0` and `FMAX` selects `+0.0`. `==` cannot see this
+    ///   — `-0.0 == 0.0` — but `1.0 / x` turns it into `+inf` vs `-inf`.
+    /// - `Gt`/`Ge` with a NaN operand: x86 uses the unordered predicates
+    ///   (imm8 6/5), TRUE for NaN; aarch64 `FCMGT`/`FCMGE` are ordered, FALSE.
+    /// - `Round` at an exact tie: nearest-even on x86 (`vroundps` imm 0x00),
+    ///   ties-away on aarch64 (`FRINTA`), and `(x + 0.5).floor()` in the
+    ///   combinator tier — three answers at `±n.5`.
     ///
-    /// `Lt`/`Le`/`Eq` are ordered on both, `Ne` unordered on both, and `Round`
-    /// is nearest-even on both — those agree and are pinned by tests.
+    /// x86 has no ties-away rounding mode and NaN/zero blending costs extra
+    /// instructions, so unifying any of these would spend hot-path work on
+    /// cases the language does not promise.
     ///
-    /// Callers that must produce one answer for all targets (constant folding
-    /// above all: a folded result that differs from the runtime one is a
-    /// miscompile) have to DECLINE rather than pick a platform's answer. That
-    /// is what this predicate is for; `eval_binary` still returns a value,
-    /// which is this build's behavior and no promise about any other.
+    /// **Why a fold in particular must decline:** constant folding happens on
+    /// the BUILD host at macro-expansion time, but the constant it produces
+    /// executes on the TARGET. Folding one of these bakes the build machine's
+    /// arithmetic into a binary that may run somewhere computing differently —
+    /// so this is not merely an optimized-vs-unoptimized discrepancy.
+    ///
+    /// `eval_unary`/`eval_binary` still return a value for these; it is this
+    /// build's behavior and no promise about any other.
     #[must_use]
-    pub const fn nan_result_is_platform_specific(self) -> bool {
-        matches!(self, Self::Min | Self::Max | Self::Gt | Self::Ge)
-    }
-
-    /// Whether this op's result is **platform-specific on an exact tie**
-    /// (a half-integer input), independently of NaN.
-    ///
-    /// `Round` is: nearest-even on x86 (`vroundps`/`vrndscaleps` imm 0x00),
-    /// ties-away on aarch64 (`FRINTA`), and `(x + 0.5).floor()` in the
-    /// combinator tier (`SimdVector::round`) — three behaviors, disagreeing at
-    /// `±n.5`. `round(2.5)` is 2, 3 and 3 respectively; `round(-1.5)` is -2, -2
-    /// and -1.
-    ///
-    /// x86 has no ties-away rounding mode, so unifying them costs extra
-    /// instructions in the hot path — which the FP contract declines to spend.
-    /// The result at a tie is therefore unspecified.
-    #[must_use]
-    pub const fn tie_result_is_platform_specific(self) -> bool {
-        matches!(self, Self::Round)
+    pub fn fold_is_platform_specific(self, args: &[f32]) -> bool {
+        match self {
+            Self::Min | Self::Max => match args {
+                // Equal but distinguishable is exactly ±0.0: x86 picks by
+                // operand order, ARM by sign.
+                [a, b] => a.is_nan() || b.is_nan() || (a == b && a.to_bits() != b.to_bits()),
+                _ => false,
+            },
+            Self::Gt | Self::Ge => args.iter().any(|a| a.is_nan()),
+            Self::Round => args.iter().any(|a| a.fract().abs() == 0.5),
+            _ => false,
+        }
     }
 
     /// Whether `self` is a valid reduction combiner (an associative monoid op
@@ -595,7 +600,7 @@ impl OpKind {
             // x86's answer (`vroundps` imm 0x00 is nearest-even). aarch64
             // `FRINTA` is ties-away and the combinator tier is
             // `(x + 0.5).floor()`, so at a tie this is one of three behaviors
-            // and no promise — see `tie_result_is_platform_specific`.
+            // and no promise — see `fold_is_platform_specific`.
             Self::Round => Some(x.round_ties_even()),
             // Integer-domain primitives. A lane holds an f32 bit pattern; these
             // reinterpret it as i32, exactly as the hardware instructions do
@@ -628,7 +633,7 @@ impl OpKind {
             Self::Div => Some(x / y),
             // `minps`/`maxps` semantics on x86: `(a OP b) ? a : b`, so a NaN in
             // EITHER operand yields the second. aarch64 `FMIN`/`FMAX` propagate
-            // the NaN instead — see `nan_result_is_platform_specific`. This arm
+            // the NaN instead — see `fold_is_platform_specific`. This arm
             // is x86's answer and is not a promise for other targets.
             Self::Min => Some(if x < y { x } else { y }),
             Self::Max => Some(if x > y { x } else { y }),
@@ -637,7 +642,7 @@ impl OpKind {
             // Gt/Ge are x86's UNORDERED predicates (imm8 6 = NLE_US, 5 =
             // NLT_US), so unlike Lt/Le they are TRUE when either operand is
             // NaN. ARM's FCMGT/FCMGE are ordered and give FALSE — see
-            // `nan_result_is_platform_specific`.
+            // `fold_is_platform_specific`.
             Self::Gt => Some(if x <= y { 0.0 } else { 1.0 }),
             Self::Ge => Some(if x < y { 0.0 } else { 1.0 }),
             // Exact, as every emitter compares. The old `(x-y).abs() < EPSILON`

--- a/pixelflow-ir/src/kind.rs
+++ b/pixelflow-ir/src/kind.rs
@@ -550,7 +550,11 @@ impl OpKind {
             Self::Recip => Some(1.0 / x),
             Self::Floor => Some(x.floor()),
             Self::Ceil => Some(x.ceil()),
-            Self::Round => Some(x.round()),
+            // Nearest-EVEN, not ties-away: this is what `vroundps`/`vrndscaleps`
+            // imm 0x00 does on every backend, and the folder must agree with the
+            // code it folds. `f32::round` (ties-away) would make `round(2.5)`
+            // fold to 3 and compute to 2. See the FP contract in CLAUDE.md.
+            Self::Round => Some(x.round_ties_even()),
             // Integer-domain primitives. A lane holds an f32 bit pattern; these
             // reinterpret it as i32, exactly as the hardware instructions do
             // (`cvttps2dq` / `cvtdq2ps`). They exist so exp/log can lower to
@@ -580,12 +584,19 @@ impl OpKind {
             Self::Sub => Some(x - y),
             Self::Mul => Some(x * y),
             Self::Div => Some(x / y),
-            Self::Min => Some(x.min(y)),
-            Self::Max => Some(x.max(y)),
+            // `minps`/`maxps` semantics, NOT `f32::min`/`f32::max`: the hardware
+            // computes `(a OP b) ? a : b`, so a NaN in EITHER operand yields the
+            // second one. `f32::min` instead returns the numeric operand, which
+            // would make `min(1.0, NaN)` fold to 1.0 and compute to NaN.
+            Self::Min => Some(if x < y { x } else { y }),
+            Self::Max => Some(if x > y { x } else { y }),
             Self::Lt => Some(if x < y { 1.0 } else { 0.0 }),
             Self::Le => Some(if x <= y { 1.0 } else { 0.0 }),
-            Self::Gt => Some(if x > y { 1.0 } else { 0.0 }),
-            Self::Ge => Some(if x >= y { 1.0 } else { 0.0 }),
+            // Gt/Ge are the UNORDERED predicates (imm8 6 = NLE_US, 5 = NLT_US),
+            // so unlike Lt/Le they are TRUE when either operand is NaN. Written
+            // as the negations the hardware actually evaluates.
+            Self::Gt => Some(if x <= y { 0.0 } else { 1.0 }),
+            Self::Ge => Some(if x < y { 0.0 } else { 1.0 }),
             Self::Eq => Some(if (x - y).abs() < f32::EPSILON {
                 1.0
             } else {

--- a/pixelflow-ir/tests/transcendental_jit.rs
+++ b/pixelflow-ir/tests/transcendental_jit.rs
@@ -221,11 +221,13 @@ fn round_agrees_between_tiers_away_from_ties() {
     }
 }
 
-/// The ops whose NaN answer is platform-specific must not be constant-folded
-/// with a NaN operand: folding bakes in the building target's answer, and the
-/// same expression computed at runtime on another target would differ.
+/// Which ops carry the platform-specific marker. The marker's *effect* on
+/// constant folding is covered where the folder lives
+/// (`pixelflow-search::math::algebra`, `platform_specific_fold_tests`) — this
+/// only pins the classification, which is what the emitters and the contract
+/// table in CLAUDE.md are written against.
 #[test]
-fn folder_declines_platform_specific_nan_cases() {
+fn platform_specific_ops_are_classified() {
     use pixelflow_ir::OpKind;
     for op in [OpKind::Min, OpKind::Max, OpKind::Gt, OpKind::Ge] {
         assert!(

--- a/pixelflow-ir/tests/transcendental_jit.rs
+++ b/pixelflow-ir/tests/transcendental_jit.rs
@@ -56,6 +56,48 @@ fn call_x(jit: &pixelflow_ir::JitManifold, x: f32) -> f32 {
     }
 }
 
+/// Two-operand form of [`call_x`]: X = `x`, Y = `y`, lane 0 of the result.
+#[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
+fn call_xy(jit: &pixelflow_ir::JitManifold, x: f32, y: f32) -> f32 {
+    use core::arch::x86_64::*;
+    unsafe {
+        let z = _mm512_setzero_ps();
+        _mm512_cvtss_f32(jit.call(_mm512_set1_ps(x), _mm512_set1_ps(y), z, z))
+    }
+}
+#[cfg(all(
+    target_arch = "x86_64",
+    target_feature = "avx2",
+    not(target_feature = "avx512f")
+))]
+fn call_xy(jit: &pixelflow_ir::JitManifold, x: f32, y: f32) -> f32 {
+    use core::arch::x86_64::*;
+    unsafe {
+        let z = _mm256_setzero_ps();
+        _mm256_cvtss_f32(jit.call(_mm256_set1_ps(x), _mm256_set1_ps(y), z, z))
+    }
+}
+#[cfg(all(
+    target_arch = "x86_64",
+    not(target_feature = "avx2"),
+    not(target_feature = "avx512f")
+))]
+fn call_xy(jit: &pixelflow_ir::JitManifold, x: f32, y: f32) -> f32 {
+    use core::arch::x86_64::*;
+    unsafe {
+        let z = _mm_setzero_ps();
+        _mm_cvtss_f32(jit.call(_mm_set1_ps(x), _mm_set1_ps(y), z, z))
+    }
+}
+#[cfg(target_arch = "aarch64")]
+fn call_xy(jit: &pixelflow_ir::JitManifold, x: f32, y: f32) -> f32 {
+    use core::arch::aarch64::*;
+    unsafe {
+        let z = vdupq_n_f32(0.0);
+        vgetq_lane_f32::<0>(jit.call(vdupq_n_f32(x), vdupq_n_f32(y), z, z))
+    }
+}
+
 fn check(name: &str, k: &Kernel, inputs: &[f32], reference: impl Fn(f32) -> f32) {
     let (arena, root) = k.parts();
     let jit = jit_cache::compile_cached(arena, root)
@@ -84,4 +126,86 @@ fn exp_log_kernels_compile_and_agree_with_std() {
     check("ln", &Kernel::x().ln(), &logs, f32::ln);
     check("exp", &Kernel::x().exp(), &exps, f32::exp);
     check("exp2", &Kernel::x().exp2(), &exps, f32::exp2);
+}
+
+// ── Floating-point edge cases: the documented contract, not IEEE ─────────────
+//
+// The language's FP contract (CLAUDE.md, "Floating point at the edges") is
+// *hardware semantics*, deliberately not scalar Rust's: NaN comparisons,
+// Min/Max NaN handling and Round's tie-breaking follow whatever the SIMD
+// instruction does, because matching `f32::min`/`f32::round` would cost extra
+// instructions in the hot path for cases the language does not promise.
+//
+// What the contract DOES require is that the two tiers agree: the JIT and
+// `OpKind::eval_*` (the differential oracle, and the e-graph's constant
+// folder) must produce the same answer, or a folded expression differs from
+// the same expression computed at runtime. These tests pin that agreement at
+// whatever width the build selects — they are the reason the oracle was
+// changed to match the hardware rather than the encoders changed to match
+// scalar Rust.
+
+/// Every lane of a binary kernel, JIT vs oracle, on edge-case inputs.
+fn assert_tiers_agree_binary(name: &str, k: &Kernel, op: pixelflow_ir::OpKind) {
+    let (arena, root) = k.parts();
+    let jit = jit_cache::compile_cached(arena, root).unwrap_or_else(|e| panic!("{name}: {e}"));
+    let nan = f32::NAN;
+    for (x, y) in [
+        (1.0f32, nan),
+        (nan, 1.0f32),
+        (nan, nan),
+        (2.5, 2.5),
+        (-0.0, 0.0),
+        (1.0, 2.0),
+        (2.0, 1.0),
+        (f32::INFINITY, 1.0),
+    ] {
+        let got = call_xy(&jit, x, y);
+        let want = op.eval_binary(x, y).expect("oracle covers this op");
+        assert!(
+            got == want || (got.is_nan() && want.is_nan()),
+            "{name}({x}, {y}): JIT gave {got}, oracle gave {want} — tiers must agree"
+        );
+    }
+}
+
+#[test]
+fn min_max_nan_handling_agrees_between_tiers() {
+    use pixelflow_ir::OpKind;
+    assert_tiers_agree_binary("min", &Kernel::x().min(&Kernel::y()), OpKind::Min);
+    assert_tiers_agree_binary("max", &Kernel::x().max(&Kernel::y()), OpKind::Max);
+}
+
+#[test]
+fn nan_comparisons_agree_between_tiers() {
+    use pixelflow_ir::OpKind;
+    // Gt/Ge are the unordered predicates (true for NaN); Lt/Le are ordered.
+    // The asymmetry is the hardware's, and the oracle now records it.
+    let one = Kernel::constant(1.0);
+    let zero = Kernel::constant(0.0);
+    for (name, op, k) in [
+        ("gt", OpKind::Gt, Kernel::x().gt(&Kernel::y())),
+        ("ge", OpKind::Ge, Kernel::x().ge(&Kernel::y())),
+        ("lt", OpKind::Lt, Kernel::x().lt(&Kernel::y())),
+        ("le", OpKind::Le, Kernel::x().le(&Kernel::y())),
+    ] {
+        // Masks are not numbers; select turns one back into 1.0/0.0 so the
+        // comparison against the oracle's 1.0/0.0 is meaningful.
+        assert_tiers_agree_binary(name, &k.select(&one, &zero), op);
+    }
+}
+
+#[test]
+fn round_breaks_ties_to_even_in_both_tiers() {
+    use pixelflow_ir::OpKind;
+    let rounded = Kernel::x().round();
+    let (arena, root) = rounded.parts();
+    let jit = jit_cache::compile_cached(arena, root).expect("round compiles");
+    for x in [0.5f32, 1.5, 2.5, 3.5, -0.5, -1.5, -2.5, 2.4, 2.6] {
+        let got = call_x(&jit, x);
+        let want = OpKind::Round.eval_unary(x).expect("oracle covers Round");
+        assert_eq!(got, want, "round({x}): JIT {got} vs oracle {want}");
+    }
+    // And the contract itself: nearest-even, so 2.5 -> 2, not 3.
+    assert_eq!(call_x(&jit, 2.5), 2.0);
+    assert_eq!(call_x(&jit, 3.5), 4.0);
 }

--- a/pixelflow-ir/tests/transcendental_jit.rs
+++ b/pixelflow-ir/tests/transcendental_jit.rs
@@ -166,13 +166,15 @@ fn assert_tiers_agree_binary(name: &str, k: &Kernel, op: pixelflow_ir::OpKind) {
         // NaN; x86's Gt/Ge are unordered while ARM's are ordered. CI caught
         // this on macos-latest: `min(NaN, 1)` gave NaN on aarch64 against an
         // oracle written from x86's behavior.
-        if op.nan_result_is_platform_specific() && (x.is_nan() || y.is_nan()) {
+        if op.fold_is_platform_specific(&[x, y]) {
             continue;
         }
         let got = call_xy(&jit, x, y);
         let want = op.eval_binary(x, y).expect("oracle covers this op");
+        // Bit-exact, not `==`: `-0.0 == 0.0` would hide a signed-zero
+        // disagreement, which is observable downstream as `1.0/x` = ∓inf.
         assert!(
-            got == want || (got.is_nan() && want.is_nan()),
+            got.to_bits() == want.to_bits() || (got.is_nan() && want.is_nan()),
             "{name}({x}, {y}): JIT gave {got}, oracle gave {want} — tiers must agree"
         );
     }
@@ -213,7 +215,7 @@ fn round_agrees_between_tiers_away_from_ties() {
     // Non-ties only. At a tie the three tiers disagree by design (x86
     // nearest-even, aarch64 FRINTA ties-away, combinator `(x+0.5).floor()`), so
     // there is no answer to assert — see `tie_result_is_platform_specific`.
-    assert!(OpKind::Round.tie_result_is_platform_specific());
+    assert!(OpKind::Round.fold_is_platform_specific(&[2.5]));
     for x in [2.4f32, 2.6, -2.4, -2.6, 0.2, 7.0, -7.0] {
         let got = call_x(&jit, x);
         let want = OpKind::Round.eval_unary(x).expect("oracle covers Round");
@@ -231,14 +233,14 @@ fn platform_specific_ops_are_classified() {
     use pixelflow_ir::OpKind;
     for op in [OpKind::Min, OpKind::Max, OpKind::Gt, OpKind::Ge] {
         assert!(
-            op.nan_result_is_platform_specific(),
+            op.fold_is_platform_specific(&[f32::NAN, 1.0]),
             "{op:?} diverges between x86 and aarch64 on NaN"
         );
     }
     // The ones both hardwares agree on stay foldable.
     for op in [OpKind::Lt, OpKind::Le, OpKind::Eq, OpKind::Ne, OpKind::Add] {
         assert!(
-            !op.nan_result_is_platform_specific(),
+            !op.fold_is_platform_specific(&[f32::NAN, 1.0]),
             "{op:?} agrees across targets and should remain foldable"
         );
     }

--- a/pixelflow-ir/tests/transcendental_jit.rs
+++ b/pixelflow-ir/tests/transcendental_jit.rs
@@ -159,6 +159,16 @@ fn assert_tiers_agree_binary(name: &str, k: &Kernel, op: pixelflow_ir::OpKind) {
         (2.0, 1.0),
         (f32::INFINITY, 1.0),
     ] {
+        // Where the two hardwares disagree, the language promises nothing, so
+        // there is no answer to assert — only that the folder declines to pick
+        // one (checked by `folder_declines_platform_specific_nan_cases`).
+        // x86 `minps` yields the second operand while ARM `FMIN` propagates the
+        // NaN; x86's Gt/Ge are unordered while ARM's are ordered. CI caught
+        // this on macos-latest: `min(NaN, 1)` gave NaN on aarch64 against an
+        // oracle written from x86's behavior.
+        if op.nan_result_is_platform_specific() && (x.is_nan() || y.is_nan()) {
+            continue;
+        }
         let got = call_xy(&jit, x, y);
         let want = op.eval_binary(x, y).expect("oracle covers this op");
         assert!(
@@ -195,17 +205,66 @@ fn nan_comparisons_agree_between_tiers() {
 }
 
 #[test]
-fn round_breaks_ties_to_even_in_both_tiers() {
+fn round_agrees_between_tiers_away_from_ties() {
     use pixelflow_ir::OpKind;
     let rounded = Kernel::x().round();
     let (arena, root) = rounded.parts();
     let jit = jit_cache::compile_cached(arena, root).expect("round compiles");
-    for x in [0.5f32, 1.5, 2.5, 3.5, -0.5, -1.5, -2.5, 2.4, 2.6] {
+    // Non-ties only. At a tie the three tiers disagree by design (x86
+    // nearest-even, aarch64 FRINTA ties-away, combinator `(x+0.5).floor()`), so
+    // there is no answer to assert — see `tie_result_is_platform_specific`.
+    assert!(OpKind::Round.tie_result_is_platform_specific());
+    for x in [2.4f32, 2.6, -2.4, -2.6, 0.2, 7.0, -7.0] {
         let got = call_x(&jit, x);
         let want = OpKind::Round.eval_unary(x).expect("oracle covers Round");
         assert_eq!(got, want, "round({x}): JIT {got} vs oracle {want}");
     }
-    // And the contract itself: nearest-even, so 2.5 -> 2, not 3.
-    assert_eq!(call_x(&jit, 2.5), 2.0);
-    assert_eq!(call_x(&jit, 3.5), 4.0);
+}
+
+/// The ops whose NaN answer is platform-specific must not be constant-folded
+/// with a NaN operand: folding bakes in the building target's answer, and the
+/// same expression computed at runtime on another target would differ.
+#[test]
+fn folder_declines_platform_specific_nan_cases() {
+    use pixelflow_ir::OpKind;
+    for op in [OpKind::Min, OpKind::Max, OpKind::Gt, OpKind::Ge] {
+        assert!(
+            op.nan_result_is_platform_specific(),
+            "{op:?} diverges between x86 and aarch64 on NaN"
+        );
+    }
+    // The ones both hardwares agree on stay foldable.
+    for op in [OpKind::Lt, OpKind::Le, OpKind::Eq, OpKind::Ne, OpKind::Add] {
+        assert!(
+            !op.nan_result_is_platform_specific(),
+            "{op:?} agrees across targets and should remain foldable"
+        );
+    }
+}
+
+/// `Eq`/`Ne` are exact in every emitter, so the oracle must be too. The old
+/// `(x-y).abs() < f32::EPSILON` form folded 0.5 and its next representable
+/// neighbour to "equal" while the hardware said "not equal" — a fold-vs-runtime
+/// miscompile on ordinary finite values, with no NaN or platform difference
+/// involved.
+#[test]
+fn eq_ne_are_exact_not_epsilon() {
+    use pixelflow_ir::OpKind;
+
+    let near = f32::from_bits(0.5f32.to_bits() + 1);
+    assert_ne!(0.5f32, near, "the two values really are distinct f32s");
+    assert!((0.5f32 - near).abs() < f32::EPSILON, "and closer than EPSILON");
+
+    assert_eq!(OpKind::Eq.eval_binary(0.5, near), Some(0.0));
+    assert_eq!(OpKind::Ne.eval_binary(0.5, near), Some(1.0));
+    assert_eq!(OpKind::Eq.eval_binary(0.5, 0.5), Some(1.0));
+
+    // NaN: never equal, always unequal — agreed by every emitter.
+    let nan = f32::NAN;
+    assert_eq!(OpKind::Eq.eval_binary(nan, nan), Some(0.0));
+    assert_eq!(OpKind::Ne.eval_binary(nan, nan), Some(1.0));
+
+    // `Kernel` exposes no eq/ne constructor, so there is no JIT side to compare
+    // against here — the folder IS the consumer that was wrong, and these
+    // assertions are what pins it.
 }

--- a/pixelflow-ir/tests/transcendental_jit.rs
+++ b/pixelflow-ir/tests/transcendental_jit.rs
@@ -187,23 +187,80 @@ fn min_max_nan_handling_agrees_between_tiers() {
     assert_tiers_agree_binary("max", &Kernel::x().max(&Kernel::y()), OpKind::Max);
 }
 
+/// Gt/Ge are the unordered predicates (true for NaN); Lt/Le are ordered. The
+/// asymmetry is the hardware's, and the oracle records it.
+///
+/// Compared bit-for-bit against the raw comparison — no `select` wrapper and no
+/// NaN escape hatch — because the *bit pattern* is the contract, not merely
+/// which branch it would pick. An all-ones lane is a NaN, so a NaN-tolerant
+/// comparison would accept `f32::NAN` where the hardware writes `0xFFFFFFFF`
+/// and both would still "agree".
 #[test]
 fn nan_comparisons_agree_between_tiers() {
     use pixelflow_ir::OpKind;
-    // Gt/Ge are the unordered predicates (true for NaN); Lt/Le are ordered.
-    // The asymmetry is the hardware's, and the oracle now records it.
-    let one = Kernel::constant(1.0);
-    let zero = Kernel::constant(0.0);
+    let nan = f32::NAN;
     for (name, op, k) in [
         ("gt", OpKind::Gt, Kernel::x().gt(&Kernel::y())),
         ("ge", OpKind::Ge, Kernel::x().ge(&Kernel::y())),
         ("lt", OpKind::Lt, Kernel::x().lt(&Kernel::y())),
         ("le", OpKind::Le, Kernel::x().le(&Kernel::y())),
     ] {
-        // Masks are not numbers; select turns one back into 1.0/0.0 so the
-        // comparison against the oracle's 1.0/0.0 is meaningful.
-        assert_tiers_agree_binary(name, &k.select(&one, &zero), op);
+        let (arena, root) = k.parts();
+        let jit = jit_cache::compile_cached(arena, root).unwrap_or_else(|e| panic!("{name}: {e}"));
+        for (x, y) in [
+            (1.0f32, nan),
+            (nan, 1.0f32),
+            (nan, nan),
+            (1.0, 2.0),
+            (2.0, 1.0),
+            (2.5, 2.5),
+            (-0.0, 0.0),
+        ] {
+            if op.fold_is_platform_specific(&[x, y]) {
+                continue;
+            }
+            let got = call_xy(&jit, x, y);
+            let want = op.eval_binary(x, y).expect("oracle covers this op");
+            assert_eq!(
+                got.to_bits(),
+                want.to_bits(),
+                "{name}({x}, {y}): JIT wrote {:#010x}, oracle {:#010x} — a mask \
+                 lane is all-ones or all-zero in both tiers or it is not a mask",
+                got.to_bits(),
+                want.to_bits()
+            );
+        }
     }
+}
+
+/// A folded comparison must be substitutable for an executed one.
+///
+/// `Select` and `BitAnd` are bitwise on every backend, so a mask lane that is
+/// merely *truthy* corrupts them: with `1.0` (`0x3f800000`) standing in for
+/// true, `runtime_mask & 1.0` is `0x3f800000`, and blending `7.0` against `9.0`
+/// through that pattern yields `4.5` — a value neither branch held. This is the
+/// end-to-end shape: one operand of the `&` is a constant the folder produced,
+/// the other is computed at runtime.
+#[test]
+fn a_folded_mask_blends_like_a_computed_one() {
+    use pixelflow_ir::OpKind;
+
+    // The folder's answer for `0.5 != nextafter(0.5)` — true, and (since the
+    // epsilon fix) reachable for ordinary finite values.
+    let near = f32::from_bits(0.5f32.to_bits() + 1);
+    let folded = OpKind::Ne
+        .eval_binary(0.5, near)
+        .expect("oracle covers Ne");
+
+    let k = Kernel::x()
+        .gt(&Kernel::constant(0.0))
+        .and(&Kernel::constant(folded))
+        .select(&Kernel::constant(7.0), &Kernel::constant(9.0));
+    let (arena, root) = k.parts();
+    let jit = jit_cache::compile_cached(arena, root).expect("mask kernel compiles");
+
+    assert_eq!(call_x(&jit, 1.0), 7.0, "mask true must select if_true exactly");
+    assert_eq!(call_x(&jit, -1.0), 9.0, "mask false must select if_false exactly");
 }
 
 #[test]
@@ -244,6 +301,28 @@ fn platform_specific_ops_are_classified() {
             "{op:?} agrees across targets and should remain foldable"
         );
     }
+
+    // Estimate instructions: no argument is safe, because an estimate is only
+    // guaranteed close and the three targets are not close to each other.
+    for op in [OpKind::Recip, OpKind::Rsqrt] {
+        for x in [2.0f32, 3.0, 0.5, 1.0] {
+            assert!(
+                op.fold_is_platform_specific(&[x]),
+                "{op:?}({x}) is an estimate and must never fold"
+            );
+        }
+    }
+
+    // MulAdd is value-aware: one rounding or two, and most inputs cannot tell.
+    let fused_differs = [1.000_000_1f32, 4097.0, 4097.0];
+    assert!(
+        OpKind::MulAdd.fold_is_platform_specific(&fused_differs),
+        "an input where FMA and mul-then-add disagree must not fold"
+    );
+    assert!(
+        !OpKind::MulAdd.fold_is_platform_specific(&[2.0, 3.0, 4.0]),
+        "exact inputs are the same either way and stay foldable"
+    );
 }
 
 /// `Eq`/`Ne` are exact in every emitter, so the oracle must be too. The old
@@ -259,14 +338,16 @@ fn eq_ne_are_exact_not_epsilon() {
     assert_ne!(0.5f32, near, "the two values really are distinct f32s");
     assert!((0.5f32 - near).abs() < f32::EPSILON, "and closer than EPSILON");
 
-    assert_eq!(OpKind::Eq.eval_binary(0.5, near), Some(0.0));
-    assert_eq!(OpKind::Ne.eval_binary(0.5, near), Some(1.0));
-    assert_eq!(OpKind::Eq.eval_binary(0.5, 0.5), Some(1.0));
+    let t = OpKind::mask(true);
+    let f = OpKind::mask(false);
+    assert_eq!(OpKind::Eq.eval_binary(0.5, near).map(f32::to_bits), Some(f.to_bits()));
+    assert_eq!(OpKind::Ne.eval_binary(0.5, near).map(f32::to_bits), Some(t.to_bits()));
+    assert_eq!(OpKind::Eq.eval_binary(0.5, 0.5).map(f32::to_bits), Some(t.to_bits()));
 
     // NaN: never equal, always unequal — agreed by every emitter.
     let nan = f32::NAN;
-    assert_eq!(OpKind::Eq.eval_binary(nan, nan), Some(0.0));
-    assert_eq!(OpKind::Ne.eval_binary(nan, nan), Some(1.0));
+    assert_eq!(OpKind::Eq.eval_binary(nan, nan).map(f32::to_bits), Some(f.to_bits()));
+    assert_eq!(OpKind::Ne.eval_binary(nan, nan).map(f32::to_bits), Some(t.to_bits()));
 
     // `Kernel` exposes no eq/ne constructor, so there is no JIT side to compare
     // against here — the folder IS the consumer that was wrong, and these

--- a/pixelflow-runtime/tests/actor_model_tests.rs
+++ b/pixelflow-runtime/tests/actor_model_tests.rs
@@ -180,8 +180,39 @@ impl Actor<(), (), ()> for ParkTrackingActor {
 // so the actor was already draining and could legitimately process an early
 // data message before a control message had even been sent. They passed by
 // timing luck and failed under load — one of them broke a CI run, which is how
-// they were found. What IS guaranteed, and is still tested below: FIFO within a
-// single lane, delivery of every message, and no starvation of a lower lane.
+// they were found. What IS guaranteed, and is still tested below: the drain
+// order of messages that ARE simultaneously pending, FIFO within a single lane,
+// delivery of every message, and no starvation of a lower lane.
+
+/// The guarantee the deleted tests were reaching for, stated so it can actually
+/// hold: among messages **already pending**, a drain pass takes Control, then
+/// Management, then Data.
+///
+/// No consumer thread — `poll_once` drains on this thread, so all three messages
+/// are provably enqueued before the actor sees any of them. Sending in reverse
+/// priority order means FIFO across lanes would produce exactly the opposite
+/// log, so the assertion has something to fail on.
+#[test]
+fn pending_messages_drain_in_priority_order() {
+    let (tx, mut rx) = ActorScheduler::new(10, 100);
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let mut actor = OrderingActor { log: log.clone() };
+
+    tx.send(Message::Data("d".to_string())).unwrap();
+    tx.send(Message::Management("m".to_string())).unwrap();
+    tx.send(Message::Control("c".to_string())).unwrap();
+
+    // Keep polling until every message has been handled; the drain may batch.
+    while log.lock().unwrap().len() < 3 {
+        assert!(
+            rx.poll_once(&mut actor).is_none(),
+            "the scheduler exited before draining the three pending messages"
+        );
+    }
+
+    let order: Vec<String> = log.lock().unwrap().iter().map(|(s, _)| s.clone()).collect();
+    assert_eq!(order, vec!["C:c", "M:m", "D:d"]);
+}
 
 #[test]
 fn fifo_ordering_within_same_lane() {

--- a/pixelflow-runtime/tests/actor_model_tests.rs
+++ b/pixelflow-runtime/tests/actor_model_tests.rs
@@ -172,139 +172,16 @@ impl Actor<(), (), ()> for ParkTrackingActor {
 // ============================================================================
 // Priority Ordering Tests
 // ============================================================================
-
-#[test]
-fn control_messages_processed_before_earlier_data_messages() {
-    let (tx, mut rx) = ActorScheduler::new(10, 100);
-    let log = Arc::new(Mutex::new(Vec::new()));
-    let log_clone = log.clone();
-
-    let handle = thread::spawn(move || {
-        let mut actor = OrderingActor { log: log_clone };
-        rx.run(&mut actor);
-    });
-
-    // Send data first, then control
-    tx.send(Message::Data("first".to_string())).unwrap();
-    tx.send(Message::Data("second".to_string())).unwrap();
-    tx.send(Message::Control("priority".to_string())).unwrap();
-    tx.send(Message::Data("third".to_string())).unwrap();
-
-    thread::sleep(Duration::from_millis(50));
-    drop(tx);
-    handle.join().unwrap();
-
-    let messages = log.lock().unwrap();
-    let ctrl_idx = messages.iter().position(|(s, _)| s.starts_with("C:"));
-    let first_data_idx = messages
-        .iter()
-        .position(|(s, _)| s == "D:first")
-        .unwrap_or(usize::MAX);
-
-    // Control should be processed before any data that arrived before it
-    assert!(
-        ctrl_idx.unwrap() < first_data_idx,
-        "Control message should be processed before earlier data messages. Got: {:?}",
-        messages.iter().map(|(s, _)| s).collect::<Vec<_>>()
-    );
-}
-
-#[test]
-fn management_messages_processed_before_data_messages() {
-    let (tx, mut rx) = ActorScheduler::new(10, 100);
-    let log = Arc::new(Mutex::new(Vec::new()));
-    let log_clone = log.clone();
-
-    let handle = thread::spawn(move || {
-        let mut actor = OrderingActor { log: log_clone };
-        rx.run(&mut actor);
-    });
-
-    // Send data, then management
-    tx.send(Message::Data("data1".to_string())).unwrap();
-    tx.send(Message::Management("mgmt".to_string())).unwrap();
-    tx.send(Message::Data("data2".to_string())).unwrap();
-
-    thread::sleep(Duration::from_millis(50));
-    drop(tx);
-    handle.join().unwrap();
-
-    let messages = log.lock().unwrap();
-    let mgmt_idx = messages.iter().position(|(s, _)| s.starts_with("M:"));
-    let data1_idx = messages
-        .iter()
-        .position(|(s, _)| s == "D:data1")
-        .unwrap_or(usize::MAX);
-
-    assert!(
-        mgmt_idx.unwrap() < data1_idx,
-        "Management should be processed before earlier data. Got: {:?}",
-        messages.iter().map(|(s, _)| s).collect::<Vec<_>>()
-    );
-}
-
-#[test]
-fn control_processed_before_management() {
-    // This test verifies that when control and management messages are both
-    // queued, control is processed first. We check which one triggers processing
-    // FIRST by having the actor track the first message of each type it sees.
-    let (tx, mut rx) = ActorScheduler::new(10, 100);
-    let control_first = Arc::new(AtomicBool::new(false));
-    let management_first = Arc::new(AtomicBool::new(false));
-    let control_first_clone = control_first.clone();
-    let management_first_clone = management_first.clone();
-
-    let handle = thread::spawn(move || {
-        struct FirstWinsActor {
-            control_first: Arc<AtomicBool>,
-            management_first: Arc<AtomicBool>,
-            control_seen: bool,
-            management_seen: bool,
-        }
-        impl Actor<(), (), ()> for FirstWinsActor {
-            fn handle_control(&mut self, _: ()) -> HandlerResult {
-                if !self.control_seen && !self.management_seen {
-                    self.control_first.store(true, Ordering::SeqCst);
-                }
-                self.control_seen = true;
-                Ok(())
-            }
-            fn handle_management(&mut self, _: ()) -> HandlerResult {
-                if !self.control_seen && !self.management_seen {
-                    self.management_first.store(true, Ordering::SeqCst);
-                }
-                self.management_seen = true;
-                Ok(())
-            }
-            fn handle_data(&mut self, _: ()) -> HandlerResult {
-                Ok(())
-            }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
-                Ok(ActorStatus::Idle)
-            }
-        }
-        let mut actor = FirstWinsActor {
-            control_first: control_first_clone,
-            management_first: management_first_clone,
-            control_seen: false,
-            management_seen: false,
-        };
-        rx.run(&mut actor);
-    });
-
-    // Send both control and management rapidly to ensure they're queued before processing
-    tx.send(Message::Management(())).unwrap();
-    tx.send(Message::Control(())).unwrap();
-
-    thread::sleep(Duration::from_millis(50));
-    drop(tx);
-    handle.join().unwrap();
-
-    assert!(
-        control_first.load(Ordering::SeqCst),
-        "Control message should be processed before management message"
-    );
-}
+//
+// Cross-lane ordering is BEST EFFORT and is deliberately not asserted here.
+// Priority lanes reorder messages that are *simultaneously pending*; they
+// cannot retroactively preempt one the actor has already dequeued. Four tests
+// asserting otherwise were deleted: each spawned the consumer before sending,
+// so the actor was already draining and could legitimately process an early
+// data message before a control message had even been sent. They passed by
+// timing luck and failed under load — one of them broke a CI run, which is how
+// they were found. What IS guaranteed, and is still tested below: FIFO within a
+// single lane, delivery of every message, and no starvation of a lower lane.
 
 #[test]
 fn fifo_ordering_within_same_lane() {
@@ -1061,68 +938,6 @@ fn concurrent_senders_stress_test() {
         count.load(Ordering::SeqCst),
         num_senders * msgs_per_sender,
         "All messages from all senders should be processed"
-    );
-}
-
-#[test]
-fn priority_maintained_when_both_lanes_have_messages() {
-    // This test verifies that when BOTH control and data are queued,
-    // control is processed first. It does NOT test that control sent LATER
-    // interrupts data processing - that's not how the scheduler works.
-    //
-    // The scheduler checks priority at the start of each batch, so if
-    // data is sent first and control second, some data may be processed
-    // before control arrives. This is expected.
-
-    let (tx, mut rx) = ActorScheduler::new(50, 500);
-    let first_message_type = Arc::new(Mutex::new(None::<&'static str>));
-
-    let first_clone = first_message_type.clone();
-
-    let handle = thread::spawn(move || {
-        struct FirstChecker {
-            first: Arc<Mutex<Option<&'static str>>>,
-        }
-        impl Actor<i32, i32, i32> for FirstChecker {
-            fn handle_data(&mut self, _: i32) -> HandlerResult {
-                let mut first = self.first.lock().unwrap();
-                if first.is_none() {
-                    *first = Some("data");
-                }
-                Ok(())
-            }
-            fn handle_control(&mut self, _: i32) -> HandlerResult {
-                let mut first = self.first.lock().unwrap();
-                if first.is_none() {
-                    *first = Some("control");
-                }
-                Ok(())
-            }
-            fn handle_management(&mut self, _: i32) -> HandlerResult {
-                Ok(())
-            }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
-                Ok(ActorStatus::Idle)
-            }
-        }
-        rx.run(&mut FirstChecker { first: first_clone });
-    });
-
-    // Send both control and data before scheduler processes anything
-    // by sending them quickly
-    tx.send(Message::Data(1)).unwrap();
-    tx.send(Message::Control(1)).unwrap();
-
-    thread::sleep(Duration::from_millis(100));
-    drop(tx);
-    handle.join().unwrap();
-
-    // Control should be processed first since it has higher priority
-    let first = first_message_type.lock().unwrap();
-    assert_eq!(
-        *first,
-        Some("control"),
-        "Control should be processed before data when both are queued"
     );
 }
 

--- a/pixelflow-search/src/egraph/codegen.rs
+++ b/pixelflow-search/src/egraph/codegen.rs
@@ -39,7 +39,12 @@ use pixelflow_ir::EmitStyle;
 /// Format a constant value as Rust code.
 fn format_const(v: f32) -> String {
     if v.is_nan() {
-        "f32::NAN".to_string()
+        // By bits, not `f32::NAN`: NaN is a family of bit patterns and the one
+        // that matters here is all-ones, the true comparison mask
+        // (`OpKind::mask`) and `BitAnd`'s monoid identity. `f32::NAN` is
+        // `0x7fc00000`, so emitting it would turn a mask into a pattern that
+        // blends to garbage rather than to `if_true`.
+        format!("f32::from_bits({:#010x})", v.to_bits())
     } else if v.is_infinite() {
         if v.is_sign_positive() {
             "f32::INFINITY".to_string()

--- a/pixelflow-search/src/math/algebra.rs
+++ b/pixelflow-search/src/math/algebra.rs
@@ -910,24 +910,16 @@ impl Rewrite for ConstantFold {
         // matters more than a same-machine consistency nicety: the folder runs
         // on the BUILD host at macro-expansion time, while the folded constant
         // executes on the TARGET, so folding here bakes the build machine's
-        // answer into code that may run somewhere that computes differently.
+        // arithmetic into code that may run somewhere that computes
+        // differently. `fold_is_platform_specific` owns the classification
+        // (NaN and signed-zero Min/Max, NaN Gt/Ge, Round at a tie) so it lives
+        // in one place next to the semantics rather than as conditions here.
         //
-        // - `Round` at an exact tie: x86 nearest-even (2.5 -> 2), aarch64
-        //   `FRINTA` ties-away (-> 3). Round is unary, so declining is a
-        //   COMPLETE fix — there is no rewrite that can reintroduce the fold.
-        // - `Min`/`Max` with a NaN operand: x86 yields the second operand,
-        //   aarch64 propagates the NaN. Declining is only PARTIAL here: the
-        //   e-graph installs commutativity for these ops, so `min(1.0, NaN)`
-        //   can still be commuted to `min(NaN, 1.0)` and folded. That is
-        //   permitted (the result is unspecified — see CLAUDE.md) but this
-        //   still removes the direct path, and claiming otherwise would be
-        //   the overreach an earlier revision of this guard was reverted for.
-        if kind.nan_result_is_platform_specific() && args.iter().any(|a| a.is_nan()) {
-            return None;
-        }
-        if kind.tie_result_is_platform_specific()
-            && args.iter().any(|a| a.fract().abs() == 0.5)
-        {
+        // Complete for `Round` (unary — no rewrite can reintroduce the fold).
+        // Partial for `Min`/`Max`: the e-graph installs commutativity for them,
+        // so a commuted form can still be folded. That is permitted, since the
+        // result is unspecified, but this removes the direct path.
+        if kind.fold_is_platform_specific(&args) {
             return None;
         }
 
@@ -1057,5 +1049,18 @@ mod platform_specific_fold_tests {
         // Without a NaN the targets agree and folding proceeds.
         assert_eq!(folds(&ops::Min, &[1.0, 2.0]), Some(1.0));
         assert_eq!(folds(&ops::Max, &[1.0, 2.0]), Some(2.0));
+    }
+
+    /// Opposite-signed zeros are the non-NaN case where Min/Max still diverge:
+    /// x86 picks by operand order (`-0.0 < 0.0` is false, so the second wins),
+    /// aarch64 `FMIN` picks `-0.0` and `FMAX` picks `+0.0`. `==` cannot tell
+    /// them apart, but `1.0 / x` makes it `+inf` versus `-inf`.
+    #[test]
+    fn declines_signed_zero_min_max() {
+        assert_eq!(folds(&ops::Min, &[-0.0, 0.0]), None);
+        assert_eq!(folds(&ops::Min, &[0.0, -0.0]), None);
+        assert_eq!(folds(&ops::Max, &[-0.0, 0.0]), None);
+        // Same-signed zeros are indistinguishable, so folding is fine.
+        assert_eq!(folds(&ops::Min, &[0.0, 0.0]).map(f32::to_bits), Some(0.0f32.to_bits()));
     }
 }

--- a/pixelflow-search/src/math/algebra.rs
+++ b/pixelflow-search/src/math/algebra.rs
@@ -906,6 +906,31 @@ impl Rewrite for ConstantFold {
             args.push(found_const?);
         }
 
+        // Refuse to fold anything whose answer is platform-specific. This
+        // matters more than a same-machine consistency nicety: the folder runs
+        // on the BUILD host at macro-expansion time, while the folded constant
+        // executes on the TARGET, so folding here bakes the build machine's
+        // answer into code that may run somewhere that computes differently.
+        //
+        // - `Round` at an exact tie: x86 nearest-even (2.5 -> 2), aarch64
+        //   `FRINTA` ties-away (-> 3). Round is unary, so declining is a
+        //   COMPLETE fix — there is no rewrite that can reintroduce the fold.
+        // - `Min`/`Max` with a NaN operand: x86 yields the second operand,
+        //   aarch64 propagates the NaN. Declining is only PARTIAL here: the
+        //   e-graph installs commutativity for these ops, so `min(1.0, NaN)`
+        //   can still be commuted to `min(NaN, 1.0)` and folded. That is
+        //   permitted (the result is unspecified — see CLAUDE.md) but this
+        //   still removes the direct path, and claiming otherwise would be
+        //   the overreach an earlier revision of this guard was reverted for.
+        if kind.nan_result_is_platform_specific() && args.iter().any(|a| a.is_nan()) {
+            return None;
+        }
+        if kind.tie_result_is_platform_specific()
+            && args.iter().any(|a| a.fract().abs() == 0.5)
+        {
+            return None;
+        }
+
         // Evaluate based on arity
         let result = match args.len() {
             1 => kind.eval_unary(args[0])?,
@@ -987,4 +1012,50 @@ pub fn algebra_rules() -> Vec<Box<dyn Rewrite>> {
     let mut rules = inverse_pair_rules();
     rules.extend(basic_algebra_rules());
     rules
+}
+
+#[cfg(test)]
+mod platform_specific_fold_tests {
+    use super::*;
+    use crate::egraph::{EGraph, ENode};
+    use crate::egraph::rewrite::{Rewrite, RewriteAction};
+
+    /// Drive `ConstantFold::apply` directly on `op(consts...)` and report
+    /// whether it produced a folded constant.
+    fn folds(op: &'static dyn Op, args: &[f32]) -> Option<f32> {
+        let mut eg = EGraph::new();
+        let children: Vec<_> = args.iter().map(|&v| eg.add(ENode::constant(v))).collect();
+        let node = ENode::Op { op, children };
+        let id = eg.add(node.clone());
+        match ConstantFold.apply(&eg, id, &node) {
+            Some(RewriteAction::Create(ENode::Const(bits))) => Some(f32::from_bits(bits)),
+            _ => None,
+        }
+    }
+
+    /// The folder runs on the BUILD host; the constant it bakes in executes on
+    /// the TARGET. For ops whose answer differs between targets it must decline,
+    /// or a cross-compile silently ships the build machine's arithmetic.
+    #[test]
+    fn declines_platform_specific_rounding_ties() {
+        // x86 nearest-even says 2, aarch64 FRINTA says 3 — so neither.
+        assert_eq!(folds(&ops::Round, &[2.5]), None);
+        assert_eq!(folds(&ops::Round, &[-1.5]), None);
+        assert_eq!(folds(&ops::Round, &[0.5]), None);
+        // Away from a tie every target agrees, so folding is still allowed.
+        assert_eq!(folds(&ops::Round, &[2.4]), Some(2.0));
+        assert_eq!(folds(&ops::Round, &[2.6]), Some(3.0));
+    }
+
+    #[test]
+    fn declines_platform_specific_nan_min_max() {
+        let nan = f32::NAN;
+        // x86 yields the second operand, aarch64 propagates the NaN.
+        assert_eq!(folds(&ops::Min, &[nan, 1.0]), None);
+        assert_eq!(folds(&ops::Min, &[1.0, nan]), None);
+        assert_eq!(folds(&ops::Max, &[nan, 1.0]), None);
+        // Without a NaN the targets agree and folding proceeds.
+        assert_eq!(folds(&ops::Min, &[1.0, 2.0]), Some(1.0));
+        assert_eq!(folds(&ops::Max, &[1.0, 2.0]), Some(2.0));
+    }
 }

--- a/pixelflow-search/src/math/algebra.rs
+++ b/pixelflow-search/src/math/algebra.rs
@@ -1039,6 +1039,21 @@ mod platform_specific_fold_tests {
         assert_eq!(folds(&ops::Round, &[2.6]), Some(3.0));
     }
 
+    /// Non-tie inputs in `[-0.5, -0.0]` round to `-0.0` in both JIT tiers but
+    /// to `+0.0` through the combinator tier's `(x + 0.5).floor()`, so the
+    /// folder must decline there too — `1.0 / x` makes the difference `-inf`
+    /// versus `+inf`.
+    #[test]
+    fn declines_round_folds_that_lose_the_sign_of_zero() {
+        assert_eq!(folds(&ops::Round, &[-0.2]), None);
+        assert_eq!(folds(&ops::Round, &[-0.4]), None);
+        assert_eq!(folds(&ops::Round, &[-0.0]), None);
+        // Past -0.5 the result is -1.0 in every tier, so folding is fine again.
+        assert_eq!(folds(&ops::Round, &[-0.6]), Some(-1.0));
+        // And positive inputs never had the ambiguity.
+        assert_eq!(folds(&ops::Round, &[0.2]).map(f32::to_bits), Some(0.0f32.to_bits()));
+    }
+
     #[test]
     fn declines_platform_specific_nan_min_max() {
         let nan = f32::NAN;

--- a/pixelflow-search/src/math/algebra.rs
+++ b/pixelflow-search/src/math/algebra.rs
@@ -911,13 +911,16 @@ impl Rewrite for ConstantFold {
         // on the BUILD host at macro-expansion time, while the folded constant
         // executes on the TARGET, so folding here bakes the build machine's
         // arithmetic into code that may run somewhere that computes
-        // differently. `fold_is_platform_specific` owns the classification
-        // (NaN and signed-zero Min/Max, NaN Gt/Ge, Round at a tie) so it lives
-        // in one place next to the semantics rather than as conditions here.
+        // differently. `fold_is_platform_specific` owns the classification (NaN
+        // and signed-zero Min/Max, NaN Gt/Ge, Round at a tie, the reciprocal
+        // estimates, MulAdd's one-vs-two roundings) so it lives in one place
+        // next to the semantics rather than as conditions here.
         //
-        // Complete for `Round` (unary — no rewrite can reintroduce the fold).
-        // Partial for `Min`/`Max`: the e-graph installs commutativity for them,
-        // so a commuted form can still be folded. That is permitted, since the
+        // Complete for `Round`/`Recip`/`Rsqrt` (unary — no rewrite can
+        // reintroduce the fold) and for `MulAdd` (its only commutable pair is
+        // the two multiplicands, which round identically either way). Partial
+        // for `Min`/`Max`: the e-graph installs commutativity for them, so a
+        // commuted form can still be folded. That is permitted, since the
         // result is unspecified, but this removes the direct path.
         if kind.fold_is_platform_specific(&args) {
             return None;
@@ -931,8 +934,16 @@ impl Rewrite for ConstantFold {
             _ => return None,
         };
 
-        // Don't fold NaN or infinity - they can cause issues
-        if !result.is_finite() {
+        // Don't bake in a non-finite result of ARITHMETIC: `1e38 * 1e38` folding
+        // to `inf` freezes an overflow no source constant asked for. Ops in the
+        // bitwise domain are exempt, because for them a non-finite float reading
+        // IS the intended output — a true comparison mask is all-ones, which
+        // reads as NaN by construction (`OpKind::mask`, and the same pattern
+        // `BitAnd`'s monoid identity uses), and the integer-domain primitives
+        // exp/log lower to build exponents out of raw bit patterns. Without the
+        // exemption this guard silently switches off comparison and exp/log
+        // folding while looking like a safety check.
+        if !result.is_finite() && !kind.is_bitwise_domain() {
             return None;
         }
 
@@ -1077,5 +1088,50 @@ mod platform_specific_fold_tests {
         assert_eq!(folds(&ops::Max, &[-0.0, 0.0]), None);
         // Same-signed zeros are indistinguishable, so folding is fine.
         assert_eq!(folds(&ops::Min, &[0.0, 0.0]).map(f32::to_bits), Some(0.0f32.to_bits()));
+    }
+
+    /// `Recip`/`Rsqrt` are estimate instructions, and each target estimates
+    /// differently: `rcpps` gives ~12 bits, `vrcp14ps` ~14, aarch64 runs
+    /// `FRECPE` plus a `FRECPS` Newton step. `recip(3.0)` executes as
+    /// `0.33325195` on SSE2 against the exact `0.33333334` the folder would
+    /// compute — so unlike the cases above there is no argument that is safe.
+    #[test]
+    fn never_folds_reciprocal_estimates() {
+        for x in [3.0f32, 2.0, 1.0, 0.5, 16.0] {
+            assert_eq!(folds(&ops::Recip, &[x]), None, "recip({x}) is an estimate");
+            assert_eq!(folds(&ops::Rsqrt, &[x]), None, "rsqrt({x}) is an estimate");
+        }
+    }
+
+    /// `MulAdd` rounds once on every target with an FMA (`vfmadd`, `FMLA`) and
+    /// twice on SSE2 (`mulps` then `addps`). Value-aware, because the two agree
+    /// for most inputs — declining everything would give up real folding to
+    /// guard a narrow set of arguments.
+    #[test]
+    fn declines_muladd_only_where_the_roundings_differ() {
+        // One rounding gives 8194.001, two give 8194.0.
+        assert_eq!(folds(&ops::MulAdd, &[1.000_000_1, 4097.0, 4097.0]), None);
+        // Exactly representable throughout: both forms agree.
+        assert_eq!(folds(&ops::MulAdd, &[2.0, 3.0, 4.0]), Some(10.0));
+    }
+
+    /// A folded comparison and an executed one have to be the same operand.
+    /// `Select`/`BitAnd` are bitwise on every backend, so a folded `1.0` would
+    /// blend `7.0` against `9.0` into `4.5`; the mask has to be all-ones.
+    #[test]
+    fn comparison_folds_produce_mask_bit_patterns() {
+        let t = pixelflow_ir::OpKind::mask(true).to_bits();
+        let f = pixelflow_ir::OpKind::mask(false).to_bits();
+        assert_eq!(folds(&ops::Lt, &[1.0, 2.0]).map(f32::to_bits), Some(t));
+        assert_eq!(folds(&ops::Lt, &[2.0, 1.0]).map(f32::to_bits), Some(f));
+        assert_eq!(folds(&ops::Eq, &[2.0, 2.0]).map(f32::to_bits), Some(t));
+        assert_eq!(folds(&ops::Ne, &[2.0, 2.0]).map(f32::to_bits), Some(f));
+        // And such a mask blends exactly, through the same bitwise formula the
+        // backends emit. (`BitAnd`/`BitOr` have no e-graph `Op` — they appear
+        // only after lowering — so `Select` is the folder-visible consumer; the
+        // end-to-end path through a real `and` is covered by
+        // `pixelflow-ir/tests/transcendental_jit.rs`.)
+        assert_eq!(folds(&ops::Select, &[f32::from_bits(t), 7.0, 9.0]), Some(7.0));
+        assert_eq!(folds(&ops::Select, &[f32::from_bits(f), 7.0, 9.0]), Some(9.0));
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -21,8 +21,8 @@ fn main() {
         eprintln!("Commands:");
         eprintln!("  bundle-run    Build and run the bundled macOS app");
         eprintln!("  bake-eigen    Parse Stam's eigenstructure binary → Rust consts");
-        eprintln!("  isa-matrix    Run the workspace test suite at every x86-64 ISA");
-        eprintln!("                level this host actually supports (SSE2/AVX2/AVX-512)");
+        eprintln!("  isa-matrix    Build+lint every x86-64 ISA level (SSE2/AVX2/AVX-512);");
+        eprintln!("                run the tests for those this host can execute");
         eprintln!("                [--clippy to also run clippy per level]");
         std::process::exit(1);
     }
@@ -198,11 +198,24 @@ fn bundle_run(extra_args: &[String]) {
 // `.cargo/config.toml` sets no `target-cpu`/`target-feature`, so a plain
 // `cargo build`/`cargo test` always produces SSE2 code on x86-64 — even on a
 // machine with AVX2 or AVX-512 available. Nothing in the default CI pipeline
-// ever exercised the wider JIT backends. This runs the workspace test suite
-// (and optionally clippy) once per x86-64 ISA level the CURRENT HOST actually
-// supports, via explicit `-C target-feature` flags rather than
-// `-C target-cpu=native` (which bakes in whatever the build machine happens
-// to be and isn't reproducible across machines/CI runners).
+// ever exercised the wider JIT backends. This walks every x86-64 ISA level via
+// explicit `-C target-feature` flags — not `-C target-cpu=native`, which bakes
+// in whatever the build machine happens to be and is not reproducible across
+// machines or CI runners.
+//
+// Build and execute are separated deliberately, because they have different
+// requirements. COMPILING for a target feature needs no matching hardware;
+// only RUNNING the result does. So every level is built and linted
+// unconditionally — that is what catches cfg mistakes, missing backend ops and
+// lints, none of which need the CPU — and only the execution step is gated on
+// `is_x86_feature_detected!`. A level the host cannot run therefore reports
+// BUILT+LINT, not SKIP: an AVX-512-less runner still type-checks and lints the
+// AVX-512 build, which is most of the value.
+//
+// Note the gate is per-LEVEL, not per-test: the whole workspace is compiled
+// with the level's target-feature, so rustc may emit those instructions
+// anywhere in the binary. It is not sufficient that an individual test avoids
+// them.
 
 /// One row of the ISA test matrix: a human-readable name, the
 /// `-C target-feature` value to pass (empty = the SSE2 baseline, no flag),
@@ -264,12 +277,14 @@ fn host_has_feature(feature: &str) -> bool {
 
 /// Outcome of attempting one [`IsaLevel`].
 enum LevelResult {
-    /// Test suite (and clippy, if requested) both succeeded.
+    /// Compiled, linted, and the test binaries ran.
     Passed,
-    /// A command ran and failed; the bool distinguishes which one for the summary.
-    Failed { clippy: bool },
-    /// Host lacks a required CPU feature; skipped cleanly, not a failure.
-    Skipped { missing: &'static str },
+    /// Compiled and linted, but the tests were not executed: the host CPU
+    /// cannot run this level's instructions. NOT a skip — everything that can
+    /// be checked without the hardware was checked.
+    BuiltNotRun { missing: &'static str },
+    /// A command failed; `stage` names which for the summary.
+    Failed { stage: &'static str },
 }
 
 /// Run the workspace test suite (`cargo test --workspace`), and optionally
@@ -304,20 +319,6 @@ fn isa_matrix(with_clippy: bool) {
         for level in ISA_LEVELS {
             println!("\n=== ISA level: {} ===", level.name);
 
-            let missing = level
-                .requires
-                .iter()
-                .find(|&&feat| !host_has_feature(feat));
-            if let Some(&feat) = missing {
-                println!(
-                    "isa-matrix: skipping {} — host CPU lacks {feat} \
-                     (checked via is_x86_feature_detected!)",
-                    level.name
-                );
-                results.push((level.name, LevelResult::Skipped { missing: feat }));
-                continue;
-            }
-
             let rustflags = if level.target_feature.is_empty() {
                 FP_CONTRACT.to_string()
             } else {
@@ -325,14 +326,12 @@ fn isa_matrix(with_clippy: bool) {
             };
             println!("isa-matrix: RUSTFLAGS=\"{rustflags}\"");
 
-            // Each level's RUSTFLAGS produce a disjoint artifact set (the
-            // flags feed -C metadata), so levels sharing a target dir
-            // accumulate ~one full workspace build EACH — three levels
-            // exhausted a 21 GB disk the first time this ran for real.
-            // Every level therefore builds in one dedicated dir, wiped
-            // before each level: peak disk is a single artifact set, and
-            // the developer's own target/ (their incremental cache) is
-            // never touched.
+            // Each level's RUSTFLAGS produce a disjoint artifact set (the flags
+            // feed -C metadata), so levels sharing a target dir accumulate one
+            // full workspace build EACH — three levels filled this container's
+            // disk the first time it ran for real. One dedicated dir, wiped per
+            // level: peak disk is a single artifact set, and the developer's
+            // own target/ (their incremental cache) is never touched.
             let matrix_target = workspace_root.join("target/isa-matrix");
             if matrix_target.exists() {
                 if let Err(e) = std::fs::remove_dir_all(&matrix_target) {
@@ -343,18 +342,24 @@ fn isa_matrix(with_clippy: bool) {
                 }
             }
 
-            let test_ok = run_with_rustflags(
+            // COMPILING a level needs no special hardware — only running the
+            // result does. So build and lint every level unconditionally: that
+            // is what catches cfg mistakes (a backend compiled out of a wide
+            // build, a coverage sweep referring to a struct that no longer
+            // exists there), missing ops, and lints, none of which need an
+            // AVX-512 CPU to detect. Skipping a level outright, as this used to,
+            // threw all of that away because the runner lacked one CPU flag.
+            if !run_with_rustflags(
                 &workspace_root,
                 &matrix_target,
                 &rustflags,
-                &["test", "--workspace", "--no-fail-fast"],
-            );
-            if !test_ok {
-                println!("isa-matrix: {} — cargo test FAILED", level.name);
-                results.push((level.name, LevelResult::Failed { clippy: false }));
+                &["test", "--workspace", "--no-run"],
+            ) {
+                println!("isa-matrix: {} — test build FAILED", level.name);
+                results.push((level.name, LevelResult::Failed { stage: "build" }));
                 continue;
             }
-            println!("isa-matrix: {} — cargo test passed", level.name);
+            println!("isa-matrix: {} — test build ok", level.name);
 
             if with_clippy {
                 let clippy_ok = run_with_rustflags(
@@ -365,11 +370,41 @@ fn isa_matrix(with_clippy: bool) {
                 );
                 if !clippy_ok {
                     println!("isa-matrix: {} — cargo clippy FAILED", level.name);
-                    results.push((level.name, LevelResult::Failed { clippy: true }));
+                    results.push((level.name, LevelResult::Failed { stage: "clippy" }));
                     continue;
                 }
                 println!("isa-matrix: {} — cargo clippy passed", level.name);
             }
+
+            // Executing is the part that genuinely needs the CPU. Note the
+            // whole workspace is built with this level's target-feature, so
+            // rustc may emit those instructions anywhere in the binary — it is
+            // not enough that a given test avoids them.
+            if let Some(&feat) = level
+                .requires
+                .iter()
+                .find(|&&feat| !host_has_feature(feat))
+            {
+                println!(
+                    "isa-matrix: {} — built and linted; NOT running tests \
+                     (host CPU lacks {feat})",
+                    level.name
+                );
+                results.push((level.name, LevelResult::BuiltNotRun { missing: feat }));
+                continue;
+            }
+
+            if !run_with_rustflags(
+                &workspace_root,
+                &matrix_target,
+                &rustflags,
+                &["test", "--workspace", "--no-fail-fast"],
+            ) {
+                println!("isa-matrix: {} — cargo test FAILED", level.name);
+                results.push((level.name, LevelResult::Failed { stage: "test" }));
+                continue;
+            }
+            println!("isa-matrix: {} — cargo test passed", level.name);
 
             results.push((level.name, LevelResult::Passed));
         }
@@ -379,16 +414,12 @@ fn isa_matrix(with_clippy: bool) {
         for (name, result) in &results {
             let line = match result {
                 LevelResult::Passed => "PASS".to_string(),
-                LevelResult::Failed { clippy } => {
+                LevelResult::Failed { stage } => {
                     any_failed = true;
-                    if *clippy {
-                        "FAIL (clippy)".to_string()
-                    } else {
-                        "FAIL (test)".to_string()
-                    }
+                    format!("FAIL ({stage})")
                 }
-                LevelResult::Skipped { missing } => {
-                    format!("SKIP (host lacks {missing})")
+                LevelResult::BuiltNotRun { missing } => {
+                    format!("BUILT+LINT (not run: host lacks {missing})")
                 }
             };
             println!("  {name:<20} {line}");


### PR DESCRIPTION
Follow-up to #922 (merged). Answers the float edge cases Codex raised there, per the decision: *"don't care at the edges. we want fp to work mostly as a non computer scientist would expect. IEEE is over specified."*

> **Note:** this description was rewritten after the fact. The original presented x86's answers as the promised contract, which review and CI then disproved — aarch64 differs on every one of them. The history below is kept deliberately, because the corrections are the substance of the PR.

## The premise, stated the right way round

Rust already ships reasonably fast IEEE arithmetic — `f32::min`, `f32::round`, ordered comparisons, all correct and quick enough for almost everything. **Choosing pixelflow *is* the decision that conformant-and-quick is inadequate on performance grounds.** So the trade is deliberate and one-directional: the language gives you the instruction. Edge-case IEEE conformance is not on offer, and code that needs it should compute that part in scalar `f32`, where it is already available and already fast.

That reframing is not cosmetic — it changed what the guard in this PR is *for* (see below).

## The real defect

`OpKind::eval_binary`/`eval_unary` are the differential oracle **and** the e-graph's constant folder (`pixelflow-search/src/math/algebra.rs`). Two genuine bugs followed:

1. **`Eq`/`Ne` compared with `(x - y).abs() < f32::EPSILON`** while every emitter compares exactly. `0.5` and its next representable neighbour folded to "equal" where the hardware says "not equal" — ordinary finite values, no NaN or platform difference involved. Now exact.
2. **Folding baked in the build host's arithmetic.** The folder runs at macro-expansion time on the *build host*; the constant executes on the *target*. For anything the two disagree on, folding ships the wrong value for that target. `ConstantFold` now declines those cases — and that, not conformance or optimizer consistency, is the whole justification.

## Corrections made during review

Each of these was wrong in my earlier commits and is worth reading as part of the diff:

- **"Hardware semantics" is not one answer.** aarch64 `FMIN`/`FMAX` propagate NaN where x86 yields the second operand; `FCMGT`/`FCMGE` are ordered where x86's imm8 6/5 are unordered; `FRINTA` is ties-away where `vroundps` imm 0 is nearest-even. CI's macOS leg caught this by failing `min(NaN, 1) → NaN` against an x86-shaped oracle.
- **Signed zeros are a second, non-NaN Min/Max divergence.** `min(-0.0, +0.0)` is `+0.0` on x86, `-0.0` on aarch64, observable via `1.0/x` as `±inf`. The tier-agreement test already fed this input but compared with `==`, which cannot see it — now bit-exact.
- **`Round` diverges beyond ties.** For `-0.5 ≤ x ≤ -0.0` both JIT tiers give `-0.0` while the combinator formula gives `+0.0`.
- **One revert of mine over-generalized.** I removed the fold guard entirely after a correct observation that e-graph commutativity defeats it for `Min`/`Max` — but `Round` is *unary*, so no rewrite can reintroduce that fold and the guard is a complete fix there. Both are back, with their scope stated at the guard.
- **The classification had to become value-aware.** "Is this op divergent?" was the wrong question: `min(1.0, 2.0)` folds fine, `min(-0.0, 0.0)` does not. Two predicates collapsed into one `fold_is_platform_specific(args)`.

## Contract, as landed

Agreed on every target, promised and tested: `Lt`/`Le` ordered, `Eq`/`Ne` exact, `exp`/`exp2` saturating.

Differs by target because the instructions do — do not depend on a single answer: `Min`/`Max` on NaN and on opposite-signed zeros, `Gt`/`Ge` on NaN, `Round` at a tie and on `-0.5 ≤ x ≤ -0.0`. Full table in the new CLAUDE.md section.

Also recorded there: the combinator tier's `(x + 0.5).floor()` is **not** an instance of this trade. It is two instructions where `roundps` is one, and `round(-1.5)` is `-1` there against `-2` everywhere else — slower *and* wrong. The trade justifies taking what the hardware gives, never hand-rolling something worse. Tracked separately.

## Bonus: a flake terminated

The ISA matrix from #922 runs the suite 3–4× per PR, which multiplies flake exposure — and duly failed `actor_model_tests`. Investigation showed **four** tests asserting cross-lane message ordering the scheduler never promised: each spawned the consumer before sending, so the actor was already draining and could legitimately process an early data message before a control message existed. Two even carried comments claiming they only tested the "both already queued" case without establishing it. All four deleted; FIFO-within-a-lane, delivery, and no-starvation coverage kept.

## Verification

- Differential tests pin JIT == oracle on NaN, signed zero, infinity and exact halves at whatever width the build selects; folder tests drive `ConstantFold::apply` directly rather than asserting the marker
- Workspace green; `actor_model_tests` hammered 25 consecutive runs, zero failures
- CI green on all four checks: ISA matrix (SSE2 / AVX2-no-FMA / AVX2+FMA / AVX-512), Clippy `-D warnings`, ubuntu-latest, macos-latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWyemrN5XvyS5kcXw8vYVL