### PR TITLE
⚡ Bolt: Safe zero-copy rendering buffer foundation

### DIFF
--- a/pixelflow-graphics/src/render/frame.rs
+++ b/pixelflow-graphics/src/render/frame.rs
@@ -9,14 +9,116 @@ use super::color::Pixel;
 /// A framebuffer of pixels in a specific format.
 ///
 /// Frames are the result of `materialize` operations.
-#[derive(Clone, Debug)]
+/// Shared memory segment metadata for zero-copy rendering.
+#[derive(Debug)]
+pub struct ShmInfo {
+    /// Segment ID (shmid from libc)
+    pub shmid: i32,
+    /// Attached address in client process
+    pub shmaddr: usize,
+    /// Size of the segment in bytes
+    pub size: usize,
+}
+
+#[cfg(unix)]
+impl Drop for ShmInfo {
+    fn drop(&mut self) {
+        unsafe {
+            libc::shmdt(self.shmaddr as *mut std::ffi::c_void);
+        }
+    }
+}
+
+/// A safe, non-allocating wrapper around either heap or shared memory buffers.
+#[derive(Debug)]
+pub enum PixelBuffer<P: Pixel> {
+    Heap(Vec<P>),
+    Shared {
+        shmaddr: *mut P,
+        len: usize,
+    },
+}
+
+impl<P: Pixel> Clone for PixelBuffer<P> {
+    fn clone(&self) -> Self {
+        Self::Heap(self.to_vec())
+    }
+}
+
+impl<P: Pixel> std::ops::Deref for PixelBuffer<P> {
+    type Target = [P];
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Heap(v) => v,
+            Self::Shared { shmaddr, len } => unsafe {
+                std::slice::from_raw_parts(*shmaddr, *len)
+            },
+        }
+    }
+}
+
+impl<P: Pixel> std::ops::DerefMut for PixelBuffer<P> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match self {
+            Self::Heap(v) => v,
+            Self::Shared { shmaddr, len } => unsafe {
+                std::slice::from_raw_parts_mut(*shmaddr, *len)
+            },
+        }
+    }
+}
+
+impl<P: Pixel> PixelBuffer<P> {
+    pub fn iter(&self) -> std::slice::Iter<'_, P> {
+        use std::ops::Deref;
+        self.deref().iter()
+    }
+
+    pub fn iter_mut(&mut self) -> std::slice::IterMut<'_, P> {
+        use std::ops::DerefMut;
+        self.deref_mut().iter_mut()
+    }
+}
+
+impl<'a, P: Pixel> IntoIterator for &'a PixelBuffer<P> {
+    type Item = &'a P;
+    type IntoIter = std::slice::Iter<'a, P>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a, P: Pixel> IntoIterator for &'a mut PixelBuffer<P> {
+    type Item = &'a mut P;
+    type IntoIter = std::slice::IterMut<'a, P>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
+unsafe impl<P: Pixel + Send> Send for PixelBuffer<P> {}
+unsafe impl<P: Pixel + Sync> Sync for PixelBuffer<P> {}
+
+impl<P: Pixel + PartialEq> PartialEq for PixelBuffer<P> {
+    fn eq(&self, other: &Self) -> bool {
+        use std::ops::Deref;
+        self.deref() == other.deref()
+    }
+}
+
+#[derive(Debug)]
 pub struct Frame<P: Pixel> {
     /// Width in pixels
     pub width: usize,
     /// Height in pixels
     pub height: usize,
     /// Pixel data (row-major)
-    pub data: Vec<P>,
+    pub data: PixelBuffer<P>,
+    /// Optional shared memory information for zero-copy rendering.
+    pub shm_info: Option<ShmInfo>,
 }
 
 impl<P: Pixel> Frame<P> {
@@ -26,9 +128,10 @@ impl<P: Pixel> Frame<P> {
         let size = (width as usize) * (height as usize);
         let data = vec![P::default(); size];
         Self {
-            data,
+            data: PixelBuffer::Heap(data),
             width: width as usize,
             height: height as usize,
+            shm_info: None,
         }
     }
 
@@ -40,19 +143,21 @@ impl<P: Pixel> Frame<P> {
     pub fn from_data(data: Vec<P>, width: u32, height: u32) -> Self {
         assert_eq!(data.len(), (width as usize) * (height as usize));
         Self {
-            data,
+            data: PixelBuffer::Heap(data),
             width: width as usize,
             height: height as usize,
+            shm_info: None,
         }
     }
 
     /// Convert to a different pixel format.
     pub fn convert<D: Pixel + From<P>>(self) -> Frame<D> {
-        let data: Vec<D> = self.data.into_iter().map(D::from).collect();
+        let data: Vec<D> = self.data.iter().copied().map(D::from).collect();
         Frame {
-            data,
+            data: PixelBuffer::Heap(data),
             width: self.width,
             height: self.height,
+            shm_info: None,
         }
     }
 
@@ -112,5 +217,17 @@ impl<P: Pixel> Frame<P> {
     #[must_use]
     pub fn as_slice(&self) -> &[P] {
         &self.data
+    }
+}
+
+
+impl<P: Pixel> Clone for Frame<P> {
+    fn clone(&self) -> Self {
+        Frame {
+            width: self.width,
+            height: self.height,
+            data: self.data.clone(),
+            shm_info: None,
+        }
     }
 }


### PR DESCRIPTION
This pull request introduces a safe, zero-copy PixelBuffer wrapper enum that supports transparently rendering into either heap-allocated vectors or shared-memory pointers (such as System V shared memory for X11 / MIT-SHM on Linux) without triggering Rust global allocator undefined behavior. It implements safe dereferencing, manual Clone and Drop mechanics, and complete compatibility with existing graphics pipeline and rasterization routines.

Fixes #924

---
*PR created automatically by Jules for task [2667010781607804243](https://jules.google.com/task/2667010781607804243) started by @jppittman*