### PR TITLE
ci: make post-submit quality gates actually work

### DIFF
--- a/.github/workflows/automatic-revert.yaml
+++ b/.github/workflows/automatic-revert.yaml
@@ -10,6 +10,9 @@ jobs:
   revert:
     name: Revert failed commit
     runs-on: ubuntu-latest
+    # The flake-detection workflow only concludes 'failure' on consistent
+    # breakage (build failure, or a suite failing all 5 iterations); flaky
+    # suites file an issue and leave it green, so this never reverts a flake.
     if: github.event.workflow_run.conclusion == 'failure'
     permissions:
       contents: write
@@ -20,58 +23,105 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_branch }}
 
       - name: Configure Git
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Create Tracking Issue and Revert PR
+      - name: Create tracking issue and revert PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FAILING_SHA: ${{ github.event.workflow_run.head_sha }}
+          BASE_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          RUN_NUMBER: ${{ github.event.workflow_run.run_number }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
         run: |
-          # 1. Create a descriptive branch name
+          set -euo pipefail
+
+          SUBJECT=$(git log -1 --format=%s "$FAILING_SHA")
+          AUTHOR=$(git log -1 --format=%an "$FAILING_SHA")
           BRANCH_NAME="revert-failed-postsubmit-${FAILING_SHA:0:7}"
-          git checkout -b $BRANCH_NAME
 
-          # 2. Revert the failing commit
-          git revert --no-edit $FAILING_SHA
+          # Labels must exist before `gh issue create --label`; -f makes this
+          # idempotent.
+          gh label create "automatic-revert" -f \
+            --color "B60205" --description "Created by the automatic revert workflow"
+          gh label create "postsubmit-failure" -f \
+            --color "D93F0B" --description "Commit failed postsubmit checks on main"
 
-          # 3. Push the branch
-          git push origin $BRANCH_NAME
+          # Dedup: one revert PR per failing commit, no matter how many
+          # postsubmit runs report it.
+          if git ls-remote --exit-code --heads origin "$BRANCH_NAME" > /dev/null 2>&1; then
+            echo "Revert branch $BRANCH_NAME already exists; nothing to do."
+            exit 0
+          fi
 
-          # 4. Create the Tracking Issue first
-          ISSUE_OUTPUT=$(gh issue create \
-            --title "Postsubmit Failure: $(git log -1 --format=%s $FAILING_SHA)" \
-            --body "Commit $FAILING_SHA failed postsubmit tests.
+          open_issue() {
+            gh issue create \
+              --title "$1" \
+              --body "$2" \
+              --label "automatic-revert,postsubmit-failure"
+          }
 
-## Details
-- **Workflow Run**: [#${{ github.event.workflow_run.run_number }}](${{ github.event.workflow_run.html_url }})
-- **Failing Commit**: $FAILING_SHA
-- **Author**: $(git log -1 --format=%an $FAILING_SHA)
+          DETAILS="## Details
+          - **Workflow run**: [#${RUN_NUMBER}](${RUN_URL})
+          - **Failing commit**: ${FAILING_SHA}
+          - **Author**: ${AUTHOR}"
 
-A revert PR has been automatically created to address this failure." \
-            --label "automatic-revert,postsubmit-failure")
+          # Loop guard: if the failing commit is itself an automated revert,
+          # reverting it would re-land the original bad commit and ping-pong
+          # forever. Escalate to a human instead.
+          COMMITTER=$(git log -1 --format=%cn "$FAILING_SHA")
+          if [[ "$SUBJECT" == Revert\ \"* && "$COMMITTER" == "github-actions[bot]" ]]; then
+            open_issue "Postsubmit failure on automated revert ${FAILING_SHA:0:7} — manual intervention needed" \
+              "The automated revert commit $FAILING_SHA itself failed postsubmit. Re-reverting would re-land the original bad commit, so no automatic action was taken.
 
-          # Extract issue number from output (format: "https://github.com/owner/repo/issues/NUMBER")
-          ISSUE_NUMBER=$(echo $ISSUE_OUTPUT | grep -oE '[0-9]+$')
+          $DETAILS"
+            exit 0
+          fi
 
-          # 5. Create the Revert PR and link it to the issue
+          git checkout -b "$BRANCH_NAME"
+
+          # Merge commits need a mainline; -m 1 reverts to the first parent.
+          PARENTS=$(git rev-list --parents -n 1 "$FAILING_SHA" | wc -w)
+          if [ "$PARENTS" -gt 2 ]; then
+            REVERT_ARGS=(-m 1)
+          else
+            REVERT_ARGS=()
+          fi
+
+          if ! git revert --no-edit "${REVERT_ARGS[@]}" "$FAILING_SHA"; then
+            git revert --abort || true
+            open_issue "Postsubmit failure: $SUBJECT" \
+              "Commit $FAILING_SHA failed postsubmit tests, and the automatic revert hit conflicts. Please revert manually.
+
+          $DETAILS"
+            exit 0
+          fi
+
+          git push -u origin "$BRANCH_NAME"
+
+          ISSUE_URL=$(open_issue "Postsubmit failure: $SUBJECT" \
+            "Commit $FAILING_SHA failed postsubmit tests (all 5 iterations of a test suite failed, or the build broke).
+
+          A revert PR has been automatically created to address this failure.
+
+          $DETAILS")
+          ISSUE_NUMBER=$(echo "$ISSUE_URL" | grep -oE '[0-9]+$')
+
           PR_URL=$(gh pr create \
-            --title "Revert \"$(git log -1 --format=%s $FAILING_SHA)\"" \
+            --title "Revert \"$SUBJECT\"" \
             --body "Reverting $FAILING_SHA due to postsubmit failure.
 
-## Related Issue
-Fixes #$ISSUE_NUMBER
+          ## Related issue
+          Fixes #$ISSUE_NUMBER
 
-## Details
-- **Workflow Run**: [#${{ github.event.workflow_run.run_number }}](${{ github.event.workflow_run.html_url }})
-- **Failing SHA**: $FAILING_SHA
-- **Commit Author**: $(git log -1 --format=%an $FAILING_SHA)
+          $DETAILS
 
-This revert was automatically created by the postsubmit failure detection system." \
-            --base main \
-            --head $BRANCH_NAME)
+          This revert was automatically created by the postsubmit failure detection system." \
+            --base "$BASE_BRANCH" \
+            --head "$BRANCH_NAME")
 
           echo "Created issue #$ISSUE_NUMBER and revert PR at $PR_URL"

--- a/.github/workflows/benchmark_regression.yaml
+++ b/.github/workflows/benchmark_regression.yaml
@@ -5,14 +5,27 @@ on:
     branches: [ "main" ]
 
 permissions:
-  # Required to push to gh-pages
+  # Required to push the baseline to gh-pages
   contents: write
-  # Required to open issues
+  # Required to open issues on regression
   issues: write
+
+# Baselines must land in commit order: never run two baseline updates at
+# once, and never skip a commit (skipping would attribute a regression to
+# the wrong commit).
+concurrency:
+  group: benchmark-baseline
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
 
 jobs:
   benchmark:
     runs-on: ubuntu-latest
+    # Full workspace benchmarks are intentionally long, but a deadlocked
+    # bench must not hold the runner for GitHub's multi-hour default.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
         with:
@@ -21,48 +34,90 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
-      # 1. Run Benchmarks
-      - name: Run Cargo Bench
+      # The workspace includes the Linux X11 runtime; cargo builds it even
+      # though no benchmark opens a window.
+      - name: Install X11 dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libx11-dev libxcursor-dev libxrandr-dev libxi-dev
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-bench-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-bench-
+
+      # --benches restricts cargo to declared benchmark targets. Library and
+      # binary targets run under the libtest harness, which rejects
+      # Criterion's `--output-format bencher`; every [lib] in the workspace
+      # therefore sets `bench = false` and every [[bench]] is Criterion with
+      # `harness = false`.
+      - name: Run benchmarks
         run: |
           set -o pipefail
           mkdir -p benchmark_results
-          cargo bench --workspace -- --output-format bencher | tee benchmark_results/output.txt
+          cargo bench --workspace --benches -- --output-format bencher | tee benchmark_results/output.txt
 
-      # 2. Compare against History
-      - name: Check for Regression
+      - name: Upload benchmark output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results-${{ github.sha }}
+          path: benchmark_results/output.txt
+          if-no-files-found: error
+
+      - name: Compare against baseline and publish
         id: benchmark_check
         uses: benchmark-action/github-action-benchmark@v1
         with:
           tool: 'cargo'
           output-file-path: benchmark_results/output.txt
           gh-pages-branch: gh-pages
-          alert-threshold: '115%'    # Alert if 15% slower
-          fail-on-alert: true        # Fail step to trigger the issue creation
+          # Hosted runners are noisy neighbors; 15% is within observed
+          # run-to-run variance and alerted on infrastructure, not code.
+          alert-threshold: '125%'
+          fail-on-alert: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
           comment-on-alert: true
 
-      # 3. Open Issue on Regression
-      - name: Create Performance Issue
+      - name: Open performance regression issue
         if: failure() && steps.benchmark_check.outcome == 'failure'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Get the author of the commit to tag them
+          set -euo pipefail
+          gh label create "performance-regression" -f \
+            --color "D93F0B" --description "Postsubmit benchmark regression"
+
           AUTHOR=$(git log -1 --pretty=format:'%an')
           SHA=$(git rev-parse --short HEAD)
-          
-          gh issue create \
-            --title "⚠️ Performance Regression Detected in $SHA" \
-            --body "### 🚨 Benchmark Regression Report
-            
-            **Commit:** $SHA
-            **Author:** $AUTHOR
-            
-            A performance regression of **>15%** was detected compared to the previous baseline.
-            
-            [View Benchmark Logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-            
-            Please investigate to determine if this slowdown is expected." \
-            --label "performance-regression" \
-            --assignee "${{ github.actor }}"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          BODY="### Benchmark regression report
+
+          **Commit:** $SHA
+          **Author:** $AUTHOR
+
+          One or more benchmarks regressed by more than **25%** against the previous baseline.
+
+          [View benchmark logs]($RUN_URL)
+
+          If the slowdown is expected (e.g. an intentional trade), close this issue with a note; otherwise fix or revert."
+
+          # One open issue at a time: pile new reports onto the existing one
+          # instead of spamming a fresh issue per commit.
+          EXISTING=$(gh issue list --label performance-regression --state open \
+            --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "$BODY"
+          else
+            gh issue create \
+              --title "Performance regression detected on main ($SHA)" \
+              --body "$BODY" \
+              --label "performance-regression"
+          fi

--- a/.github/workflows/postsubmit-flake-detection.yaml
+++ b/.github/workflows/postsubmit-flake-detection.yaml
@@ -7,20 +7,25 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
   test:
-    name: Test ${{ matrix.test-suite }} on ${{ matrix.os }} (run ${{ matrix.run-number }}/5)
+    name: ${{ matrix.test-suite }} on ${{ matrix.os }} (5 iterations)
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
     strategy:
-      # Continue running other jobs even if one fails, to see all failures
+      # A failure in one suite must not hide results from the others.
       fail-fast: false
       matrix:
-        # Test on multiple operating systems
         os: [ubuntu-latest, macos-latest]
-        # Parallel runs to catch flaky tests and maximize CI throughput
         test-suite: [actor-scheduler, other-crates]
-        # Run each test suite 5 times in parallel for flake detection
-        run-number: [1, 2, 3, 4, 5]
+        include:
+          - test-suite: actor-scheduler
+            cargo-args: "-p actor-scheduler -p actor-scheduler-macros"
+          - test-suite: other-crates
+            cargo-args: "--workspace --exclude actor-scheduler --exclude actor-scheduler-macros"
 
     steps:
       - name: Checkout code
@@ -29,9 +34,19 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      # Caching dependencies speeds up subsequent runs.
+      - name: Install X11 dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libx11-dev libxcursor-dev libxrandr-dev libxi-dev
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -41,28 +56,114 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
-      - name: Run actor-scheduler tests
-        if: matrix.test-suite == 'actor-scheduler'
+      # A build failure is a hard postsubmit failure in its own right; keeping
+      # it a separate step also means the iteration loop below measures test
+      # stability, not compilation.
+      - name: Build tests
         shell: bash
-        run: cargo test -p actor-scheduler -p actor-scheduler-macros --verbose
+        run: cargo nextest run ${{ matrix.cargo-args }} --no-run
 
-      - name: Run other crates tests
-        if: matrix.test-suite == 'other-crates'
+      # Run the suite 5 times to separate flaky tests from broken ones:
+      #   5/5 pass  -> green
+      #   1-4 fail  -> FLAKY: reported as an issue by the flake-report job,
+      #                but the workflow stays green (no revert for flakes)
+      #   5/5 fail  -> consistent failure: job fails, which fails the
+      #                workflow and triggers the automatic revert
+      - name: Run test suite 5 times
         shell: bash
-        run: cargo test --workspace --exclude actor-scheduler --exclude actor-scheduler-macros --verbose
+        run: |
+          set -o pipefail
+          PASSES=0
+          : > failed_tests.txt
+          for i in 1 2 3 4 5; do
+            echo "::group::Iteration $i/5"
+            if cargo nextest run ${{ matrix.cargo-args }} --profile ci 2>&1 | tee "run_$i.log"; then
+              PASSES=$((PASSES + 1))
+            else
+              # Per-test timeouts (.config/nextest.toml) surface as TIMEOUT.
+              grep -E '^[[:space:]]+(FAIL|TIMEOUT|SIGSEGV|SIGABRT|ABORT)' "run_$i.log" >> failed_tests.txt || true
+            fi
+            echo "::endgroup::"
+          done
 
-  # Report flake detection status
-  flake-detection-status:
-    name: Flake Detection Status
+          SLUG="${{ matrix.os }}-${{ matrix.test-suite }}"
+          echo "$SLUG: $PASSES/5 iterations passed"
+          if [ "$PASSES" -eq 5 ]; then
+            exit 0
+          elif [ "$PASSES" -eq 0 ]; then
+            echo "::error::$SLUG: all 5 iterations failed — consistent breakage, revert will be proposed"
+            exit 1
+          fi
+
+          echo "::warning::$SLUG: $((5 - PASSES))/5 iterations failed — flaky, filing an issue instead of reverting"
+          mkdir -p flake-results
+          {
+            echo "### \`$SLUG\`: $((5 - PASSES))/5 iterations failed"
+            echo ""
+            echo '```'
+            sort -u failed_tests.txt
+            echo '```'
+          } > "flake-results/$SLUG.md"
+
+      - name: Upload flake report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: flake-${{ matrix.os }}-${{ matrix.test-suite }}
+          path: flake-results/
+          if-no-files-found: ignore
+
+  # Files (or updates) a tracking issue when any suite was flaky. This job
+  # must never fail the workflow: a hiccup filing an issue is not a
+  # postsubmit failure and must not trigger the automatic revert.
+  flake-report:
+    name: File flake report
     runs-on: ubuntu-latest
     needs: test
     if: always()
+    continue-on-error: true
+    permissions:
+      issues: write
     steps:
-      - name: Check flake detection results
+      - name: Download flake reports
+        uses: actions/download-artifact@v4
+        with:
+          pattern: flake-*
+          merge-multiple: true
+          path: flake-results
+
+      - name: Create or update flake issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ "${{ needs.test.result }}" = "failure" ]; then
-            echo "Flake detection found failures - triggering automatic revert"
-            exit 1
+          set -euo pipefail
+          shopt -s nullglob
+          reports=(flake-results/*.md)
+          if [ "${#reports[@]}" -eq 0 ]; then
+            echo "No flaky suites detected."
+            exit 0
+          fi
+
+          gh label create "flaky-test" -f \
+            --color "FBCA04" --description "Test failed intermittently in postsubmit" \
+            --repo "${{ github.repository }}"
+
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          BODY="Intermittent test failures detected on \`${{ github.sha }}\` ([run]($RUN_URL)).
+
+          A flaky suite passed some of its 5 postsubmit iterations and failed others, so the commit was **not** reverted. Deflake or quarantine the tests below.
+
+          $(cat "${reports[@]}")"
+
+          EXISTING=$(gh issue list --repo "${{ github.repository }}" \
+            --label flaky-test --state open \
+            --search "Flaky tests detected on main in:title" \
+            --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --repo "${{ github.repository }}" --body "$BODY"
           else
-            echo "All flake detection tests passed"
+            gh issue create --repo "${{ github.repository }}" \
+              --title "Flaky tests detected on main" \
+              --body "$BODY" \
+              --label "flaky-test"
           fi

--- a/docs/POSTSUBMIT.md
+++ b/docs/POSTSUBMIT.md
@@ -1,0 +1,65 @@
+# Post-submit quality pipeline
+
+Three workflows run against every push to `main`. Together they answer: did
+this commit break tests, make them flaky, or slow the hot paths — and if it
+broke them, who backs it out?
+
+```
+push to main
+  ├── Postsubmit Flake Detection ──(conclusion: failure)──▶ Automatic Revert
+  │     5× per (OS, suite); flaky ⇒ issue, consistent ⇒ fail
+  └── Benchmark Regression Check
+        Criterion vs gh-pages baseline; >25% ⇒ issue + commit comment
+```
+
+## Flake detection (`postsubmit-flake-detection.yaml`)
+
+Each (OS × suite) job builds the tests once, then runs the suite **5 times**
+with nextest (per-test 10-minute cap from `.config/nextest.toml`). The five
+iterations classify the commit:
+
+| Result | Meaning | Action |
+|---|---|---|
+| 5/5 pass | healthy | nothing |
+| 1–4/5 fail | **flaky** | file/update a `flaky-test` issue; workflow stays green |
+| 0/5 pass (or build fails) | **consistently broken** | workflow fails → automatic revert |
+
+The distinction is the point: a flake reverted is a lie recorded (the next
+commit "fixes" it by luck), and a hard breakage merely issue-filed rots on
+main. The `flake-report` job runs with `continue-on-error` so an issue-filing
+hiccup can never masquerade as a postsubmit failure and trigger a revert.
+
+## Automatic revert (`automatic-revert.yaml`)
+
+Fires on a failed flake-detection run. Creates a tracking issue and a revert
+PR (branch `revert-failed-postsubmit-<sha7>`), with guards:
+
+- **Dedup** — one revert branch per failing SHA, however many runs report it.
+- **Loop guard** — if the failing commit is itself an automated revert,
+  re-reverting would re-land the original bad commit; it escalates to an
+  issue instead.
+- **Merge commits** — reverted against the first parent (`-m 1`).
+- **Conflicts** — a revert that doesn't apply cleanly becomes an issue
+  asking for a manual revert, not a broken branch.
+
+Reverts are proposed as PRs, not pushed to `main` directly: presubmit still
+gets to check that the revert itself builds.
+
+## Benchmark regression (`benchmark_regression.yaml`)
+
+Runs `cargo bench --workspace --benches -- --output-format bencher` and feeds
+the result to `benchmark-action/github-action-benchmark`, which keeps the
+baseline series on the `gh-pages` branch. A benchmark more than **25%** slower
+than baseline gets a commit comment and one open `performance-regression`
+issue (subsequent regressions comment on the existing issue rather than
+piling up new ones). Runs are serialized by a concurrency group so baselines
+land in commit order.
+
+Perf regressions do **not** auto-revert: hosted-runner noise makes a
+threshold breach evidence, not proof. The issue is the escalation path.
+
+`--benches` only works because every `[lib]` in the workspace sets
+`bench = false` and every `[[bench]]` target is Criterion with
+`harness = false` — the libtest harness rejects `--output-format bencher`.
+Keep new crates on that convention or the benchmark job will fail at
+flag-parse time.

--- a/pixelflow-compiler/Cargo.toml
+++ b/pixelflow-compiler/Cargo.toml
@@ -8,6 +8,8 @@ license = "Apache-2.0"
 
 [lib]
 proc-macro = true
+# libtest harness rejects Criterion's bencher flags under `cargo bench --benches`.
+bench = false
 
 [features]
 # P3 transition scaffolding (docs/plans/2026-07-20-kernel-unification.md):

--- a/pixelflow-core/Cargo.toml
+++ b/pixelflow-core/Cargo.toml
@@ -19,3 +19,9 @@ criterion = { version = "0.5", features = ["html_reports"] }
 [[bench]]
 name = "core_benches"
 harness = false
+
+[[bin]]
+name = "calibrate_costs"
+path = "src/bin/calibrate_costs.rs"
+# libtest harness rejects Criterion's bencher flags under `cargo bench --benches`.
+bench = false

--- a/pixelflow-graphics/Cargo.toml
+++ b/pixelflow-graphics/Cargo.toml
@@ -7,7 +7,10 @@ edition = "2021"
 workspace = true
 
 [lib]
-bench = true
+# The lib's harness is libtest, which rejects Criterion's `--output-format
+# bencher`; CI passes that flag to every `--benches` target, so only the
+# declared Criterion [[bench]] targets may run as benchmarks.
+bench = false
 
 [dependencies]
 # Core dependencies

--- a/pixelflow-ir/Cargo.toml
+++ b/pixelflow-ir/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2024"
 description = "Unified Intermediate Representation and SIMD Backends for PixelFlow"
 
+[lib]
+# libtest harness rejects Criterion's bencher flags under `cargo bench --benches`.
+bench = false
+
 [lints]
 workspace = true
 

--- a/pixelflow-pipeline/Cargo.toml
+++ b/pixelflow-pipeline/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2024"
 description = "Training and data generation pipeline for PixelFlow"
 
+[lib]
+# libtest harness rejects Criterion's bencher flags under `cargo bench --benches`.
+bench = false
+
 [features]
 default = []
 training = ["pixelflow-search/std"]
@@ -28,6 +32,10 @@ pixelflow-compiler = { path = "../pixelflow-compiler" }
 
 [[bench]]
 name = "nnue_training_suite"
+harness = false
+
+[[bench]]
+name = "macro_bench"
 harness = false
 
 

--- a/pixelflow-pipeline/Cargo.toml
+++ b/pixelflow-pipeline/Cargo.toml
@@ -40,6 +40,12 @@ harness = false
 
 
 [[bin]]
+name = "bench_hoisted_scanline"
+path = "src/bin/bench_hoisted_scanline.rs"
+# libtest harness rejects Criterion's bencher flags under `cargo bench --benches`.
+bench = false
+
+[[bin]]
 name = "bench_jit_corpus"
 path = "src/bin/bench_jit_corpus.rs"
 required-features = ["training"]

--- a/pixelflow-search/Cargo.toml
+++ b/pixelflow-search/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2024"
 description = "A generic graph search framework for algebraic optimization and scheduling"
 
+[lib]
+# libtest harness rejects Criterion's bencher flags under `cargo bench --benches`.
+bench = false
+
 [dependencies]
 libm = "0.2.15"
 rand = "0.8"


### PR DESCRIPTION
## What was broken

Every post-submit run on `main` has been red since the workflows landed — not because of bad commits, but because of the workflows themselves:

- **Both post-submit workflows never installed X11.** `pixelflow-runtime/build.rs` hard-requires `libx11-dev`; the presubmit workflow installs it, the post-submit ones didn't. So flake detection failed at *build* time on every push, and the automatic revert fired on infrastructure failure rather than on broken code.
- **The benchmark job passed a Criterion-only flag to libtest.** `cargo bench --workspace -- --output-format bencher` invokes every target with `bench = true` — including plain lib/bin targets whose libtest harness rejects `--output-format` (`error: Unrecognized option`).
- **Flake "detection" detected nothing.** 20 jobs (2 OS × 2 suites × 5 reruns) each rebuilt the workspace with plain `cargo test`, and *any* failure — flaky or consistent — triggered a revert. Reverting a flake re-lands as "fixed" by luck; that's the opposite of what a flake gate is for.

## What this PR does

**Flake detection** (`postsubmit-flake-detection.yaml`)
- Installs X11 on Linux; switches to nextest with the existing `ci` profile (per-test 10-minute cap).
- Builds once per (OS, suite), then runs the suite 5× in the same job (4 jobs instead of 20; one build instead of five).
- Classifies the outcome: **5/5 pass** → green; **1–4/5 fail** → flaky: files/updates a `flaky-test` issue with the failing test names and stays green (flakes never revert); **0/5 pass or build failure** → workflow fails → automatic revert.
- The issue-filing job runs with `continue-on-error` so a `gh` hiccup can't masquerade as a postsubmit failure and trigger a revert.

**Automatic revert** (`automatic-revert.yaml`)
- Dedup: one revert branch/PR per failing SHA, however many runs report it.
- Merge commits reverted against the first parent (`-m 1`).
- Revert conflicts become a manual-revert tracking issue instead of a failed job.
- Loop guard: if the failing commit is itself an automated revert, re-reverting would re-land the original bad commit — escalates to an issue instead.
- Labels created idempotently (`gh label create -f`) before use, so issue creation can't fail on a missing label.

**Benchmark regression** (`benchmark_regression.yaml`)
- Installs X11, adds caching and a 90-minute timeout.
- Restricts to declared Criterion targets with `--benches`.
- Serializes runs with a non-canceling concurrency group so gh-pages baselines land in commit order.
- Alert threshold 115% → 125% (hosted-runner noise routinely exceeds 15%, and a gate that cries wolf gets ignored).
- Repeat regressions comment on the existing open `performance-regression` issue instead of opening one per commit.

**Manifests** — the fix that makes `--benches` sound: every `[lib]` (pixelflow-ir, -search, -compiler, -graphics, -pipeline) now sets `bench = false`, two stray auto-discovered bins (`calibrate_costs`, `bench_hoisted_scanline`) are declared with `bench = false`, and pixelflow-pipeline's `macro_bench` is declared with `harness = false`.

**Docs** — `docs/POSTSUBMIT.md` records the pipeline and its contracts (flaky ≠ revert; consistent = revert; perf regression = issue, not revert).

## Verification

- `cargo bench --workspace --benches -- --output-format bencher --list` exits 0 locally and enumerates **277 Criterion benchmarks** with zero harness errors (this exact invocation previously died on two libtest targets — found and fixed by running it).
- All three workflows validated: YAML parses, and every embedded `run:` script passes `bash -n` after block-scalar dedent.

## Notes for reviewers

- Perf regressions intentionally do **not** auto-revert — benchmark noise on shared runners makes a threshold breach evidence, not proof. The issue is the escalation path.
- A suite that fails 1–4 of 5 iterations because a commit introduced a *racy* (not deterministic) breakage will be flagged as flaky rather than reverted; the `flaky-test` issue is the paper trail for that judgment call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XSWdHjJjgvrxMcT9RRb14y

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSWdHjJjgvrxMcT9RRb14y)_