### PR TITLE
feat(actor-scheduler): report a dead target instead of swallowing the payload

### DIFF
--- a/actor-scheduler/src/host.rs
+++ b/actor-scheduler/src/host.rs
@@ -74,6 +74,8 @@ where
 pub struct Host {
     nodes: Vec<Box<dyn Green>>,
     exits: Vec<Exit>,
+    /// Indices of nodes whose flush hit a gone target, in the order it happened.
+    disconnected: Vec<usize>,
 }
 
 impl Host {
@@ -98,6 +100,24 @@ impl Host {
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.nodes.is_empty()
+    }
+
+    /// Green actors that hit a gone target while flushing, in the order it happened.
+    ///
+    /// Each entry is the node's index at the time. The node is **still adopted** and its outbox
+    /// **still holds the undelivered payload**, so a supervisor can retry it, take the value
+    /// elsewhere, or drop the node deliberately. Without this the disconnection would be
+    /// invisible: [`sweep`](Host::sweep) reports `Idle` for such a node — deliberately, since
+    /// reporting `Busy` would spin the scheduler against a peer that is never coming back — and
+    /// the outer loop would then block on its doorbell with the payload stranded.
+    #[must_use]
+    pub fn disconnected(&self) -> &[usize] {
+        &self.disconnected
+    }
+
+    /// Clear the recorded disconnections, after a supervisor has dealt with them.
+    pub fn clear_disconnected(&mut self) {
+        self.disconnected.clear();
     }
 
     /// The exits of green actors that have halted, in the order they halted.
@@ -126,11 +146,19 @@ impl Host {
                 }
                 Step::Blocked | Step::Idle => i += 1,
                 // A peer is gone and the payload is retained in the node's outbox. `Host` has
-                // no supervision policy to apply — it keeps the node alive rather than
-                // dropping it, so whatever the outbox holds stays recoverable, and does not
-                // count the node as having run, so a dead peer cannot spin the sweep.
-                // Choosing retry/escalate/graceful-shutdown belongs a layer up.
-                Step::Disconnected => i += 1,
+                // no supervision policy to apply — it keeps the node alive rather than dropping
+                // it, so whatever the outbox holds stays recoverable, and does not count it as
+                // having run, so a dead peer cannot spin the sweep against a peer that is never
+                // coming back. But it must *record* the fact: choosing retry, handoff or
+                // graceful shutdown belongs a layer up, and that layer can only choose if it is
+                // told. Reported via `disconnected()`, not by the `ActorStatus` return, which
+                // has no way to say "stuck, not idle".
+                Step::Disconnected => {
+                    if !self.disconnected.contains(&i) {
+                        self.disconnected.push(i);
+                    }
+                    i += 1;
+                }
                 Step::Halted(exit) => {
                     self.exits.push(exit);
                     // `remove`, not `swap_remove`: sweep order is load-bearing, so the
@@ -333,6 +361,37 @@ mod tests {
             3,
             "one sweep should have carried the message through all three stages"
         );
+    }
+
+    #[test]
+    fn a_gone_target_is_recorded_and_the_payload_survives() {
+        // The point of `Step::Disconnected` is that a supervisor can act on it. If `Host`
+        // swallowed the signal — as an earlier revision did, treating it like `Idle` — the
+        // scheduler would go back to sleep on its doorbell with the node's payload stranded in
+        // its outbox and nothing able to observe that it happened.
+        let (tx_in, rx_in) = spsc_channel::<u32>(8);
+        let (tx_out, rx_out) = spsc_channel::<u32>(8);
+
+        let mut host = Host::new();
+        host.adopt(Node::new(
+            Forward { seen: 0 },
+            rx_in,
+            ForwardWiring { next: tx_out },
+        ));
+
+        drop(rx_out); // the *downstream* target dies, not this actor's own inbox
+        tx_in.try_send(0).unwrap();
+        host.sweep();
+
+        assert_eq!(
+            host.disconnected(),
+            &[0],
+            "a supervisor must be able to see which node hit a gone peer"
+        );
+        assert_eq!(host.len(), 1, "and the node is kept, not silently discarded");
+
+        host.clear_disconnected();
+        assert!(host.disconnected().is_empty());
     }
 
     #[test]

--- a/actor-scheduler/src/host.rs
+++ b/actor-scheduler/src/host.rs
@@ -61,15 +61,6 @@ where
     }
 }
 
-/// An OS-thread actor that owns green actors and runs them in its `park`.
-///
-/// A host has **no messages of its own**: all three lane types are [`Infallible`], so the
-/// compiler knows its handlers are unreachable and the `match msg {}` bodies below are total.
-/// Work reaches a hosted actor by being pushed straight into that actor's inbox with a
-/// [`GreenSender`], which then rings the host's doorbell. The host routes nothing; it hosts.
-///
-/// `Message::Shutdown` still stops it, because shutdown travels on the doorbell rather than a
-/// lane.
 /// Stable identity for an adopted green actor.
 ///
 /// Deliberately not a position: `Host` removes halted nodes with `Vec::remove`, so any index
@@ -117,6 +108,15 @@ pub struct Sweep {
     pub stuck: Vec<Supervision>,
 }
 
+/// An OS-thread actor that owns green actors and runs them in its `park`.
+///
+/// A host has **no messages of its own**: all three lane types are [`Infallible`], so the
+/// compiler knows its handlers are unreachable and the `match msg {}` bodies below are total.
+/// Work reaches a hosted actor by being pushed straight into that actor's inbox with a
+/// [`GreenSender`], which then rings the host's doorbell. The host routes nothing; it hosts.
+///
+/// `Message::Shutdown` still stops it, because shutdown travels on the doorbell rather than a
+/// lane.
 #[derive(Default)]
 pub struct Host {
     nodes: Vec<(NodeId, Box<dyn Green>)>,
@@ -132,10 +132,32 @@ impl Host {
     }
 
     /// Take ownership of a green actor. Sweep order is adoption order.
-    pub fn adopt(&mut self, node: impl Green + 'static) {
+    /// Returns the actor's [`NodeId`], which is how a supervisor later names it — an event
+    /// reporting an actor you cannot identify is not actionable.
+    pub fn adopt(&mut self, node: impl Green + 'static) -> NodeId {
         let id = NodeId(self.next_id);
         self.next_id += 1;
         self.nodes.push((id, Box::new(node)));
+        id
+    }
+
+    /// Stop hosting one green actor, returning whether it was found.
+    ///
+    /// The minimum a supervisor needs to act on a [`Supervision`] event. Retrying a
+    /// [`Stuck::TargetGone`] node in place only reaches the same dead sender, so the recovery
+    /// available today is to take it out — deliberately, rather than by dropping the whole host.
+    ///
+    /// The node's retained outbox goes with it. Handing that payload back to the supervisor
+    /// needs `Green` to expose more than `poll`, which is deferred until something concrete
+    /// wants it rather than guessed at now.
+    pub fn remove(&mut self, id: NodeId) -> bool {
+        // `retain`-style removal, not `swap_remove`: sweep order is adoption order and load
+        // bearing, so survivors keep their relative positions.
+        let Some(pos) = self.nodes.iter().position(|(node_id, _)| *node_id == id) else {
+            return false;
+        };
+        self.nodes.remove(pos);
+        true
     }
 
     /// How many green actors are still running.
@@ -436,6 +458,12 @@ mod tests {
         );
         assert_eq!(sweep.stuck[0].reason, Stuck::TargetGone);
         assert_eq!(host.len(), 1, "and the node is kept, not silently discarded");
+
+        // The identity has to be actionable, or reporting it is theatre: retrying in place only
+        // reaches the same dead sender, so taking the node out is the recovery available today.
+        assert!(host.remove(sweep.stuck[0].node), "the reported id names a real node");
+        assert!(host.is_empty());
+        assert!(!host.remove(sweep.stuck[0].node), "and removing it twice is not a panic");
     }
 
     #[test]

--- a/actor-scheduler/src/host.rs
+++ b/actor-scheduler/src/host.rs
@@ -70,12 +70,58 @@ where
 ///
 /// `Message::Shutdown` still stops it, because shutdown travels on the doorbell rather than a
 /// lane.
+/// Stable identity for an adopted green actor.
+///
+/// Deliberately not a position: `Host` removes halted nodes with `Vec::remove`, so any index
+/// recorded in one sweep names a *different* actor by the next. An earlier revision reported
+/// disconnections by index and had exactly that bug.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct NodeId(u64);
+
+/// Why a green actor is stuck — i.e. alive, holding work, and unable to make progress alone.
+///
+/// One variant today, deliberately. Adding reasons later is additive; inventing a family for
+/// stucks nobody has hit would be machinery ahead of need.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Stuck {
+    /// A flush target is gone. The node's outbox **still holds the undelivered payload**, so
+    /// whatever it carries is recoverable — retry it, take the value elsewhere, or drop the node
+    /// deliberately.
+    TargetGone,
+}
+
+/// A green actor needs supervision. Returned by [`Host::sweep`], never sent.
+///
+/// This is a *returned value*, not a message the host pushes through a handle it holds. Giving
+/// `Host` a supervisor handle would reintroduce exactly the coupling the transducer model
+/// exists to remove: an actor reaching out mid-step instead of describing what happened and
+/// letting its wiring decide where that goes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Supervision {
+    pub node: NodeId,
+    pub reason: Stuck,
+}
+
+/// What one [`sweep`](Host::sweep) did.
+#[derive(Debug)]
+#[must_use = "a sweep can report actors needing supervision; dropping it discards them"]
+pub struct Sweep {
+    /// `Busy` if any green actor ran, so the scheduler keeps sweeping; `Idle` when they are all
+    /// quiet and the thread may sleep.
+    pub status: ActorStatus,
+    /// Actors that are stuck. Empty on the common path.
+    ///
+    /// Returned rather than accumulated in the host, so it cannot be missed by a caller that
+    /// never thinks to ask — the previous revision stored these and exposed an accessor, which
+    /// nothing on the `sched.run(&mut host)` path could ever reach.
+    pub stuck: Vec<Supervision>,
+}
+
 #[derive(Default)]
 pub struct Host {
-    nodes: Vec<Box<dyn Green>>,
+    nodes: Vec<(NodeId, Box<dyn Green>)>,
     exits: Vec<Exit>,
-    /// Indices of nodes whose flush hit a gone target, in the order it happened.
-    disconnected: Vec<usize>,
+    next_id: u64,
 }
 
 impl Host {
@@ -87,7 +133,9 @@ impl Host {
 
     /// Take ownership of a green actor. Sweep order is adoption order.
     pub fn adopt(&mut self, node: impl Green + 'static) {
-        self.nodes.push(Box::new(node));
+        let id = NodeId(self.next_id);
+        self.next_id += 1;
+        self.nodes.push((id, Box::new(node)));
     }
 
     /// How many green actors are still running.
@@ -102,24 +150,6 @@ impl Host {
         self.nodes.is_empty()
     }
 
-    /// Green actors that hit a gone target while flushing, in the order it happened.
-    ///
-    /// Each entry is the node's index at the time. The node is **still adopted** and its outbox
-    /// **still holds the undelivered payload**, so a supervisor can retry it, take the value
-    /// elsewhere, or drop the node deliberately. Without this the disconnection would be
-    /// invisible: [`sweep`](Host::sweep) reports `Idle` for such a node — deliberately, since
-    /// reporting `Busy` would spin the scheduler against a peer that is never coming back — and
-    /// the outer loop would then block on its doorbell with the payload stranded.
-    #[must_use]
-    pub fn disconnected(&self) -> &[usize] {
-        &self.disconnected
-    }
-
-    /// Clear the recorded disconnections, after a supervisor has dealt with them.
-    pub fn clear_disconnected(&mut self) {
-        self.disconnected.clear();
-    }
-
     /// The exits of green actors that have halted, in the order they halted.
     ///
     /// A supervisor reads this to decide what to restart. The host itself has no restart
@@ -131,32 +161,33 @@ impl Host {
 
     /// Advance every green actor by at most one step, in adoption order.
     ///
-    /// Returns `Busy` if any of them ran, so the scheduler keeps sweeping without blocking;
-    /// `Idle` when they are all quiet — parked on backpressure or out of input — so the
-    /// scheduler blocks on the doorbell and the thread sleeps.
-    pub fn sweep(&mut self) -> ActorStatus {
+    /// Returns what happened, including any actors that are stuck — see [`Sweep`]. The host
+    /// *describes*; it does not act. Restart, retry and shutdown are supervision policy, and a
+    /// host that hosts should not also decide them.
+    pub fn sweep(&mut self) -> Sweep {
         let mut ran = false;
+        let mut stuck = Vec::new();
         let mut i = 0;
 
         while i < self.nodes.len() {
-            match self.nodes[i].poll() {
+            let (id, node) = &mut self.nodes[i];
+            let id = *id;
+            match node.poll() {
                 Step::Ran => {
                     ran = true;
                     i += 1;
                 }
                 Step::Blocked | Step::Idle => i += 1,
-                // A peer is gone and the payload is retained in the node's outbox. `Host` has
-                // no supervision policy to apply — it keeps the node alive rather than dropping
-                // it, so whatever the outbox holds stays recoverable, and does not count it as
-                // having run, so a dead peer cannot spin the sweep against a peer that is never
-                // coming back. But it must *record* the fact: choosing retry, handoff or
-                // graceful shutdown belongs a layer up, and that layer can only choose if it is
-                // told. Reported via `disconnected()`, not by the `ActorStatus` return, which
-                // has no way to say "stuck, not idle".
+                // A peer is gone and the payload is retained in the node's outbox. Keep the
+                // node — whatever the outbox holds stays recoverable — and do *not* count it as
+                // having run, so a dead peer cannot spin the sweep against something that is
+                // never coming back. Report it upward instead: the layer that chooses retry,
+                // handoff or graceful shutdown can only choose if it is told.
                 Step::Disconnected => {
-                    if !self.disconnected.contains(&i) {
-                        self.disconnected.push(i);
-                    }
+                    stuck.push(Supervision {
+                        node: id,
+                        reason: Stuck::TargetGone,
+                    });
                     i += 1;
                 }
                 Step::Halted(exit) => {
@@ -168,11 +199,13 @@ impl Host {
             }
         }
 
-        if ran {
+        let status = if ran {
             ActorStatus::Busy
         } else {
             ActorStatus::Idle
-        }
+        };
+
+        Sweep { status, stuck }
     }
 }
 
@@ -245,8 +278,21 @@ impl Actor<Infallible, Infallible, Infallible> for Host {
         match msg {}
     }
 
+    /// Sweeps, and **discards any supervision events**, because this signature has nowhere to
+    /// put them.
+    ///
+    /// That is the honest limit of running a `Host` through the old `Actor`/`ActorScheduler`
+    /// shell: `park` returns an `ActorStatus`, which can say "busy" or "idle" and cannot say
+    /// "one of my actors is stuck holding a payload". Callers that need supervision must drive
+    /// [`sweep`](Host::sweep) directly and read [`Sweep::stuck`].
+    ///
+    /// Closing this properly means `Host` becoming a transducer whose `Out` carries supervision
+    /// events, so its wiring delivers them like any other output and `Topology` checks that edge
+    /// — the same conversion vsync and the rasterizer already went through. Until then a `Host`
+    /// under `sched.run` is unsupervised, and this comment is the warning rather than a silent
+    /// drop.
     fn park(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
-        Ok(self.sweep())
+        Ok(self.sweep().status)
     }
 }
 
@@ -302,7 +348,7 @@ mod tests {
         ));
 
         tx_in.try_send(1).unwrap();
-        assert_eq!(host.sweep(), ActorStatus::Busy, "a green actor had work");
+        assert_eq!(host.sweep().status, ActorStatus::Busy, "a green actor had work");
         assert_eq!(rx_out.try_recv().unwrap(), 2);
     }
 
@@ -320,11 +366,11 @@ mod tests {
             ForwardWiring { next: tx_out },
         ));
 
-        assert_eq!(host.sweep(), ActorStatus::Idle, "no input, nothing ran");
+        assert_eq!(host.sweep().status, ActorStatus::Idle, "no input, nothing ran");
 
         tx_in.try_send(7).unwrap();
-        assert_eq!(host.sweep(), ActorStatus::Busy);
-        assert_eq!(host.sweep(), ActorStatus::Idle, "quiet again after draining");
+        assert_eq!(host.sweep().status, ActorStatus::Busy);
+        assert_eq!(host.sweep().status, ActorStatus::Idle, "quiet again after draining");
     }
 
     #[test]
@@ -355,7 +401,7 @@ mod tests {
         ));
 
         tx_in.try_send(0).unwrap();
-        assert_eq!(host.sweep(), ActorStatus::Busy);
+        assert_eq!(host.sweep().status, ActorStatus::Busy);
         assert_eq!(
             rx_out.try_recv().unwrap(),
             3,
@@ -381,17 +427,15 @@ mod tests {
 
         drop(rx_out); // the *downstream* target dies, not this actor's own inbox
         tx_in.try_send(0).unwrap();
-        host.sweep();
 
+        let sweep = host.sweep();
         assert_eq!(
-            host.disconnected(),
-            &[0],
-            "a supervisor must be able to see which node hit a gone peer"
+            sweep.stuck.len(),
+            1,
+            "a supervisor must be told which node hit a gone peer"
         );
+        assert_eq!(sweep.stuck[0].reason, Stuck::TargetGone);
         assert_eq!(host.len(), 1, "and the node is kept, not silently discarded");
-
-        host.clear_disconnected();
-        assert!(host.disconnected().is_empty());
     }
 
     #[test]
@@ -408,7 +452,8 @@ mod tests {
         assert_eq!(host.len(), 1);
 
         drop(tx_in); // the green actor's inbox disconnects
-        host.sweep();
+        let sweep = host.sweep(); // this test is about exits, not supervision
+        assert!(sweep.stuck.is_empty());
 
         assert!(host.is_empty(), "a halted green actor is removed");
         assert_eq!(host.exits(), &[Exit::Completed]);
@@ -444,7 +489,8 @@ mod tests {
 
         drop(tx_dead);
         tx_a.try_send(0).unwrap();
-        host.sweep();
+        let sweep = host.sweep(); // this test is about sweep order, not supervision
+        assert!(sweep.stuck.is_empty());
 
         assert_eq!(host.len(), 2);
         assert_eq!(

--- a/actor-scheduler/src/host.rs
+++ b/actor-scheduler/src/host.rs
@@ -125,6 +125,12 @@ impl Host {
                     i += 1;
                 }
                 Step::Blocked | Step::Idle => i += 1,
+                // A peer is gone and the payload is retained in the node's outbox. `Host` has
+                // no supervision policy to apply — it keeps the node alive rather than
+                // dropping it, so whatever the outbox holds stays recoverable, and does not
+                // count the node as having run, so a dead peer cannot spin the sweep.
+                // Choosing retry/escalate/graceful-shutdown belongs a layer up.
+                Step::Disconnected => i += 1,
                 Step::Halted(exit) => {
                     self.exits.push(exit);
                     // `remove`, not `swap_remove`: sweep order is load-bearing, so the

--- a/actor-scheduler/src/host.rs
+++ b/actor-scheduler/src/host.rs
@@ -94,18 +94,24 @@ pub struct Supervision {
 }
 
 /// What one [`sweep`](Host::sweep) did.
+///
+/// Borrows the host for as long as it is held, because the buffer behind `stuck` belongs to the
+/// host and is reused across sweeps — a sweep on a hot path must not allocate. Read what you
+/// need out of it ([`Supervision`] is `Copy`) and let it go before acting on the host.
 #[derive(Debug)]
 #[must_use = "a sweep can report actors needing supervision; dropping it discards them"]
-pub struct Sweep {
+pub struct Sweep<'a> {
     /// `Busy` if any green actor ran, so the scheduler keeps sweeping; `Idle` when they are all
     /// quiet and the thread may sleep.
     pub status: ActorStatus,
     /// Actors that are stuck. Empty on the common path.
     ///
-    /// Returned rather than accumulated in the host, so it cannot be missed by a caller that
-    /// never thinks to ask — the previous revision stored these and exposed an accessor, which
-    /// nothing on the `sched.run(&mut host)` path could ever reach.
-    pub stuck: Vec<Supervision>,
+    /// Handed back from each sweep rather than accumulated behind an accessor, so it cannot be
+    /// missed by a caller that never thinks to ask — the previous revision stored these and
+    /// exposed a getter, which nothing on the `sched.run(&mut host)` path could ever reach. The
+    /// slice is only valid until the next sweep, which is the same window in which acting on it
+    /// makes sense.
+    pub stuck: &'a [Supervision],
 }
 
 /// An OS-thread actor that owns green actors and runs them in its `park`.
@@ -122,6 +128,10 @@ pub struct Host {
     nodes: Vec<(NodeId, Box<dyn Green>)>,
     exits: Vec<Exit>,
     next_id: u64,
+    /// Scratch for [`sweep`](Host::sweep), cleared and refilled each call. A sweep runs whenever
+    /// the thread has work, so building this fresh each time would allocate on the hot path for
+    /// a buffer that is empty almost every sweep and never grows past the node count.
+    stuck: Vec<Supervision>,
 }
 
 impl Host {
@@ -186,15 +196,18 @@ impl Host {
     /// Returns what happened, including any actors that are stuck — see [`Sweep`]. The host
     /// *describes*; it does not act. Restart, retry and shutdown are supervision policy, and a
     /// host that hosts should not also decide them.
-    pub fn sweep(&mut self) -> Sweep {
+    pub fn sweep(&mut self) -> Sweep<'_> {
         let mut ran = false;
-        let mut stuck = Vec::new();
+        self.stuck.clear();
         let mut i = 0;
 
         while i < self.nodes.len() {
             let (id, node) = &mut self.nodes[i];
             let id = *id;
-            match node.poll() {
+            // Poll before the match so the borrow of `self.nodes` ends here and the arms below
+            // are free to touch `self.stuck` and `self.exits`.
+            let step = node.poll();
+            match step {
                 Step::Ran => {
                     ran = true;
                     i += 1;
@@ -206,7 +219,7 @@ impl Host {
                 // never coming back. Report it upward instead: the layer that chooses retry,
                 // handoff or graceful shutdown can only choose if it is told.
                 Step::Disconnected => {
-                    stuck.push(Supervision {
+                    self.stuck.push(Supervision {
                         node: id,
                         reason: Stuck::TargetGone,
                     });
@@ -227,7 +240,10 @@ impl Host {
             ActorStatus::Idle
         };
 
-        Sweep { status, stuck }
+        Sweep {
+            status,
+            stuck: &self.stuck,
+        }
     }
 }
 
@@ -450,20 +466,57 @@ mod tests {
         drop(rx_out); // the *downstream* target dies, not this actor's own inbox
         tx_in.try_send(0).unwrap();
 
-        let sweep = host.sweep();
-        assert_eq!(
-            sweep.stuck.len(),
-            1,
-            "a supervisor must be told which node hit a gone peer"
-        );
-        assert_eq!(sweep.stuck[0].reason, Stuck::TargetGone);
+        let reported = {
+            let sweep = host.sweep();
+            assert_eq!(
+                sweep.stuck.len(),
+                1,
+                "a supervisor must be told which node hit a gone peer"
+            );
+            assert_eq!(sweep.stuck[0].reason, Stuck::TargetGone);
+            sweep.stuck[0]
+        };
         assert_eq!(host.len(), 1, "and the node is kept, not silently discarded");
 
         // The identity has to be actionable, or reporting it is theatre: retrying in place only
         // reaches the same dead sender, so taking the node out is the recovery available today.
-        assert!(host.remove(sweep.stuck[0].node), "the reported id names a real node");
+        assert!(host.remove(reported.node), "the reported id names a real node");
         assert!(host.is_empty());
-        assert!(!host.remove(sweep.stuck[0].node), "and removing it twice is not a panic");
+        assert!(!host.remove(reported.node), "and removing it twice is not a panic");
+    }
+
+    #[test]
+    fn each_sweep_reports_only_its_own_stuck_actors() {
+        // The failure mode introduced by reusing one buffer across sweeps: forget to clear it
+        // and a supervisor that removed a node keeps being told about it forever, or a
+        // recovered node stays reported. `stuck` describes *this* sweep, not the history.
+        let (tx_in, rx_in) = spsc_channel::<u32>(8);
+        let (tx_out, rx_out) = spsc_channel::<u32>(8);
+
+        let mut host = Host::new();
+        host.adopt(Node::new(
+            Forward { seen: 0 },
+            rx_in,
+            ForwardWiring { next: tx_out },
+        ));
+
+        drop(rx_out);
+        tx_in.try_send(0).unwrap();
+        let stuck = {
+            let sweep = host.sweep();
+            assert_eq!(sweep.stuck.len(), 1);
+            sweep.stuck[0].node
+        };
+
+        // A sweep *does* keep re-reporting a node that is still stuck — the retained outbox is
+        // re-flushed and hits the same dead sender. What must not survive is the report of a
+        // node the supervisor has already dealt with.
+        assert_eq!(host.sweep().stuck.len(), 1, "still stuck, still reported");
+        assert!(host.remove(stuck));
+        assert!(
+            host.sweep().stuck.is_empty(),
+            "the supervised node is gone; the sweep must not re-report it from the last one"
+        );
     }
 
     #[test]
@@ -480,8 +533,7 @@ mod tests {
         assert_eq!(host.len(), 1);
 
         drop(tx_in); // the green actor's inbox disconnects
-        let sweep = host.sweep(); // this test is about exits, not supervision
-        assert!(sweep.stuck.is_empty());
+        assert!(host.sweep().stuck.is_empty(), "a halt is not a stuck actor");
 
         assert!(host.is_empty(), "a halted green actor is removed");
         assert_eq!(host.exits(), &[Exit::Completed]);
@@ -517,8 +569,7 @@ mod tests {
 
         drop(tx_dead);
         tx_a.try_send(0).unwrap();
-        let sweep = host.sweep(); // this test is about sweep order, not supervision
-        assert!(sweep.stuck.is_empty());
+        assert!(host.sweep().stuck.is_empty(), "a halt is not a stuck actor");
 
         assert_eq!(host.len(), 2);
         assert_eq!(

--- a/actor-scheduler/src/mealy.rs
+++ b/actor-scheduler/src/mealy.rs
@@ -129,6 +129,18 @@ pub enum Flush {
     /// At least one port could not be delivered (target full). The undelivered ports are
     /// still set in the output word, which the [`Node`] keeps as its parked outbox.
     Blocked,
+    /// At least one target is **gone**. Like [`Blocked`](Flush::Blocked), the undelivered ports
+    /// are **retained** in the output word — that is the load-bearing half of this variant.
+    ///
+    /// Previously a disconnected target was reported as [`Done`](Flush::Done), which consumed
+    /// the message. For a port carrying a moved resource — the render pipeline's sole frame
+    /// buffer, say — that silently destroyed it, and left the sender believing it had been
+    /// delivered. Retaining the payload keeps every recovery open: retry, hand off, escalate,
+    /// or shut down gracefully with the resource still in hand.
+    ///
+    /// This variant deliberately carries no policy. What to do about a dead peer is the
+    /// supervisor's call, not the port's; see [`Step::Disconnected`].
+    Disconnected,
 }
 
 /// Where an actor's output ports go.
@@ -174,7 +186,13 @@ pub fn send_port<T>(port: &mut Option<T>, tx: &SpscSender<T>, delivery: Delivery
         return Flush::Done;
     };
     match (tx.try_send(msg), delivery) {
-        (Ok(()), _) | (Err(TrySendError::Disconnected(_)), _) => Flush::Done,
+        (Ok(()), _) => Flush::Done,
+        // The target is gone. Put the message back rather than dropping it: for a port carrying
+        // a moved resource, dropping here destroys it with nobody having decided to.
+        (Err(TrySendError::Disconnected(msg)), _) => {
+            *port = Some(msg);
+            Flush::Disconnected
+        }
         (Err(TrySendError::Full(_)), Delivery::Droppable) => Flush::Done,
         (Err(TrySendError::Full(msg)), Delivery::Blocking) => {
             *port = Some(msg);
@@ -183,15 +201,20 @@ pub fn send_port<T>(port: &mut Option<T>, tx: &SpscSender<T>, delivery: Delivery
     }
 }
 
-/// Combine port outcomes: blocked if any port is blocked.
+/// Combine port outcomes. `Disconnected` outranks `Blocked` outranks `Done` — a dead peer is
+/// news the caller needs even if another port merely filled up, and it does not resolve by
+/// waiting the way backpressure does.
 #[must_use]
 pub fn all(outcomes: impl IntoIterator<Item = Flush>) -> Flush {
+    let mut worst = Flush::Done;
     for outcome in outcomes {
-        if outcome == Flush::Blocked {
-            return Flush::Blocked;
+        match outcome {
+            Flush::Disconnected => return Flush::Disconnected,
+            Flush::Blocked => worst = Flush::Blocked,
+            Flush::Done => {}
         }
     }
-    Flush::Done
+    worst
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -210,6 +233,15 @@ pub enum Step {
     Idle,
     /// Terminal. The actor is done and should be removed (and possibly restarted).
     Halted(Exit),
+    /// A target is gone. The outbox **still holds the undelivered ports**, so whatever they
+    /// carry is recoverable.
+    ///
+    /// Distinct from [`Blocked`](Step::Blocked) because backpressure resolves by waiting and
+    /// this does not — retrying a dead peer forever is a hang, and dropping the payload is data
+    /// loss. Surfaced rather than handled here on purpose: retry, escalate, or shut down
+    /// gracefully is a supervision decision, and the caller can make any of them because the
+    /// resource is still in hand.
+    Disconnected,
 }
 
 /// Pulling one input symbol. Implemented for the SPSC receiver; a trait so tests can drive a
@@ -403,8 +435,10 @@ where
     ///    never reaches [`Wiring`] and so the slot is empty at the moment it is written.
     pub fn poll(&mut self) -> Step {
         if let Some(pending) = &mut self.outbox {
-            if self.wiring.flush(pending) == Flush::Blocked {
-                return Step::Blocked;
+            match self.wiring.flush(pending) {
+                Flush::Blocked => return Step::Blocked,
+                Flush::Disconnected => return Step::Disconnected,
+                Flush::Done => {}
             }
             self.outbox = None;
         }
@@ -527,8 +561,16 @@ where
         // The slot was emptied before dispatch runs, so this write can never overflow.
         self.continuation = T::take_continuation(&mut out);
 
-        if self.wiring.flush(&mut out) == Flush::Blocked {
-            self.outbox = Some(out);
+        match self.wiring.flush(&mut out) {
+            Flush::Blocked => {
+                self.outbox = Some(out);
+            }
+            Flush::Disconnected => {
+                // Retained, not dropped — the payload is still in `out`.
+                self.outbox = Some(out);
+                return Step::Disconnected;
+            }
+            Flush::Done => {}
         }
 
         Step::Ran
@@ -1053,13 +1095,39 @@ mod tests {
     }
 
     #[test]
-    fn a_droppable_port_to_a_dead_target_is_still_done() {
-        let (tx, rx) = spsc_channel::<Render>(4);
-        drop(rx);
+    fn a_port_to_a_dead_target_reports_it_and_keeps_the_payload() {
+        // This previously asserted `Flush::Done` with the payload consumed — a dead peer was
+        // indistinguishable from a successful send. For a port carrying a moved resource that
+        // silently destroyed it while the sender believed it had been delivered. Retention is
+        // the point of the variant; the caller can still retry, hand off, or shut down with the
+        // value in hand.
+        for delivery in [Delivery::Droppable, Delivery::Blocking] {
+            let (tx, rx) = spsc_channel::<Render>(4);
+            drop(rx);
 
-        let mut port = Some(Render(1));
-        assert_eq!(send_port(&mut port, &tx, Delivery::Droppable), Flush::Done);
-        assert!(port.is_none());
+            let mut port = Some(Render(1));
+            assert_eq!(
+                send_port(&mut port, &tx, delivery),
+                Flush::Disconnected,
+                "a gone target is reported, not silently swallowed ({delivery:?})"
+            );
+            assert!(
+                port.is_some(),
+                "and the payload stays recoverable ({delivery:?})"
+            );
+        }
+    }
+
+    #[test]
+    fn disconnected_outranks_blocked_when_combining_outcomes() {
+        // Backpressure resolves by waiting; a dead peer does not. If both happen in one flush
+        // the caller needs to hear the one that won't fix itself.
+        assert_eq!(
+            all([Flush::Done, Flush::Blocked, Flush::Disconnected]),
+            Flush::Disconnected
+        );
+        assert_eq!(all([Flush::Done, Flush::Blocked]), Flush::Blocked);
+        assert_eq!(all([Flush::Done, Flush::Done]), Flush::Done);
     }
 
     // ── Credit: a request/response edge bounded without a new port kind ─────

--- a/actor-scheduler/src/mealy.rs
+++ b/actor-scheduler/src/mealy.rs
@@ -178,9 +178,20 @@ pub enum Delivery {
 
 /// Deliver one port according to `delivery`.
 ///
-/// The building block every generated `Wiring::flush` is made of. A disconnected target
-/// drops the message and reports success either way — the target is gone, so there is
-/// nothing to wait for, and blocking forever on a dead consumer would deadlock the sender.
+/// The building block every generated `Wiring::flush` is made of.
+///
+/// Outcomes:
+/// - **Delivered**, or the port was empty → [`Flush::Done`].
+/// - **Target full**, [`Delivery::Droppable`] → the message is discarded, [`Flush::Done`].
+///   Silence on a full ring is the whole point of that delivery kind, and also its whole risk.
+/// - **Target full**, [`Delivery::Blocking`] → the message is put back in `port`,
+///   [`Flush::Blocked`]. Retry when the ring drains.
+/// - **Target gone** (either delivery kind) → the message is **put back in `port`**,
+///   [`Flush::Disconnected`]. It is deliberately *not* dropped: for a port carrying a moved
+///   resource, dropping here would destroy it with nobody having decided to, while the sender
+///   believed it was delivered. Blocking forever on a dead consumer would deadlock, so this
+///   reports rather than parks — the caller decides whether to retry, hand off, or shut down,
+///   and can do any of them because the value is still in hand.
 pub fn send_port<T>(port: &mut Option<T>, tx: &SpscSender<T>, delivery: Delivery) -> Flush {
     let Some(msg) = port.take() else {
         return Flush::Done;
@@ -204,15 +215,21 @@ pub fn send_port<T>(port: &mut Option<T>, tx: &SpscSender<T>, delivery: Delivery
 /// Combine port outcomes. `Disconnected` outranks `Blocked` outranks `Done` — a dead peer is
 /// news the caller needs even if another port merely filled up, and it does not resolve by
 /// waiting the way backpressure does.
+///
+/// **Consumes the iterator fully; never short-circuits.** A hand-written `Wiring::flush` may
+/// pass a lazy iterator of [`send_port`] calls, so returning early would skip the sends that
+/// hadn't been evaluated yet. Since a disconnected port stays set in the outbox and is retried
+/// from the front every time, those later ports would be starved permanently — which is exactly
+/// the independent-port partial flush this module promises.
 #[must_use]
 pub fn all(outcomes: impl IntoIterator<Item = Flush>) -> Flush {
     let mut worst = Flush::Done;
     for outcome in outcomes {
-        match outcome {
-            Flush::Disconnected => return Flush::Disconnected,
-            Flush::Blocked => worst = Flush::Blocked,
-            Flush::Done => {}
-        }
+        worst = match (worst, outcome) {
+            (Flush::Disconnected, _) | (_, Flush::Disconnected) => Flush::Disconnected,
+            (Flush::Blocked, _) | (_, Flush::Blocked) => Flush::Blocked,
+            (Flush::Done, Flush::Done) => Flush::Done,
+        };
     }
     worst
 }

--- a/core-term/tests/actor_roundtrip_tests.rs
+++ b/core-term/tests/actor_roundtrip_tests.rs
@@ -506,6 +506,18 @@ fn terminal_app_roundtrip_priority_ordering() {
     let keypress_clone = keypress_count.clone();
     let frame_clone = frame_count.clone();
 
+    // Enqueue all three *before* anything is draining them. Priority selection can only be
+    // observed among messages the actor has to choose between; sending while it is already
+    // running tests arrival order instead, and the actor is then free to handle the keypress
+    // before the resize has even been sent. That is what this test used to do, and it lost the
+    // race on CI — `x` arrived where `RESIZE:800x600` was asserted.
+    tx.send(Message::Data(TestEngineData::FrameRequest))
+        .unwrap();
+    tx.send(Message::Management(TestEngineManagement::KeyPress('x')))
+        .unwrap();
+    tx.send(Message::Control(TestEngineControl::Resize(800, 600)))
+        .unwrap();
+
     let handle = thread::spawn(move || {
         let mut actor = TestTerminalAppActor {
             pty_output_tx: pty_tx,
@@ -516,30 +528,20 @@ fn terminal_app_roundtrip_priority_ordering() {
         rx.run(&mut actor);
     });
 
-    // Send in reverse priority order
-    tx.send(Message::Data(TestEngineData::FrameRequest))
-        .unwrap();
-    tx.send(Message::Management(TestEngineManagement::KeyPress('x')))
-        .unwrap();
-    tx.send(Message::Control(TestEngineControl::Resize(800, 600)))
-        .unwrap();
+    // Control before Management, whatever order they were sent in. Blocking on the output is
+    // the synchronisation — no sleep to be too short on a loaded runner.
+    let first = pty_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+    assert_eq!(first, b"RESIZE:800x600");
+    let second = pty_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+    assert_eq!(second, vec![b'x']);
 
-    thread::sleep(Duration::from_millis(100));
     drop(tx);
     handle.join().unwrap();
 
-    // Verify all processed
+    // Every lane ran, including Data, which emits nothing to the pty.
     assert_eq!(resize_count.load(Ordering::SeqCst), 1);
     assert_eq!(keypress_count.load(Ordering::SeqCst), 1);
     assert_eq!(frame_count.load(Ordering::SeqCst), 1);
-
-    // Control should be processed first (resize)
-    let first = pty_rx.recv_timeout(Duration::from_millis(100)).unwrap();
-    assert_eq!(first, b"RESIZE:800x600");
-
-    // Then management (keypress)
-    let second = pty_rx.recv_timeout(Duration::from_millis(100)).unwrap();
-    assert_eq!(second, vec![b'x']);
 }
 
 // =============================================================================

--- a/docs/designs/pixelflow-runtime-engine-mesh-migration.md
+++ b/docs/designs/pixelflow-runtime-engine-mesh-migration.md
@@ -44,7 +44,7 @@ not by re-reading it), and only then touch a live actor.
 | Render request | engine → rasterizer | **Credit(1) + Droppable backstop** | Mirrors the window-return case: `pending_render` tracks exactly one outstanding render, so ring capacity ≥ 1 makes the backstop unreachable by construction. |
 | Render complete | rasterizer → engine | **Credit(1) + Droppable backstop** (same credit as above; it's the reply half) | Same reasoning as `PresentComplete`. If this bound is ever wrong (more than 1 outstanding), the failure mode changes from "spin-forever under adversarial timing" (today) to "one dropped frame, `pending_render` never clears, next resize/vsync recovers" — recorded as an explicit design trade-off, not an oversight. |
 | Frame request (`RequestFrame`) | engine → app | **Credit(N) + Droppable backstop** | N-outstanding-requests bound; a dropped request is recovered by the next vsync tick. |
-| Manifold submission (`AppData::RenderSurface`) | app → engine | **Droppable, no credit needed** | Losing one submission is fine — another follows. But the receiver **keeps its `pending_manifold` slot and overwrites it**: a droppable port discards the *newest* message, which is the opposite of keep-latest, so the port cannot be the staleness policy. An earlier revision said it could and had the field deleted. |
+| Manifold submission (`AppData::RenderSurface`) | app → engine | **Blocking** — *revised* | Two earlier revisions got this wrong. It is not droppable-because-another-follows: if the app's *last* state change is the dropped one, none follows, and the coordinator renders a stale kernel forever. Nor does keeping the receiver's slot fix it — a dropped message never reaches the slot to overwrite it. An app parking behind a busy coordinator is correct backpressure. The receiver **still keeps its `pending_manifold` slot** (overwritten on arrival), since a droppable port discards the *newest* message and so can never be the staleness policy. |
 
 Every reply edge above is the closing edge of a cycle; every one is legal under the DAG rule
 (§3.1 of the Mealy doc) specifically because it's Droppable, whether or not `Credit` additionally
@@ -433,11 +433,6 @@ checked:
   nothing outside can observe the record while it is running. Needs a real notification path
   (callback, channel, or an `ActorStatus` that can say "stuck, not idle"); that is a supervision
   API decision, not a mechanical one.
-- **Manifold submission delivery.** Keeping the receiver's slot does not help if the *newest*
-  submission is dropped in transit — nothing arrives to overwrite it, and the coordinator renders
-  a stale kernel indefinitely if the app has nothing further to send. Wants `Blocking` (an app
-  parking behind a busy coordinator is correct backpressure, and `ActorHandle`'s backoff
-  effectively does this today) rather than plain `Droppable`.
 - **Credit-bearing replies that can be dropped.** `ReturnToken` releases vsync's tick budget; if
   its edge can lose messages, the budget shrinks permanently. Same shape as the paste deadlock
   in §3.2 — worth checking every credit whose release travels a droppable edge.

--- a/docs/designs/pixelflow-runtime-engine-mesh-migration.md
+++ b/docs/designs/pixelflow-runtime-engine-mesh-migration.md
@@ -34,15 +34,15 @@ not by re-reading it), and only then touch a live actor.
 |------|-----------|------|-----|
 | Input + window-lifecycle events (`DisplayEvent` minus `PasteData`: key, mouse, scroll, focus, resize, close, scale, window created/destroyed, clipboard-data-requested) | driver → engine | **Blocking** | Discrete, non-idempotent events. None may be lost, and none coalesce with another. |
 | `Present` | engine → driver | **Credit(1) + Droppable backstop** | Not a judgment call this doc is inventing: `DisplayData::Present`'s own doc comment already specifies the receiver's contract as "3. NOT block the sender (use backpressure if buffer full)". The original table lumped it into a generic "commands, never lose" bucket and missed that the code already disagrees. Exactly one window is ever in flight (the ping-pong buffer), so this is the *same* structurally-unreachable shape as the row below, not a new risk. |
-| `PresentComplete` (window return) | driver → engine | **Credit(1) + Droppable backstop** | The reply half of `Present`, sharing its credit. Exactly one window is ever in flight, so the reply ring's capacity is provisioned ≥ 1 and can **never actually be full** when the reply lands — the droppable backstop exists for `Topology`'s proof, but is unreachable by construction, not merely rare. Not the same case as a true "acceptable loss" droppable edge (§9.2) — safe only because the credit bound is airtight. |
-| `SetTitle` / `SetSize` / `SetCursor` / `Copy` | engine → driver | **Droppable, no credit needed** | Idempotent, "latest write wins" state — the exact shape already handled for `pending_manifold` below. Two queued `SetTitle`s only ever needed the second one anyway. |
+| `PresentComplete` (window return) | driver → engine | **Credit(1) + Droppable backstop** | The reply half of `Present`, sharing its credit. Exactly one window is ever in flight, so the reply ring's capacity is provisioned ≥ 1 and can **never actually be full** when the reply lands — the droppable backstop exists for `Topology`'s proof, but is unreachable by construction, not merely rare. Not the same case as a true "acceptable loss" droppable edge (§9.2 of the Mealy doc) — safe only because the credit bound is airtight. |
+| `SetTitle` / `SetSize` / `SetCursor` / `Copy` | engine → driver | **Droppable — flagged, see Known-unsettled** | What the code does today, *not* an endorsement. This row used to justify itself as "latest write wins, the same shape as `pending_manifold`" — and that precedent has since gone the other way: manifold submission is `Blocking` precisely because a dropped *final* update has nothing following it. These have identical shape at lower stakes (a wrong title, not a wrong screen), so they are recorded as unresolved rather than grandfathered on an argument this table no longer accepts. |
 | `RequestPaste` | engine → driver | **Droppable, no credit** — *revised, see §3.2* | Originally planned as Credit(1); that would deadlock paste permanently. |
 | `PasteData` (reply to `RequestPaste`) | driver → engine | **Droppable, no credit** — *revised, see §3.2* | The reply is not merely losable, it is *routinely absent*: pasting from an empty clipboard produces no reply at all, by design. A credit released only by the reply would never come back. |
 | `Create` (window creation) | engine → driver | **Not part of the steady-state graph — see §3.1** | One-shot bootstrap per window, not a member of the continuously-live mesh at all. |
 | VSync tick | vsync → engine | **Credit(100) + Droppable backstop** | Direct replacement for `VSYNC_TOKEN_BUCKET`. A dropped tick under a bug is a missed/late frame, genuinely tolerable — this *is* an ordinary acceptable-loss droppable edge, unlike the row above. |
 | Frame-rendered notice (`RenderedResponse`, FPS tracking only) | engine → vsync | **Droppable, no credit needed** | Pure telemetry. Losing a sample changes nothing but a displayed FPS number. |
-| Render request | engine → rasterizer | **Credit(1) + Droppable backstop** | Mirrors the window-return case: `pending_render` tracks exactly one outstanding render, so ring capacity ≥ 1 makes the backstop unreachable by construction. |
-| Render complete | rasterizer → engine | **Credit(1) + Droppable backstop** (same credit as above; it's the reply half) | Same reasoning as `PresentComplete`. If this bound is ever wrong (more than 1 outstanding), the failure mode changes from "spin-forever under adversarial timing" (today) to "one dropped frame, `pending_render` never clears, next resize/vsync recovers" — recorded as an explicit design trade-off, not an oversight. |
+| Render request | engine → rasterizer | **Credit(1) + Droppable backstop** | Mirrors the window-return case: the edge carries exactly one outstanding render, so ring capacity ≥ 1 makes the backstop unreachable by construction. (`pending_render` was the field tracking that when this row was written; it is now a real `Credit` — §7.1.) |
+| Render complete | rasterizer → engine | **Credit(1) + Droppable backstop** (same credit as above; it's the reply half) | Same reasoning as `PresentComplete`. If this bound is ever wrong (more than 1 outstanding), the failure mode changes from "spin-forever under adversarial timing" (today) to "one dropped frame, the credit never returns, next resize/vsync recovers" — recorded as an explicit design trade-off, not an oversight. |
 | Frame request (`RequestFrame`) | engine → app | **Credit(N) + Droppable backstop** | N-outstanding-requests bound; a dropped request is recovered by the next vsync tick. |
 | Manifold submission (`AppData::RenderSurface`) | app → engine | **Blocking** — *revised* | Two earlier revisions got this wrong. It is not droppable-because-another-follows: if the app's *last* state change is the dropped one, none follows, and the coordinator renders a stale kernel forever. Nor does keeping the receiver's slot fix it — a dropped message never reaches the slot to overwrite it. An app parking behind a busy coordinator is correct backpressure. The receiver **still keeps its `pending_manifold` slot** (overwritten on arrival), since a droppable port discards the *newest* message and so can never be the staleness policy. |
 
@@ -65,7 +65,7 @@ later. Manifold submission is `Blocking` for exactly this reason; the `engine �
 pushes have the same shape at lower stakes and are flagged in Known-unsettled rather than quietly
 grandfathered.
 
-Conflating these two would be exactly the mistake §9.2 warned against.
+Conflating these two would be exactly the mistake the Mealy doc's §9.2 warned against.
 
 ### 3.1 driver ↔ engine: resolved by decomposing, not by picking an excuse
 
@@ -156,8 +156,7 @@ lost.
   `Send`-bounded migratable-pool exception the Mealy doc's §5.2 carved out, not the owned-green
   default.
 - **engine**: ceases to exist as a distinct actor. `EngineHandler` today isn't a pure router —
-  it holds real coordination state (`window`, `pending_render`, `pending_manifold`,
-  `frame_number`) and makes real decisions (stale-render discarding, catch-up rendering).
+  it holds real coordination state (`window`, `pending_manifold`, `frame_number`) and makes real decisions (stale-render discarding, catch-up rendering).
   Deleting it means that state and logic goes *somewhere*: split across the actor that
   naturally owns each piece (driver already owns window lifecycle; app already owns the
   manifold it produces), or a new, deliberately small coordinator that does only the glue

--- a/docs/designs/pixelflow-runtime-engine-mesh-migration.md
+++ b/docs/designs/pixelflow-runtime-engine-mesh-migration.md
@@ -371,6 +371,38 @@ display, and the bug is invisible on a 1:1 monitor. It stays in `pixelflow-runti
 coordinate mapping, not general rasterization (`CLAUDE.md` — no terminal-adjacent logic in the
 graphics crate). Worth a test at a non-1:1 logical/frame ratio, which nothing currently covers.
 
+### Nothing is decided before it's drawn
+
+Two decisions that between them delete most of the machinery earlier drafts of this section
+accumulated. Both are the same move — don't commit early and then validate, derive at the moment
+of use — which is the engine's own principle applied to its coordination.
+
+**The coordinator holds the latest kernel, not a queued frame.** A tick or a new kernel arriving
+with no buffer available does nothing but overwrite the slot. When a buffer comes back, whatever
+kernel is current *then* is what gets rasterised. Because kernels are lazy, "render later" and
+"render the current frame" are the same operation — there is no stale pixel data to detect,
+because there are no pixels until something samples. Frame skipping falls out for free: falling
+behind means fewer rasterisations, each of the then-current kernel, which is exactly the
+drop-and-catch-up behaviour, with no skip logic anywhere.
+
+**The kernel is bound to the frame at draw time.** The sampling `Lattice`'s extent comes from the
+buffer being filled, and the point→pixel warp is derived from that same buffer — so the buffer
+carries its own logical extent, and the contramap is a pure function of the thing you were
+handed:
+
+```rust
+let sx = frame.logical_w / frame.width as f32;   // everything from the buffer itself
+At { inner: kernel, x: X * sx, y: Y * sy, z: Z, w: W }
+```
+
+**Therefore there is no such thing as a wrong-sized frame.** The kernel was warped to *that*
+buffer, so blitting it is always correct for the buffer it was drawn into. A resize means the
+next buffer carries different numbers and the kernel adapts on the next rasterisation. **The
+driver stays dumb: it blits what arrives.** No size check, no discard, no pending dimensions.
+
+What this deletes, rather than solves: stale-render detection, generation stamping, driver-side
+resize bookkeeping, and the size comparison that would otherwise have to live in the driver.
+
 ### The judgment calls
 
 `Topology` proves acyclicity. It cannot tell you what may be lost — that's per-edge judgment, and
@@ -395,21 +427,20 @@ it's the reason this doc exists at all:
 Recorded so they aren't mistaken for solved. Each needs to be answered in code, where it can be
 checked:
 
-- **Lane separation.** Requests and `Present` share a `rasterizer → driver` direction; if they
-  share a ring, queued retries can force a `Present` drop. `Topology` doesn't model lanes, so
-  nothing currently checks this.
-- **Disconnected receivers.** `send_port` treats `Disconnected` as success and drops the payload
-  regardless of delivery kind — so a coordinator restart can destroy the buffer. Ring capacity
-  arguments don't cover this; it needs a stated terminal-failure policy.
+- **Supervision of a disconnected peer.** `send_port` now reports `Flush::Disconnected` and
+  retains the payload rather than destroying it, and `Node` surfaces `Step::Disconnected` — but
+  `Host` runs under `sched.run(&mut host)`, which holds the borrow and blocks on the doorbell, so
+  nothing outside can observe the record while it is running. Needs a real notification path
+  (callback, channel, or an `ActorStatus` that can say "stuck, not idle"); that is a supervision
+  API decision, not a mechanical one.
+- **Manifold submission delivery.** Keeping the receiver's slot does not help if the *newest*
+  submission is dropped in transit — nothing arrives to overwrite it, and the coordinator renders
+  a stale kernel indefinitely if the app has nothing further to send. Wants `Blocking` (an app
+  parking behind a busy coordinator is correct backpressure, and `ActorHandle`'s backoff
+  effectively does this today) rather than plain `Droppable`.
 - **Credit-bearing replies that can be dropped.** `ReturnToken` releases vsync's tick budget; if
   its edge can lose messages, the budget shrinks permanently. Same shape as the paste deadlock
   in §3.2 — worth checking every credit whose release travels a droppable edge.
-- **Stale-return protocol under pull.** §7.2 has the *coordinator* detect a stale render by
-  comparing against the current window — but under pull the coordinator never learns dimensions,
-  and the driver alone knows a resize is pending. Nothing yet defines how the driver rejects the
-  old-size frame, swaps the buffer, and triggers a new grant. §7.2 is superseded on this point
-  and the replacement is unwritten; the generation stamping in `EngineHandler` is the closest
-  existing mechanism.
 - **Zero-copy.** Tracked separately; the copy in both backends is a defect, not the target.
 
 ### Out of scope here

--- a/docs/designs/pixelflow-runtime-engine-mesh-migration.md
+++ b/docs/designs/pixelflow-runtime-engine-mesh-migration.md
@@ -23,7 +23,8 @@ This is production code driving a real, running terminal renderer, not a prototy
 (§9) found four real bidirectional cycles held together today by an untyped global atomic and a
 hand-rolled `stale` flag. Reclassifying each edge is a per-edge *judgment call* about what may be
 lost — the audit was explicit that the type system cannot make this call automatically
-(`PresentComplete` dropped is catastrophic; `SetTitle` dropped is nothing, since another follows). Getting one of these wrong is worse than the status quo, not better.
+(`PresentComplete` dropped is catastrophic; a dropped vsync tick is nothing, because the clock
+emits another). Getting one of these wrong is worse than the status quo, not better.
 So: classify every edge on paper first, prove the resulting graph is actually a DAG (mechanically,
 not by re-reading it), and only then touch a live actor.
 
@@ -52,10 +53,17 @@ makes that backstop unreachable by construction. **Two different reasons an edge
 
 - **Structurally unreachable** (window return, render complete): the credit bound is airtight,
   so the drop path is dead code in the well-behaved system and only fires on an actual bug.
-- **Genuinely acceptable loss** (vsync tick, FPS notice, idempotent state pushes): dropping is a
-  normal, expected outcome, not a bug symptom. Manifold submission looks like it belongs here and
-  does not — see its row: if the app's *last* submission is the dropped one, nothing follows to
-  correct it.
+- **Genuinely acceptable loss** (vsync tick, FPS notice): dropping is a normal, expected
+  outcome, not a bug symptom.
+
+**The line between them is not "is this message important" — it is *does something else regenerate
+it*.** Periodic traffic is safe because a clock or a sampler emits the next one regardless. *Edge
+triggered* state is not, however idempotent it looks: `SetTitle`, `SetSize`, `SetCursor`, `Copy`
+and manifold submission all fire on a change, so if the *last* one is dropped nothing follows to
+correct it and the stale value stands indefinitely. "Latest wins" only helps when there is a
+later. Manifold submission is `Blocking` for exactly this reason; the `engine → driver` state
+pushes have the same shape at lower stakes and are flagged in Known-unsettled rather than quietly
+grandfathered.
 
 Conflating these two would be exactly the mistake §9.2 warned against.
 
@@ -320,8 +328,8 @@ coupling as the `VSYNC_TOKEN_BUCKET` global that step 2 removed, just local inst
 
 So `EngineHandler` collapses to: two fields deleted outright (`pending_render`, `render_threads`),
 one flag replaced by a comparison (`stale`), one absorbed into a port's semantics
-(`pending_manifold` — *corrected: it relocates rather than dissolving*), and two genuine
-relocations (`window` → driver, `frame_number` →
+and three genuine relocations (`pending_manifold` → the coordinator as an explicit slot,
+`window` → driver, `frame_number` →
 rasterizer). Nothing needs a new home invented for it, which is the sign the mediator was
 holding state on behalf of actors that should have held it themselves.
 
@@ -430,6 +438,12 @@ it's the reason this doc exists at all:
   **never by a delivery failure**, which destroys something nobody chose to and leaves both sides
   believing the other has it.
 
+**§7.2 is superseded.** It has render completion compare returned *dimensions* against the
+coordinator's current window. Under the pull protocol the coordinator has no current window to
+compare against, and dimensions are not an identity anyway — resize out and back and they repeat.
+The check is the driver's, against buffer identity (the existing generation stamp), not the
+coordinator's against size.
+
 ### Known-unsettled
 
 Recorded so they aren't mistaken for solved. Each needs to be answered in code, where it can be
@@ -444,6 +458,10 @@ checked:
 - **Credit-bearing replies that can be dropped.** `ReturnToken` releases vsync's tick budget; if
   its edge can lose messages, the budget shrinks permanently. Same shape as the paste deadlock
   in §3.2 — worth checking every credit whose release travels a droppable edge.
+- **`engine → driver` state pushes.** `SetTitle`/`SetSize`/`SetCursor`/`Copy` are edge-triggered,
+  so a dropped *final* update stands forever — the same failure that made manifold submission
+  `Blocking`, at lower stakes (a wrong title, not a wrong screen). Currently plain `Droppable`.
+  Either they take the same treatment or the reason they differ needs writing down.
 - **Zero-copy.** Tracked separately; the copy in both backends is a defect, not the target.
 
 ### Out of scope here

--- a/docs/designs/pixelflow-runtime-engine-mesh-migration.md
+++ b/docs/designs/pixelflow-runtime-engine-mesh-migration.md
@@ -44,7 +44,7 @@ not by re-reading it), and only then touch a live actor.
 | Render request | engine → rasterizer | **Credit(1) + Droppable backstop** | Mirrors the window-return case: `pending_render` tracks exactly one outstanding render, so ring capacity ≥ 1 makes the backstop unreachable by construction. |
 | Render complete | rasterizer → engine | **Credit(1) + Droppable backstop** (same credit as above; it's the reply half) | Same reasoning as `PresentComplete`. If this bound is ever wrong (more than 1 outstanding), the failure mode changes from "spin-forever under adversarial timing" (today) to "one dropped frame, `pending_render` never clears, next resize/vsync recovers" — recorded as an explicit design trade-off, not an oversight. |
 | Frame request (`RequestFrame`) | engine → app | **Credit(N) + Droppable backstop** | N-outstanding-requests bound; a dropped request is recovered by the next vsync tick. |
-| Manifold submission (`AppData::RenderSurface`) | app → engine | **Droppable, no credit needed** | The *existing* code already implements "always keep the most recent, drop old ones" for `pending_manifold` by hand. This edge doesn't need `Credit` — it needs to be declared `[drop]` and the hand-rolled staleness logic deleted, because the port *is* the staleness policy. |
+| Manifold submission (`AppData::RenderSurface`) | app → engine | **Droppable, no credit needed** | Losing one submission is fine — another follows. But the receiver **keeps its `pending_manifold` slot and overwrites it**: a droppable port discards the *newest* message, which is the opposite of keep-latest, so the port cannot be the staleness policy. An earlier revision said it could and had the field deleted. |
 
 Every reply edge above is the closing edge of a cycle; every one is legal under the DAG rule
 (§3.1 of the Mealy doc) specifically because it's Droppable, whether or not `Credit` additionally
@@ -311,7 +311,7 @@ coupling as the `VSYNC_TOKEN_BUCKET` global that step 2 removed, just local inst
 
 | Field | Goes to | Why |
 |---|---|---|
-| `pending_manifold` | the app → rasterizer edge, as a droppable keep-latest port | §3 already called this: the *port is* the staleness policy, so the hand-rolled "keep newest, drop old" logic is deleted along with the field. |
+| `pending_manifold` | **stays** — moves to the coordinator, unchanged | Not deletable. A droppable port drops the *newest* message; keep-latest requires dropping the *oldest*. If the app's last state change were the dropped one and later frame requests returned `Skipped`, a stale surface would sit on screen indefinitely. An overwritten slot is a few lines and obviously correct; making the channel do it would mean a new delivery mode in the protocol to avoid them. |
 | `window` | **driver** | It already creates the window (`WindowCreated`) and presents it. With the mediator gone the buffer circulates driver → rasterizer → driver; the driver is the only actor that outlives every stage of that loop. |
 | `frame_number` | **rasterizer** | It is a count of completed renders, and its only consumer is the FPS telemetry edge to vsync. It belongs to the thing doing the counting. |
 | `render_threads` | **bootstrap config, needs a real owner** | *Corrected during implementation.* This row first claimed the field was a redundant copy of `RasterCore::num_threads`, deletable outright. It isn't: the engine passes it to `spawn_with_setup` at bootstrap, so it is the *source* of the rasterizer's value, not a duplicate of it. It has to be supplied by whoever spawns the rasterizer once the engine no longer does — small, but a genuine open question rather than a deletion. |
@@ -319,7 +319,8 @@ coupling as the `VSYNC_TOKEN_BUCKET` global that step 2 removed, just local inst
 
 So `EngineHandler` collapses to: two fields deleted outright (`pending_render`, `render_threads`),
 one flag replaced by a comparison (`stale`), one absorbed into a port's semantics
-(`pending_manifold`), and two genuine relocations (`window` → driver, `frame_number` →
+(`pending_manifold` — *corrected: it relocates rather than dissolving*), and two genuine
+relocations (`window` → driver, `frame_number` →
 rasterizer). Nothing needs a new home invented for it, which is the sign the mediator was
 holding state on behalf of actors that should have held it themselves.
 
@@ -403,11 +404,6 @@ checked:
 - **Credit-bearing replies that can be dropped.** `ReturnToken` releases vsync's tick budget; if
   its edge can lose messages, the budget shrinks permanently. Same shape as the paste deadlock
   in §3.2 — worth checking every credit whose release travels a droppable edge.
-- **Keep-latest for manifold submission.** §3 and §7.3 delete `pending_manifold` on the grounds
-  that the droppable port *is* the staleness policy — but droppable discards the **newest**
-  message, not the oldest. If the app's final state change is the one dropped and subsequent
-  frame requests return `Skipped`, a stale surface stays on screen indefinitely. Needs either a
-  real drop-oldest delivery or an explicit coalescing slot before that state is removed.
 - **Stale-return protocol under pull.** §7.2 has the *coordinator* detect a stale render by
   comparing against the current window — but under pull the coordinator never learns dimensions,
   and the driver alone knows a resize is pending. Nothing yet defines how the driver rejects the

--- a/docs/designs/pixelflow-runtime-engine-mesh-migration.md
+++ b/docs/designs/pixelflow-runtime-engine-mesh-migration.md
@@ -23,8 +23,7 @@ This is production code driving a real, running terminal renderer, not a prototy
 (§9) found four real bidirectional cycles held together today by an untyped global atomic and a
 hand-rolled `stale` flag. Reclassifying each edge is a per-edge *judgment call* about what may be
 lost — the audit was explicit that the type system cannot make this call automatically
-(`PresentComplete` dropped is catastrophic; `AppData::RenderSurface` dropped is nothing, the code
-already treats it that way). Getting one of these wrong is worse than the status quo, not better.
+(`PresentComplete` dropped is catastrophic; `SetTitle` dropped is nothing, since another follows). Getting one of these wrong is worse than the status quo, not better.
 So: classify every edge on paper first, prove the resulting graph is actually a DAG (mechanically,
 not by re-reading it), and only then touch a live actor.
 
@@ -53,8 +52,10 @@ makes that backstop unreachable by construction. **Two different reasons an edge
 
 - **Structurally unreachable** (window return, render complete): the credit bound is airtight,
   so the drop path is dead code in the well-behaved system and only fires on an actual bug.
-- **Genuinely acceptable loss** (vsync tick, FPS notice, manifold submission): dropping is a
-  normal, expected outcome, not a bug symptom.
+- **Genuinely acceptable loss** (vsync tick, FPS notice, idempotent state pushes): dropping is a
+  normal, expected outcome, not a bug symptom. Manifold submission looks like it belongs here and
+  does not — see its row: if the app's *last* submission is the dropped one, nothing follows to
+  correct it.
 
 Conflating these two would be exactly the mistake §9.2 warned against.
 
@@ -395,13 +396,20 @@ let sx = frame.logical_w / frame.width as f32;   // everything from the buffer i
 At { inner: kernel, x: X * sx, y: Y * sy, z: Z, w: W }
 ```
 
-**Therefore there is no such thing as a wrong-sized frame.** The kernel was warped to *that*
-buffer, so blitting it is always correct for the buffer it was drawn into. A resize means the
-next buffer carries different numbers and the kernel adapts on the next rasterisation. **The
-driver stays dumb: it blits what arrives.** No size check, no discard, no pending dimensions.
+This makes the frame's *contents* correct for the frame — but **not** for the window, and an
+earlier draft of this paragraph claimed otherwise. If a resize lands while a buffer is out, the
+buffer is still the old size when it returns; the pixels in it are internally consistent and the
+native window is a different shape. Blitting it is wrong however carefully the kernel was bound.
 
-What this deletes, rather than solves: stale-render detection, generation stamping, driver-side
-resize bookkeeping, and the size comparison that would otherwise have to live in the driver.
+So one identity check survives: **the driver blits a returned buffer only if it is still the
+buffer it currently wants.** That is what the existing generation stamping does, and the same
+draft wrongly listed it among the deletions. Kernel-frame binding removes the need to *repair* a
+mismatched buffer — there is no rescaling, no partial redraw, just discard and re-grant, because
+the next rasterisation is already correct by construction. It does not remove the need to notice.
+
+What this genuinely deletes: stale-render *detection* in the coordinator (it never needs to know),
+driver-side pending-dimension bookkeeping, and any rescale-on-mismatch path. What it keeps: one
+comparison in the driver, against state the driver already owns.
 
 ### The judgment calls
 

--- a/pixelflow-runtime/tests/target_topology.rs
+++ b/pixelflow-runtime/tests/target_topology.rs
@@ -108,7 +108,12 @@ fn the_target_engine_mesh_is_a_dag() {
     // window-bearing traffic; it says nothing about unrelated messages in the same ring.
     topo.droppable_edge(rasterizer, driver); // window request (Management lane; carries nothing)
     topo.droppable_edge(driver, rasterizer); // window grant (unreachable: can't grant unheld)
-    topo.droppable_edge(app, rasterizer); // manifold submission (keep-latest, as today)
+    // Blocking, not droppable: keeping a slot on the receiver does not help if the *newest*
+    // submission is lost in transit — nothing then arrives to overwrite it, and the coordinator
+    // renders a stale kernel indefinitely if the app has nothing further to send. An app parking
+    // behind a busy coordinator is correct backpressure. There is no rasterizer -> app edge, so
+    // one blocking direction here cannot cycle.
+    topo.blocking_edge(app, rasterizer); // manifold submission
     topo.droppable_edge(rasterizer, driver); // Present (unreachable: can't present unheld)
     topo.droppable_edge(rasterizer, vsync); // RenderedResponse (FPS telemetry only)
     topo.droppable_edge(app, vsync); // ReturnToken — previously an engine->vsync Control-lane


### PR DESCRIPTION
## The bug

```rust
(Ok(()), _) | (Err(TrySendError::Disconnected(_)), _) => Flush::Done,
```

A send to a gone peer was indistinguishable from a successful one — and because the arm binds the message with `_`, **the payload was dropped**. For a port carrying a moved resource that silently destroys it while the sender believes it was delivered. The render pipeline's sole frame buffer is exactly such a port.

## The fix

`Flush` gains `Disconnected`, but the load-bearing half is that **the payload is retained in the port**, the way `Blocked` already retains it. That alone keeps every recovery open: retry, hand off, escalate, or shut down gracefully with the resource still in hand.

**The variant deliberately carries no policy.** What to do about a dead peer — retry, crash, drain and exit — differs per system and per edge, and a port is the wrong place to decide it. So:

- `Node` surfaces `Step::Disconnected` rather than folding it into `Blocked`. Backpressure resolves by waiting; this doesn't. Retrying a dead peer forever is a hang, and dropping the payload is data loss — the caller needs to tell those apart.
- `Host` keeps such a node alive and doesn't count it as having run, so a dead peer can't spin the sweep. Supervision belongs a layer up.
- `all()` ranks `Disconnected` > `Blocked` > `Done` — a dead peer is news the caller needs even when another port merely filled up.

## Testing

- `actor-scheduler`: 124 tests pass
- `pixelflow-runtime` and `core-term` build unchanged
- clippy clean

The existing test asserting the old contract was named `a_droppable_port_to_a_dead_target_is_still_done` — which described the defect precisely. Rewritten to cover both delivery kinds, since the old behavior applied to both, plus a case for the new `all()` ranking.

## Note

Found while auditing the engine-mesh migration: the design leaned on "a dropped message is structurally unreachable," which was true for full rings and false for disconnected ones. Ring capacity arguments never covered this case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Y5cNzR9PnASfGfjBh5kJc

---
_Generated by [Claude Code](https://claude.ai/code/session_015Y5cNzR9PnASfGfjBh5kJc)_