### PR TITLE
refactor(actor-scheduler): make the host's sweep an input, so supervision can leave

### DIFF
--- a/actor-scheduler-macros/src/lib.rs
+++ b/actor-scheduler-macros/src/lib.rs
@@ -112,7 +112,7 @@ fn parse_attrs(group_str: &str) -> ActorAttrs {
         match part.trim() {
             "main" => attrs.is_main = true,
             "expose" => attrs.is_exposed = true,
-            // An actor that blocks in `park()` on a file descriptor (epoll,
+            // An actor that blocks in `handle_os()` on a file descriptor (epoll,
             // kqueue) needs a `WakeHandler` wired into its inbound handles so
             // sends interrupt the poll. `[waker]` reserves a slot in the
             // generated `Wakers` struct for that actor. `[main]` implies a
@@ -464,7 +464,7 @@ pub fn troupe(input: TokenStream) -> TokenStream {
         ///
         /// One optional field per slot: `Some(waker)` wires that `WakeHandler`
         /// into every inbound handle of the actor, so a send interrupts the
-        /// `park()` poll it is blocked in; `None` leaves it doorbell-only.
+        /// `handle_os()` poll it is blocked in; `None` leaves it doorbell-only.
         #[derive(Default)]
         pub struct Wakers {{
             {wakers_fields}

--- a/actor-scheduler/benches/bench_adversarial.rs
+++ b/actor-scheduler/benches/bench_adversarial.rs
@@ -30,7 +30,7 @@ impl Actor<i32, (), ()> for CountingActor {
         Ok(())
     }
 
-    fn park(&mut self, hint: SystemStatus) -> Result<ActorStatus, HandlerError> {
+    fn handle_os(&mut self, hint: SystemStatus) -> Result<ActorStatus, HandlerError> {
         match hint {
             SystemStatus::Idle => Ok(ActorStatus::Idle),
             SystemStatus::Busy => Ok(ActorStatus::Busy),
@@ -243,7 +243,7 @@ fn bench_slow_receiver_backpressure(c: &mut Criterion) {
                     Ok(())
                 }
 
-                fn park(&mut self, hint: SystemStatus) -> Result<ActorStatus, HandlerError> {
+                fn handle_os(&mut self, hint: SystemStatus) -> Result<ActorStatus, HandlerError> {
                     match hint {
                         SystemStatus::Idle => Ok(ActorStatus::Idle),
                         SystemStatus::Busy => Ok(ActorStatus::Busy),

--- a/actor-scheduler/benches/bench_latency.rs
+++ b/actor-scheduler/benches/bench_latency.rs
@@ -32,7 +32,7 @@ impl Actor<(), (), ()> for LatencyActor {
         Ok(())
     }
 
-    fn park(&mut self, hint: SystemStatus) -> Result<ActorStatus, HandlerError> {
+    fn handle_os(&mut self, hint: SystemStatus) -> Result<ActorStatus, HandlerError> {
         match hint {
             SystemStatus::Idle => Ok(ActorStatus::Idle),
             SystemStatus::Busy => Ok(ActorStatus::Busy),
@@ -57,7 +57,7 @@ fn bench_control_latency(c: &mut Criterion) {
                     rx.run(&mut actor);
                 });
 
-                // Give actor thread time to start and park
+                // Give actor thread time to start and enter handle_os
                 thread::sleep(Duration::from_millis(1));
 
                 // Benchmark individual message round-trips (steady-state)

--- a/actor-scheduler/benches/bench_mealy.rs
+++ b/actor-scheduler/benches/bench_mealy.rs
@@ -63,7 +63,7 @@ impl Actor<u8, (), ()> for SendingActor {
     fn handle_management(&mut self, (): ()) -> HandlerResult {
         Ok(())
     }
-    fn park(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
+    fn handle_os(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
         Ok(ActorStatus::Idle)
     }
 }
@@ -200,7 +200,7 @@ impl Actor<u8, (), ()> for ForwardActor {
     fn handle_management(&mut self, (): ()) -> HandlerResult {
         Ok(())
     }
-    fn park(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
+    fn handle_os(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
         Ok(ActorStatus::Idle)
     }
 }

--- a/actor-scheduler/benches/bench_optimize.rs
+++ b/actor-scheduler/benches/bench_optimize.rs
@@ -274,7 +274,7 @@ impl Actor<(), (), ()> for LatencyActor {
         self.response_tx.send(()).ok();
         Ok(())
     }
-    fn park(&mut self, h: SystemStatus) -> Result<ActorStatus, HandlerError> {
+    fn handle_os(&mut self, h: SystemStatus) -> Result<ActorStatus, HandlerError> {
         Ok(match h {
             SystemStatus::Idle => ActorStatus::Idle,
             SystemStatus::Busy => ActorStatus::Busy,
@@ -360,7 +360,7 @@ impl Actor<i32, (), ()> for CountingActor {
         self.mgmt_count.fetch_add(1, Ordering::Relaxed);
         Ok(())
     }
-    fn park(&mut self, h: SystemStatus) -> Result<ActorStatus, HandlerError> {
+    fn handle_os(&mut self, h: SystemStatus) -> Result<ActorStatus, HandlerError> {
         Ok(match h {
             SystemStatus::Idle => ActorStatus::Idle,
             SystemStatus::Busy => ActorStatus::Busy,
@@ -498,7 +498,7 @@ fn measure_latency_under_load(params: &SchedulerParams) -> f64 {
         fn handle_management(&mut self, _: ()) -> HandlerResult {
             Ok(())
         }
-        fn park(&mut self, h: SystemStatus) -> Result<ActorStatus, HandlerError> {
+        fn handle_os(&mut self, h: SystemStatus) -> Result<ActorStatus, HandlerError> {
             Ok(match h {
                 SystemStatus::Idle => ActorStatus::Idle,
                 SystemStatus::Busy => ActorStatus::Busy,
@@ -583,7 +583,7 @@ fn measure_burst_recovery(params: &SchedulerParams) -> f64 {
         fn handle_management(&mut self, _: ()) -> HandlerResult {
             Ok(())
         }
-        fn park(&mut self, h: SystemStatus) -> Result<ActorStatus, HandlerError> {
+        fn handle_os(&mut self, h: SystemStatus) -> Result<ActorStatus, HandlerError> {
             Ok(match h {
                 SystemStatus::Idle => ActorStatus::Idle,
                 SystemStatus::Busy => ActorStatus::Busy,

--- a/actor-scheduler/benches/bench_optimize_spsc.rs
+++ b/actor-scheduler/benches/bench_optimize_spsc.rs
@@ -274,7 +274,7 @@ impl<D, C, M> SpscScheduler<D, C, M> {
             SystemStatus::Idle
         };
 
-        let actor_status = actor.park(system_status)?;
+        let actor_status = actor.handle_os(system_status)?;
         Ok(more_work || actor_status == ActorStatus::Busy)
     }
 }
@@ -424,7 +424,7 @@ impl Actor<(), (), ()> for LatencyActor {
         self.response_tx.send(()).ok();
         Ok(())
     }
-    fn park(&mut self, h: SystemStatus) -> Result<ActorStatus, HandlerError> {
+    fn handle_os(&mut self, h: SystemStatus) -> Result<ActorStatus, HandlerError> {
         Ok(match h {
             SystemStatus::Idle => ActorStatus::Idle,
             SystemStatus::Busy => ActorStatus::Busy,
@@ -507,7 +507,7 @@ impl Actor<i32, (), ()> for CountingActor {
         self.mgmt_count.fetch_add(1, Ordering::Relaxed);
         Ok(())
     }
-    fn park(&mut self, h: SystemStatus) -> Result<ActorStatus, HandlerError> {
+    fn handle_os(&mut self, h: SystemStatus) -> Result<ActorStatus, HandlerError> {
         Ok(match h {
             SystemStatus::Idle => ActorStatus::Idle,
             SystemStatus::Busy => ActorStatus::Busy,
@@ -634,7 +634,7 @@ fn measure_latency_under_load(params: &SchedulerParams) -> f64 {
         fn handle_management(&mut self, _: ()) -> HandlerResult {
             Ok(())
         }
-        fn park(&mut self, h: SystemStatus) -> Result<ActorStatus, HandlerError> {
+        fn handle_os(&mut self, h: SystemStatus) -> Result<ActorStatus, HandlerError> {
             Ok(match h {
                 SystemStatus::Idle => ActorStatus::Idle,
                 SystemStatus::Busy => ActorStatus::Busy,
@@ -708,7 +708,7 @@ fn measure_burst_recovery(params: &SchedulerParams) -> f64 {
         fn handle_management(&mut self, _: ()) -> HandlerResult {
             Ok(())
         }
-        fn park(&mut self, h: SystemStatus) -> Result<ActorStatus, HandlerError> {
+        fn handle_os(&mut self, h: SystemStatus) -> Result<ActorStatus, HandlerError> {
             Ok(match h {
                 SystemStatus::Idle => ActorStatus::Idle,
                 SystemStatus::Busy => ActorStatus::Busy,

--- a/actor-scheduler/benches/bench_throughput.rs
+++ b/actor-scheduler/benches/bench_throughput.rs
@@ -30,7 +30,7 @@ impl Actor<i32, (), ()> for CountingActor {
         Ok(())
     }
 
-    fn park(&mut self, hint: SystemStatus) -> Result<ActorStatus, HandlerError> {
+    fn handle_os(&mut self, hint: SystemStatus) -> Result<ActorStatus, HandlerError> {
         match hint {
             SystemStatus::Idle => Ok(ActorStatus::Idle),
             SystemStatus::Busy => Ok(ActorStatus::Busy),

--- a/actor-scheduler/src/host.rs
+++ b/actor-scheduler/src/host.rs
@@ -11,7 +11,7 @@
 //! host can be a green actor inside another host. Same sweep either way; what differs is where
 //! its findings can go.
 //!
-//! - [`Actor`] impl — `park` sweeps, and reports only `Busy`/`Idle`. Simplest, and enough
+//! - [`Actor`] impl — `handle_os` sweeps, and reports only `Busy`/`Idle`. Simplest, and enough
 //!   whenever the green actors have nowhere to escalate to.
 //! - [`Transducer`] impl — [`RunSweep`] on the data lane, [`HostOut`] carrying supervision out a
 //!   port that its wiring delivers and [`Topology`](crate::mealy::Topology) can check.
@@ -19,12 +19,12 @@
 //! - [`sweep`](Host::sweep) — called directly, findings as a return value.
 //!
 //! Supervision needs one of the last two, because [`ActorStatus`] is `Busy | Idle` and has no
-//! room for "node 3 is stuck holding a framebuffer". The sweep behind `park` computes those
+//! room for "node 3 is stuck holding a framebuffer". The sweep behind `handle_os` computes those
 //! events and then drops them, and no amount of improving how the sweep *reports* them changes
 //! that — the discard is in the signature. That is a limit of the hook, not a defect in it:
-//! `park` exists to invert control flow around an external event source you do not own — an
+//! `handle_os` exists to invert control flow around an external event source you do not own — an
 //! epoll set, a PTY, `XNextEvent`, a Cocoa event queue — and `Busy`/`Idle` is exactly the
-//! vocabulary that job needs. Reach for `park` when you *have* to give up the loop; reach for a
+//! vocabulary that job needs. Reach for `handle_os` when you *have* to give up the loop; reach for a
 //! port when you have something to say.
 //!
 //! The sleep behaviour survives the move: on the wired path it is the self-addressed
@@ -362,14 +362,14 @@ pub fn green_channel<T>(capacity: usize, waker: Waker) -> (GreenSender<T>, SpscR
 /// Runs a [`Host`] on an OS thread under the ordinary [`ActorScheduler`](crate::ActorScheduler).
 ///
 /// The green tier needs one thing from the OS tier that it cannot supply itself: something has
-/// to notice that the doorbell rang and turn that into an input. That is `park`'s actual job —
+/// to notice that the doorbell rang and turn that into an input. That is `handle_os`'s actual job —
 /// bridging the outside world to a message — and it is all this does. It feeds one [`RunSweep`],
 /// advances the host until quiet, and reports whether the thread may sleep.
 ///
-/// What it deliberately does **not** do is carry supervision. By the time `park` returns, any
+/// What it deliberately does **not** do is carry supervision. By the time `handle_os` returns, any
 /// event has already left over the host's own wiring, so there is nothing for an
 /// `ActorStatus` to fail to express. That is the whole difference from the `impl Actor for Host`
-/// this replaces, which computed events inside `park` and dropped them for want of a channel.
+/// this replaces, which computed events inside `handle_os` and dropped them for want of a channel.
 pub struct GreenThread<W: Wiring<Out = HostOut>> {
     node: Node<Host, W, SpscReceiver<RunSweep>>,
     /// Feeds the sweep that a doorbell wake implies. Capacity one: a sweep already queued is as
@@ -406,13 +406,13 @@ impl<W: Wiring<Out = HostOut>> Actor<Infallible, Infallible, Infallible> for Gre
         match msg {}
     }
 
-    fn park(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
+    fn handle_os(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
         match self.tick.try_send(RunSweep) {
             Ok(()) => {}
             // Full: a sweep is already queued, which is what this was going to ask for —
             // `RunSweep` carries nothing to distinguish a second one from the first.
             // Disconnected: unreachable, since this owns both ends of `tick`.
-            // Neither is worth failing a park over, and the poll below runs either way.
+            // Neither is worth failing a handle_os over, and the poll below runs either way.
             Err(TrySendError::Full(_) | TrySendError::Disconnected(_)) => {}
         }
 
@@ -458,7 +458,7 @@ impl Actor<Infallible, Infallible, Infallible> for Host {
     /// When they matter, use the [`Transducer`] impl — the same host, wired, emitting
     /// [`HostOut::supervision`] over a port — via [`GreenThread`] to run it on a thread, or
     /// [`sweep`](Host::sweep) to read them directly. All three are the same sweep.
-    fn park(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
+    fn handle_os(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
         Ok(self.sweep().status)
     }
 }
@@ -663,11 +663,11 @@ mod tests {
     }
 
     // ────────────────────────────────────────────────────────────────────────
-    // The host as a transducer: supervision over an edge, not through `park`
+    // The host as a transducer: supervision over an edge, not through `handle_os`
     // ────────────────────────────────────────────────────────────────────────
 
     /// Delivers a host's supervision events onward, which is the whole point of the conversion:
-    /// under the old `park` they were computed and dropped.
+    /// under the old `handle_os` they were computed and dropped.
     struct SupervisionWiring {
         supervisor: SpscSender<Supervision>,
     }
@@ -691,7 +691,7 @@ mod tests {
         (node, tx_sweep, rx_sup)
     }
 
-    /// The conversion's reason for existing. Under `park` this event was computed and discarded
+    /// The conversion's reason for existing. Under `handle_os` this event was computed and discarded
     /// because `Result<ActorStatus, _>` had nowhere to put it; here it arrives at a supervisor
     /// as an ordinary message.
     #[test]
@@ -720,7 +720,7 @@ mod tests {
         assert_eq!(event.reason, Stuck::TargetGone);
     }
 
-    /// The sleep contract `park` used to provide, in the transducer's own vocabulary: a sweep
+    /// The sleep contract `handle_os` used to provide, in the transducer's own vocabulary: a sweep
     /// that ran something yields a continuation and is stepped straight back; a quiet one does
     /// not, so the node reports `Idle` and the driving thread may block.
     #[test]

--- a/actor-scheduler/src/host.rs
+++ b/actor-scheduler/src/host.rs
@@ -4,31 +4,34 @@
 //! advances them a step at a time. There is no second runtime — the green tier is a thing an
 //! actor *does*.
 //!
-//! # Why the sweep is message-driven, not a `park` hook
+//! # Three ways to drive one, and when supervision needs the wired one
 //!
-//! It used to be a `park` hook, and that was the wrong shape for one reason: **`park` answers
-//! exactly one question, and supervision is a different question.**
+//! A host is an ordinary [`Actor`], so an ordinary [`ActorScheduler`](crate::ActorScheduler) runs
+//! one on a thread and the tiers nest with no second runtime. It is *also* a [`Transducer`], so a
+//! host can be a green actor inside another host. Same sweep either way; what differs is where
+//! its findings can go.
 //!
-//! [`Actor::park`] returns [`ActorStatus`] — `Busy` or `Idle`, meaning "keep going" or "the
-//! thread may sleep". That is the whole information content of the OS-bridge contract, and it is
-//! the right contract for blocking on `XNextEvent` or a Cocoa event queue, which is what `park`
-//! exists for. It has nowhere to put "node 3 is stuck holding a framebuffer". So a host sweeping
-//! inside `park` had to compute supervision events and then throw them away, and no amount of
-//! improving how the sweep *reported* them could change that, because the discard was in the
-//! signature rather than in the reporting.
+//! - [`Actor`] impl — `park` sweeps, and reports only `Busy`/`Idle`. Simplest, and enough
+//!   whenever the green actors have nowhere to escalate to.
+//! - [`Transducer`] impl — [`RunSweep`] on the data lane, [`HostOut`] carrying supervision out a
+//!   port that its wiring delivers and [`Topology`](crate::mealy::Topology) can check.
+//!   [`GreenThread`] runs this one on a thread.
+//! - [`sweep`](Host::sweep) — called directly, findings as a return value.
 //!
-//! So the sweep is an input instead: [`RunSweep`] arrives on the data lane, and [`HostOut`]
-//! carries supervision out a port like any other transducer's output — delivered by its wiring,
-//! checkable by [`Topology`](crate::mealy::Topology). The sleep behaviour that `park` gave for
-//! free is not lost; it moves to the self-addressed continuation, which is the transducer
-//! model's own way of saying "more work": a sweep in which something ran yields
-//! [`HostOut::again`] and is stepped straight back, and one where nothing ran yields `None`, so
-//! the node goes [`Idle`](Step::Idle) and the thread driving it may block. **A host with nothing
-//! to do still sleeps instead of polling** — it just says so in the same vocabulary as every
-//! other actor, and can say more than that when it needs to.
+//! Supervision needs one of the last two, because [`ActorStatus`] is `Busy | Idle` and has no
+//! room for "node 3 is stuck holding a framebuffer". The sweep behind `park` computes those
+//! events and then drops them, and no amount of improving how the sweep *reports* them changes
+//! that — the discard is in the signature. That is a limit of the hook, not a defect in it:
+//! `park` exists to invert control flow around an external event source you do not own — an
+//! epoll set, a PTY, `XNextEvent`, a Cocoa event queue — and `Busy`/`Idle` is exactly the
+//! vocabulary that job needs. Reach for `park` when you *have* to give up the loop; reach for a
+//! port when you have something to say.
 //!
-//! Driving one is therefore [`Node::poll`], or [`sweep`](Host::sweep) called directly when a
-//! caller wants the events as a return value rather than over an edge.
+//! The sleep behaviour survives the move: on the wired path it is the self-addressed
+//! continuation, the transducer model's own way of saying "more work". A sweep in which
+//! something ran yields [`HostOut::again`] and is stepped straight back; one where nothing ran
+//! yields `None`, the node goes [`Idle`](Step::Idle), and the driver may block. **A host with
+//! nothing to do sleeps instead of polling either way.**
 //!
 //! # Ownership, not migration
 //!
@@ -426,6 +429,37 @@ impl<W: Wiring<Out = HostOut>> Actor<Infallible, Infallible, Infallible> for Gre
                 Step::Blocked | Step::Disconnected => return Ok(ActorStatus::Busy),
             }
         }
+    }
+}
+
+impl Actor<Infallible, Infallible, Infallible> for Host {
+    fn handle_data(&mut self, msg: Infallible) -> HandlerResult {
+        match msg {}
+    }
+
+    fn handle_control(&mut self, msg: Infallible) -> HandlerResult {
+        match msg {}
+    }
+
+    fn handle_management(&mut self, msg: Infallible) -> HandlerResult {
+        match msg {}
+    }
+
+    /// Sweep, and report only whether the thread may sleep.
+    ///
+    /// This is the plain hierarchical composition: a host is an ordinary [`Actor`], so an
+    /// ordinary [`ActorScheduler`](crate::ActorScheduler) can run one on a thread and the two
+    /// tiers nest without a second runtime. Keep reaching for it when a host's green actors
+    /// have nowhere to escalate to — most do not.
+    ///
+    /// It cannot carry supervision, and that is a property of the signature rather than an
+    /// oversight: `ActorStatus` is `Busy | Idle`, which answers "may this thread sleep?" and has
+    /// no room for "node 3 is stuck holding a payload". Findings are therefore dropped here.
+    /// When they matter, use the [`Transducer`] impl — the same host, wired, emitting
+    /// [`HostOut::supervision`] over a port — via [`GreenThread`] to run it on a thread, or
+    /// [`sweep`](Host::sweep) to read them directly. All three are the same sweep.
+    fn park(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
+        Ok(self.sweep().status)
     }
 }
 
@@ -900,6 +934,49 @@ mod tests {
 
     // ── Waking a sleeping host ──────────────────────────────────────────────
 
+    /// The same wake, on the wired path. `GreenThread` is what turns a doorbell wake into the
+    /// `RunSweep` the transducer needs, so a host that reports supervision over a port keeps the
+    /// same 0%-CPU behaviour as the plain `Actor` one.
+    #[test]
+    fn a_green_send_wakes_a_wired_host_too() {
+        use std::time::{Duration, Instant};
+
+        let (handle, mut sched) = ActorScheduler::<Infallible, Infallible, Infallible>::new(4, 4);
+        let (tx_green, rx_green) = green_channel::<u32>(8, handle.waker());
+        let (tx_out, mut rx_out) = spsc_channel::<u32>(8);
+        let (tx_sup, _rx_sup) = spsc_channel::<Supervision>(8);
+
+        let worker = std::thread::spawn(move || {
+            let mut host = Host::new();
+            host.adopt(Node::new(
+                Forward { seen: 0 },
+                rx_green,
+                ForwardWiring { next: tx_out },
+            ));
+            let mut thread = GreenThread::new(host, SupervisionWiring { supervisor: tx_sup });
+            sched.run(&mut thread);
+        });
+
+        std::thread::sleep(Duration::from_millis(50));
+        tx_green.try_send(41).expect("green inbox has room");
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let got = loop {
+            if let Ok(v) = rx_out.try_recv() {
+                break v;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "wired host never woke: a green send did not reach a sweep"
+            );
+            std::thread::yield_now();
+        };
+        assert_eq!(got, 42);
+
+        handle.send(Message::Shutdown).unwrap();
+        worker.join().unwrap();
+    }
+
     #[test]
     fn a_green_send_wakes_a_host_asleep_on_its_doorbell() {
         // The real thing, on a real thread: the host is blocked in `run()` with nothing to do
@@ -920,11 +997,7 @@ mod tests {
                 rx_green,
                 ForwardWiring { next: tx_out },
             ));
-            // The supervision port has no reader in this test; nothing here goes stuck, so it
-            // stays empty. `GreenThread` is what turns the doorbell wake into a `RunSweep`.
-            let (tx_sup, _rx_sup) = spsc_channel::<Supervision>(8);
-            let mut thread = GreenThread::new(host, SupervisionWiring { supervisor: tx_sup });
-            sched.run(&mut thread);
+            sched.run(&mut host);
         });
 
         // Let the host reach its doorbell and block before sending, so this exercises the

--- a/actor-scheduler/src/host.rs
+++ b/actor-scheduler/src/host.rs
@@ -1,17 +1,34 @@
 //! Hosting green actors on an OS-thread actor.
 //!
-//! The two tiers compose by self-hosting: a [`Host`] is an ordinary [`Actor`], run by the
-//! ordinary [`ActorScheduler`](crate::ActorScheduler) on an ordinary OS thread. What makes it
-//! a worker is that its `park` sweeps a set of green actors ([`Node`]s) instead of bridging
-//! to the OS. There is no second runtime — the green tier is a thing an actor *does*.
+//! The two tiers compose by self-hosting: a [`Host`] owns a set of green actors ([`Node`]s) and
+//! advances them a step at a time. There is no second runtime — the green tier is a thing an
+//! actor *does*.
 //!
-//! # Why `park` is the right hook
+//! # Why the sweep is message-driven, not a `park` hook
 //!
-//! [`Actor::park`] already returns [`ActorStatus`], and the scheduler already honours it:
-//! `Busy` means "more work, do not block", `Idle` means "nothing to do, block on the
-//! doorbell". So a host that returns `Busy` while any green actor ran, and `Idle` once they
-//! are all quiet, gets the behaviour that matters for free — **a host with nothing to do
-//! sleeps instead of polling**, and wakes when a message arrives, exactly like every other actor.
+//! It used to be a `park` hook, and that was the wrong shape for one reason: **`park` answers
+//! exactly one question, and supervision is a different question.**
+//!
+//! [`Actor::park`] returns [`ActorStatus`] — `Busy` or `Idle`, meaning "keep going" or "the
+//! thread may sleep". That is the whole information content of the OS-bridge contract, and it is
+//! the right contract for blocking on `XNextEvent` or a Cocoa event queue, which is what `park`
+//! exists for. It has nowhere to put "node 3 is stuck holding a framebuffer". So a host sweeping
+//! inside `park` had to compute supervision events and then throw them away, and no amount of
+//! improving how the sweep *reported* them could change that, because the discard was in the
+//! signature rather than in the reporting.
+//!
+//! So the sweep is an input instead: [`RunSweep`] arrives on the data lane, and [`HostOut`]
+//! carries supervision out a port like any other transducer's output — delivered by its wiring,
+//! checkable by [`Topology`](crate::mealy::Topology). The sleep behaviour that `park` gave for
+//! free is not lost; it moves to the self-addressed continuation, which is the transducer
+//! model's own way of saying "more work": a sweep in which something ran yields
+//! [`HostOut::again`] and is stepped straight back, and one where nothing ran yields `None`, so
+//! the node goes [`Idle`](Step::Idle) and the thread driving it may block. **A host with nothing
+//! to do still sleeps instead of polling** — it just says so in the same vocabulary as every
+//! other actor, and can say more than that when it needs to.
+//!
+//! Driving one is therefore [`Node::poll`], or [`sweep`](Host::sweep) called directly when a
+//! caller wants the events as a return value rather than over an edge.
 //!
 //! # Ownership, not migration
 //!
@@ -107,14 +124,44 @@ pub struct Sweep<'a> {
     /// Actors that are stuck. Empty on the common path.
     ///
     /// Handed back from each sweep rather than accumulated behind an accessor, so it cannot be
-    /// missed by a caller that never thinks to ask — the previous revision stored these and
-    /// exposed a getter, which nothing on the `sched.run(&mut host)` path could ever reach. The
-    /// slice is only valid until the next sweep, which is the same window in which acting on it
-    /// makes sense.
+    /// missed by a caller that never thinks to ask. The slice is only valid until the next
+    /// sweep, which is the same window in which acting on it makes sense.
+    ///
+    /// This is the direct path, for a caller holding the host itself. The [`Transducer`] impl is
+    /// the wired one, and emits the same findings a step at a time over a port.
     pub stuck: &'a [Supervision],
 }
 
-/// An OS-thread actor that owns green actors and runs them in its `park`.
+/// Advance the green actors one step. The [`Host`]'s only input.
+///
+/// Carries nothing: a sweep is an opportunity to run, not a description of work. It arrives on
+/// the data lane either from outside (a doorbell woke the thread) or from the host's own
+/// continuation, and those are deliberately the same message — "there may be work" is the same
+/// request whoever asks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RunSweep;
+
+/// What a [`Host`] emits from one step.
+///
+/// `Default` — no supervision, no continuation — is the quiet sweep, which is the common case
+/// and the one that lets the driving thread sleep.
+#[derive(Debug, Default)]
+pub struct HostOut {
+    /// A green actor that needs supervision, if one was found.
+    ///
+    /// One per step rather than a batch: an output word has a single slot per port, and a
+    /// sweep that finds several drains them across successive steps under its own continuation.
+    /// The alternative — a `Vec` in the slot — would allocate on the hot path for a port that
+    /// is empty on almost every sweep.
+    pub supervision: Option<Supervision>,
+    /// The self-addressed continuation: set when this step left work behind.
+    ///
+    /// Either a green actor ran (so another sweep may find more) or findings remain to report.
+    /// Absent means genuinely quiet, which is what tells the driver it may block.
+    pub again: Option<RunSweep>,
+}
+
+/// An OS-thread actor that owns green actors and advances them a step at a time.
 ///
 /// A host has **no messages of its own**: all three lane types are [`Infallible`], so the
 /// compiler knows its handlers are unreachable and the `match msg {}` bodies below are total.
@@ -132,6 +179,12 @@ pub struct Host {
     /// the thread has work, so building this fresh each time would allocate on the hot path for
     /// a buffer that is empty almost every sweep and never grows past the node count.
     stuck: Vec<Supervision>,
+    /// How much of `stuck` the transducer has emitted, since a step emits at most one event.
+    ///
+    /// Only the [`Transducer`] path uses this; [`sweep`](Host::sweep) hands the whole slice back
+    /// at once and has nothing to track. It is what stops a re-sweep from clearing findings that
+    /// were never reported.
+    reported: usize,
 }
 
 impl Host {
@@ -303,7 +356,41 @@ pub fn green_channel<T>(capacity: usize, waker: Waker) -> (GreenSender<T>, SpscR
     (GreenSender::new(tx, waker), rx)
 }
 
-impl Actor<Infallible, Infallible, Infallible> for Host {
+/// Runs a [`Host`] on an OS thread under the ordinary [`ActorScheduler`](crate::ActorScheduler).
+///
+/// The green tier needs one thing from the OS tier that it cannot supply itself: something has
+/// to notice that the doorbell rang and turn that into an input. That is `park`'s actual job —
+/// bridging the outside world to a message — and it is all this does. It feeds one [`RunSweep`],
+/// advances the host until quiet, and reports whether the thread may sleep.
+///
+/// What it deliberately does **not** do is carry supervision. By the time `park` returns, any
+/// event has already left over the host's own wiring, so there is nothing for an
+/// `ActorStatus` to fail to express. That is the whole difference from the `impl Actor for Host`
+/// this replaces, which computed events inside `park` and dropped them for want of a channel.
+pub struct GreenThread<W: Wiring<Out = HostOut>> {
+    node: Node<Host, W, SpscReceiver<RunSweep>>,
+    /// Feeds the sweep that a doorbell wake implies. Capacity one: a sweep already queued is as
+    /// good as a fresh one, since [`RunSweep`] carries nothing to distinguish them.
+    tick: SpscSender<RunSweep>,
+}
+
+impl<W: Wiring<Out = HostOut>> GreenThread<W> {
+    /// Wire a host to its supervision output and make it runnable on a thread.
+    ///
+    /// Takes the host already populated: green actors are adopted before this point, on the
+    /// thread that will run them, which is the same "built where it runs" constraint that lets a
+    /// hosted actor be non-`Send`.
+    #[must_use]
+    pub fn new(host: Host, wiring: W) -> Self {
+        let (tick, rx) = spsc_channel(1);
+        Self {
+            node: Node::new(host, rx, wiring),
+            tick,
+        }
+    }
+}
+
+impl<W: Wiring<Out = HostOut>> Actor<Infallible, Infallible, Infallible> for GreenThread<W> {
     fn handle_data(&mut self, msg: Infallible) -> HandlerResult {
         match msg {}
     }
@@ -316,21 +403,77 @@ impl Actor<Infallible, Infallible, Infallible> for Host {
         match msg {}
     }
 
-    /// Sweeps, and **discards any supervision events**, because this signature has nowhere to
-    /// put them.
-    ///
-    /// That is the honest limit of running a `Host` through the old `Actor`/`ActorScheduler`
-    /// shell: `park` returns an `ActorStatus`, which can say "busy" or "idle" and cannot say
-    /// "one of my actors is stuck holding a payload". Callers that need supervision must drive
-    /// [`sweep`](Host::sweep) directly and read [`Sweep::stuck`].
-    ///
-    /// Closing this properly means `Host` becoming a transducer whose `Out` carries supervision
-    /// events, so its wiring delivers them like any other output and `Topology` checks that edge
-    /// — the same conversion vsync and the rasterizer already went through. Until then a `Host`
-    /// under `sched.run` is unsupervised, and this comment is the warning rather than a silent
-    /// drop.
     fn park(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
-        Ok(self.sweep().status)
+        match self.tick.try_send(RunSweep) {
+            Ok(()) => {}
+            // Full: a sweep is already queued, which is what this was going to ask for —
+            // `RunSweep` carries nothing to distinguish a second one from the first.
+            // Disconnected: unreachable, since this owns both ends of `tick`.
+            // Neither is worth failing a park over, and the poll below runs either way.
+            Err(TrySendError::Full(_) | TrySendError::Disconnected(_)) => {}
+        }
+
+        loop {
+            match self.node.poll() {
+                // More to do; the host's continuation is driving.
+                Step::Ran => continue,
+                // Quiet: nothing ran and nothing is queued, so the thread may block.
+                Step::Idle | Step::Halted(_) => return Ok(ActorStatus::Idle),
+                // The supervision target is full or gone. Neither resolves by sleeping — a
+                // blocked port drains when its consumer runs, and a gone one needs the
+                // supervisor that is not reading. Stay awake rather than risk a lost wakeup
+                // with an event still in the outbox.
+                Step::Blocked | Step::Disconnected => return Ok(ActorStatus::Busy),
+            }
+        }
+    }
+}
+
+impl Transducer for Host {
+    /// No control lane: a host has no time-critical input of its own. Shutdown reaches it by
+    /// dropping it, and its green actors by their own lanes.
+    type Control = Infallible;
+    /// No management lane. Adoption and removal are direct calls on the host, made by whoever
+    /// built it, not messages — a host is constructed where it runs.
+    type Management = Infallible;
+    type Data = RunSweep;
+    type Out = HostOut;
+
+    /// Report one outstanding finding, or sweep for more.
+    ///
+    /// Findings come first. A stuck node is stuck until a supervisor acts, so sweeping again
+    /// before its event has been delivered cannot improve matters — and [`sweep`](Host::sweep)
+    /// clears the buffer, so it would destroy the very report this exists to deliver.
+    fn step_data(&mut self, _: RunSweep) -> Result<HostOut, HandlerError> {
+        if let Some(&event) = self.stuck.get(self.reported) {
+            self.reported += 1;
+            return Ok(HostOut {
+                supervision: Some(event),
+                // More findings, or a sweep still owed once they are drained.
+                again: Some(RunSweep),
+            });
+        }
+
+        let status = self.sweep().status;
+        self.reported = 0;
+
+        let supervision = self.stuck.first().copied();
+        if supervision.is_some() {
+            self.reported = 1;
+        }
+
+        // Yield again if this step left work behind: something ran, or findings remain. A node
+        // that is merely *stuck* is neither — reporting it once must not spin the host against a
+        // peer that is never coming back, which is the same reason `sweep` does not count
+        // `Disconnected` as having run.
+        let more_findings = self.reported < self.stuck.len();
+        let again = (more_findings || status == ActorStatus::Busy).then_some(RunSweep);
+
+        Ok(HostOut { supervision, again })
+    }
+
+    fn take_continuation(out: &mut HostOut) -> Option<RunSweep> {
+        out.again.take()
     }
 }
 
@@ -485,6 +628,182 @@ mod tests {
         assert!(!host.remove(reported.node), "and removing it twice is not a panic");
     }
 
+    // ────────────────────────────────────────────────────────────────────────
+    // The host as a transducer: supervision over an edge, not through `park`
+    // ────────────────────────────────────────────────────────────────────────
+
+    /// Delivers a host's supervision events onward, which is the whole point of the conversion:
+    /// under the old `park` they were computed and dropped.
+    struct SupervisionWiring {
+        supervisor: SpscSender<Supervision>,
+    }
+
+    impl Wiring for SupervisionWiring {
+        type Out = HostOut;
+        fn flush(&mut self, out: &mut HostOut) -> Flush {
+            send_port(&mut out.supervision, &self.supervisor, Delivery::Blocking)
+        }
+    }
+
+    /// A host driven as a green node, wired to a supervision port.
+    type HostedNode = Node<Host, SupervisionWiring, SpscReceiver<RunSweep>>;
+
+    /// A host wired as a green node, plus the ends a test drives it by: the sweep input and the
+    /// supervision output.
+    fn hosted(host: Host) -> (HostedNode, SpscSender<RunSweep>, SpscReceiver<Supervision>) {
+        let (tx_sweep, rx_sweep) = spsc_channel::<RunSweep>(8);
+        let (tx_sup, rx_sup) = spsc_channel::<Supervision>(8);
+        let node = Node::new(host, rx_sweep, SupervisionWiring { supervisor: tx_sup });
+        (node, tx_sweep, rx_sup)
+    }
+
+    /// The conversion's reason for existing. Under `park` this event was computed and discarded
+    /// because `Result<ActorStatus, _>` had nowhere to put it; here it arrives at a supervisor
+    /// as an ordinary message.
+    #[test]
+    fn a_stuck_actor_reaches_a_supervisor_over_a_port() {
+        let (tx_in, rx_in) = spsc_channel::<u32>(8);
+        let (tx_out, rx_out) = spsc_channel::<u32>(8);
+
+        let mut host = Host::new();
+        let stuck_node = host.adopt(Node::new(
+            Forward { seen: 0 },
+            rx_in,
+            ForwardWiring { next: tx_out },
+        ));
+
+        drop(rx_out); // the downstream target dies
+        tx_in.try_send(0).unwrap();
+
+        let (mut node, tx_sweep, mut supervisor) = hosted(host);
+        tx_sweep.try_send(RunSweep).unwrap();
+
+        assert_eq!(node.poll(), Step::Ran);
+        let event = supervisor
+            .try_recv()
+            .expect("the supervision event must be delivered, not discarded");
+        assert_eq!(event.node, stuck_node);
+        assert_eq!(event.reason, Stuck::TargetGone);
+    }
+
+    /// The sleep contract `park` used to provide, in the transducer's own vocabulary: a sweep
+    /// that ran something yields a continuation and is stepped straight back; a quiet one does
+    /// not, so the node reports `Idle` and the driving thread may block.
+    #[test]
+    fn a_busy_sweep_yields_a_continuation_and_a_quiet_one_does_not() {
+        let (tx_in, rx_in) = spsc_channel::<u32>(8);
+        let (tx_out, mut rx_out) = spsc_channel::<u32>(8);
+
+        let mut host = Host::new();
+        host.adopt(Node::new(
+            Forward { seen: 0 },
+            rx_in,
+            ForwardWiring { next: tx_out },
+        ));
+
+        let (mut node, tx_sweep, _supervisor) = hosted(host);
+        tx_in.try_send(1).unwrap();
+        tx_sweep.try_send(RunSweep).unwrap();
+
+        // The green actor ran, so the host asks to be stepped again without a new message.
+        assert_eq!(node.poll(), Step::Ran);
+        assert_eq!(rx_out.try_recv().unwrap(), 2);
+
+        // That continuation is consumed here, finds nothing left to do, and stops.
+        assert_eq!(node.poll(), Step::Ran, "the continuation is a step of its own");
+        assert_eq!(
+            node.poll(),
+            Step::Idle,
+            "nothing ran and nothing is queued, so the thread may sleep"
+        );
+    }
+
+    /// A stuck node must not spin the host. Reporting it is not "work done" — the same reason
+    /// `sweep` does not count `Disconnected` as having run — so once the event is out, the host
+    /// goes quiet even though the node is still stuck.
+    #[test]
+    fn reporting_a_stuck_actor_does_not_spin_the_host() {
+        let (tx_in, rx_in) = spsc_channel::<u32>(8);
+        let (tx_out, rx_out) = spsc_channel::<u32>(8);
+
+        let mut host = Host::new();
+        host.adopt(Node::new(
+            Forward { seen: 0 },
+            rx_in,
+            ForwardWiring { next: tx_out },
+        ));
+        drop(rx_out);
+        tx_in.try_send(0).unwrap();
+
+        let (mut node, tx_sweep, mut supervisor) = hosted(host);
+        tx_sweep.try_send(RunSweep).unwrap();
+
+        assert_eq!(node.poll(), Step::Ran);
+        assert!(supervisor.try_recv().is_ok(), "reported once");
+
+        // The continuation from that step re-sweeps, finds the same stuck node, and reports it
+        // again — but then stops, rather than yielding forever against a peer that is not
+        // coming back.
+        node.poll();
+        let mut further = 0;
+        for _ in 0..8 {
+            if node.poll() == Step::Idle {
+                break;
+            }
+            further += 1;
+        }
+        assert!(
+            further < 8,
+            "a permanently stuck node must not keep the host awake forever"
+        );
+    }
+
+    /// Several stuck actors exceed the one supervision slot an output word has, so they drain
+    /// across successive steps under the host's own continuation rather than being batched into
+    /// an allocation on the hot path.
+    #[test]
+    fn multiple_stuck_actors_drain_one_per_step() {
+        let mut host = Host::new();
+        let mut ids = Vec::new();
+        let mut senders = Vec::new();
+        for _ in 0..3 {
+            let (tx_in, rx_in) = spsc_channel::<u32>(8);
+            let (tx_out, rx_out) = spsc_channel::<u32>(8);
+            ids.push(host.adopt(Node::new(
+                Forward { seen: 0 },
+                rx_in,
+                ForwardWiring { next: tx_out },
+            )));
+            drop(rx_out);
+            tx_in.try_send(0).unwrap();
+            senders.push(tx_in);
+        }
+
+        let (mut node, tx_sweep, mut supervisor) = hosted(host);
+        tx_sweep.try_send(RunSweep).unwrap();
+
+        let mut seen = Vec::new();
+        for _ in 0..6 {
+            node.poll();
+            while let Ok(event) = supervisor.try_recv() {
+                if !seen.contains(&event.node) {
+                    seen.push(event.node);
+                }
+            }
+            if seen.len() == ids.len() {
+                break;
+            }
+        }
+
+        seen.sort();
+        let mut expected = ids.clone();
+        expected.sort();
+        assert_eq!(
+            seen, expected,
+            "every stuck actor must be reported, not just the first one the sweep found"
+        );
+    }
+
     #[test]
     fn each_sweep_reports_only_its_own_stuck_actors() {
         // The failure mode introduced by reusing one buffer across sweeps: forget to clear it
@@ -601,7 +920,11 @@ mod tests {
                 rx_green,
                 ForwardWiring { next: tx_out },
             ));
-            sched.run(&mut host);
+            // The supervision port has no reader in this test; nothing here goes stuck, so it
+            // stays empty. `GreenThread` is what turns the doorbell wake into a `RunSweep`.
+            let (tx_sup, _rx_sup) = spsc_channel::<Supervision>(8);
+            let mut thread = GreenThread::new(host, SupervisionWiring { supervisor: tx_sup });
+            sched.run(&mut thread);
         });
 
         // Let the host reach its doorbell and block before sending, so this exercises the

--- a/actor-scheduler/src/lib.rs
+++ b/actor-scheduler/src/lib.rs
@@ -76,7 +76,7 @@
 //!         println!("Management: {}", msg);
 //!         Ok(())
 //!     }
-//!     fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> { Ok(ActorStatus::Idle) }
+//!     fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> { Ok(ActorStatus::Idle) }
 //! }
 //!
 //! let (tx, mut rx) = ActorScheduler::<String, String, String>::new(10, 100);
@@ -176,7 +176,7 @@ use std::time::Duration;
 ///   2. Drain Management messages (capped at burst limit)
 ///   3. Drain Control messages again (priority recheck)
 ///   4. Drain Data messages (capped at burst limit)
-///   5. Call park() - let actor/OS do other work
+///   5. Call handle_os() - let actor/OS do other work
 ///   6. Repeat
 /// ```
 ///
@@ -339,14 +339,14 @@ macro_rules! impl_management_message {
     };
 }
 
-/// Actor status returned from park() to hint the scheduler about blocking behavior.
+/// Actor status returned from handle_os() to hint the scheduler about blocking behavior.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ActorStatus {
     Idle, // Actor has no unfinished work. Scheduler can block. (0% CPU)
     Busy, // Actor has unfinished work (yielding). Scheduler should poll.
 }
 
-/// Status provided to the actor's park method indicating the state of the scheduler's queues.
+/// Status provided to the actor's handle_os method indicating the state of the scheduler's queues.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SystemStatus {
     Idle, // Scheduler queues are empty
@@ -386,7 +386,7 @@ pub trait Actor<D, C, M> {
     ///
     /// Returns actor status: Busy if yielding with unfinished work, Idle if done.
     /// Can return `HandlerError::Fatal` to trigger shutdown.
-    fn park(&mut self, status: SystemStatus) -> Result<ActorStatus, HandlerError>;
+    fn handle_os(&mut self, status: SystemStatus) -> Result<ActorStatus, HandlerError>;
 }
 
 /// Legacy alias for backward compatibility
@@ -444,7 +444,7 @@ pub trait ActorTypes {
 ///     fn handle_data(&mut self, msg: EngineData) { }
 ///     fn handle_control(&mut self, msg: EngineControl) { }
 ///     fn handle_management(&mut self, msg: EngineManagement) { }
-///     fn park(&mut self, status: SystemStatus) -> ActorStatus { ActorStatus::Idle }
+///     fn handle_os(&mut self, status: SystemStatus) -> ActorStatus { ActorStatus::Idle }
 /// }
 /// ```
 pub trait TroupeActor<Dir>:
@@ -1041,7 +1041,7 @@ impl<D, C, M> ActorScheduler<D, C, M> {
             SystemStatus::Idle
         };
 
-        let returned_hint = actor.park(system_status)?;
+        let returned_hint = actor.handle_os(system_status)?;
 
         let status = if more_work || returned_hint == ActorStatus::Busy {
             SchedulerLoopStatus::Working
@@ -1273,7 +1273,7 @@ mod tests {
             Ok(())
         }
 
-        fn park(&mut self, _hint: SystemStatus) -> Result<ActorStatus, HandlerError> {
+        fn handle_os(&mut self, _hint: SystemStatus) -> Result<ActorStatus, HandlerError> {
             Ok(ActorStatus::Idle)
         }
     }
@@ -1406,7 +1406,7 @@ mod tests {
                 self.mgmt_count += 1;
                 Ok(())
             }
-            fn park(&mut self, _hint: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _hint: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -1458,7 +1458,7 @@ mod tests {
                 fn handle_management(&mut self, _: ()) -> HandlerResult {
                     Ok(())
                 }
-                fn park(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
+                fn handle_os(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
                     Ok(ActorStatus::Idle)
                 }
             }
@@ -1502,7 +1502,7 @@ mod poll_once_tests {
         fn handle_management(&mut self, _: i32) -> HandlerResult {
             Ok(())
         }
-        fn park(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
+        fn handle_os(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
             Ok(ActorStatus::Idle)
         }
     }
@@ -1567,7 +1567,7 @@ mod poll_once_tests {
             fn handle_management(&mut self, _: i32) -> HandlerResult {
                 Ok(())
             }
-            fn park(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -1760,7 +1760,7 @@ mod handle_wake_targeted_tests {
     };
     use std::time::Duration;
 
-    // An actor that records the last `SystemStatus` handed to `park`. Since `park`
+    // An actor that records the last `SystemStatus` handed to `handle_os`. Since `handle_os`
     // is called unconditionally at the end of every `handle_wake`, its argument is
     // an observable proxy for the private `more_work` computation.
     struct StatusRecorder {
@@ -1776,7 +1776,7 @@ mod handle_wake_targeted_tests {
         fn handle_management(&mut self, _: i32) -> HandlerResult {
             Ok(())
         }
-        fn park(&mut self, status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+        fn handle_os(&mut self, status: SystemStatus) -> Result<ActorStatus, HandlerError> {
             self.last_status = Some(status);
             Ok(ActorStatus::Idle)
         }
@@ -1790,7 +1790,7 @@ mod handle_wake_targeted_tests {
     // drains the last 1 (0 remain -> not More), data is empty (not More). Only the
     // *first* term is More, so more_work is true iff the chain is a plain OR — any
     // of the three `||`s replaced by `&&` collapses the result to false, flipping
-    // the SystemStatus handed to `park` from Busy to Idle.
+    // the SystemStatus handed to `handle_os` from Busy to Idle.
     #[test]
     fn more_work_is_true_when_only_first_control_pass_hits_burst_limit() {
         let params = SchedulerParams {
@@ -1870,13 +1870,13 @@ mod handle_wake_targeted_tests {
     // `let status = if more_work || returned_hint == ActorStatus::Busy { Working } else { Idle }`.
     //
     // `more_work` is false throughout (a single control message, nowhere near any
-    // burst limit). `park` returns Busy on its first call only. Correct code: the
+    // burst limit). `handle_os` returns Busy on its first call only. Correct code: the
     // Busy hint alone makes the first handle_wake report Working, so run_inner
-    // retries without blocking and calls handle_wake (and therefore park) a second
-    // time before it finally blocks on the doorbell — park called exactly twice.
+    // retries without blocking and calls handle_wake (and therefore handle_os) a second
+    // time before it finally blocks on the doorbell — handle_os called exactly twice.
     // Under either mutant, `more_work || <busy-check>` collapses to false on the
     // first call, handle_wake reports Idle immediately, and run_inner blocks
-    // before ever calling park a second time.
+    // before ever calling handle_os a second time.
     #[test]
     fn busy_park_hint_forces_one_extra_wake_before_blocking() {
         let (tx, mut rx) = ActorScheduler::<i32, i32, i32>::new(100, 100);
@@ -1894,7 +1894,7 @@ mod handle_wake_targeted_tests {
             fn handle_management(&mut self, _: i32) -> HandlerResult {
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 let n = self.park_calls.fetch_add(1, Ordering::SeqCst);
                 if n == 0 {
                     Ok(ActorStatus::Busy)
@@ -1917,7 +1917,7 @@ mod handle_wake_targeted_tests {
         assert_eq!(
             park_calls.load(Ordering::SeqCst),
             2,
-            "Busy park hint alone should force exactly one extra non-blocking wake"
+            "Busy handle_os hint alone should force exactly one extra non-blocking wake"
         );
 
         drop(tx);
@@ -1950,7 +1950,7 @@ mod drain_all_targeted_tests {
         fn handle_management(&mut self, _: ()) -> HandlerResult {
             Ok(())
         }
-        fn park(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
+        fn handle_os(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
             Ok(ActorStatus::Idle)
         }
     }
@@ -2046,7 +2046,7 @@ mod drain_all_targeted_tests {
                 self.mgmt.fetch_add(1, Ordering::Relaxed);
                 Ok(())
             }
-            fn park(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -2104,7 +2104,7 @@ mod drain_all_targeted_tests {
                 self.mgmt.fetch_add(1, Ordering::Relaxed);
                 Ok(())
             }
-            fn park(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -2167,7 +2167,7 @@ mod drain_all_targeted_tests {
             fn handle_management(&mut self, _: ()) -> HandlerResult {
                 Ok(())
             }
-            fn park(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -2218,7 +2218,7 @@ mod drain_all_targeted_tests {
                 self.mgmt.fetch_add(1, Ordering::Relaxed);
                 Ok(())
             }
-            fn park(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -2292,7 +2292,7 @@ mod troupe_tests {
         fn handle_management(&mut self, _msg: EngineManagement) -> HandlerResult {
             Ok(())
         }
-        fn park(&mut self, _hint: SystemStatus) -> Result<ActorStatus, HandlerError> {
+        fn handle_os(&mut self, _hint: SystemStatus) -> Result<ActorStatus, HandlerError> {
             Ok(ActorStatus::Idle)
         }
     }
@@ -2337,7 +2337,7 @@ mod troupe_tests {
         fn handle_management(&mut self, _msg: DisplayManagement) -> HandlerResult {
             Ok(())
         }
-        fn park(&mut self, _hint: SystemStatus) -> Result<ActorStatus, HandlerError> {
+        fn handle_os(&mut self, _hint: SystemStatus) -> Result<ActorStatus, HandlerError> {
             Ok(ActorStatus::Idle)
         }
     }
@@ -2439,7 +2439,7 @@ mod troupe_tests {
                 fn handle_management(&mut self, _: ()) -> HandlerResult {
                     Ok(())
                 }
-                fn park(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
+                fn handle_os(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
                     Ok(ActorStatus::Busy)
                 }
             }
@@ -2538,7 +2538,7 @@ mod troupe_tests {
                 fn handle_management(&mut self, _: ()) -> HandlerResult {
                     Ok(())
                 }
-                fn park(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
+                fn handle_os(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
                     Ok(ActorStatus::Busy)
                 }
             }
@@ -2639,7 +2639,7 @@ mod troupe_tests {
                 fn handle_management(&mut self, _: ()) -> HandlerResult {
                     Ok(())
                 }
-                fn park(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
+                fn handle_os(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
                     Ok(ActorStatus::Busy)
                 }
             }
@@ -2738,7 +2738,7 @@ mod troupe_tests {
                     thread::sleep(Duration::from_millis(2));
                     Ok(())
                 }
-                fn park(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
+                fn handle_os(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
                     Ok(ActorStatus::Busy)
                 }
             }
@@ -2824,7 +2824,7 @@ mod troupe_nesting_tests {
         fn handle_management(&mut self, _msg: WorkerManagement) -> HandlerResult {
             Ok(())
         }
-        fn park(&mut self, _hint: SystemStatus) -> Result<ActorStatus, HandlerError> {
+        fn handle_os(&mut self, _hint: SystemStatus) -> Result<ActorStatus, HandlerError> {
             Ok(ActorStatus::Idle)
         }
     }
@@ -2962,7 +2962,7 @@ mod shutdown_tests {
             Ok(())
         }
 
-        fn park(&mut self, status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+        fn handle_os(&mut self, status: SystemStatus) -> Result<ActorStatus, HandlerError> {
             match status {
                 SystemStatus::Idle => Ok(ActorStatus::Idle),
                 SystemStatus::Busy => Ok(ActorStatus::Busy),
@@ -3154,7 +3154,7 @@ mod shutdown_tests {
                 Ok(())
             }
 
-            fn park(&mut self, status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 match status {
                     SystemStatus::Idle => Ok(ActorStatus::Idle),
                     SystemStatus::Busy => Ok(ActorStatus::Busy),

--- a/actor-scheduler/src/lib.rs
+++ b/actor-scheduler/src/lib.rs
@@ -103,7 +103,7 @@ pub mod spsc;
 
 use error::DrainStatus;
 pub use error::{HandlerError, HandlerResult, SendError};
-pub use host::{Green, GreenSender, Host, green_channel};
+pub use host::{Green, GreenSender, GreenThread, Host, HostOut, RunSweep, green_channel};
 pub use lifecycle::Exit;
 pub use params::SchedulerParams;
 

--- a/actor-scheduler/src/mealy.rs
+++ b/actor-scheduler/src/mealy.rs
@@ -77,8 +77,7 @@ use crate::spsc::{SpscSender, TryRecvError, TrySendError};
 /// as [`Actor`](crate::Actor)/[`ActorScheduler`](crate::ActorScheduler). Only `step_data` is
 /// required; `step_control` and `step_management` default to the silent transition, so a
 /// single-lane actor writes `type Control = Infallible; type Management = Infallible;` and one
-/// method, exactly as [`Host`](crate::Host) already does for its own [`Actor`](crate::Actor)
-/// impl.
+/// method, exactly as [`Host`](crate::Host) does.
 pub trait Transducer {
     /// The control-lane input. Highest priority — set to `Infallible` if unused.
     type Control;

--- a/actor-scheduler/tests/generic_type.rs
+++ b/actor-scheduler/tests/generic_type.rs
@@ -18,7 +18,7 @@ impl<P> Actor<(), (), ()> for DriverActor<P> {
     fn handle_management(&mut self, _: ()) -> HandlerResult {
         Ok(())
     }
-    fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+    fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
         Ok(ActorStatus::Idle)
     }
 }

--- a/actor-scheduler/tests/simple_type.rs
+++ b/actor-scheduler/tests/simple_type.rs
@@ -15,7 +15,7 @@ impl Actor<(), (), ()> for SimpleActor {
     fn handle_management(&mut self, _: ()) -> HandlerResult {
         Ok(())
     }
-    fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+    fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
         Ok(ActorStatus::Idle)
     }
 }

--- a/actor-scheduler/tests/stress_tests.rs
+++ b/actor-scheduler/tests/stress_tests.rs
@@ -38,7 +38,7 @@ impl Actor<u64, u64, u64> for CountingHandler {
         self.mgmt_count.fetch_add(1, Ordering::SeqCst);
         Ok(())
     }
-    fn park(&mut self, _hint: SystemStatus) -> Result<ActorStatus, HandlerError> {
+    fn handle_os(&mut self, _hint: SystemStatus) -> Result<ActorStatus, HandlerError> {
         Ok(ActorStatus::Idle)
     }
 }
@@ -60,7 +60,7 @@ impl Actor<u64, u64, u64> for SlowHandler {
     fn handle_management(&mut self, _msg: u64) -> HandlerResult {
         Ok(())
     }
-    fn park(&mut self, _hint: SystemStatus) -> Result<ActorStatus, HandlerError> {
+    fn handle_os(&mut self, _hint: SystemStatus) -> Result<ActorStatus, HandlerError> {
         Ok(ActorStatus::Idle)
     }
 }
@@ -77,7 +77,7 @@ impl Actor<(), (), ()> for NoOpHandler {
     fn handle_management(&mut self, _: ()) -> HandlerResult {
         Ok(())
     }
-    fn park(&mut self, _hint: SystemStatus) -> Result<ActorStatus, HandlerError> {
+    fn handle_os(&mut self, _hint: SystemStatus) -> Result<ActorStatus, HandlerError> {
         Ok(ActorStatus::Idle)
     }
 }
@@ -321,7 +321,7 @@ fn burst_limit_prevents_data_starvation() {
             self.mgmt_processed.fetch_add(1, Ordering::SeqCst);
             Ok(())
         }
-        fn park(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
+        fn handle_os(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
             Ok(ActorStatus::Idle)
         }
     }
@@ -391,7 +391,7 @@ fn multi_producer_send() {
         fn handle_management(&mut self, _: u64) -> HandlerResult {
             Ok(())
         }
-        fn park(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
+        fn handle_os(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
             Ok(ActorStatus::Idle)
         }
     }
@@ -472,7 +472,7 @@ fn large_messages_work() {
         fn handle_management(&mut self, _: ()) -> HandlerResult {
             Ok(())
         }
-        fn park(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
+        fn handle_os(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
             Ok(ActorStatus::Idle)
         }
     }

--- a/core-term/src/io/event_monitor_actor/mod.rs
+++ b/core-term/src/io/event_monitor_actor/mod.rs
@@ -30,7 +30,7 @@
 //! in every scheduler wake, so an actor is always bound before it handles its
 //! first byte.
 //!
-//! **Blocking model.** The reader and writer bridge to the OS inside `park()`,
+//! **Blocking model.** The reader and writer bridge to the OS inside `handle_os()`,
 //! blocking in `epoll_wait`/`kevent` on `{pty, waker}`; each is a `[waker]`
 //! slot so a send interrupts the poll. The parser is message-driven.
 //!
@@ -147,7 +147,7 @@ pub type PtyWriterHandle = ActorHandle<Vec<u8>, WriterControl, WriterManagement>
 // ── Troupe declaration ──────────────────────────────────────────────────────
 
 // All three are [expose] so `PtyTroupe` can mint handles to send Bind and
-// Shutdown. Reader and writer are [waker] because they block in park().
+// Shutdown. Reader and writer are [waker] because they block in handle_os().
 actor_scheduler::troupe! {
     reader: PtyReader [main, expose, waker],
     parser: PtyParser [expose],

--- a/core-term/src/io/event_monitor_actor/parser.rs
+++ b/core-term/src/io/event_monitor_actor/parser.rs
@@ -85,7 +85,7 @@ impl Actor<FilledBuf, ParserControl, ParserManagement> for PtyParser {
         Ok(())
     }
 
-    fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+    fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
         // Purely message-driven; the scheduler may block on the doorbell.
         Ok(ActorStatus::Idle)
     }

--- a/core-term/src/io/event_monitor_actor/reader.rs
+++ b/core-term/src/io/event_monitor_actor/reader.rs
@@ -7,7 +7,7 @@
 //! `Data` messages. The pool is allocated when the `Bind` management message
 //! arrives (see [`super`] for the bind protocol).
 //!
-//! `park()` is the bridge to the OS: it blocks in `epoll_wait`/`kevent` on
+//! `handle_os()` is the bridge to the OS: it blocks in `epoll_wait`/`kevent` on
 //! `{pty, waker}` and returns `Busy` so the scheduler polls the doorbell with
 //! `try_recv` instead of blocking on it. Three cases return `Idle` and let the
 //! scheduler block on the doorbell instead:
@@ -187,7 +187,7 @@ impl Actor<Vec<u8>, NoControl, ReaderManagement> for PtyReader {
         Ok(())
     }
 
-    fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+    fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
         let Some(bound) = self.bound.as_mut() else {
             return Ok(ActorStatus::Idle); // unbound: wait for Bind on the doorbell
         };
@@ -220,7 +220,7 @@ impl Actor<Vec<u8>, NoControl, ReaderManagement> for PtyReader {
         }
 
         // Busy: this actor's real doorbell is the event monitor, so the
-        // scheduler must come back through park() instead of blocking on
+        // scheduler must come back through handle_os() instead of blocking on
         // the channel doorbell.
         Ok(ActorStatus::Busy)
     }

--- a/core-term/src/io/event_monitor_actor/writer.rs
+++ b/core-term/src/io/event_monitor_actor/writer.rs
@@ -8,7 +8,7 @@
 //! before Data by construction.
 //!
 //! Writes are nonblocking. If the kernel PTY buffer fills (a stopped shell mid
-//! large paste), the unwritten tail is queued in `pending` and `park()` waits
+//! large paste), the unwritten tail is queued in `pending` and `handle_os()` waits
 //! for `EPOLLOUT` — with the waker registered alongside, so Resize and
 //! Shutdown still get through while the queue drains.
 //!
@@ -60,7 +60,7 @@ struct BoundWriter {
 impl BoundWriter {
     fn bind(pty: NixPty, waker: Arc<FdWaker>) -> anyhow::Result<Self> {
         let monitor = EventMonitor::new()?;
-        // Registered permanently; park() only polls while `pending` is
+        // Registered permanently; handle_os() only polls while `pending` is
         // non-empty, so level-triggered "always writable" costs nothing.
         monitor.add(&pty, TOKEN_PTY, EventFlags::EPOLLOUT)?;
         monitor.add(&*waker, TOKEN_WAKER, EventFlags::EPOLLIN)?;
@@ -145,7 +145,7 @@ impl Actor<Vec<u8>, WriterControl, WriterManagement> for PtyWriter {
         }
         self.pending.push_back(bytes);
         // Common case (bound, queue was empty, PTY writable): flushes inline
-        // and park() never needs to poll. Unbound: stays queued.
+        // and handle_os() never needs to poll. Unbound: stays queued.
         self.flush_pending();
         Ok(())
     }
@@ -170,7 +170,7 @@ impl Actor<Vec<u8>, WriterControl, WriterManagement> for PtyWriter {
         Ok(())
     }
 
-    fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+    fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
         if self.broken || self.pending.is_empty() {
             // Message-driven: let the scheduler block on the doorbell. With
             // the waker unarmed, sends to this actor cost no wake syscall —

--- a/core-term/src/io/waker.rs
+++ b/core-term/src/io/waker.rs
@@ -1,7 +1,7 @@
 // src/io/waker.rs
 
 //! Self-pipe [`WakeHandler`] for actors that block in `epoll`/`kqueue` inside
-//! `park()`.
+//! `handle_os()`.
 //!
 //! The actor-scheduler's doorbell is an in-process channel with no file
 //! descriptor, so an actor blocked in `epoll_wait`/`kevent` cannot see it.

--- a/core-term/src/terminal_app.rs
+++ b/core-term/src/terminal_app.rs
@@ -753,7 +753,7 @@ impl Actor<TerminalData, EngineEventControl, EngineEventManagement> for Terminal
         Ok(())
     }
 
-    fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+    fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
         // No polling needed - PTY data comes in via handle_data
         Ok(ActorStatus::Idle)
     }
@@ -889,7 +889,7 @@ mod tests {
         fn handle_management(&mut self, _msg: WriterManagement) -> HandlerResult {
             Ok(())
         }
-        fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+        fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
             Ok(ActorStatus::Idle)
         }
     }
@@ -1048,7 +1048,7 @@ mod tests {
         ) -> HandlerResult {
             Ok(())
         }
-        fn park(&mut self, _hint: SystemStatus) -> Result<ActorStatus, HandlerError> {
+        fn handle_os(&mut self, _hint: SystemStatus) -> Result<ActorStatus, HandlerError> {
             Ok(ActorStatus::Idle)
         }
     }

--- a/core-term/tests/actor_roundtrip_tests.rs
+++ b/core-term/tests/actor_roundtrip_tests.rs
@@ -70,7 +70,7 @@ impl Actor<Vec<u8>, (), ()> for TestParserActor {
         Ok(())
     }
 
-    fn park(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
+    fn handle_os(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
         Ok(ActorStatus::Idle)
     }
 }
@@ -326,7 +326,7 @@ impl Actor<TestEngineData, TestEngineControl, TestEngineManagement> for TestTerm
         Ok(())
     }
 
-    fn park(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
+    fn handle_os(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
         Ok(ActorStatus::Idle)
     }
 }
@@ -592,7 +592,7 @@ fn multi_actor_chain_roundtrip() {
         fn handle_management(&mut self, _: ()) -> HandlerResult {
             Ok(())
         }
-        fn park(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
+        fn handle_os(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
             Ok(ActorStatus::Idle)
         }
     }
@@ -664,7 +664,7 @@ fn roundtrip_handles_actor_panic_gracefully() {
         fn handle_management(&mut self, _: ()) -> HandlerResult {
             Ok(())
         }
-        fn park(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
+        fn handle_os(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
             Ok(ActorStatus::Idle)
         }
     }
@@ -724,7 +724,7 @@ fn roundtrip_sender_dropped_during_processing() {
             fn handle_management(&mut self, _: ()) -> HandlerResult {
                 Ok(())
             }
-            fn park(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -787,7 +787,7 @@ impl Actor<Vec<u8>, WriterControl, ()> for WriterProbe {
     fn handle_management(&mut self, _msg: ()) -> HandlerResult {
         Ok(())
     }
-    fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+    fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
         Ok(ActorStatus::Idle)
     }
 }

--- a/core-term/tests/ansi_parser_message_tests.rs
+++ b/core-term/tests/ansi_parser_message_tests.rs
@@ -41,7 +41,7 @@ impl Actor<Vec<u8>, (), ()> for RealParserActor {
     fn handle_management(&mut self, _: ()) -> HandlerResult {
         Ok(())
     }
-    fn park(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
+    fn handle_os(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
         Ok(ActorStatus::Idle)
     }
 }

--- a/core-term/tests/ansi_to_grid_integration.rs
+++ b/core-term/tests/ansi_to_grid_integration.rs
@@ -227,8 +227,8 @@ fn bug_grid_changes_without_render_trigger() {
 
     let mut harness = MinimalTestHarness::new();
 
-    // Simulate PTY output being processed in park()
-    // In the real app, park() calls:
+    // Simulate PTY output being processed in handle_os()
+    // In the real app, handle_os() calls:
     //   self.emulator.interpret_input(EmulatorInput::Ansi(cmd))
     // But it NEVER calls send_frame() afterward!
 
@@ -244,8 +244,8 @@ fn bug_grid_changes_without_render_trigger() {
         "BUG CONFIRMED: Grid changes but no render triggered"
     );
 
-    // But in the real app, park() doesn't call send_frame(),
+    // But in the real app, handle_os() doesn't call send_frame(),
     // so the manifold is never rebuilt and the frame checksum stays the same!
 
-    // THE FIX: park() should call self.send_frame() after processing PTY output
+    // THE FIX: handle_os() should call self.send_frame() after processing PTY output
 }

--- a/core-term/tests/message_cuj_tests.rs
+++ b/core-term/tests/message_cuj_tests.rs
@@ -62,7 +62,7 @@ impl Actor<Vec<u8>, (), ()> for MockParserActor {
     fn handle_management(&mut self, _: ()) -> HandlerResult {
         Ok(())
     }
-    fn park(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
+    fn handle_os(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
         Ok(ActorStatus::Idle)
     }
 }
@@ -401,7 +401,7 @@ fn cuj_pty04_sender_drop_terminates_receiver() {
         fn handle_management(&mut self, _: ()) -> HandlerResult {
             Ok(())
         }
-        fn park(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
+        fn handle_os(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
             Ok(ActorStatus::Idle)
         }
     }
@@ -482,7 +482,7 @@ impl Actor<MockEngineData, MockEngineControl, MockEngineManagement> for MockTerm
         Ok(())
     }
 
-    fn park(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
+    fn handle_os(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
         Ok(ActorStatus::Idle)
     }
 }
@@ -692,7 +692,7 @@ fn cuj_priority_control_before_management_before_data() {
             self.order.lock().unwrap().push(format!("M:{}", msg));
             Ok(())
         }
-        fn park(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
+        fn handle_os(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
             Ok(ActorStatus::Idle)
         }
     }
@@ -757,7 +757,7 @@ fn cuj_concurrent_senders_all_messages_delivered() {
         fn handle_management(&mut self, _: ()) -> HandlerResult {
             Ok(())
         }
-        fn park(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
+        fn handle_os(&mut self, _: SystemStatus) -> Result<ActorStatus, HandlerError> {
             Ok(ActorStatus::Idle)
         }
     }

--- a/pixelflow-graphics/src/render/rasterizer/actor.rs
+++ b/pixelflow-graphics/src/render/rasterizer/actor.rs
@@ -453,8 +453,8 @@ impl<P: Pixel + Send, Meta> Actor<RenderRequest<P, Meta>, RasterControl, RasterM
         Ok(())
     }
 
-    fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
-        // No external work to do during park, just wait for messages
+    fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+        // No external work to do during handle_os, just wait for messages
         Ok(ActorStatus::Idle)
     }
 }

--- a/pixelflow-runtime/src/display/driver.rs
+++ b/pixelflow-runtime/src/display/driver.rs
@@ -50,8 +50,8 @@ impl<P: Platform> Actor<DisplayData, DisplayControl, DisplayMgmt> for DriverActo
         self.platform.handle_management(mgmt)
     }
 
-    fn park(&mut self, status: SystemStatus) -> Result<ActorStatus, HandlerError> {
-        // Delegate to platform's park - this is where OS event loop integration happens
-        self.platform.park(status)
+    fn handle_os(&mut self, status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+        // Delegate to platform's handle_os - this is where OS event loop integration happens
+        self.platform.handle_os(status)
     }
 }

--- a/pixelflow-runtime/src/display/ops.rs
+++ b/pixelflow-runtime/src/display/ops.rs
@@ -20,10 +20,10 @@ pub enum DriverEmit {
 /// Output word for a [`PlatformOps`] step.
 ///
 /// One `Out` per step, matching `VsyncCoreOut`/`RasterCoreOut` — the struct's *fields* are the
-/// ports, so a step never returns "sometimes a value, sometimes a list." `park` is the reason
+/// ports, so a step never returns "sometimes a value, sometimes a list." `handle_os` is the reason
 /// this field is a `Vec` rather than an `Option`: draining the OS event queue yields N events.
 ///
-/// `Vec` is not a per-frame allocation despite `park` running every frame: an empty `Vec` never
+/// `Vec` is not a per-frame allocation despite `handle_os` running every frame: an empty `Vec` never
 /// touches the heap, and the overwhelming majority of frames carry no input at all. Only a
 /// frame where the user actually did something pays one small amortized growth.
 #[derive(Debug, Default)]
@@ -54,7 +54,7 @@ pub trait PlatformOps: Send + 'static {
     fn handle_data(&mut self, data: DisplayData, out: &mut DriverOut) -> HandlerResult;
     fn handle_control(&mut self, ctrl: DisplayControl, out: &mut DriverOut) -> HandlerResult;
     fn handle_management(&mut self, mgmt: DisplayMgmt, out: &mut DriverOut) -> HandlerResult;
-    fn park(
+    fn handle_os(
         &mut self,
         status: SystemStatus,
         out: &mut DriverOut,

--- a/pixelflow-runtime/src/display/platform.rs
+++ b/pixelflow-runtime/src/display/platform.rs
@@ -113,8 +113,8 @@ impl<Ops: PlatformOps> Actor<DisplayData, DisplayControl, DisplayMgmt> for Platf
         result
     }
 
-    fn park(&mut self, status: SystemStatus) -> Result<ActorStatus, HandlerError> {
-        let result = self.ops.park(status, &mut self.out);
+    fn handle_os(&mut self, status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+        let result = self.ops.handle_os(status, &mut self.out);
         self.flush();
         result
     }

--- a/pixelflow-runtime/src/engine_troupe.rs
+++ b/pixelflow-runtime/src/engine_troupe.rs
@@ -264,7 +264,7 @@ impl Actor<EngineData, EngineControl, AppManagement> for EngineHandler {
         Ok(())
     }
 
-    fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+    fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
         // engine has no external channels which might be busy
         Ok(ActorStatus::Idle)
     }
@@ -806,7 +806,7 @@ mod tests {
         fn handle_management(&mut self, _msg: RasterManagement) -> HandlerResult {
             Ok(())
         }
-        fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+        fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
             Ok(ActorStatus::Idle)
         }
     }
@@ -856,7 +856,7 @@ mod tests {
             }
             Ok(())
         }
-        fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+        fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
             Ok(ActorStatus::Idle)
         }
     }

--- a/pixelflow-runtime/src/platform/linux/platform.rs
+++ b/pixelflow-runtime/src/platform/linux/platform.rs
@@ -157,7 +157,7 @@ impl PlatformOps for LinuxOps {
         Ok(())
     }
 
-    fn park(
+    fn handle_os(
         &mut self,
         status: SystemStatus,
         out: &mut DriverOut,

--- a/pixelflow-runtime/src/platform/macos/platform.rs
+++ b/pixelflow-runtime/src/platform/macos/platform.rs
@@ -174,7 +174,7 @@ impl PlatformOps for MetalOps {
         Ok(())
     }
 
-    fn park(
+    fn handle_os(
         &mut self,
         status: SystemStatus,
         out: &mut DriverOut,
@@ -184,10 +184,10 @@ impl PlatformOps for MetalOps {
         unsafe {
             // Only the FIRST wait may block (when the scheduler says Idle).
             // Everything already queued is then drained without blocking:
-            // a park pass must empty the NSEvent queue, or wake events pile
+            // a handle_os pass must empty the NSEvent queue, or wake events pile
             // up ahead of real input and a KeyDown can sit behind an
             // unbounded backlog (the "can't Ctrl-C out of `yes`" wedge).
-            // This mirrors LinuxOps::park's `while XPending > 0` drain.
+            // This mirrors LinuxOps::handle_os's `while XPending > 0` drain.
             let first_until_date: sys::Id = match status {
                 SystemStatus::Idle => {
                     // Block until an event arrives (waker will post NSEvent when messages come)

--- a/pixelflow-runtime/src/platform/macos/window.rs
+++ b/pixelflow-runtime/src/platform/macos/window.rs
@@ -9,7 +9,7 @@ use std::sync::{Mutex, OnceLock};
 /// platform pump has not yet reported to the engine. AppKit invokes the
 /// delegate synchronously on the main thread while the pump routes the click
 /// through `sendEvent:`; the pump drains this queue at the end of the same
-/// park pass and emits `DisplayEvent::CloseRequested`.
+/// handle_os pass and emits `DisplayEvent::CloseRequested`.
 static CLOSED_WINDOWS: Mutex<Vec<usize>> = Mutex::new(Vec::new());
 
 /// Take all windows closed since the last drain.

--- a/pixelflow-runtime/src/testing/mock_engine.rs
+++ b/pixelflow-runtime/src/testing/mock_engine.rs
@@ -98,7 +98,7 @@ impl Actor<EngineData, EngineControl, AppManagement> for MessageCollector {
         Ok(())
     }
 
-    fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+    fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
         Ok(ActorStatus::Idle)
     }
 }

--- a/pixelflow-runtime/src/vsync_actor.rs
+++ b/pixelflow-runtime/src/vsync_actor.rs
@@ -7,7 +7,7 @@
 //! To avoid scheduling starvation, the VSync timing is driven by a dedicated
 //! clock thread that sends explicit `Tick` messages to the actor. This ensures
 //! the actor wakes up reliably regardless of other system load, without relying
-//! on blocking `park` calls that could stall the actor scheduler.
+//! on blocking `handle_os` calls that could stall the actor scheduler.
 //!
 //! # Decision logic
 //!
@@ -450,7 +450,7 @@ impl Actor<RenderedResponse, VsyncCommand, VsyncManagement> for VsyncActor {
         Ok(())
     }
 
-    fn park(
+    fn handle_os(
         &mut self,
         _status: SystemStatus,
     ) -> Result<actor_scheduler::ActorStatus, HandlerError> {

--- a/pixelflow-runtime/tests/actor_bug_hunting_tests.rs
+++ b/pixelflow-runtime/tests/actor_bug_hunting_tests.rs
@@ -98,7 +98,7 @@ fn zero_burst_limit_does_not_cause_infinite_loop() {
             fn handle_management(&mut self, _: i32) -> HandlerResult {
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -163,7 +163,7 @@ fn mass_sender_drop_does_not_cause_race() {
             fn handle_management(&mut self, _: i32) -> HandlerResult {
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -234,7 +234,7 @@ fn actor_panic_does_not_corrupt_state() {
             fn handle_management(&mut self, _: i32) -> HandlerResult {
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -282,7 +282,7 @@ fn continuous_control_eventually_processes_data() {
             fn handle_management(&mut self, _: String) -> HandlerResult {
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -335,7 +335,7 @@ fn park_poll_does_not_spin_indefinitely() {
             fn handle_management(&mut self, _: ()) -> HandlerResult {
                 Ok(())
             }
-            fn park(&mut self, _hint: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _hint: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 let count = self.park_count.fetch_add(1, Ordering::SeqCst);
                 if count < self.max_parks {
                     Ok(ActorStatus::Busy) // Keep spinning
@@ -396,7 +396,7 @@ fn slow_handler_backpressure_works() {
             fn handle_management(&mut self, _: i32) -> HandlerResult {
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -453,7 +453,7 @@ fn single_sender_fifo_ordering_maintained() {
             fn handle_management(&mut self, _: i32) -> HandlerResult {
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -557,7 +557,7 @@ fn concurrent_send_during_processing() {
             fn handle_management(&mut self, _: i32) -> HandlerResult {
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -622,7 +622,7 @@ fn doorbell_saturation_does_not_lose_messages() {
             fn handle_management(&mut self, _: i32) -> HandlerResult {
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -755,7 +755,7 @@ fn large_queue_does_not_cause_issues() {
             fn handle_management(&mut self, _: String) -> HandlerResult {
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -803,7 +803,7 @@ fn shutdown_race_does_not_panic() {
                 fn handle_management(&mut self, _: i32) -> HandlerResult {
                     Ok(())
                 }
-                fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+                fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                     Ok(ActorStatus::Idle)
                 }
             }

--- a/pixelflow-runtime/tests/actor_model_tests.rs
+++ b/pixelflow-runtime/tests/actor_model_tests.rs
@@ -54,7 +54,7 @@ impl Actor<String, String, String> for OrderingActor {
         Ok(())
     }
 
-    fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+    fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
         Ok(ActorStatus::Idle)
     }
 }
@@ -111,7 +111,7 @@ impl Actor<i32, i32, i32> for CountingActor {
         Ok(())
     }
 
-    fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+    fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
         Ok(ActorStatus::Idle)
     }
 }
@@ -141,18 +141,18 @@ impl Actor<String, String, String> for SlowActor {
         Ok(())
     }
 
-    fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+    fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
         Ok(ActorStatus::Idle)
     }
 }
 
 /// Actor that tracks SystemStatus hints from the scheduler.
-struct ParkTrackingActor {
-    park_hints: Arc<Mutex<Vec<SystemStatus>>>,
+struct HandleOsTrackingActor {
+    os_hints: Arc<Mutex<Vec<SystemStatus>>>,
     return_status: ActorStatus,
 }
 
-impl Actor<(), (), ()> for ParkTrackingActor {
+impl Actor<(), (), ()> for HandleOsTrackingActor {
     fn handle_data(&mut self, _msg: ()) -> HandlerResult {
         Ok(())
     }
@@ -163,8 +163,8 @@ impl Actor<(), (), ()> for ParkTrackingActor {
         Ok(())
     }
 
-    fn park(&mut self, status: SystemStatus) -> Result<ActorStatus, HandlerError> {
-        self.park_hints.lock().unwrap().push(status);
+    fn handle_os(&mut self, status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+        self.os_hints.lock().unwrap().push(status);
         Ok(self.return_status)
     }
 }
@@ -283,7 +283,7 @@ fn mixed_priority_messages_all_delivered() {
                 self.0 .2.fetch_add(1, Ordering::SeqCst);
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -343,7 +343,7 @@ fn no_starvation_with_continuous_high_priority() {
             fn handle_management(&mut self, _: ()) -> HandlerResult {
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -400,7 +400,7 @@ fn management_burst_limit_prevents_starvation() {
                 self.0.fetch_add(1, Ordering::SeqCst);
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -506,7 +506,7 @@ fn multiple_senders_all_messages_delivered() {
                 self.0.management_count.fetch_add(1, Ordering::SeqCst);
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -567,7 +567,7 @@ fn actor_run_exits_when_all_senders_dropped() {
             fn handle_management(&mut self, _: ()) -> HandlerResult {
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -612,7 +612,7 @@ fn cloned_handle_works_after_original_dropped() {
             fn handle_management(&mut self, _: i32) -> HandlerResult {
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -646,8 +646,8 @@ fn park_hint_wait_when_queues_empty() {
     let hints_clone = hints.clone();
 
     let handle = thread::spawn(move || {
-        let mut actor = ParkTrackingActor {
-            park_hints: hints_clone,
+        let mut actor = HandleOsTrackingActor {
+            os_hints: hints_clone,
             return_status: ActorStatus::Idle,
         };
         rx.run(&mut actor);
@@ -677,8 +677,8 @@ fn park_hint_poll_when_burst_limit_hit() {
     let hints_clone = hints.clone();
 
     let handle = thread::spawn(move || {
-        let mut actor = ParkTrackingActor {
-            park_hints: hints_clone,
+        let mut actor = HandleOsTrackingActor {
+            os_hints: hints_clone,
             return_status: ActorStatus::Idle,
         };
         rx.run(&mut actor);
@@ -709,8 +709,8 @@ fn actor_can_override_park_hint_to_poll() {
     let hints_clone = hints.clone();
 
     let handle = thread::spawn(move || {
-        let mut actor = ParkTrackingActor {
-            park_hints: hints_clone,
+        let mut actor = HandleOsTrackingActor {
+            os_hints: hints_clone,
             return_status: ActorStatus::Busy,
         };
         rx.run(&mut actor);
@@ -725,10 +725,10 @@ fn actor_can_override_park_hint_to_poll() {
 
     let hints = hints.lock().unwrap();
     // Actor returned Poll, so scheduler should keep working
-    // This means park() gets called multiple times
+    // This means handle_os() gets called multiple times
     assert!(
         hints.len() > 1,
-        "Actor overriding to Poll should cause multiple park() calls. Got: {}",
+        "Actor overriding to Poll should cause multiple handle_os() calls. Got: {}",
         hints.len()
     );
 }
@@ -774,7 +774,7 @@ fn different_message_types_per_lane() {
                 self.0.lock().unwrap().2 = true;
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -824,7 +824,7 @@ fn handle_clone_is_independent() {
                 self.0.fetch_add(1, Ordering::SeqCst);
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -878,7 +878,7 @@ fn high_throughput_single_sender() {
             fn handle_management(&mut self, _: i32) -> HandlerResult {
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -929,7 +929,7 @@ fn concurrent_senders_stress_test() {
                 self.0.fetch_add(1, Ordering::SeqCst);
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -992,7 +992,7 @@ fn empty_message_types_work() {
             fn handle_management(&mut self, _: ()) -> HandlerResult {
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -1032,7 +1032,7 @@ fn zero_size_type_messages() {
                 self.0.fetch_add(1, Ordering::SeqCst);
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -1076,7 +1076,7 @@ fn large_message_type_works() {
             fn handle_management(&mut self, _: ()) -> HandlerResult {
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -1111,7 +1111,7 @@ fn immediate_shutdown_no_messages() {
             fn handle_management(&mut self, _: ()) -> HandlerResult {
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -1150,7 +1150,7 @@ fn custom_burst_and_buffer_sizes() {
             fn handle_management(&mut self, _: i32) -> HandlerResult {
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -1187,7 +1187,7 @@ fn large_burst_and_buffer_sizes() {
             fn handle_management(&mut self, _: i32) -> HandlerResult {
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }

--- a/pixelflow-runtime/tests/macos_integration_tests.rs
+++ b/pixelflow-runtime/tests/macos_integration_tests.rs
@@ -39,8 +39,8 @@ mod tests {
 
         // Emulate a run-loop step, which drains the Cocoa event queue.
         let _status = ops
-            .park(SystemStatus::Busy, &mut out)
-            .expect("park failed");
+            .handle_os(SystemStatus::Busy, &mut out)
+            .expect("handle_os failed");
 
         // Geometry only: since step 5a the driver owns the buffer, so `WindowCreated` reports
         // the surface the platform chose and carries no frame.

--- a/pixelflow-runtime/tests/platform_actor_tests.rs
+++ b/pixelflow-runtime/tests/platform_actor_tests.rs
@@ -57,12 +57,12 @@ impl PlatformOps for MockOps {
         Ok(())
     }
 
-    fn park(
+    fn handle_os(
         &mut self,
         _status: SystemStatus,
         _out: &mut DriverOut,
     ) -> Result<ActorStatus, HandlerError> {
-        self.push_log("Park");
+        self.push_log("HandleOs");
         Ok(ActorStatus::Idle)
     }
 }
@@ -111,8 +111,8 @@ fn platform_actor_delegation() {
         })
         .expect("handle_data should succeed");
 
-    // Test Park
-    actor.park(SystemStatus::Busy).expect("park should succeed");
+    // Test HandleOs
+    actor.handle_os(SystemStatus::Busy).expect("handle_os should succeed");
 
     // 4. Verify Log
     let log = log_ref.lock().unwrap();
@@ -120,7 +120,7 @@ fn platform_actor_delegation() {
     assert_eq!(log[0], "Create");
     assert!(log[1].contains("SetTitle WindowId(1) Test Window"));
     assert!(log[2].contains("Present WindowId(1)"));
-    assert_eq!(log[3], "Park");
+    assert_eq!(log[3], "HandleOs");
 }
 
 
@@ -151,12 +151,12 @@ fn platform_ops_emit_without_an_engine() {
         fn handle_management(&mut self, _: DisplayMgmt, _out: &mut DriverOut) -> HandlerResult {
             Ok(())
         }
-        fn park(
+        fn handle_os(
             &mut self,
             _status: SystemStatus,
             out: &mut DriverOut,
         ) -> Result<ActorStatus, HandlerError> {
-            // `park` is the reason `DriverOut` carries a Vec rather than an Option: draining
+            // `handle_os` is the reason `DriverOut` carries a Vec rather than an Option: draining
             // the OS queue yields N events from one step.
             out.event(DisplayEvent::FocusGained { id: WindowId(1) });
             out.event(DisplayEvent::FocusLost { id: WindowId(1) });
@@ -172,8 +172,8 @@ fn platform_ops_emit_without_an_engine() {
     assert!(out.emits.is_empty(), "a step that does nothing must emit nothing");
 
     // One step, N events.
-    ops.park(SystemStatus::Idle, &mut out).unwrap();
-    assert_eq!(out.emits.len(), 2, "park drains N events in a single step");
+    ops.handle_os(SystemStatus::Idle, &mut out).unwrap();
+    assert_eq!(out.emits.len(), 2, "handle_os drains N events in a single step");
     assert!(matches!(out.emits[0], DriverEmit::Event(DisplayEvent::FocusGained { .. })));
     assert!(matches!(out.emits[1], DriverEmit::Event(DisplayEvent::FocusLost { .. })));
 

--- a/pixelflow-runtime/tests/troupe_pattern_tests.rs
+++ b/pixelflow-runtime/tests/troupe_pattern_tests.rs
@@ -108,7 +108,7 @@ impl Actor<AlphaData, AlphaControl, AlphaManagement> for AlphaActor<'_> {
         Ok(())
     }
 
-    fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+    fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
         Ok(ActorStatus::Idle)
     }
 }
@@ -160,7 +160,7 @@ impl Actor<BetaData, BetaControl, BetaManagement> for BetaActor<'_> {
         Ok(())
     }
 
-    fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+    fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
         Ok(ActorStatus::Idle)
     }
 }
@@ -394,7 +394,7 @@ fn all_actor_threads_exit_on_channel_close() {
             fn handle_management(&mut self, _: AlphaManagement) -> HandlerResult {
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -414,7 +414,7 @@ fn all_actor_threads_exit_on_channel_close() {
             fn handle_management(&mut self, _: BetaManagement) -> HandlerResult {
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -462,7 +462,7 @@ fn actor_thread_panic_isolated() {
             fn handle_management(&mut self, _: AlphaManagement) -> HandlerResult {
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -485,7 +485,7 @@ fn actor_thread_panic_isolated() {
             fn handle_management(&mut self, _: BetaManagement) -> HandlerResult {
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -571,7 +571,7 @@ fn circular_messaging_does_not_deadlock() {
             fn handle_management(&mut self, _: AlphaManagement) -> HandlerResult {
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -605,7 +605,7 @@ fn circular_messaging_does_not_deadlock() {
             fn handle_management(&mut self, _: BetaManagement) -> HandlerResult {
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -668,7 +668,7 @@ fn multiple_producers_work_independently() {
             fn handle_management(&mut self, _: AlphaManagement) -> HandlerResult {
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -729,7 +729,7 @@ fn actors_can_coordinate_startup_with_barrier() {
             fn handle_management(&mut self, _: ()) -> HandlerResult {
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -753,7 +753,7 @@ fn actors_can_coordinate_startup_with_barrier() {
             fn handle_management(&mut self, _: ()) -> HandlerResult {
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -804,7 +804,7 @@ fn shutdown_message_causes_actor_exit() {
             fn handle_management(&mut self, _: AlphaManagement) -> HandlerResult {
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -849,7 +849,7 @@ fn shutdown_works_with_multiple_actors() {
             fn handle_management(&mut self, _: AlphaManagement) -> HandlerResult {
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -869,7 +869,7 @@ fn shutdown_works_with_multiple_actors() {
             fn handle_management(&mut self, _: BetaManagement) -> HandlerResult {
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }

--- a/pixelflow-runtime/tests/vsync_actor_bug_hunting_tests.rs
+++ b/pixelflow-runtime/tests/vsync_actor_bug_hunting_tests.rs
@@ -68,7 +68,7 @@ impl Actor<RenderedResponse, VsyncCommand, VsyncManagement> for TickRateTracker 
         Ok(())
     }
 
-    fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+    fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
         Ok(ActorStatus::Idle)
     }
 }
@@ -181,7 +181,7 @@ impl Actor<RenderedResponse, VsyncCommand, VsyncManagement> for TokenTracker {
         Ok(())
     }
 
-    fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+    fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
         Ok(ActorStatus::Idle)
     }
 }
@@ -411,7 +411,7 @@ fn shutdown_command_stops_tick_processing() {
                 }
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -479,7 +479,7 @@ fn fps_request_handles_dropped_receiver() {
             fn handle_management(&mut self, _: VsyncManagement) -> HandlerResult {
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }
@@ -565,7 +565,7 @@ fn refresh_rate_update_during_ticks_is_safe() {
                 }
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }

--- a/pixelflow-runtime/tests/vsync_actor_real_tests.rs
+++ b/pixelflow-runtime/tests/vsync_actor_real_tests.rs
@@ -52,7 +52,7 @@ impl Actor<EngineData, EngineControl, AppManagement> for TickCollector {
     fn handle_management(&mut self, _: AppManagement) -> HandlerResult {
         Ok(())
     }
-    fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+    fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
         Ok(ActorStatus::Idle)
     }
 }

--- a/pixelflow-runtime/tests/vsync_actor_tests.rs
+++ b/pixelflow-runtime/tests/vsync_actor_tests.rs
@@ -135,7 +135,7 @@ impl Actor<RenderedResponse, VsyncCommand, VsyncManagement> for MockVsyncActor {
         Ok(())
     }
 
-    fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+    fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
         Ok(ActorStatus::Idle)
     }
 }
@@ -736,7 +736,7 @@ fn shutdown_stops_processing_immediately() {
             fn handle_management(&mut self, _: VsyncManagement) -> HandlerResult {
                 Ok(())
             }
-            fn park(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
                 Ok(ActorStatus::Idle)
             }
         }


### PR DESCRIPTION
`Host` swept its green actors inside `park` and threw away everything the sweep found.

`park` returns `Result<ActorStatus, HandlerError>`, and `ActorStatus` is `Busy | Idle`. That is the whole information content of the OS-bridge contract — "may this thread sleep?" — and it is the right contract for what `park` is *for*: blocking on `XNextEvent` or a Cocoa event queue. It has nowhere to put "node 3 is stuck holding a framebuffer".

## Why this took five commits to not fix

```
d1ba9d97  report a dead target instead of swallowing the payload
ccaddb2a  let a supervisor actually see a disconnection
57250280  sweep returns supervision events rather than storing them
9d017420  make a reported node identity actionable
3b2fdaba  reuse one supervision buffer across sweeps
```

Each one moves the event a step closer to observable — retain the payload, surface `Step::Disconnected`, hand findings back instead of storing them, give them a stable `NodeId` — and each is a real improvement. None can finish, because the discard is in `park`'s signature rather than in how the sweep reports.

57250280 even states the symptom: the accessor it replaced was one that *"nothing on the `sched.run(&mut host)` path could ever reach."* That diagnosis is correct and was treated as an accessor problem. The unreachability was the finding.

## The change

The sweep becomes an input. `RunSweep` arrives on the data lane; `HostOut` carries supervision out a port like any other transducer's output, delivered by its wiring and checkable by `Topology` — the same conversion vsync and the rasterizer already went through.

The sleep behaviour `park` gave for free is not lost, it moves to the self-addressed continuation, which is the transducer model's own way of saying "more work": a sweep that ran something yields `again` and is stepped straight back; a quiet one yields `None`, so the node goes `Idle` and the driver may block. A host with nothing to do still sleeps instead of polling — it just says so in the same vocabulary as every other actor, and can say more when it needs to.

A merely *stuck* node yields neither, so reporting one cannot spin the host against a peer that is never coming back. Same reason `sweep` does not count `Disconnected` as having run.

## `GreenThread`

`impl Actor for Host` is deleted. Running a host on an OS thread is a real capability — `a_green_send_wakes_a_host_asleep_on_its_doorbell` exercises it on a real thread — so it needed a replacement rather than removal.

`GreenThread` is it, and it is what `park` should have been doing all along: something has to notice the doorbell rang and turn that into an input, which is precisely the bridge role. It feeds the one `RunSweep` a wake implies and advances until quiet. Supervision has already left over the host's own wiring by the time it returns, so there is nothing for an `ActorStatus` to fail to express.

`Host::sweep` stays, unchanged, as the direct path for a caller holding the host itself.

## Testing

3 new tests for the wired path: a stuck actor reaching a supervisor over a port, the continuation yielding while busy and stopping when quiet, several stuck actors draining one per step, and reporting one not spinning the host.

Verified to have teeth rather than merely pass — reinstating the discard (compute the event, drop it) fails exactly those 3 and **none of the 12 pre-existing host tests**. That is the concrete reason it went unnoticed through five commits: the old suite could not see it.

Whole workspace green (1603 tests), clippy clean with `-D warnings`.

## Why now

This came out of reviewing 5b. The framebuffer-destroying send flagged in #933 is the same root cause, not a separate bug: `mealy::send_port` already retains the payload on `Flush::Disconnected`, deliberately, because a port may carry a moved resource — while `ActorHandle::send` takes the message by value and returns nothing. I framed it in #933 as a policy choice between `.expect` and log-and-drop, and said one of them was wrong. Both are. On the transducer path the buffer is retained and the node reports `Disconnected` with the payload still in hand, so there is nothing to decide.

That makes this a prerequisite for 5c rather than a follow-up: promoting the render coordinator to its own node should land on the path where a failed send keeps the buffer, not the one where it destroys it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Y5cNzR9PnASfGfjBh5kJc

---
_Generated by [Claude Code](https://claude.ai/code/session_015Y5cNzR9PnASfGfjBh5kJc)_