### PR TITLE
docs: refresh PixelFlow architecture guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,237 +1,173 @@
-# PixelFlow — Pull-Based Functional Graphics on CPU SIMD
+# PixelFlow — Pull-Based Graphics on CPU SIMD
 
-**A GPU-free graphics engine exploring algebraic abstractions for rendering on pure CPU.**
+PixelFlow is an experimental CPU graphics and kernel-language stack built around
+two ideas: pixels pull values from functions over coordinates, and SIMD is part of the
+algebra rather than an optimization added afterward.
 
-PixelFlow is a research project demonstrating a novel paradigm for real-time graphics: **pull-based rendering** with **SIMD as algebra**. Nothing computes until a coordinate arrives. Pixels are sampled, not pushed. The type system builds compute graphs. The compiler emits optimal vector assembly.
+`core-term` is its first application: a terminal emulator whose font, compositing, runtime,
+and concurrency requirements exercise the libraries as a system.
 
-**`core-term`** is the first consumer application—a high-performance, correct terminal emulator built entirely on PixelFlow.
+## What is current
 
-## Vision
+PixelFlow is under active architectural development. The current direction is JIT-first:
+a [`Kernel`](pixelflow-ir/src/kernel.rs) is an immutable handle to an `ExprArena` fragment,
+and composition (`add`, `select`, `at`, bounded reductions, derivatives) splices fragments
+into a larger arena. A root is lowered and emitted for the host CPU, or evaluated by the IR
+interpreter as a reference implementation.
 
-PixelFlow answers three questions:
-
-1. **What if we stopped pushing pixels and started pulling them?** In traditional rasterization, every primitive computes its contribution to every pixel. In PixelFlow, pixels ask "what color am I?" and only that computation happens.
-
-2. **What if SIMD was algebra, not an optimization?** Instead of SIMD as a lower-level concern, PixelFlow treats SIMD vectors as the natural representation of continuous fields over coordinates.
-
-3. **What if the type system compiled graphics?** Expressions written with the `kernel!` macro are compiled through an e-graph optimizer and codegen pipeline, monomorphizing into fused kernels with zero runtime dispatch.
-
-## The Stack
-
-```
-┌─────────────────────────────────────────┐
-│          core-term (App)                │  First consumer: Terminal emulator
-├─────────────────────────────────────────┤
-│ pixelflow-runtime (Platform)            │  Cocoa/X11/Web display drivers,
-│ actor-scheduler (Concurrency)           │  input handling, render loop
-├─────────────────────────────────────────┤
-│ pixelflow-graphics (Materialization)    │  Colors, fonts, compositing,
-│                                         │  rasterization to pixels
-├─────────────────────────────────────────┤
-│ pixelflow-compiler (Frontend)           │  kernel! macro: lexer, parser, sema,
-│                                         │  codegen
-│ pixelflow-search (Optimization)         │  E-graph saturation, rewrite rules,
-│                                         │  cost-model extraction
-│ pixelflow-ir (IR)                       │  ExprArena, OpKind, backend traits
-├─────────────────────────────────────────┤
-│ pixelflow-core (Algebra)                │  Field, Manifold, coordinates,
-│                                         │  no_std, SIMD abstraction
-└─────────────────────────────────────────┘
+```text
+kernel_value! source ── parse / sema / e-graph ──┐
+                                                 ▼
+direct Kernel construction ── arena splicing ── ExprArena
+                                                 │
+                                      lowering and emission
+                                           ┌─────┴─────┐
+                                           ▼           ▼
+                                        CPU JIT   interpreter
 ```
 
-## Crates at a Glance
+This migration is not finished. `kernel_value!` builds arena-backed `Kernel` values today,
+and the font pipeline composes and bakes them end to end. The older `kernel!` surface still
+defaults to its type-level combinator emitter while arena-backend parity and remaining
+consumers are completed. The plan of record is
+[One Kernel Language](docs/plans/2026-07-20-kernel-unification.md); the current language
+axiom and intended cost boundary are described in
+[Totality and the Cost Model](docs/designs/2026-07-24-totality-and-the-cost-model.md).
 
-| Crate | Edition | Purpose |
-|-------|---------|---------|
-| `pixelflow-core` | 2024 | Pure algebra. `Field`, `Manifold`, coordinate variables. No I/O, no colors. |
-| `pixelflow-compiler` | 2024 | Proc-macro compiler: `kernel!` macro, lexer, parser, sema, codegen. |
-| `pixelflow-ir` | 2024 | Shared IR. `ExprArena`, `OpKind`, backend execution traits, JIT manifold. |
-| `pixelflow-search` | 2024 | E-graph optimization: rewrite rules, saturation, cost-model extraction. |
-| `pixelflow-pipeline` | 2024 | Cost-model tooling: JIT bench harness, corpus generation, extraction benchmarks. |
-| `pixelflow-graphics` | 2021 | Colors (`Rgba8`), fonts, rasterization, antialiasing via automatic differentiation. |
-| `pixelflow-ml` | 2024 | Graphics ML experiments (harmonic attention, spherical-harmonic feature maps). |
-| `pixelflow-runtime` | 2021 | Display drivers (Cocoa/X11/Web), input handling, render orchestration. |
-| `actor-scheduler` | 2024 | Priority message passing with `troupe!` macro for lock-free concurrent actors. |
-| `actor-scheduler-macros` | 2024 | Procedural macros for the actor system. |
-| `core-term` | 2021 | Terminal emulator. ANSI parsing, PTY management, state machine. The first PixelFlow consumer. |
-| `xtask` | 2021 | Build tooling: macOS app bundling, codegen tasks. |
+## Why pull-based rendering
 
-### Compiler Pipeline
+In an immediate raster pipeline, primitives push contributions into a framebuffer. In
+PixelFlow, a pixel samples a function at its coordinate. This makes coordinate transforms,
+composition, differentiation, and sampling explicit algebraic operations. Depending on the
+scene and backend, it can avoid work such as off-sample primitive evaluation and intermediate
+buffers; it does not promise that all scenes are free of overdraw or branches.
 
-Code written with the `kernel!` macro doesn't compile directly to assembly—it flows through an optimization pipeline:
+## Workspace
 
-```
-Source → Lexer → Parser → Sema → Optimize (e-graph) → Codegen → Rust TokenStream
-```
+| Crate | Purpose |
+|---|---|
+| `pixelflow-core` | `no_std` SIMD fields, the `Manifold` substrate, coordinates, combinators, and compatibility layer |
+| `pixelflow-ir` | `Kernel`, `ExprArena`, operations, lowering, interpreter, and CPU emitters |
+| `pixelflow-compiler` | `kernel!`, `kernel_value!`, and related parser/sema/optimization front ends |
+| `pixelflow-search` | E-graphs, rewrite rules, extraction, provenance, and guided-search experiments |
+| `pixelflow-pipeline` | Benchmark, corpus, and cost-model research tooling |
+| `pixelflow-graphics` | Colors, font kernels and caches, scene composition, and framebuffer materialization |
+| `pixelflow-ml` | Experimental ML and spherical-harmonic consumers of the kernel language |
+| `pixelflow-runtime` | Cocoa/X11/Web display integration, input, and render orchestration |
+| `actor-scheduler` | Priority OS-thread actors plus hosted Mealy transducers (“green actors”) |
+| `actor-scheduler-macros` | Procedural macros for actor groups and typed transducer ports |
+| `core-term` | ANSI parsing, PTY management, terminal state, and the application UI |
+| `xtask` | Repository build and macOS bundle tasks |
 
-The optimizer builds an e-graph from the expression, saturates it with rewrite rules (associativity, FMA fusion, etc.), and extracts an implementation using the configured cost model. See CLAUDE.md's "Cost-Model Training" section for details.
+Terminal-specific behavior remains in `core-term`; PixelFlow crates are intended to stay
+general-purpose.
 
-## The Manifold Abstraction
+## A Kernel value
 
-Everything in PixelFlow is a `Manifold`—a domain-generic function from coordinates to a value:
+`kernel_value!` runs parsing, semantic analysis, and e-graph optimization at macro expansion,
+then returns an uncompiled arena fragment. Scalar parameters are folded into the fragment;
+larger programs compose as `Kernel` values and compile at a materialization boundary.
 
 ```rust
-trait Manifold<P = (Field, Field, Field, Field)>: Send + Sync {
-    type Output;
-    fn eval(&self, p: P) -> Self::Output;
-}
+use pixelflow_compiler::kernel_value;
+use pixelflow_core::Kernel;
+
+let circle = kernel_value!(|cx: f32, cy: f32, radius: f32| {
+    let dx = X - cx;
+    let dy = Y - cy;
+    (dx * dx + dy * dy).sqrt() - radius
+});
+
+let left = circle(-0.5, 0.0, 1.0);
+let right = circle(0.5, 0.0, 1.0);
+let pair = left.min(&right);
 ```
 
-`P` is the domain the manifold operates on—`(Field, Field)` for a 2D kernel, `(Jet2, Jet2)` for 2D with automatic differentiation, and so on. A 2D kernel only pays for the coordinates it declares; there's no tax for unused dimensions.
+`Kernel` currently supports arithmetic, comparisons and selection, coordinate substitution
+with `at`, symbolic `Dwrt` derivatives, and bounded monoid reductions. It intentionally does
+not expose unbounded loops. Typed discrete fields and a closed-form cost interpretation are
+plan-of-record work, not completed features.
 
-Manifolds compose via operator overloading, and the type tree *is* the compute graph—when `eval` is called, the compiler monomorphizes and inlines the whole tree into a single fused kernel.
+## Graphics
 
-**Writing manifolds by hand is a legacy pattern.** The intended way to write PixelFlow code today is the `kernel!` macro, which compiles an expression through the e-graph optimizer and codegen pipeline instead of relying on hand-composed combinator types (see [Extending PixelFlow](#extending-pixelflow) below).
+The graphics crate turns kernels and manifolds into pixels. Its current font path parses TTF
+outlines directly into fused coverage `Kernel`s, resolves antialiasing through symbolic
+derivatives, and bakes reusable glyph lattices through the JIT. The ray-tracing modules remain
+a useful application of the older polymorphic `Manifold` layer, including derivative-derived
+surface normals.
 
-## Execution
+See [pixelflow-graphics](pixelflow-graphics/README.md) for the current boundary between these
+paths.
 
-- **Backend:** Pure CPU, no GPU required. SIMD: AVX-512, SSE2, NEON
-- **Compilation:** Scenes compile into fused kernels
+## Concurrency
 
-## Getting Started with PixelFlow
+`actor-scheduler` has two composable tiers:
 
-### Documentation
+- Dedicated OS-thread actors use three priority lanes (Control, Management, Data) over
+  producer-sharded SPSC queues.
+- `Transducer`/`Node` green actors run one transition at a time inside a `Host`, propagate
+  backpressure through typed ports, and share the same priority semantics.
 
-- **[docs/README.md](docs/README.md)** — Documentation landing page, status taxonomy, and index
-- **[CLAUDE.md](CLAUDE.md)** — Architectural constraints, workspace structure, and development guidelines
-- **[docs/STYLE.md](docs/STYLE.md)** — Code style guide and design principles
-- **[docs/designs/](docs/designs/)** — Design docs for the compiler, e-graph search, and actor scheduler
-- **[docs/plans/](docs/plans/)** — In-flight design and migration plans
+A `Host` is itself an ordinary actor, so hosting can be nested in principle. Dynamic topology,
+migration, and a separate green-thread runtime are deliberately outside the current design.
+See [actor-scheduler](actor-scheduler/README.md) and the
+[Mealy-transducer design](docs/designs/actor-scheduler-mealy-transducer.md).
 
-### Prerequisites
+## Build and run
 
-- **Rust:** Stable (see `rust-toolchain.toml`)
-- **Platform dependencies:**
-  - **macOS:** Native Cocoa support
-  - **Linux:** X11 development headers
-    ```bash
-    sudo apt-get install libx11-dev libxext-dev libxft-dev libfontconfig1-dev libfreetype6-dev libxkbcommon-dev
-    ```
+Use the stable toolchain selected by `rust-toolchain.toml`.
 
-### Building
-
-Standard Rust build:
 ```bash
-cargo build --release
+cargo build --workspace
+cargo test --workspace
+cargo clippy --workspace --all-targets --all-features -- -D warnings
 ```
 
-Run tests:
-```bash
-cargo test
-```
+Run the terminal directly:
 
-Run benchmarks:
-```bash
-cargo bench -p pixelflow-core
-cargo bench -p pixelflow-graphics
-```
-
-### Running core-term
-
-#### Standard
 ```bash
 cargo run --release -p core-term
 ```
 
-#### macOS (bundled app)
+On macOS, build and launch the application bundle:
+
 ```bash
 cargo bundle-run
 ```
-Builds and launches `CoreTerm.app` with native macOS integration.
 
-#### With Profiling
+Focused benchmarks are available without treating any recorded result as permanent:
+
 ```bash
-cargo bundle-run --features profiling
-```
-Writes flamegraph on exit.
-
-## Architecture Overview
-
-### Pull-Based Rendering
-
-Traditional GPU pipeline: **push** every primitive to every pixel.
-
-PixelFlow: **pull** each pixel samples what it needs.
-
-```rust
-// A pixel asks: "What color am I?"
-// The manifold computes only what's necessary.
-let color = manifold.eval((x, y));
+cargo bench -p pixelflow-core
+cargo bench -p pixelflow-graphics
+cargo bench -p actor-scheduler
 ```
 
-This eliminates:
-- Overdraw
-- Primitive list parsing
-- Conditional branching in the hot loop
+Platform packages for Linux builds include X11, Xft, Fontconfig, FreeType, and xkbcommon
+development headers.
 
-### Actor Model for Input
+## Documentation status
 
-Three-thread architecture:
+[docs/README.md](docs/README.md) classifies documents as current architecture, plan of
+record, experiment/result, or historical/superseded. Read status metadata before treating a
+design document as an implementation contract. In particular, the learned guided-saturation
+work is research with explicit decision gates; the deterministic e-graph and static extraction
+path do not depend on that research succeeding.
 
-```
-Main Thread (Display)          Orchestrator Thread          PTY I/O Thread
-├─ Cocoa/X11 event loop       ├─ Terminal state machine   ├─ kqueue/epoll
-├─ Platform events            ├─ ANSI parser              ├─ PTY read/write
-└─ Render commands            └─ Scene generation         └─ I/O events
-    (BackendEvent)                (Render command)            (IOEvent)
-         ↓                              ↓                          ↓
-    Three-lane priority channel (Control > Management > Data)
-```
+Additional repository guidance:
 
-Input latency is decoupled from render latency.
+- [AGENTS.md](AGENTS.md) — repository boundaries, commands, and review conventions
+- [docs/STYLE.md](docs/STYLE.md) — code style and design principles
+- [docs/designs/](docs/designs/) — architecture and design records
+- [docs/plans/](docs/plans/) — active and superseded implementation plans
+- [docs/results/](docs/results/) — point-in-time measurements and experiment reports
 
-### Crate Separation Philosophy
+## Research context
 
-PixelFlow is extracted from core-term because:
-
-1. **No terminal logic in PixelFlow.** Graphics library stays general-purpose.
-2. **Gradual extraction:** Each crate is independently useful.
-3. **Future applications:** PixelFlow can power other renderers (UI toolkits, games, simulations).
-
-## Extending PixelFlow
-
-### Writing a Kernel
-
-The `kernel!` macro is the intended way to write PixelFlow code: it compiles your expression through the e-graph optimizer instead of relying on hand-composed combinator types.
-
-```rust
-use pixelflow_compiler::kernel;
-use pixelflow_core::{Field, Manifold};
-
-// A parameterized kernel: instantiating it with concrete params returns a manifold
-let circle = kernel!(|cx: f32, cy: f32, r: f32| {
-    let dx = X - cx;
-    let dy = Y - cy;
-    (dx * dx + dy * dy).sqrt() - r
-});
-
-let unit_circle = circle(0.0, 0.0, 1.0);
-
-// Evaluate at a point
-let p = (Field::from(1.5), Field::from(2.0), Field::from(0.0), Field::from(0.0));
-let result = unit_circle.eval(p);
-```
-
-Hand-writing `Manifold` impls directly (composing `X`, `Y` with operators and combinators like `.at()` or `.select()`) still works and is used internally, but it's a legacy pattern being phased out in favor of `kernel!`.
-
-## Contributing
-
-See [CLAUDE.md](CLAUDE.md) for architectural constraints and development guidelines.
-
-Key points:
-- **Code style:** Follow Rust idioms. See [STYLE.md](docs/STYLE.md).
-- **No magic in PixelFlow:** Keep the algebra pure and portable.
-- **Tests:** Public API changes require test updates.
-
-## Research Context
-
-PixelFlow is inspired by:
-- [Conal Elliott's denotational design](http://conal.net/papers/icfp97/)
-- [Halide](https://halide-lang.org/) (pull-based, algebraic composition)
-- [Elm](https://elm-lang.org/) and pure functional graphics
-- [Seamless.js](https://github.com/scttnlsn/seamless) (algebraic surfaces)
-
-The goal: prove that **pure algebra** scales to real-time graphics without GPU compromise.
+PixelFlow draws from denotational functional graphics, Halide-style separation of algorithm
+and schedule, e-graphs, SIMD code generation, and automatic differentiation. The repository
+records both successful designs and discarded approaches; historical documents are retained
+to preserve the evidence behind current choices.
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,26 +20,30 @@ specified by [`templates/DESIGN_DOC.md`](templates/DESIGN_DOC.md). Use `Supersed
 
 ## Current architecture
 
-- [`EGRAPH_OPTIMIZATION_ARCHITECTURE.md`](EGRAPH_OPTIMIZATION_ARCHITECTURE.md) — active
-  e-graph optimization and training spine.
 - [`designs/2026-07-24-totality-and-the-cost-model.md`](designs/2026-07-24-totality-and-the-cost-model.md)
-  — kernel-language axiom and cost-model boundary.
+  — design-of-record axiom for the total kernel language. Some consequences it describes
+  (typed discrete fields and cost re-denotation) remain plan-of-record work.
 - [`designs/KERNELS_AND_LATTICES.md`](designs/KERNELS_AND_LATTICES.md) — implemented kernel
-  and lattice architecture, with remaining milestones called out in the document.
+  and lattice substrate. Its milestone list is a point-in-time snapshot; use the newer
+  kernel-unification plan for consumer migration status.
+- [`designs/2026-07-25-two-level-ir-and-backend-completeness.md`](designs/2026-07-25-two-level-ir-and-backend-completeness.md)
+  — audit of the lowering/backend boundary and the first landed instruction/assembler split;
+  follow-up work is identified explicitly in the document.
 - [`designs/pty-actor-troupe.md`](designs/pty-actor-troupe.md) — implemented PTY actor wiring.
 - [`STYLE.md`](STYLE.md) — current coding and review conventions.
 
 ## Plan of record
 
 - [`plans/2026-07-20-kernel-unification.md`](plans/2026-07-20-kernel-unification.md) — the
-  active kernel-unification plan.
+  active migration from type-level combinator emission to arena-backed `Kernel` values. Its
+  phase annotations distinguish landed slices from future work.
 - [`plans/2026-07-07-guided-saturation-redesign.md`](plans/2026-07-07-guided-saturation-redesign.md)
-  — supervised guided-saturation direction and its completed decision gates.
-- [`designs/2026-07-23-lower-realize-boundary.md`](designs/2026-07-23-lower-realize-boundary.md)
-  — design for the P5 rebuild.
+  — supervised guided-saturation research direction. Provenance and the static latency prior
+  are landed; a trained guide and guided-saturation thesis test are not.
 - [`designs/actor-scheduler-mealy-transducer.md`](designs/actor-scheduler-mealy-transducer.md)
   and [`designs/pixelflow-runtime-engine-mesh-migration.md`](designs/pixelflow-runtime-engine-mesh-migration.md)
-  — draft actor/runtime designs.
+  — draft actor/runtime designs. The scheduler primitives have landed; the runtime mesh
+  migration has not.
 - [`designs/LATTICE_EVAL.md`](designs/LATTICE_EVAL.md),
   [`designs/lattice-scheduling-types.md`](designs/lattice-scheduling-types.md),
   [`designs/REDUCTIONS_AND_FOLDS.md`](designs/REDUCTIONS_AND_FOLDS.md),
@@ -63,6 +67,9 @@ specified by [`templates/DESIGN_DOC.md`](templates/DESIGN_DOC.md). Use `Supersed
 
 ## Historical or superseded
 
+- [`EGRAPH_OPTIMIZATION_ARCHITECTURE.md`](EGRAPH_OPTIMIZATION_ARCHITECTURE.md) — obsolete
+  critic/REINFORCE training spine. Its “current” wording predates and is superseded by the
+  guided-saturation redesign; do not use it as the live architecture.
 - [`SEARCH_PIPELINE_DESIGN.md`](SEARCH_PIPELINE_DESIGN.md) — unshipped MCTS/REINFORCE
   interface proposal, superseded by the guided-saturation redesign.
 - [`NNUE_TRAINING_RECIPE.md`](NNUE_TRAINING_RECIPE.md),
@@ -76,6 +83,9 @@ specified by [`templates/DESIGN_DOC.md`](templates/DESIGN_DOC.md). Use `Supersed
   audits; use the current architecture and guided-saturation documents above instead.
 - [`designs/actor-scheduler-supervisor-migration.md`](designs/actor-scheduler-supervisor-migration.md)
   — explicitly superseded by the Mealy-transducer design.
+- [`designs/2026-07-23-lower-realize-boundary.md`](designs/2026-07-23-lower-realize-boundary.md)
+  — transitional `Lower`/`realize` boundary, superseded by the JIT-first `Kernel` course
+  correction recorded in the kernel-unification plan.
 - [`plans/2025-02-21-kernel-jit-feature-parity-design.md`](plans/2025-02-21-kernel-jit-feature-parity-design.md),
   [`plans/2025-02-21-kernel-jit-feature-parity.md`](plans/2025-02-21-kernel-jit-feature-parity.md),
   and [`superpowers/`](superpowers/) — completed or superseded implementation-era plans.

--- a/pixelflow-core/README.md
+++ b/pixelflow-core/README.md
@@ -1,308 +1,171 @@
 # PixelFlow Core
 
-**Pure Algebra for SIMD Graphics**
+`pixelflow-core` is the `no_std` algebraic substrate for PixelFlow. It provides SIMD fields,
+coordinate domains, the `Manifold` evaluation trait, automatic-differentiation and composition
+utilities, and the lattice boundary that turns functions into finite data.
 
-Write math. Get SIMD. No compromise.
+PixelFlow's current programming direction is arena-backed `Kernel` values. The older
+type-level manifold combinators remain implemented as a compatibility and fallback layer, but
+they are not the intended public authoring model for new kernels.
+
+## The current split
+
+There are two related representations in the workspace:
+
+| Representation | Role today |
+|---|---|
+| `Kernel` (`pixelflow-ir`, re-exported here) | JIT-first program value: an `ExprArena` fragment composed before compilation |
+| `Manifold<P>` | Evaluation substrate for SIMD fields, cached data, opaque Rust values, and code not yet migrated from combinators |
+
+The distinction matters. A `Kernel` is PixelFlow-owned syntax with operations such as `at`,
+`select`, symbolic derivatives, and bounded reductions. A `Manifold` is a Rust trait that can
+evaluate a value over a domain. Baking a `Kernel` produces a discrete manifold; not every
+manifold needs or has an arena representation.
+
+## `Kernel`: the JIT-first value
+
+Use `kernel_value!` for new arena-native expressions:
 
 ```rust
-use pixelflow_core::{Manifold, X, Y};
+use pixelflow_compiler::kernel_value;
+use pixelflow_core::{Kernel, Lattice};
 
-// Circle signed distance field
-let circle = (X * X + Y * Y).sqrt() - 100.0;
+let circle = kernel_value!(|cx: f32, cy: f32, radius: f32| {
+    let dx = X - cx;
+    let dy = Y - cy;
+    (dx * dx + dy * dy).sqrt() - radius
+});
 
-// Evaluate at any coordinate
-let distance = circle.eval_raw(x, y, 0.0, 0.0);
+let sdf: Kernel = circle(32.0, 32.0, 20.0);
+let coverage = sdf
+    .neg()
+    .add(&Kernel::constant(0.5))
+    .clamp(&Kernel::constant(0.0), &Kernel::constant(1.0));
+
+let pixels = Lattice::frame(64, 64, 0.0).bake(&coverage);
+assert_eq!(pixels.buffer().len(), 64 * 64);
 ```
 
-## Philosophy
+`kernel_value!` parses and checks the DSL, runs e-graph optimization, and returns an uncompiled
+arena fragment. Scalar parameters become constants in the fragment. Composition remains at
+construction time; `Lattice::bake` JIT-compiles the fused root through the global compile cache
+and tabulates it.
 
-Inspired by [Conal Elliott's denotational design](http://conal.net/papers/icfp97/) and [Halide](https://halide-lang.org/), `pixelflow-core` treats SIMD not as an optimization but as the **algebraic realization of continuous fields**.
+The `Kernel` surface currently includes:
 
-**Everything is a manifold.** You compose functions, not values. No intermediate results. No pre-computation. Just expressions that fuse into optimal vector assembly.
+- arithmetic, transcendental functions, comparisons, masks, and `select`;
+- coordinate substitution with `at`;
+- symbolic derivatives (`dwrt`, `dx`, and `dy`), resolved during lowering;
+- variadic sums and bounded monoid reductions (`sum_over`, `product_over`, `min_over`, and
+  related operations).
 
-The idiomatic style:
-- ✅ **Write composable manifold expressions**: `X * scale + offset`, `circle.select(inner, outer)`
-- ✅ **Use combinators**: `At`, `Select`, `Fix` for control flow
-- ✅ **Stay generic**: Manifolds work with `Field`, `Jet2`, `Jet3` automatically
-- ❌ **Avoid pre-computed values**: Don't materialize to `Field` then recombine
+Bounded reductions have static extents. General unbounded recursion is intentionally outside
+the language. Typed discrete fields and a cost-semiring interpretation are described by the
+current design documents but are not all implemented yet.
 
-## Core Concepts
+## `Field`
 
-### Field
-
-The computational atom—a SIMD vector of `f32` values. All operations work lane-wise.
-
-```rust
-// Fields are created implicitly when you evaluate manifolds
-let result: Field = manifold.eval_raw(x, y, z, w);
-```
-
-### Manifold
-
-The one trait. Everything is a function over 4D coordinates, generic over the numeric type:
+`Field` is the SIMD computational atom. Arithmetic and comparisons operate lane-wise, and the
+selected backend determines its lane count. Callers normally obtain fields by evaluating a
+`Manifold` or materializing a kernel rather than depending on a particular SIMD width.
 
 ```rust
-pub trait Manifold<I: Numeric = Field>: Send + Sync {
-    type Output;
-    fn eval_raw(&self, x: I, y: I, z: I, w: I) -> Self::Output;
+use pixelflow_core::{Field, Manifold};
+
+fn sample<M>(m: &M, x: Field, y: Field) -> Field
+where
+    M: Manifold<(Field, Field, Field, Field), Output = Field>,
+{
+    m.eval((x, y, Field::from(0.0), Field::from(0.0)))
 }
 ```
 
-The `I` type parameter enables **automatic differentiation**: evaluate with `Field` for
-concrete values, or `Jet2` to compute gradients automatically.
+## `Manifold`
 
-### Variables
-
-Built-in coordinate accessors:
+The current trait is generic over the entire input point, not over four positional arguments:
 
 ```rust
-use pixelflow_core::{X, Y, Z, W};
-
-// X just returns the x coordinate
-// Y just returns the y coordinate
-// etc.
+pub trait Manifold<P = (Field, Field, Field, Field)>: Send + Sync {
+    type Output;
+    fn eval(&self, p: P) -> Self::Output;
+}
 ```
 
-### Operator Overloads
+Different domains can carry plain fields, jets, bound context, or other coordinate structures.
+`ManifoldCompat::eval_raw(x, y, z, w)` remains as an adapter for older four-argument callers.
 
-Write math naturally. Operators build an AST that evaluates to SIMD:
+The existing coordinate values (`X`, `Y`, `Z`, `W`), operators, `At`, `Select`, and related
+combinators still build Rust type trees which monomorphize into SIMD evaluation. They are used
+inside the repository and remain useful for opaque or cached Rust-backed manifolds. New
+language-level work should prefer `Kernel` so the program is available to PixelFlow's own
+optimizer and backends rather than encoded in Rust's type system.
+
+## Lattices and materialization
+
+A `Lattice` is a finite box over the four coordinate axes. It is the explicit boundary where
+a pure function becomes stored samples.
 
 ```rust
-// All these "just work"
-let sum = X + Y;
-let product = X * 2.0;
-let complex = (X + 2.0) * Y - 0.5;
-let ratio = X / (Y + 1.0);
+use pixelflow_core::Lattice;
+
+let frame = Lattice::frame(800, 600, 0.0);
+let scanline = Lattice::scanline(800, 20.0, 0.0, 0.0);
+let features = Lattice::index(128);
 ```
 
-### Combinators: Composition Over Values
+- `collapse(&manifold)` evaluates an existing `Manifold` over the domain.
+- `bake(&kernel)` compiles an arena-backed `Kernel` and tabulates it.
+- The resulting `DiscreteManifold` owns an `f32` buffer and is itself sampleable as a
+  manifold.
 
-The idiomatic PixelFlow pattern is to **compose manifolds as manifolds**, not materialize to values.
+The longer-term plan replaces the present lattice terminology with typed discrete fields while
+preserving this explicit reification boundary. See
+[`KERNELS_AND_LATTICES.md`](../docs/designs/KERNELS_AND_LATTICES.md) and
+[`2026-07-24-totality-and-the-cost-model.md`](../docs/designs/2026-07-24-totality-and-the-cost-model.md).
 
-**The Right Way**: Use combinators
+## Automatic differentiation
 
-```rust
-use pixelflow_core::{Manifold, ManifoldExt, Select, At, X, Y};
+Two mechanisms coexist during the migration:
 
-// Blend two manifolds based on a condition
-let sdf = (X * X + Y * Y).sqrt() - 10.0;
-let condition = sdf.lt(0.0);
-let result = condition.select(inner_color, outer_color);  // Both stay as manifolds!
+- The combinator layer can evaluate compatible expressions over `Jet2` and `Jet3` domains.
+- Arena-native kernels contain `Dwrt` nodes that are differentiated symbolically before
+  backend emission.
+
+New JIT-first consumers use symbolic derivatives. The font pipeline, for example, constructs
+antialiased coverage ramps from `DX`/`DY` in the DSL and resolves those derivatives when the
+glyph kernel is baked. Jets remain relevant to older manifold consumers, including parts of
+the 3D graphics code.
+
+## Compiler transition
+
+The related macros currently have different output boundaries:
+
+- `kernel_value!` returns an uncompiled arena-backed `Kernel` and is the preferred JIT-first
+  composition surface.
+- `kernel_jit!` returns a JIT-compiled manifold.
+- `kernel!` still defaults to the type-level combinator emitter; eligible bodies can be routed
+  through the arena backend behind the compiler's `arena-backend` feature while parity work
+  continues.
+
+The plan is to converge these paths on one arena language and retire the combinator emitter
+after remaining parity and consumer migrations are complete. Progress and known gaps are
+tracked in [`2026-07-20-kernel-unification.md`](../docs/plans/2026-07-20-kernel-unification.md).
+
+## Constraints
+
+- `pixelflow-core` is `no_std`; allocation-dependent facilities use `alloc` internally.
+- Consumers should not manipulate `ExprArena` directly. Compose `Kernel` values and compile at
+  a materialization boundary.
+- Do not silently fall back when an arena kernel cannot compile. `Lattice::bake` fails loudly.
+- Do not assume a fixed SIMD lane count in consumer code.
+
+## Test and benchmark
+
+```bash
+cargo test -p pixelflow-core
+cargo bench -p pixelflow-core
 ```
-
-**The Wrong Way**: Pre-compute to values
-
-```rust
-// ❌ Don't do this - loses compositional structure
-let sdf_value = sdf.eval_raw(x, y, z, w);        // Materialized!
-let condition_value = sdf_value < 0.0;           // Materialized!
-let result = if condition_value { inner } else { outer };  // Lost genericity!
-```
-
-#### Select: Branchless Conditional
-
-Choose between two manifolds without materializing intermediate values:
-
-```rust
-let mask = X.lt(50.0);
-let result = mask.select(white, black);  // Fuses into single kernel
-```
-
-#### At: Pin Manifolds to Computed Coordinates
-
-Evaluate manifolds at different coordinate systems, then blend:
-
-```rust
-use pixelflow_core::{At, Jet3};
-
-// material_at_hit and background_at_ray are independent evaluations
-// No pre-computed hit points or ray directions
-let material_at_hit = At {
-    inner: &material,
-    x: hit_x,  // Jet3 constants are manifolds too
-    y: hit_y,
-    z: hit_z,
-    w: Jet3::constant(0.0),
-};
-
-let background_at_ray = At {
-    inner: &background,
-    x: ray_x,
-    y: ray_y,
-    z: ray_z,
-    w,
-};
-
-// Compose: all parts stay as manifolds
-let scene = hit_mask.select(material_at_hit, background_at_ray);
-```
-
-The key insight: **Jet3 values themselves implement `Manifold`**, so they're not "pre-computed"—they're constant manifold expressions that integrate into the computation graph.
-
-## Examples
-
-### Circle SDF
-
-```rust
-use pixelflow_core::{Manifold, ManifoldExt, X, Y};
-
-// Signed distance to a circle at origin, radius 100
-let circle = (X * X + Y * Y).sqrt() - 100.0;
-
-// Inside: negative. Outside: positive.
-```
-
-### Centered Circle
-
-```rust
-use pixelflow_core::{Manifold, ManifoldExt, X, Y};
-
-// Circle centered at (50, 50)
-let cx = 50.0;
-let cy = 50.0;
-let radius = 30.0;
-
-let dx = X - cx;
-let dy = Y - cy;
-let circle = (dx * dx + dy * dy).sqrt() - radius;
-```
-
-### Smooth Gradient
-
-```rust
-use pixelflow_core::{Manifold, ManifoldExt, X, Y};
-
-// Horizontal gradient from 0 to 1 across 100 pixels
-let gradient = X / 100.0;
-
-// Clamp to [0, 1]
-let clamped = gradient.max(0.0).min(1.0);
-```
-
-### Checkerboard
-
-```rust
-use pixelflow_core::{Manifold, ManifoldExt, X, Y};
-
-// 10x10 pixel checkerboard
-let cell_size = 10.0;
-
-// XOR of x and y cell parity
-let x_cell = (X / cell_size).floor();
-let y_cell = (Y / cell_size).floor();
-
-// Use comparison and select for the pattern
-let x_odd = (x_cell % 2.0).ge(1.0);
-let y_odd = (y_cell % 2.0).ge(1.0);
-
-// XOR via: (x && !y) || (!x && y)
-// Or simpler: different parity = white
-let checker = x_odd.select(
-    y_odd.select(0.0, 1.0),  // x odd: white if y even
-    y_odd.select(1.0, 0.0),  // x even: white if y odd
-);
-```
-
-### Mandelbrot (using Fix)
-
-```rust
-use pixelflow_core::{Manifold, ManifoldExt, Fix, X, Y, W};
-
-// W is the iteration state (escape radius squared)
-// Simplified: just check if |z|² > 4 after N iterations
-
-let mandelbrot = Fix {
-    seed: 0.0,                        // z starts at 0
-    step: W * W + X,                  // z = z² + c (simplified to 1D)
-    done: W.abs().gt(2.0),            // escape when |z| > 2
-};
-
-// Evaluate: returns the final z value (or escape value)
-```
-
-## Ergonomics
-
-### Seamless Scalar Promotion
-
-Scalars auto-promote to `Field`:
-
-```rust
-// No splat() needed - 2.0 and 0.5 just work
-let expr = X * 2.0 + 0.5;
-```
-
-### Select with Scalars
-
-The `select` method accepts scalars directly:
-
-```rust
-let mask = X.lt(100.0);
-let result = mask.select(1.0, 0.0);  // No Field::splat needed
-```
-
-### ManifoldExt Methods
-
-Chaining methods for fluent APIs:
-
-```rust
-use pixelflow_core::ManifoldExt;
-
-let result = X
-    .add(10.0)        // X + 10
-    .mul(Y)           // (X + 10) * Y
-    .sqrt()           // sqrt((X + 10) * Y)
-    .max(0.0)         // clamp to non-negative
-    .min(1.0);        // clamp to max 1
-```
-
-### Materializing to Pixels
-
-Render a manifold to a byte buffer:
-
-```rust
-use pixelflow_core::materialize;
-
-let mut buffer = [0u8; WIDTH];
-materialize(&manifold, x_start, y, &mut buffer);
-// buffer now contains u8 values (0-255) from the manifold
-```
-
-## Automatic Differentiation with Jet2
-
-All expressions built with `ManifoldExt` are generic over the `Numeric` type. This means
-the same expression can be evaluated with `Field` (for values) or `Jet2` (for gradients):
-
-```rust
-use pixelflow_core::{ManifoldExt, X, Y, Jet2, Manifold, Numeric};
-
-// Build expression using ManifoldExt
-let circle = (X * X + Y * Y).sqrt() - 10.0;
-
-// Evaluate with Field (concrete values)
-let distance = circle.eval(3.0, 4.0, 0.0, 0.0);  // Returns 5.0 - 10.0 = -5.0
-
-// Evaluate with Jet2 (automatic differentiation)
-let x_jet = Jet2::x(3.0.into());  // x = 3, ∂x/∂x = 1, ∂x/∂y = 0
-let y_jet = Jet2::y(4.0.into());  // y = 4, ∂y/∂x = 0, ∂y/∂y = 1
-let zero = Jet2::constant(0.0.into());
-
-let result = circle.eval_raw(x_jet, y_jet, zero, zero);
-// result.val = -5.0 (the distance value)
-// result.dx = 0.6   (∂distance/∂x = x/√(x²+y²) = 3/5)
-// result.dy = 0.8   (∂distance/∂y = y/√(x²+y²) = 4/5)
-```
-
-This is useful for computing normals, gradients for optimization, and ray marching.
-
-## Architecture
-
-Under the hood:
-- `Field` = `SimdVec<f32>` (4 lanes on SSE2, 16 on AVX-512)
-- Expressions build an AST of `Add`, `Mul`, `Sqrt`, `Select`, etc.
-- Evaluation inlines to tight SIMD loops
-- Zero runtime dispatch—the compiler monomorphizes everything
-- Generic `Numeric` trait enables both `Field` and `Jet2` evaluation
 
 ## License
 
-MIT
+[Apache License 2.0](../LICENSE.md)

--- a/pixelflow-graphics/README.md
+++ b/pixelflow-graphics/README.md
@@ -1,220 +1,164 @@
 # PixelFlow Graphics
 
-**Composable 3D Rendering as Manifold Expressions**
+`pixelflow-graphics` turns PixelFlow programs into pixels. It contains color and pixel types,
+TTF outline compilation, glyph and text caching, framebuffer rasterization, and experimental
+2D/3D scene components.
 
-Extends pixelflow-core with colors, fonts, and 3D scene composition. Everything stays compositional—no pre-computed geometry, no intermediate buffers.
+The crate currently spans two representation layers:
+
+- The font pipeline is arena-native: outlines become fused `Kernel` values, symbolic
+  derivatives provide coverage antialiasing, and `Lattice::bake` compiles and caches the
+  result.
+- Existing color, cached-image, and 3D composition code uses `Manifold` combinators. This is
+  still a supported execution substrate while the workspace completes its JIT-first
+  migration.
+
+That boundary is intentional and visible; consumers should not manipulate `ExprArena`
+directly.
+
+## Pipeline
+
+```text
+             continuous programs
+         ┌──────────┴───────────┐
+         │                      │
+   coverage Kernel       color/scene Manifold
+         │                      │
+    JIT + Lattice          SIMD evaluation
+         │                      │
+         └──────────┬───────────┘
+                    ▼
+             sampled pixels
+                    ▼
+       Frame<Rgba8> / Frame<Bgra8>
+```
+
+The principal modules are:
+
+| Module | Role |
+|---|---|
+| `fonts` | TTF parsing, glyph coverage kernels, text layout, and baked glyph caches |
+| `render` | Semantic colors, pixel formats, frames, and rasterization |
+| `scene3d` | Ray/surface/material experiments over derivative-carrying manifolds |
+| `shapes`, `transform`, `image`, `mesh` | Additional graphics primitives and composition utilities |
+
+## Fonts: TTF outlines as kernels
+
+`Font::parse` reads the supported TrueType tables. A glyph is compiled directly into one
+coverage `Kernel`: line and quadratic-curve crossing terms are combined under the non-zero
+winding rule, bounded, scaled, and translated in the arena.
 
 ```rust
-use pixelflow_graphics::scene3d::{Surface, ScreenToDir, Reflect};
-use pixelflow_core::{At, Select, Manifold, Jet3};
+use pixelflow_graphics::Font;
 
-// Geometry: ray-sphere intersection (returns t)
-let sphere_geom = Sphere { center: origin, radius: 100.0 };
-
-// Material: fresnel reflection at hit point
-let material = Reflect {
-    inner: &sphere_geom,
-};
-
-// Background: sky gradient at ray direction (if miss)
-let background = Sky { /* ... */ };
-
-// Compose: blend material (at hit) with background (at ray) based on hit validity
-let scene = Surface {
-    geometry: sphere_geom,
-    material,
-    background,
-};
-
-// Render: evaluates fully as a manifold
-let color = scene.eval_raw(rx, ry, rz, w);
+let font = Font::parse(font_bytes).expect("invalid or unsupported TTF");
+let glyph = font
+    .glyph_kernel_scaled('A', 32.0)
+    .expect("font has no glyph for A");
 ```
 
-## Architecture: The "Mullet" Approach
+Coverage antialiasing is intrinsic to these kernels. Curve leaves construct a
+gradient-normalized ramp using `DX`/`DY`; those become `Dwrt` expressions and are resolved
+when the kernel compiles. Coordinate warps therefore carry the ramp width into screen space
+without a separate antialiasing wrapper or jet-valued JIT ABI.
 
-Three-layer pull-based architecture:
+### Glyph cache
 
-1. **Geometry** (expensive): Compute once per pixel via `Jet3` (with 3D derivatives for normals)
-2. **Surface**: Warp coordinates from ray to hit point using the computed `t`
-3. **Material**: Evaluate colors at hit point using derivatives for shading
-
-Result: One geometric computation, colors flow as opaque `Discrete` (packed RGBA).
-
-```
-Manifold<Jet3, Output = Jet3>     (geometry: returns t with derivatives)
-    ↓
-Jet3 → At { inner: material, ... } (evaluates material at warped coords)
-    ↓
-Select with At { background, ... } (blends material/background as manifolds)
-    ↓
-Manifold<Jet3, Output = Discrete> (fully composed color)
-```
-
-## Philosophy: Pure Composition
-
-**The idiomatic style**: Keep everything as manifolds. Compose at the type level.
-
-✅ **Idiomatic**: All parts stay as manifolds
-```rust
-// Surface and ColorSurface use At + Select composition
-let scene = At { inner: &material, x: hx, y: hy, z: hz, w };
-let result = mask.select(scene, fallback);
-```
-
-❌ **Not idiomatic**: Materializing to intermediate values
-```rust
-// Don't do this - loses the compositional structure
-let hit_point = t.eval_raw(...);  // Materialized!
-let color_at_hit = material.eval_raw(hit_point);  // Lost context!
-```
-
-## Key Concepts
-
-### Scene3D: Root of the Composition
-
-Three variants:
-
-- **Surface<G, M, B>**: Returns `Field` (single scalar per pixel)
-- **ColorSurface<G, M, B>**: Returns `Discrete` (packed RGBA)
-
-Both use the same pattern:
-1. Evaluate geometry to get hit distance `t`
-2. Validate `t` (positive, not too large, derivatives sensible)
-3. Warp: compute hit point `P = ray * t`
-4. Use `At` combinator to pin material/background to different coordinates
-5. Use `Select` to blend based on hit validity
+Analytically evaluating every outline at every sample is unnecessary after a glyph is stable.
+`GlyphCache` quantizes the size and display-density keys, bakes the fused kernel once, and
+stores `f32` coverage. Read-back is bilinear so fractional placement interpolates cached
+coverage.
 
 ```rust
-impl<G, M, B> Manifold<Jet3> for Surface<G, M, B> {
-    fn eval_raw(&self, rx: Jet3, ry: Jet3, rz: Jet3, w: Jet3) -> Field {
-        let t = self.geometry.eval_raw(rx, ry, rz, w);
-        let mask = validate_t(t);  // Is this a valid hit?
+use pixelflow_graphics::{Font, GlyphCache};
 
-        // Warp ray to hit point
-        let safe_t = sanitize(t, mask);
-        let hx = rx * safe_t;
-        let hy = ry * safe_t;
-        let hz = rz * safe_t;
+let font = Font::parse(font_bytes).expect("invalid or unsupported TTF");
+let mut cache = GlyphCache::new();
+cache.warm_ascii(&font, 16.0, 2.0);
 
-        // Compose as manifolds - no materialization!
-        let mat = At { inner: &self.material, x: hx, y: hy, z: hz, w };
-        let bg = At { inner: &self.background, x: rx, y: ry, z: rz, w };
-
-        // Select blends while staying compositional
-        Select { cond: FieldMask(mask), if_true: mat, if_false: bg }
-            .eval_raw(rx, ry, rz, w)
-    }
-}
+let glyph = cache
+    .get(&font, 'A', 16.0, 2.0)
+    .expect("font has no glyph for A");
 ```
 
-### Reflect: The Crown Jewel
+`fonts::text` lays a string out as one analytical `Kernel`. `CachedText` instead composes
+cached glyph samplers with advances and kerning. Both represent coverage in `[0, 1]`; mapping
+coverage to foreground/background color is a separate operation.
 
-Reconstructs surface normals from the tangent frame implied by `Jet3` derivatives.
+Supported outline coverage currently targets TrueType quadratic glyphs, cmap formats 4 and
+12, and horizontal `kern` format 0. This is not a general shaping engine.
 
-When you pin a manifold at a hit point using `At`, the derivatives tell you how the surface changes—that's the normal!
+## Colors and frames
+
+The render module separates semantic color from platform pixel layout:
+
+- `Color` and `NamedColor` represent ANSI, indexed, and RGB choices.
+- `ColorCube`, `Grayscale`, and related manifolds map continuous values to packed color.
+- `Rgba8` and `Bgra8` define framebuffer byte layout.
+- `Frame<P>` owns a row-major pixel buffer.
+
+`render::rasterize` pulls a color manifold at pixel coordinates into a frame and can divide
+the work across threads:
 
 ```rust
-pub struct Reflect<M> {
-    pub inner: M,  // Manifold<Jet3, Output = Field>
-}
+use pixelflow_graphics::render::{rasterize, Frame, Rgba8};
 
-impl<M> Manifold<Jet3> for Reflect<M> {
-    fn eval_raw(&self, x: Jet3, y: Jet3, z: Jet3, w: Jet3) -> Field {
-        // x.dx, x.dy, x.dz form the tangent frame
-        // Normal = normalize(tangent_u × tangent_v)
-    }
-}
+let mut frame = Frame::<Rgba8>::new(800, 600);
+rasterize(&color_manifold, &mut frame, 4);
 ```
 
-## Compositionality Benefits
+The exact SIMD width and platform pixel alias are backend details. Consumers should use the
+pixel types rather than assume a byte order or lane count.
 
-1. **Kernel fusion**: At + Select + geometry all inline into one SIMD kernel
-2. **Genericity**: Works with `Field` (preview), `Jet3` (production), future types
-3. **No intermediate buffers**: Rays don't materialize to hit points—they flow through the type system
-4. **Automatic differentiation**: Derivatives propagate through all combinators
+## Ray tracing and the “mullet”
 
-## Examples
+`scene3d` is an application of the polymorphic `Manifold` layer rather than the complete
+architecture of this crate. Its useful three-stage pattern is:
 
-### Simple Sphere
+1. Evaluate geometry over `Jet3` ray coordinates to obtain hit distance and derivatives.
+2. Warp the ray coordinate to the hit point (`P = ray × t`).
+3. Evaluate the material at the hit point and the background at the ray direction, selecting
+   according to hit validity.
 
-```rust
-use pixelflow_graphics::scene3d::{Surface, Sphere};
-use pixelflow_core::Manifold;
+The geometry is the expensive front; color is the discrete back—hence the internal “mullet”
+name.
 
-let sphere = Sphere {
-    center: Field::from(0.0),
-    radius: Field::from(100.0),
-};
+`Reflect` and `ColorReflect` reconstruct a normal from the tangent frame carried by the warped
+coordinate derivatives. The cross product of the two screen-space tangent directions produces
+the surface normal used for Householder reflection. This remains a compact demonstration of
+automatic differentiation carrying geometric information through composition.
 
-let material = ConstantColor { rgb: (1.0, 0.0, 0.0) };
-let background = Sky { };
+This path still uses jets and combinator manifolds. It should not be read as evidence that all
+graphics consumers have moved to arena-backed `Kernel` values.
 
-let scene = Surface {
-    geometry: sphere,
-    material,
-    background,
-};
+## Materialization boundaries
 
-// Evaluate at screen coordinates
-let color = scene.eval_raw(x_jet, y_jet, z_jet, w_jet);
+PixelFlow distinguishes composition from storage:
+
+- Compose analytical font work as `Kernel` values, then bake at a glyph or text-cache boundary.
+- Compose cached glyphs, images, and platform-backed values as ordinary manifolds.
+- Rasterize the final color manifold into a `Frame<P>` at the application boundary.
+
+Intermediate storage is allowed when it is the requested representation—a glyph cache or a
+framebuffer—not hidden as an accidental compiler fallback.
+
+## Status and validation
+
+Font kernel goldens compare JIT execution with the interpreter on the same arena. Additional
+tests cover antialiasing behavior, curve parsing, cache coordinates, color conversion, and
+rendering. Performance claims are intentionally omitted from this README; run the benchmark
+targets on the hardware and revision being evaluated.
+
+```bash
+cargo test -p pixelflow-graphics
+cargo bench -p pixelflow-graphics
+cargo bench -p pixelflow-graphics --bench font_rendering
+cargo bench -p pixelflow-graphics --bench kernel_bench
 ```
 
-### Reflective Sphere
-
-```rust
-use pixelflow_graphics::scene3d::{Surface, Sphere, Reflect};
-use pixelflow_core::Manifold;
-
-let sphere = Sphere { /* ... */ };
-
-// Material applies reflection (normal-based shading)
-let material = Reflect {
-    inner: LambertianShader {
-        albedo: Field::from(0.8),
-        normal_source: sphere,  // Computes normal from Jet3 derivatives
-    },
-};
-
-let scene = Surface {
-    geometry: sphere,
-    material,
-    background: Sky { },
-};
-```
-
-## Coordinate Types
-
-All manifolds are generic over the input coordinate type `I`:
-
-- **Field**: Concrete SIMD values (for evaluation)
-- **Jet2**: 2D automatic differentiation (gradients)
-- **Jet3**: 3D automatic differentiation (normals for 3D surfaces)
-
-The same expression works with all three—no rewrite needed.
-
-## No Pre-Computation
-
-The key rule: **Don't materialize intermediate results.**
-
-❌ Bad:
-```rust
-let hit_point_x = hx.eval_raw(rx, ry, rz, w);  // Materialized!
-```
-
-✅ Good:
-```rust
-let mat_at_hit = At { inner: &material, x: hx, y: hy, z: hz, w };
-// hx stays as a Jet3 expression, composes into the kernel
-```
-
-## Integration with pixelflow-core
-
-This crate builds on top of `pixelflow-core`:
-
-- Uses `Manifold`, `Select`, `At`, `Jet3`, etc. from core
-- Adds scene-specific types: `Surface`, `ColorSurface`, `Reflect`
-- All composition happens at the core manifold level
+The current compiler migration is tracked in
+[`2026-07-20-kernel-unification.md`](../docs/plans/2026-07-20-kernel-unification.md).
 
 ## License
 
-MIT
+[Apache License 2.0](../LICENSE.md)

--- a/pixelflow-search/README.md
+++ b/pixelflow-search/README.md
@@ -1,110 +1,161 @@
 # pixelflow-search
 
-Arena-native e-graph optimization and model scoring for PixelFlow.
+`pixelflow-search` is PixelFlow's arena-native algebraic optimization research crate. Its
+implemented core builds an e-graph from `pixelflow-ir::ExprArena`, applies rewrite rules under
+explicit budgets, records rule provenance, and extracts an equivalent arena with a pluggable
+cost function.
 
-## Overview
+Learned extraction machinery also exists, but learned rule guidance is an experiment with
+decision gates—not the default optimizer and not a completed training product.
 
-This crate provides the live optimization stack:
+## Status at a glance
 
-1. **E-graph equality saturation** - find algebraically equivalent forms
-2. **Arena-native extraction** - materialize the chosen result as `ExprArena`
-3. **EgraphOptimizationModel** - score saturation and extraction without benchmarking
+| Capability | Status |
+|---|---|
+| Arena ↔ e-graph conversion | Implemented |
+| Algebraic, transcendental, fusion, and derivative rewrites | Implemented and tested for soundness |
+| Time/class/iteration-bounded saturation | Implemented |
+| Static latency-prior extraction | Implemented; compiler default |
+| DAG-aware extraction and arena reconstruction | Implemented |
+| Rule-application provenance and hindsight labels | Implemented |
+| NNUE expression-cost model and incremental extractor | Implemented; opt-in consumer path |
+| Trained provenance guide for choosing rewrites | Research plan; thesis experiment not yet completed |
+| Beam/lookahead search over rewrite applications | Conditional future work |
 
-## Architecture
+The obsolete critic/REINFORCE dual-head architecture is retained in historical documents for
+rationale, but it is not the live training path. See
+[`guided-saturation-redesign.md`](../docs/plans/2026-07-07-guided-saturation-redesign.md).
 
+## Deterministic optimization path
+
+```text
+ExprArena
+   │
+   ▼
+EGraph::add_arena
+   │
+   ▼
+budgeted rewrite saturation
+   │
+   ▼
+CostModel / other CostFunction
+   │
+   ▼
+extracted ExprArena
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│                     Training (offline)                          │
-├─────────────────────────────────────────────────────────────────┤
-│  1. Generate seed expressions                                   │
-│  2. E-graph saturation → find all equivalents                   │
-│  3. Benchmark sampled variants (real SIMD costs)                │
-│  4. Train the shared model:                                     │
-│     - Extraction head: features(expr) → cost_ns                 │
-│     - Saturation head: graph/rule state → rewrite score         │
-└─────────────────────────────────────────────────────────────────┘
-                              ↓
-┌─────────────────────────────────────────────────────────────────┐
-│                     Inference (compile-time)                    │
-├─────────────────────────────────────────────────────────────────┤
-│  For new kernel K:                                              │
-│  1. Insert K into e-graph                                       │
-│  2. Saturate with algebraic rules                               │
-│  3. Extract the best predicted arena form                       │
-└─────────────────────────────────────────────────────────────────┘
-```
 
-## Usage
-
-### Basic E-Graph Optimization
+`EGraph::new()` deliberately contains no rules. Applications supply a rule set explicitly,
+usually `all_rules()`, so a test or compiler phase can constrain the algebra it permits.
 
 ```rust
-use pixelflow_ir::ExprArena;
-use pixelflow_search::egraph::{ops, CostModel, EGraph, ENode};
+use pixelflow_ir::{ExprArena, OpKind};
+use pixelflow_search::egraph::{CostModel, EGraph, all_rules};
 
 let mut arena = ExprArena::new();
 let x = arena.push_var(0);
 let zero = arena.push_const(0.0);
-let one = arena.push_const(1.0);
-let add = arena.push_binary(pixelflow_ir::OpKind::Add, x, zero);
-let root_expr = arena.push_binary(pixelflow_ir::OpKind::Mul, add, one);
+let root = arena.push_binary(OpKind::Add, x, zero);
 
-let mut eg = EGraph::new();
-let root = eg.add_arena(&arena, root_expr);
-eg.saturate();
+let mut egraph = EGraph::with_rules(all_rules());
+let root_class = egraph.add_arena(&arena, root);
+egraph.saturate();
 
-// Extract optimal arena form
 let costs = CostModel::default();
-let (optimized, optimized_root, cost) = eg.extract_best(root, &costs);
+let (optimized, optimized_root, estimated_cost) =
+    egraph.extract_best(root_class, &costs);
+
 assert!(optimized.node_count_subtree(optimized_root) > 0);
-assert!(cost <= 2);
+assert!(estimated_cost <= costs.cost(OpKind::Add));
 ```
+
+`saturate()` has built-in iteration, e-class, and wall-clock limits. Lower-level APIs expose
+explicit budgets for experiments that need a different stopping policy.
+
+## Cost model
+
+`CostFunction` is the extraction interface. The standard `CostModel` is an O(1) table indexed
+by `OpKind`, with optional depth penalties.
+
+`CostModel::default()` and `CostModel::latency_prior()` use the same handcrafted per-operation
+latency prior. This is the compiler's normal extraction policy. The values are estimates, not
+portable benchmark results; calibration and learned alternatives belong to the research
+tooling.
+
+The compiler enables learned extraction only when `PIXELFLOW_NNUE_WEIGHTS` names a weights
+file. Missing, unreadable, or incompatible opt-in weights fail loudly. With the variable
+unset, compilation uses the static latency prior.
+
+This opt-in path selects an expression from an already-built e-graph. It should not be confused
+with a learned policy that decides which rewrite applications to admit during saturation.
+
+## Provenance and labels
+
+The e-graph records three append-only kinds of evidence:
+
+- the origin of each stable e-node identity;
+- each rule application and the nodes it matched or created;
+- union events between e-classes.
+
+After extraction, `EpisodeLabels` walks the winning derivation and labels applications as
+load-bearing or unused for that episode. `run_episode` packages saturation, static extraction,
+and hindsight labeling for a supplied rule set.
+
+This machinery supports rule audits today. Its proposed use as supervised training data for a
+Guide remains research; provenance itself does not prove that a trained guide improves the
+optimizer.
+
+Run the checked-in report over its small illustrative corpus:
+
+```bash
+cargo run --release -p pixelflow-search --example rule_report
+```
+
+The report is corpus-conditioned. Do not generalize rule rankings from its five example
+kernels to production workloads without a representative corpus.
+
+## Guided-saturation research
+
+The current research question is whether a learned rule filter can keep a large rewrite
+library inside a fixed budget while preserving the extraction quality of smaller full
+saturation. The plan deliberately separates stages:
+
+1. Provenance and hindsight labels — landed.
+2. Static latency-prior baseline — landed and default.
+3. Greedy guide trained from provenance — not yet validated.
+4. Lookahead search — considered only if the greedy experiment exposes missed enabling chains.
+
+Each stage has a stop condition. The repository does not claim that guided saturation, an
+AlphaZero-like loop, or a learned cost model has beaten the static baseline.
 
 ## Modules
 
 | Module | Purpose |
-|--------|---------|
-| `egraph` | E-graph implementation with equality saturation |
-| `egraph::codegen` | DAG → `kernel!` macro code generation |
-| `egraph::saturate` | Budget-limited saturation |
-| `nnue` | Shared optimization model + accumulators |
-| `nnue::factored` | O(ops) factored embedding architecture |
-| `training` | Training infrastructure (feature-gated) |
+|---|---|
+| `egraph` | Graph, rewrites, saturation, extraction, provenance, and labeling |
+| `math` | Algebraic, calculus, parity, exponential, and trigonometric rewrite families |
+| `nnue` | Expression embeddings, model representation, and opt-in neural extraction support |
 
-## Features
+Training corpora, JIT measurement, and extraction comparisons live in `pixelflow-pipeline`
+rather than in this crate. Commands documented here are limited to targets that currently
+exist; older `pixelflow-compiler` training examples were removed with the superseded RL path.
 
-- `std` (default): Enable standard library features
-- `training`: Enable training utilities (data generation, backprop)
-- `nnue`: Enable NNUE integration for best-first search
-
-## Training Pipeline
+## Test
 
 ```bash
-# 1. Generate variants and benchmark code
-cargo run -p pixelflow-compiler --example gen_egraph_variants --features training
-
-# 2. Collect benchmark costs
-cargo run -p pixelflow-compiler --example collect_benchmark_costs --features training
-
-# 3. Train the Judge (value head)
-cargo run -p pixelflow-compiler --example train_with_validation --features training
-
-# 4. Collect search training data using the Judge
-cargo run -p pixelflow-compiler --example collect_search_training --features training
-
-# 5. Train the Guide (search head)
-cargo run -p pixelflow-compiler --example train_search_head --features training
+cargo test -p pixelflow-search
 ```
 
-## Integration
+Rewrite-soundness tests evaluate both sides through the IR's reference semantics. Optimization
+results and benchmark reports remain point-in-time evidence, not compatibility guarantees.
 
-This crate works with:
+## Related documents
 
-- **pixelflow-ir**: Shared IR types (Expr, OpKind)
-- **pixelflow-compiler**: Compile-time kernel optimization
+- [`guided-saturation-redesign.md`](../docs/plans/2026-07-07-guided-saturation-redesign.md) —
+  current research plan and decision gates
+- [`docs/results/`](../docs/results/) — rule and extraction experiment reports
+- [`EGRAPH_OPTIMIZATION_ARCHITECTURE.md`](../docs/EGRAPH_OPTIMIZATION_ARCHITECTURE.md) —
+  superseded critic/REINFORCE architecture, retained for history
 
-## References
+## License
 
-- [egg: E-Graphs Good](https://egraphs-good.github.io/) - E-graph background
-- [Stockfish NNUE](https://github.com/official-stockfish/Stockfish) - NNUE architecture inspiration
-- [AlphaZero](https://arxiv.org/abs/1712.01815) - Dual-head value/policy network
+[Apache License 2.0](../LICENSE.md)


### PR DESCRIPTION
## Summary

- rewrite the root overview around the current JIT-first `Kernel`/`ExprArena` direction while documenting the remaining combinator-emitter boundary
- make `pixelflow-core` distinguish arena-backed kernels, `Manifold` compatibility, lattices, and symbolic differentiation
- describe fonts, frames, and the retained derivative-based ray-tracing design in `pixelflow-graphics`
- separate deterministic e-graph extraction and provenance from unvalidated learned guided saturation in `pixelflow-search`
- repair the documentation index so superseded RL and lowering designs are no longer labeled current

## Why

The READMEs had accumulated several generations of PixelFlow architecture and presented transitional, rejected, and planned systems in the same present tense. They also contained dead training commands, stale APIs, unsupported performance language, and incorrect MIT license notices.

The revised documentation preserves the research history while labeling implemented, transitional, planned, experimental, and superseded work explicitly.

## Validation

- all relative Markdown links resolve
- Markdown fences are balanced
- `git diff --check`
- `cargo check -p pixelflow-core -p pixelflow-graphics -p pixelflow-search`
- verified documented APIs, commands, examples, and benchmark target names against the current repository

