### PR TITLE
feat(pixelflow-runtime): the render coordinator is its own green node (step 5c)

### DIFF
--- a/pixelflow-runtime/src/api/private.rs
+++ b/pixelflow-runtime/src/api/private.rs
@@ -1,6 +1,5 @@
 use actor_scheduler::{ActorHandle, ActorScheduler};
 use pixelflow_graphics::render::frame::Frame;
-use pixelflow_graphics::render::rasterizer::RenderResponse;
 use std::sync::Arc;
 
 use crate::api::public::CursorIcon;
@@ -10,7 +9,7 @@ use crate::pixel::PlatformPixel;
 // Re-export WindowId from public API for backward compatibility
 pub use crate::api::public::WindowId;
 
-use crate::display::messages::{DisplayEvent, Window, WindowMeta};
+use crate::display::messages::{DisplayEvent, Window};
 
 /// Commands sent to the Display Driver.
 #[derive(Debug)]
@@ -61,9 +60,6 @@ pub enum EngineData {
     /// *is* the return and there is nothing to acknowledge; what remains is the outbound half —
     /// the driver handing the buffer out to be drawn into.
     WindowGranted(Window),
-    /// Render complete - carries the cooked frame, timing, and the window metadata that
-    /// travelled out with the request, from which the `Window` is reassembled.
-    RenderComplete(RenderResponse<PlatformPixel, WindowMeta>),
 }
 
 impl std::fmt::Debug for EngineData {
@@ -84,11 +80,6 @@ impl std::fmt::Debug for EngineData {
             Self::WindowGranted(window) => {
                 f.debug_tuple("WindowGranted").field(window).finish()
             }
-            Self::RenderComplete(response) => f
-                .debug_struct("RenderComplete")
-                .field("render_time", &response.render_time)
-                .field("frame_size", &(response.frame.width, response.frame.height))
-                .finish(),
         }
     }
 }
@@ -107,29 +98,49 @@ impl From<DisplayEvent>
     }
 }
 
-/// The green vsync host's three handles, handed to the engine in one message by
-/// `EngineControl::VsyncActorReady`: the two inbound edges (data, control) plus a handle to the
-/// host itself for the shutdown cascade.
-type VsyncBootstrap = (
-    actor_scheduler::GreenSender<crate::vsync_actor::RenderedResponse>,
-    actor_scheduler::GreenSender<crate::vsync_actor::VsyncCommand>,
-    actor_scheduler::ActorHandle<
+/// The green-host bootstrap bundle, handed to the engine in one message by
+/// `EngineControl::GreenReady`.
+///
+/// Carries what the engine needs once vsync *and* the render coordinator (`coordinator_node.rs`,
+/// step 5c of the mesh migration doc) are both up on the one green-host thread: the vsync
+/// control edge, the coordinator's data-lane sender, and two handles kept only for the shutdown
+/// cascade. Named fields rather than a tuple because `host` and `forwarder` share a type
+/// (`ActorHandle<Infallible, Infallible, Infallible>`) and a positional tuple would let them be
+/// silently transposed.
+///
+/// The rasterizer's own live handle is deliberately **not** here. `RasterizerHandle` is not
+/// `Clone`, and its lanes are single-producer SPSC, so it cannot be shared between the
+/// coordinator (which needs it continuously, for every render) and the engine (which would only
+/// ever touch it once, at shutdown) without breaking that invariant. The coordinator keeps sole
+/// ownership; the rasterizer's own scheduler halts gracefully once that handle drops with the
+/// green host — the same disconnect-triggered shutdown the forwarder already relies on one hop
+/// downstream (`engine_troupe.rs`'s `RasterizerForwarder`).
+#[derive(Debug)]
+pub struct GreenReadyBundle {
+    pub(crate) vsync_control: actor_scheduler::GreenSender<crate::vsync_actor::VsyncCommand>,
+    pub(crate) coordinator: actor_scheduler::GreenSender<crate::coordinator_node::CoordinatorData>,
+    pub(crate) host: actor_scheduler::ActorHandle<
         std::convert::Infallible,
         std::convert::Infallible,
         std::convert::Infallible,
     >,
-);
+    pub(crate) forwarder: actor_scheduler::ActorHandle<
+        std::convert::Infallible,
+        std::convert::Infallible,
+        std::convert::Infallible,
+    >,
+}
 
 // Engine control message (low frequency, configuration/lifecycle)
 #[derive(Debug, Default)]
 pub enum EngineControl {
     UpdateRefreshRate(f64),
-    /// The green vsync host is up. Carries all three handles at once because there is exactly
-    /// one send site (`Troupe::with_config`) and one delivery (the shell intercept below) — a
-    /// single message beats three that would otherwise need to race each other into place
-    /// first. Boxed: the tuple is far larger than every other variant, and `Quit`/`DriverAck`
+    /// The green host is up, hosting both vsync and the render coordinator. There is exactly
+    /// one send site (`Troupe::with_config`) and one delivery (the shell intercept below), so a
+    /// single message beats several that would otherwise need to race each other into place
+    /// first. Boxed: the bundle is far larger than every other variant, and `Quit`/`DriverAck`
     /// are the hot ones.
-    VsyncActorReady(Box<VsyncBootstrap>),
+    GreenReady(Box<GreenReadyBundle>),
     /// A green node got stuck (design doc, `Host::sweep`'s `Supervision`). Logged for now;
     /// policy is a later slice.
     GreenStuck(actor_scheduler::host::Supervision),

--- a/pixelflow-runtime/src/api/public.rs
+++ b/pixelflow-runtime/src/api/public.rs
@@ -423,9 +423,6 @@ pub enum AppManagement {
     Configure(crate::config::EngineConfig),
     /// Register the application handle so the engine can send events back to the app.
     RegisterApp(std::sync::Arc<dyn Application + Send + Sync>),
-    /// Pre-created engine handle for rasterizer response forwarding thread.
-    /// Sent before Configure so that spawn_rasterizer has a dedicated SPSC handle.
-    SetRasterizerForwardHandle(crate::api::private::EngineActorHandle),
     /// Request window creation.
     ///
     /// # Contract
@@ -448,9 +445,6 @@ impl std::fmt::Debug for AppManagement {
         match self {
             AppManagement::Configure(config) => f.debug_tuple("Configure").field(config).finish(),
             AppManagement::RegisterApp(_) => f.debug_tuple("RegisterApp").field(&"<app>").finish(),
-            AppManagement::SetRasterizerForwardHandle(_) => {
-                f.write_str("SetRasterizerForwardHandle(<handle>)")
-            }
             AppManagement::CreateWindow(descriptor) => {
                 f.debug_tuple("CreateWindow").field(descriptor).finish()
             }

--- a/pixelflow-runtime/src/coordinator_node.rs
+++ b/pixelflow-runtime/src/coordinator_node.rs
@@ -1,0 +1,892 @@
+//! The render coordinator's own green node: a second [`Node`](actor_scheduler::mealy::Node) on
+//! the vsync green-host thread.
+//!
+//! Step 5c of `docs/designs/pixelflow-runtime-engine-mesh-migration.md` §8: [`RenderCoordinator`]
+//! (`render_coordinator.rs`) leaves `EngineCore` and runs here as a `Transducer`
+//! ([`CoordinatorCore`]) with its own `Wiring` ([`CoordinatorWiring`]) sending directly to the
+//! rasterizer, the driver, and vsync's telemetry lane. Render completions arrive straight from
+//! the rasterizer forwarder — no engine round-trip — while window grants, scene submissions, and
+//! the "try rendering again" nudge still arrive from the engine shell, which is the one relay
+//! this step leaves in place (`engine_core.rs`'s `coordinator` port).
+//!
+//! # Why two producers, two lanes
+//!
+//! [`CoordinatorData`] (engine shell → coordinator: submit/grant/advance) and
+//! [`RenderResponse`] (rasterizer forwarder → coordinator: completions) are different producers,
+//! so SPSC purity puts them on different lanes even before priority is considered. Management
+//! outranking Data is not incidental, though: a completion frees the render credit and the
+//! buffer the driver is waiting on, so finishing in-flight work before accepting a new
+//! submission is the same continuation-first discipline `Node::poll` already applies to its own
+//! self-edge — draining what is already committed before taking on more.
+//!
+//! # The delivery-feedback seam dissolved
+//!
+//! [`RenderCoordinator::request_sent`]/`render_send_failed` existed because `EngineHandler`'s own
+//! sends could fail *after* the core had already decided — a pure core cannot see a send
+//! outcome, so the shell had to report it back in. Under `Wiring`, delivery is flush's problem: a
+//! blocked port parks in the `Node`'s outbox and retries on its own, so the core never needs to
+//! learn about a transient failure. [`CoordinatorCore::route`] therefore calls
+//! [`RenderCoordinator::request_sent`] the moment it decides to ask — delivery is now
+//! guaranteed-or-parked, so "an ask is in flight" is already true at the moment of emission.
+//! `render_send_failed` has no counterpart here: a rasterizer that is truly *gone* surfaces as
+//! [`Flush::Disconnected`] → `Host` supervision → `GreenStuck`, which is strictly better than the
+//! old warn-and-release-credit path — the render's buffer is retained rather than destroyed (see
+//! [`CoordinatorWiring`]'s `render` port).
+
+use crate::display::messages::{DisplayControl, DisplayData, DisplayMgmt, Window, WindowMeta};
+use crate::platform::PlatformPixel;
+use crate::render_coordinator::{Completed, RenderCoordinator, Step};
+use crate::vsync_actor::RenderedResponse;
+use actor_scheduler::mealy::{Flush, Transducer, Wiring, all};
+use actor_scheduler::{ActorHandle, GreenSender, HandlerError, Message, TrySendError};
+use pixelflow_core::{Discrete, Manifold};
+use pixelflow_graphics::render::rasterizer::{RasterizerHandle, RenderRequest, RenderResponse};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+/// A manifold as it travels between the app and the rasterizer.
+///
+/// Duplicates `render_coordinator`'s own private alias of the same name rather than exporting
+/// it: that module's `Scene` is deliberately not part of even this crate's wider surface, and
+/// re-exporting it just to share one line would widen `RenderCoordinator`'s API for a type
+/// alias, not a capability.
+type Scene = Arc<dyn Manifold<Output = Discrete> + Send + Sync>;
+
+/// Frame counter logging cadence — moved verbatim from the old `EngineCore` copy: the telemetry
+/// edge (`rendered`, below) is a coordinator → vsync edge now, so the counter that stamps it
+/// lives with the coordinator (§7.3 of the migration doc).
+const LOG_FRAME_INTERVAL: u64 = 60;
+
+/// Input on the coordinator's data lane. Producer: the engine shell. Window grants, scene
+/// submissions, and the "something might be drawable now" nudge all still arrive by way of
+/// `EngineCore`'s `coordinator` port (driver `WindowGranted`, app `RenderSurface`, and the
+/// vsync-tick / window-lifecycle advance, respectively) rather than directly from their
+/// original sources — keeping this lane single-producer.
+pub(crate) enum CoordinatorData {
+    /// A new kernel from the app. Keep-latest — see [`RenderCoordinator::submit`].
+    Submit(Scene),
+    /// The driver granted the buffer this coordinator asked for.
+    Granted(Window),
+    /// Re-drive the pull protocol with nothing new to offer: retries a request lost in transit,
+    /// or is the first chance to render after a window appears or resizes.
+    Advance,
+}
+
+impl std::fmt::Debug for CoordinatorData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Submit(_) => f.write_str("Submit(<scene>)"),
+            Self::Granted(window) => f.debug_tuple("Granted").field(window).finish(),
+            Self::Advance => f.write_str("Advance"),
+        }
+    }
+}
+
+/// One optional slot per downstream edge. `Default` (all `None`/`false`) is the silent step —
+/// most inputs move state without telling any peer, exactly as `EngineOut`/`VsyncCoreOut`.
+#[derive(Default)]
+pub(crate) struct CoordinatorOut {
+    /// → the rasterizer. Credit(1) + droppable-backstop edge; see [`CoordinatorWiring`].
+    pub(crate) render: Option<RenderRequest<PlatformPixel, WindowMeta>>,
+    /// → the driver's management lane (`DisplayMgmt::RequestWindow`). A flag, not an
+    /// `Option<T>`: there is no payload, only "ask now or don't".
+    pub(crate) request_window: bool,
+    /// → the driver's data lane (`DisplayData::Present`). The only other copy of this buffer
+    /// besides a non-stale render completion (migration doc §9.2), so this and the render
+    /// completion are the two edges that must never drop it.
+    pub(crate) present: Option<Window>,
+    /// → vsync's data lane (FPS telemetry). Droppable in principle (§9.2): losing a sample
+    /// changes nothing but a displayed number.
+    pub(crate) rendered: Option<RenderedResponse>,
+}
+
+/// Owns the render coordinator plus the one piece of state that used to live on `EngineCore`:
+/// the frame counter, because its only consumer — FPS telemetry — is a coordinator → vsync edge
+/// now (§7.3 of the migration doc).
+pub(crate) struct CoordinatorCore {
+    render: RenderCoordinator,
+    frame_number: u64,
+}
+
+impl CoordinatorCore {
+    pub(crate) fn new() -> Self {
+        Self {
+            render: RenderCoordinator::new(),
+            frame_number: 0,
+        }
+    }
+
+    /// Whether the buffer is currently in hand. Test-only window into otherwise-private state,
+    /// mirroring `RenderCoordinator::holds_buffer` (and the old `EngineCore::holds_buffer`).
+    #[cfg(test)]
+    pub(crate) fn holds_buffer(&self) -> bool {
+        self.render.holds_buffer()
+    }
+
+    /// Map a `render_coordinator::Step` onto the port it belongs on.
+    ///
+    /// Calls `request_sent` the instant a `RequestWindow` is decided, not once it is delivered —
+    /// see the module doc's "the delivery-feedback seam dissolved".
+    fn route(&mut self, step: Step, out: &mut CoordinatorOut) {
+        match step {
+            Step::Idle => {}
+            Step::RequestWindow => {
+                out.request_window = true;
+                self.render.request_sent();
+            }
+            Step::Render(request) => out.render = Some(request),
+        }
+    }
+
+    /// Hand the drawn buffer to the `present` port and vsync's telemetry port together. Two
+    /// different ports set in one step is fine — `Wiring::flush` delivers them independently;
+    /// it is only ever a problem for two messages sharing *one* port in one step, which does not
+    /// happen here.
+    fn present_cooked_frame(&mut self, render_time: Duration, window: Window, out: &mut CoordinatorOut) {
+        out.present = Some(window);
+
+        self.frame_number += 1;
+        out.rendered = Some(RenderedResponse {
+            frame_number: self.frame_number,
+            rendered_at: Instant::now(),
+        });
+
+        if self.frame_number.is_multiple_of(LOG_FRAME_INTERVAL) {
+            log::info!("Frame {}: render={:?}", self.frame_number, render_time);
+        }
+    }
+}
+
+impl Transducer for CoordinatorCore {
+    type Control = std::convert::Infallible;
+    type Management = RenderResponse<PlatformPixel, WindowMeta>;
+    type Data = CoordinatorData;
+    type Out = CoordinatorOut;
+
+    fn step_data(&mut self, data: CoordinatorData) -> Result<CoordinatorOut, HandlerError> {
+        let mut out = CoordinatorOut::default();
+        let step = match data {
+            CoordinatorData::Submit(scene) => self.render.submit(scene),
+            CoordinatorData::Granted(window) => self.render.granted(window),
+            CoordinatorData::Advance => self.render.advance(),
+        };
+        self.route(step, &mut out);
+        Ok(out)
+    }
+
+    fn step_management(
+        &mut self,
+        response: RenderResponse<PlatformPixel, WindowMeta>,
+    ) -> Result<CoordinatorOut, HandlerError> {
+        let mut out = CoordinatorOut::default();
+        let Completed { present, next } = self.render.completed(response);
+        match present {
+            Some((window, render_time)) => self.present_cooked_frame(render_time, window, &mut out),
+            // The rasterizer was paused, so it handed the buffer back unrendered. Presenting it
+            // would blit whatever stale pixels it still holds; keeping it is the whole point of
+            // the frame coming back at all. The coordinator has retained it.
+            None => {
+                log::debug!("Render skipped (paused); retaining the buffer unpresented")
+            }
+        }
+        self.route(next, &mut out);
+        Ok(out)
+    }
+}
+
+/// Where a coordinator step's output goes: the rasterizer, the driver (present + window
+/// requests), and vsync's telemetry lane. Template: `VsyncWiring` (`vsync_actor.rs`).
+pub(crate) struct CoordinatorWiring {
+    pub(crate) rasterizer: RasterizerHandle<PlatformPixel, WindowMeta>,
+    pub(crate) driver: ActorHandle<DisplayData, DisplayControl, DisplayMgmt>,
+    pub(crate) vsync: GreenSender<RenderedResponse>,
+}
+
+impl Wiring for CoordinatorWiring {
+    type Out = CoordinatorOut;
+
+    fn flush(&mut self, out: &mut CoordinatorOut) -> Flush {
+        let render_flush = match out.render.take() {
+            None => Flush::Done,
+            Some(request) => match self.rasterizer.try_send(Message::Data(request)) {
+                Ok(()) => Flush::Done,
+                // The render credit bounds this edge to one in flight, so `Full` is provably a
+                // bug — but park, don't panic: the payload is the driver's only buffer (§9.2 of
+                // the mealy design doc).
+                Err(TrySendError::Full(msg)) => {
+                    let Message::Data(request) = msg else {
+                        unreachable!("a Data send only ever returns its Data variant back")
+                    };
+                    out.render = Some(request);
+                    Flush::Blocked
+                }
+                Err(TrySendError::Disconnected(msg)) => {
+                    let Message::Data(request) = msg else {
+                        unreachable!("a Data send only ever returns its Data variant back")
+                    };
+                    out.render = Some(request);
+                    Flush::Disconnected
+                }
+            },
+        };
+
+        let present_flush = match out.present.take() {
+            None => Flush::Done,
+            Some(window) => {
+                let msg = Message::Data(DisplayData::Present { window });
+                match self.driver.try_send(msg) {
+                    Ok(()) => Flush::Done,
+                    // Parked-and-retained replaces the old `send_render`/`present_cooked_frame`
+                    // path's destroyed-on-failure hazard (see the NOTE that used to live on
+                    // `EngineHandler::send_render`) — the payload is the ping-pong buffer's only
+                    // copy, so losing it here would freeze the display for good.
+                    Err(TrySendError::Full(msg)) => {
+                        let Message::Data(DisplayData::Present { window }) = msg else {
+                            unreachable!("a Data send only ever returns its Data variant back")
+                        };
+                        out.present = Some(window);
+                        Flush::Blocked
+                    }
+                    Err(TrySendError::Disconnected(msg)) => {
+                        let Message::Data(DisplayData::Present { window }) = msg else {
+                            unreachable!("a Data send only ever returns its Data variant back")
+                        };
+                        out.present = Some(window);
+                        Flush::Disconnected
+                    }
+                }
+            }
+        };
+
+        let request_window_flush = if out.request_window {
+            match self
+                .driver
+                .try_send(Message::Management(DisplayMgmt::RequestWindow))
+            {
+                Ok(()) => {
+                    out.request_window = false;
+                    Flush::Done
+                }
+                // Safe to park rather than drop: the latch (`RenderCoordinator::request_sent`,
+                // already applied in `CoordinatorCore::route`) means we never double-ask, so a
+                // retry after this parks is still exactly one ask.
+                Err(TrySendError::Full(_)) => Flush::Blocked,
+                Err(TrySendError::Disconnected(_)) => Flush::Disconnected,
+            }
+        } else {
+            Flush::Done
+        };
+
+        // Telemetry: droppable per §9.2 — FPS skew beats parking the render loop on a sample.
+        // Never contributes to the combined outcome below, and never blocks the coordinator.
+        if let Some(response) = out.rendered.take() {
+            match self.vsync.try_send(response) {
+                Ok(()) => {}
+                Err(TrySendError::Full(_)) => {
+                    log::debug!("vsync telemetry ring full; dropping an FPS sample");
+                }
+                Err(TrySendError::Disconnected(_)) => {
+                    // The vsync node's own host is going down too; nobody to report to.
+                }
+            }
+        }
+
+        all([render_flush, present_flush, request_window_flush])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! `CoordinatorCore` driven directly — no `Node`, no channels, no scheduler. Mirrors
+    //! `render_coordinator.rs`'s own `mod tests` one layer up: these pin the *port mapping*
+    //! (`Step` → `CoordinatorOut`), not the pull protocol itself, which is already covered there.
+
+    use super::*;
+    use crate::api::public::WindowId;
+    use crate::display::messages::Surface;
+    use crate::display::window_keeper::WindowKeeper;
+    use crate::platform::ColorCube;
+
+    fn manifold() -> Scene {
+        Arc::new(ColorCube::default().at(0.0f32, 0.0f32, 0.0f32, 1.0f32))
+    }
+
+    fn one_to_one_window() -> Window {
+        let mut keeper = WindowKeeper::new();
+        keeper.surface_changed(Surface {
+            id: WindowId(1),
+            width_px: 100,
+            height_px: 100,
+            frame_width: 100,
+            frame_height: 100,
+            scale: 1.0,
+        });
+        keeper.request();
+        keeper.pending_grant().expect("a buffer is at rest")
+    }
+
+    #[test]
+    fn a_granted_window_turns_a_submitted_scene_into_a_render_port() {
+        let mut core = CoordinatorCore::new();
+        let out = core.step_data(CoordinatorData::Submit(manifold())).unwrap();
+        assert!(out.request_window, "a scene with no buffer in hand must ask for one");
+
+        let out = core
+            .step_data(CoordinatorData::Granted(one_to_one_window()))
+            .unwrap();
+        assert!(
+            out.render.is_some(),
+            "a granted window with a pending scene must render immediately"
+        );
+        assert!(!core.holds_buffer(), "the buffer left with the render request");
+    }
+
+    #[test]
+    fn render_complete_with_a_presentable_frame_emits_present_and_vsync_telemetry() {
+        let mut core = CoordinatorCore::new();
+        core.step_data(CoordinatorData::Submit(manifold())).unwrap();
+        let out = core
+            .step_data(CoordinatorData::Granted(one_to_one_window()))
+            .unwrap();
+        let request = out.render.expect("expected a render request");
+
+        let out = core
+            .step_management(RenderResponse {
+                frame: request.frame,
+                render_time: Some(Duration::from_millis(1)),
+                meta: request.meta,
+            })
+            .unwrap();
+
+        assert!(out.present.is_some(), "a drawn frame must be presented");
+        assert!(
+            out.rendered.is_some(),
+            "presenting a frame must report FPS telemetry to vsync"
+        );
+    }
+
+    /// The delivery-feedback seam dissolved (module doc): `route` calls `request_sent` the
+    /// instant it decides to ask, not once wiring confirms delivery — so a second submission
+    /// arriving before any reply must not repeat the ask.
+    #[test]
+    fn a_request_window_step_latches_immediately_on_emission() {
+        let mut core = CoordinatorCore::new();
+        let out = core.step_data(CoordinatorData::Submit(manifold())).unwrap();
+        assert!(out.request_window);
+
+        let out = core.step_data(CoordinatorData::Submit(manifold())).unwrap();
+        assert!(
+            !out.request_window,
+            "the latch must already be set from the first ask"
+        );
+    }
+}
+
+#[cfg(test)]
+mod node_tests {
+    //! The coordinator as a real `Node`: a real driver scheduler + spy (owning a real
+    //! `WindowKeeper`, exactly as `engine_troupe.rs`'s old `Rig` did) and a real rasterizer
+    //! scheduler + spy on the other side, with `node.poll()` standing in for a `Host`'s sweep.
+    //!
+    //! These are the render-protocol interaction tests that used to live in `engine_troupe.rs`'s
+    //! `Rig`, driving `EngineHandler` directly — moved here verbatim in name and intent now that
+    //! the coordinator is its own `Node` rather than logic embedded in the engine. They found
+    //! real races (see each test's own doc); losing that coverage in the move is not acceptable.
+
+    use super::*;
+    use crate::api::public::WindowId;
+    use crate::display::messages::Surface;
+    use crate::display::window_keeper::{Presented, WindowKeeper};
+    use crate::platform::ColorCube;
+    use actor_scheduler::mealy::{Lanes, NoLane, Node, Step as NodeStep};
+    use actor_scheduler::spsc::{SpscReceiver, SpscSender, spsc_channel};
+    use actor_scheduler::{
+        Actor, ActorScheduler, ActorStatus, HandlerResult, SchedulerParams, SystemStatus,
+    };
+    use pixelflow_graphics::render::Frame;
+    use pixelflow_graphics::render::rasterizer::{RasterControl, RasterManagement};
+    use std::collections::VecDeque;
+    use std::convert::Infallible;
+
+    /// Scheduler tuning for the fixture: nothing here approaches the buffer, and the burst
+    /// limit only has to be big enough that one pump drains a test's worth of messages.
+    const LANE_BURST: usize = 16;
+    const LANE_BUFFER: usize = 16;
+
+    /// A window size, as the tests talk about them.
+    type Size = (u32, u32);
+
+    #[derive(Default)]
+    struct RasterizerSpy {
+        requests: Vec<WindowMeta>,
+    }
+
+    impl Actor<RenderRequest<PlatformPixel, WindowMeta>, RasterControl, RasterManagement>
+        for RasterizerSpy
+    {
+        fn handle_data(&mut self, req: RenderRequest<PlatformPixel, WindowMeta>) -> HandlerResult {
+            self.requests.push(req.meta);
+            Ok(())
+        }
+        fn handle_control(&mut self, _msg: RasterControl) -> HandlerResult {
+            Ok(())
+        }
+        fn handle_management(&mut self, _msg: RasterManagement) -> HandlerResult {
+            Ok(())
+        }
+        fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            Ok(ActorStatus::Idle)
+        }
+    }
+
+    /// A driver, minus the platform: real buffer ownership, no blit.
+    #[derive(Default)]
+    struct DriverSpy {
+        keeper: WindowKeeper,
+        /// Buffers lent out, waiting to reach the coordinator. A real `PlatformActor` sends
+        /// these straight back over its own engine handle; the fixture has no such handle, so
+        /// `Rig` drains this in `pump`.
+        granted: Vec<Window>,
+        /// Sizes actually blitted — excluding superseded buffers, which never reach a screen.
+        blitted: Vec<Size>,
+    }
+
+    impl DriverSpy {
+        /// What `PlatformActor::flush` does at the end of every handler: issue whatever grant
+        /// has come due.
+        fn grant(&mut self) {
+            if let Some(window) = self.keeper.pending_grant() {
+                self.granted.push(window);
+            }
+        }
+    }
+
+    impl Actor<DisplayData, DisplayControl, DisplayMgmt> for DriverSpy {
+        fn handle_data(&mut self, msg: DisplayData) -> HandlerResult {
+            let DisplayData::Present { window } = msg;
+            match self.keeper.presented(window) {
+                Presented::Blit(window) => {
+                    self.blitted.push((window.width_px, window.height_px));
+                    self.keeper.rest(window);
+                }
+                Presented::Superseded => {}
+            }
+            self.grant();
+            Ok(())
+        }
+        fn handle_control(&mut self, _msg: DisplayControl) -> HandlerResult {
+            Ok(())
+        }
+        fn handle_management(&mut self, msg: DisplayMgmt) -> HandlerResult {
+            if matches!(msg, DisplayMgmt::RequestWindow) {
+                self.keeper.request();
+                self.grant();
+            }
+            Ok(())
+        }
+        fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            Ok(ActorStatus::Idle)
+        }
+    }
+
+    type CoordinatorNode = Node<
+        CoordinatorCore,
+        CoordinatorWiring,
+        SpscReceiver<CoordinatorData>,
+        NoLane<Infallible>,
+        SpscReceiver<RenderResponse<PlatformPixel, WindowMeta>>,
+    >;
+
+    struct Rig {
+        node: CoordinatorNode,
+        data_tx: SpscSender<CoordinatorData>,
+        mgmt_tx: SpscSender<RenderResponse<PlatformPixel, WindowMeta>>,
+        raster_sched:
+            ActorScheduler<RenderRequest<PlatformPixel, WindowMeta>, RasterControl, RasterManagement>,
+        raster_spy: RasterizerSpy,
+        driver_sched: ActorScheduler<DisplayData, DisplayControl, DisplayMgmt>,
+        driver_spy: DriverSpy,
+        /// Never asserted on: these tests are not about FPS telemetry. Held only so the
+        /// coordinator's sends have somewhere to land.
+        _vsync_rx: SpscReceiver<RenderedResponse>,
+        /// Renders the rasterizer has been asked for and not yet answered, oldest first.
+        in_flight: VecDeque<WindowMeta>,
+        request_log: Vec<Size>,
+    }
+
+    impl Rig {
+        fn new() -> Self {
+            let (driver, driver_sched) = ActorScheduler::new(LANE_BURST, LANE_BUFFER);
+            let (rasterizer, raster_sched) = ActorScheduler::new(LANE_BURST, LANE_BUFFER);
+
+            // A `Waker` with nobody listening is harmless, so a throwaway scheduler dropped
+            // immediately after minting one is enough — the plain channel below never needs a
+            // real host to wake.
+            let waker = {
+                let (handle, _sched) = ActorScheduler::<Infallible, Infallible, Infallible>::new(1, 1);
+                handle.waker()
+            };
+            let (vsync_tx, vsync_rx) = spsc_channel::<RenderedResponse>(8);
+            let vsync = GreenSender::new(vsync_tx, waker);
+
+            let (data_tx, data_rx) = spsc_channel::<CoordinatorData>(64);
+            let (mgmt_tx, mgmt_rx) = spsc_channel::<RenderResponse<PlatformPixel, WindowMeta>>(64);
+
+            let node = Node::new_with_lanes(
+                CoordinatorCore::new(),
+                Lanes {
+                    control: NoLane::new(),
+                    management: mgmt_rx,
+                    data: data_rx,
+                },
+                CoordinatorWiring {
+                    rasterizer,
+                    driver,
+                    vsync,
+                },
+                SchedulerParams::DEFAULT,
+            );
+
+            Self {
+                node,
+                data_tx,
+                mgmt_tx,
+                raster_sched,
+                raster_spy: RasterizerSpy::default(),
+                driver_sched,
+                driver_spy: DriverSpy::default(),
+                _vsync_rx: vsync_rx,
+                in_flight: VecDeque::new(),
+                request_log: Vec::new(),
+            }
+        }
+
+        /// Drain the node's own outbox and lanes until it goes quiet — one input's worth of
+        /// work, mirroring the old `Rig::feed`'s synchronous `handle_data` call.
+        fn drain_node(&mut self) {
+            while let NodeStep::Ran = self.node.poll() {}
+        }
+
+        fn feed(&mut self, data: CoordinatorData) {
+            self.data_tx
+                .try_send(data)
+                .expect("coordinator data lane has room");
+            self.drain_node();
+        }
+
+        /// Carry every message in flight to its destination, in both directions, until nothing
+        /// moves. The request → grant → render loop takes several hops, so a single pass would
+        /// leave the system mid-conversation and the assertions would read a partial state.
+        fn pump(&mut self) {
+            loop {
+                let _ = self.raster_sched.poll_once(&mut self.raster_spy);
+                for meta in self.raster_spy.requests.drain(..) {
+                    self.request_log.push((meta.width_px, meta.height_px));
+                    self.in_flight.push_back(meta);
+                }
+
+                let _ = self.driver_sched.poll_once(&mut self.driver_spy);
+                let granted: Vec<_> = self.driver_spy.granted.drain(..).collect();
+                if granted.is_empty() {
+                    return;
+                }
+                for window in granted {
+                    self.feed(CoordinatorData::Granted(window));
+                }
+            }
+        }
+
+        /// The platform reported a window at this geometry. Both halves of what
+        /// `PlatformActor::flush` does: the keeper builds the buffer, the coordinator is nudged
+        /// to look. Used for the initial window and for resizes alike, because the driver
+        /// treats them identically.
+        fn surface(&mut self, (width_px, height_px): Size) {
+            let surface = Surface {
+                id: WindowId(1),
+                width_px,
+                height_px,
+                frame_width: width_px,
+                frame_height: height_px,
+                scale: 1.0,
+            };
+            self.driver_spy.keeper.surface_changed(surface);
+            // A resize can answer a request that was refused while the old buffer was out, which
+            // is why `PlatformActor` flushes here too.
+            self.driver_spy.grant();
+            self.feed(CoordinatorData::Advance);
+            self.pump();
+        }
+
+        /// Answer the oldest outstanding render, returning its `meta` untouched — which is the
+        /// rasterizer's actual contract.
+        fn complete_render(&mut self) {
+            self.pump();
+            let meta = self
+                .in_flight
+                .pop_front()
+                .expect("a render must be outstanding to complete");
+            let sent = self.mgmt_tx.try_send(RenderResponse {
+                frame: Frame::new(meta.width_px, meta.height_px),
+                render_time: Some(Duration::from_millis(1)),
+                meta,
+            });
+            assert!(sent.is_ok(), "coordinator management lane has room");
+            self.drain_node();
+            self.pump();
+        }
+
+        fn app_frame(&mut self) {
+            self.queue_frame();
+            self.pump();
+        }
+
+        /// A frame, without letting anything be delivered downstream. Two of these back to back
+        /// is one round in which the coordinator reacts twice before the driver reacts once —
+        /// which is ordinary, since they are separate actors.
+        fn queue_frame(&mut self) {
+            self.feed(CoordinatorData::Submit(manifold()));
+        }
+
+        /// A vsync tick (relayed through the engine as `CoordinatorData::Advance`), which is
+        /// what re-drives a request the driver could not answer.
+        fn tick(&mut self) {
+            self.feed(CoordinatorData::Advance);
+            self.pump();
+        }
+
+        /// Render requests emitted since the last call.
+        fn render_requests(&mut self) -> Vec<Size> {
+            self.pump();
+            std::mem::take(&mut self.request_log)
+        }
+
+        /// Frames that actually reached the screen since the last call.
+        fn blitted(&mut self) -> Vec<Size> {
+            self.pump();
+            std::mem::take(&mut self.driver_spy.blitted)
+        }
+
+        fn holds_buffer(&self) -> bool {
+            self.node.actor().holds_buffer()
+        }
+    }
+
+    /// A constant black scene — these tests care about which buffer a render is aimed at, not
+    /// what is in it.
+    fn manifold() -> Scene {
+        Arc::new(ColorCube::default().at(0.0f32, 0.0f32, 0.0f32, 1.0f32))
+    }
+
+    /// The steady state: the coordinator asks for the buffer only when it has something to
+    /// draw, draws, hands it straight back, and asks again next frame.
+    #[test]
+    fn frames_circulate_through_request_render_and_present() {
+        let mut rig = Rig::new();
+        rig.surface((100, 100));
+
+        rig.app_frame();
+        assert_eq!(rig.render_requests(), vec![(100, 100)]);
+
+        rig.complete_render();
+        assert_eq!(rig.blitted(), vec![(100, 100)]);
+
+        rig.app_frame();
+        assert_eq!(
+            rig.render_requests(),
+            vec![(100, 100)],
+            "Present returned the buffer to the driver, so the next frame can have it"
+        );
+    }
+
+    /// Nothing is requested until there is something to draw. If the coordinator held the
+    /// buffer while idle, "who has the buffer" would stop meaning "who is drawing", and that
+    /// equivalence is the entire bound on the loop.
+    #[test]
+    fn an_idle_engine_does_not_hold_the_buffer() {
+        let mut rig = Rig::new();
+        rig.surface((100, 100));
+
+        rig.tick();
+        rig.tick();
+        assert!(rig.render_requests().is_empty());
+        assert!(
+            !rig.holds_buffer(),
+            "no manifold to draw, so no reason to be holding the buffer"
+        );
+    }
+
+    /// Vsync keeps asking for frames at 60Hz regardless of how long a render takes, so a new
+    /// manifold routinely arrives while one is in flight. The refusal must keep it: dropping it
+    /// would leave the app's last state change unrendered with nothing following to correct it.
+    #[test]
+    fn a_manifold_arriving_mid_render_is_kept_not_dropped() {
+        let mut rig = Rig::new();
+        rig.surface((100, 100));
+
+        rig.app_frame();
+        assert_eq!(rig.render_requests(), vec![(100, 100)]);
+
+        rig.app_frame();
+        assert!(
+            rig.render_requests().is_empty(),
+            "the in-flight render holds the edge's only credit"
+        );
+
+        rig.complete_render();
+        assert_eq!(
+            rig.render_requests(),
+            vec![(100, 100)],
+            "the deferred manifold renders once the credit comes back"
+        );
+    }
+
+    /// The race the generation stamp exists for, end-to-end across both sides: a resize while
+    /// the buffer is out with the renderer. The old-size frame must not reach the screen, and
+    /// the next one must be at the new size.
+    #[test]
+    fn a_resize_mid_render_keeps_the_old_frame_off_the_screen() {
+        let mut rig = Rig::new();
+        rig.surface((100, 100));
+
+        rig.app_frame();
+        assert_eq!(rig.render_requests(), vec![(100, 100)]);
+
+        // Resize lands while that render is in flight.
+        rig.surface((200, 200));
+
+        rig.complete_render();
+        assert!(
+            rig.blitted().is_empty(),
+            "the old-size buffer is superseded and must not be blitted"
+        );
+
+        rig.app_frame();
+        assert_eq!(
+            rig.render_requests(),
+            vec![(200, 200)],
+            "and the driver's replacement buffer is what the next frame draws into"
+        );
+        rig.complete_render();
+        assert_eq!(rig.blitted(), vec![(200, 200)]);
+    }
+
+    /// A resize with nothing in flight: the next frame simply comes out at the new size.
+    #[test]
+    fn a_resize_between_frames_renders_at_the_new_size() {
+        let mut rig = Rig::new();
+        rig.surface((100, 100));
+
+        rig.app_frame();
+        rig.complete_render();
+        assert_eq!(rig.blitted(), vec![(100, 100)]);
+        let _ = rig.render_requests(); // drain, so the next assertion is about what follows
+
+        rig.surface((200, 200));
+        rig.app_frame();
+        assert_eq!(rig.render_requests(), vec![(200, 200)]);
+    }
+
+    /// A resize while a render is in flight, *with a frame already queued behind it*. The queued
+    /// frame makes the coordinator ask for a buffer it cannot yet use; the resize then allocates
+    /// one, so the ask is answered immediately and the coordinator is holding a second buffer
+    /// while the first is still out. The old completion then arrives with nowhere to go.
+    ///
+    /// In a debug build that trips the "one buffer" assertion. In release, a *paused*
+    /// completion — the arm that keeps its buffer rather than presenting it — overwrites the
+    /// replacement, and since the driver has already handed its only current buffer over, the
+    /// terminal never draws again.
+    #[test]
+    fn a_resize_does_not_grant_a_second_buffer_mid_render() {
+        let mut rig = Rig::new();
+        rig.surface((100, 100));
+
+        rig.app_frame();
+        assert_eq!(rig.render_requests(), vec![(100, 100)]);
+
+        // A second frame queues behind the in-flight render, and asks for a buffer.
+        rig.app_frame();
+        // The resize allocates one, which could answer that ask.
+        rig.surface((200, 200));
+
+        assert!(
+            !rig.holds_buffer(),
+            "a buffer is already out with the renderer; a second one must not be granted"
+        );
+
+        // The original render completes into a coordinator that still has exactly one buffer's
+        // worth of state to reconcile.
+        rig.complete_render();
+        assert!(rig.blitted().is_empty(), "the old-size frame is superseded");
+        assert_eq!(
+            rig.render_requests(),
+            vec![(200, 200)],
+            "and the queued frame renders into the resize's buffer"
+        );
+    }
+
+    /// The same failure one step earlier in the conversation: two asks issued *before* the
+    /// driver has answered either. The credit guard cannot see this one — no render is in flight
+    /// yet, so both asks are legitimate at the moment they are made.
+    ///
+    /// The driver answers the first and has nothing for the second, which leaves its "somebody
+    /// is waiting" latch set with nobody actually waiting any more. The next buffer to appear —
+    /// a resize allocation, while the granted one is out being drawn into — is then handed over
+    /// unasked, and the coordinator is holding two.
+    #[test]
+    fn a_second_ask_before_the_first_is_answered_does_not_earn_a_second_grant() {
+        let mut rig = Rig::new();
+        rig.surface((100, 100));
+
+        // Two asks in one round, before the driver reacts to either.
+        rig.queue_frame();
+        rig.queue_frame();
+        rig.pump();
+        assert_eq!(
+            rig.render_requests(),
+            vec![(100, 100)],
+            "the grant that did arrive is rendering"
+        );
+
+        // A resize now allocates a buffer that a stale ask would collect.
+        rig.surface((200, 200));
+        assert!(
+            !rig.holds_buffer(),
+            "the buffer is out with the renderer; an unanswered duplicate ask must not \
+             collect the resize's replacement"
+        );
+
+        // The old buffer goes back and is discarded as superseded; the app answers the resize
+        // with a new frame, which asks properly and gets the replacement.
+        rig.complete_render();
+        rig.app_frame();
+        assert_eq!(
+            rig.render_requests(),
+            vec![(200, 200)],
+            "and the next frame draws into the replacement, asked for properly"
+        );
+    }
+
+    /// Two buffers can never be out at once — the old fixture had to model that possibility and
+    /// order the returns. It is now a property of ownership: the driver cannot lend what it is
+    /// not holding, so however many times it is asked, at most one buffer is out.
+    #[test]
+    fn the_driver_never_lends_a_second_buffer() {
+        let mut rig = Rig::new();
+        rig.surface((100, 100));
+
+        rig.app_frame();
+        assert_eq!(rig.render_requests(), vec![(100, 100)]);
+
+        // Ask repeatedly while the buffer is out with the renderer.
+        for _ in 0..5 {
+            rig.tick();
+        }
+        assert!(
+            !rig.holds_buffer(),
+            "no grant can arrive while the buffer is out, however often it is requested"
+        );
+
+        rig.complete_render();
+        assert_eq!(rig.blitted(), vec![(100, 100)]);
+    }
+}

--- a/pixelflow-runtime/src/engine_core.rs
+++ b/pixelflow-runtime/src/engine_core.rs
@@ -1,98 +1,58 @@
 //! `EngineCore` — the pure decision logic behind `EngineHandler` (`engine_troupe.rs`).
 //!
-//! Mirrors the `VsyncCore`/`RasterCore` split (`vsync_actor.rs`, `pixelflow-graphics`'s
-//! `rasterizer/actor.rs`): a `step_*` call takes a message and **returns** what to emit, so the
-//! whole mediator — request/render/present, the resize races, the app/vsync/driver relays — is
-//! table-testable with no scheduler, no handles, and no threads in the loop. `EngineHandler`
-//! shrinks to the thin adapter that owns the real channels and flushes the returned word.
+//! Mirrors the `VsyncCore`/`RasterCore`/`CoordinatorCore` split: a `step_*` call takes a message
+//! and **returns** what to emit, so the app/vsync/driver relays left once rendering moved to its
+//! own node (`coordinator_node.rs`, step 5c of
+//! `docs/designs/pixelflow-runtime-engine-mesh-migration.md`) are table-testable with no
+//! scheduler, no handles, and no threads in the loop. `EngineHandler` shrinks to the thin
+//! adapter that owns the real channels and flushes the returned word.
+//!
+//! # What left
+//!
+//! The render coordinator (`RenderCoordinator`, `frame_number`, and the `rasterizer`/
+//! `driver_data`/`vsync_data` ports that used to carry its decisions) is gone from here
+//! entirely — it runs as its own `Node` now, on the same green-host thread as vsync. What
+//! remains is a single relay port, `coordinator`: every input that used to drive `self.render`
+//! directly now just describes *which* `CoordinatorData` to forward, and the coordinator decides
+//! the rest.
 
 use crate::api::private::{EngineControl, EngineData};
 use crate::api::public::{
     AppData, AppManagement, EngineEvent, EngineEventControl, EngineEventData,
     EngineEventManagement, WindowId,
 };
-use crate::display::messages::{
-    DisplayControl, DisplayData, DisplayEvent, DisplayMgmt, Window, WindowMeta,
-};
+use crate::coordinator_node::CoordinatorData;
+use crate::display::messages::{DisplayControl, DisplayEvent, DisplayMgmt};
 use crate::input::MouseButton;
-use crate::platform::PlatformPixel;
-use crate::render_coordinator::{Completed, RenderCoordinator, Step};
-use crate::vsync_actor::{RenderedResponse, VsyncCommand};
-use actor_scheduler::mealy::Transducer;
+use crate::vsync_actor::VsyncCommand;
 use actor_scheduler::HandlerError;
-use pixelflow_graphics::render::rasterizer::RenderRequest;
-use std::time::{Duration, Instant};
-
-const LOG_FRAME_INTERVAL: u64 = 60;
+use actor_scheduler::mealy::Transducer;
 
 /// One optional slot per downstream edge. Default (all `None`, `quit: false`) is the silent
 /// step — most inputs move state without telling any peer.
 #[derive(Default)]
 pub(crate) struct EngineOut {
     pub(crate) app: Option<EngineEvent>,
-    pub(crate) driver_data: Option<DisplayData>,
     pub(crate) driver_control: Option<DisplayControl>,
     pub(crate) driver_mgmt: Option<DisplayMgmt>,
-    pub(crate) vsync_data: Option<RenderedResponse>,
     pub(crate) vsync_control: Option<VsyncCommand>,
-    pub(crate) rasterizer: Option<RenderRequest<PlatformPixel, WindowMeta>>,
-    /// Run the shutdown cascade: vsync, rasterizer, forwarder, app-drop, driver, self.
+    /// → the render coordinator's data lane (`coordinator_node.rs`). Replaces the old
+    /// `rasterizer`/`driver_data`/`vsync_data` ports outright: this type relays a decision, the
+    /// coordinator makes it and owns the ports those decisions used to ride.
+    pub(crate) coordinator: Option<CoordinatorData>,
+    /// Run the shutdown cascade: the green host (vsync + the coordinator node it also runs),
+    /// the rasterizer forwarder, app-drop, driver, self.
     pub(crate) quit: bool,
 }
 
-/// Pure engine mediator: request/render/present bookkeeping and the app/driver/vsync relay
-/// decisions, with no actor handle or channel in it. No self-port — retries of a dropped
-/// `RequestWindow` ride the next VSync tick, exactly as today, so there is no continuation to
-/// take.
-pub(crate) struct EngineCore {
-    render: RenderCoordinator,
-    /// Frame counter for VSync feedback. See the field doc on the old `EngineHandler` copy of
-    /// this (moved verbatim): it stays here rather than moving to the rasterizer because the
-    /// only consumer, FPS telemetry, is a `rasterizer → vsync` edge that does not exist until
-    /// the coordinator is its own node.
-    frame_number: u64,
-}
+/// Pure engine mediator: the app/driver/vsync relay decisions, with no actor handle or channel
+/// in it. No self-port — retries of a dropped `RequestWindow` are the coordinator's own concern
+/// now, not this type's.
+pub(crate) struct EngineCore;
 
 impl EngineCore {
     pub(crate) fn new() -> Self {
-        Self {
-            render: RenderCoordinator::new(),
-            frame_number: 0,
-        }
-    }
-
-    /// Whether the render coordinator currently holds the driver's buffer. Test-only window
-    /// into otherwise-private state, mirroring `RenderCoordinator::holds_buffer`.
-    #[cfg(test)]
-    pub(crate) fn holds_buffer(&self) -> bool {
-        self.render.holds_buffer()
-    }
-
-    /// A `Step::RequestWindow` port actually reached the driver.
-    ///
-    /// A pure core cannot see send outcomes — that is the shell's job, since only it holds the
-    /// handle and calls `send`. This is the hand-written stand-in for the mealy runtime's
-    /// parked-outbox/`Flush::Blocked` bookkeeping until the engine runs as a green node: the
-    /// shell calls this after a successful send, and [`Self::render_undeliverable`] after a
-    /// failed one, so the coordinator's latch tracks what actually left rather than what the
-    /// core merely emitted.
-    pub(crate) fn request_delivered(&mut self) {
-        self.render.request_sent();
-    }
-
-    /// A `Step::Render` port could not be delivered (missing rasterizer, or the send failed).
-    /// See [`Self::request_delivered`] for why this lives on the shell side of the seam.
-    pub(crate) fn render_undeliverable(&mut self) {
-        self.render.render_send_failed();
-    }
-
-    /// Map a `render_coordinator::Step` onto the port it belongs on.
-    fn route(step: Step, out: &mut EngineOut) {
-        match step {
-            Step::Idle => {}
-            Step::RequestWindow => out.driver_mgmt = Some(DisplayMgmt::RequestWindow),
-            Step::Render(request) => out.rasterizer = Some(request),
-        }
+        Self
     }
 
     fn step_app_data(&mut self, app_data: AppData, out: &mut EngineOut) {
@@ -102,10 +62,7 @@ impl EngineCore {
                 // The app has provided its compute graph, so permit VSync to request another
                 // frame without waiting for rasterization to finish.
                 out.vsync_control = Some(VsyncCommand::ReturnToken);
-
-                // Keep-latest port: the newest compute graph replaces any frame that hasn't
-                // started rendering yet, and renders now if a window is free to draw into.
-                Self::route(self.render.submit(manifold), out);
+                out.coordinator = Some(CoordinatorData::Submit(manifold));
             }
             AppData::Skipped => {
                 // App says nothing to render - return token anyway
@@ -114,30 +71,12 @@ impl EngineCore {
         }
     }
 
-    /// Hand the drawn buffer back to the driver to be shown, and tell vsync it landed.
-    ///
-    /// This *is* the return: the driver is the buffer's resting owner, so there is no separate
-    /// acknowledgement to wait for. FPS telemetry rides the frame actually reaching the driver
-    /// port, same as before — it used to ride `PresentComplete`, which no longer exists.
-    fn present_cooked_frame(&mut self, render_time: Duration, window: Window, out: &mut EngineOut) {
-        out.driver_data = Some(DisplayData::Present { window });
-
-        self.frame_number += 1;
-        out.vsync_data = Some(RenderedResponse {
-            frame_number: self.frame_number,
-            rendered_at: Instant::now(),
-        });
-
-        if self.frame_number.is_multiple_of(LOG_FRAME_INTERVAL) {
-            log::info!("Frame {}: render={:?}", self.frame_number, render_time);
-        }
-    }
-
     fn step_driver_event(&mut self, event: DisplayEvent, out: &mut EngineOut) {
         match event {
             // Both window-lifecycle events are pure relays: the driver has already built the
             // buffer for the new geometry by the time this arrives, so there is nothing here to
-            // take delivery of, stamp, or retire. What is left is telling the app its size.
+            // take delivery of, stamp, or retire. What is left is telling the app its size, and
+            // nudging the coordinator in case a buffer can now exist to draw into.
             DisplayEvent::WindowCreated { surface } => {
                 log::debug!(
                     "Relaying WindowCreated: id={}, {}x{}, scale={}",
@@ -147,10 +86,7 @@ impl EngineCore {
                     surface.scale
                 );
 
-                // The app may already have handed us something to draw, in which case this is
-                // the first moment a buffer can exist to draw it into.
-                Self::route(self.render.advance(), out);
-
+                out.coordinator = Some(CoordinatorData::Advance);
                 out.app = Some(EngineEvent::Control(EngineEventControl::WindowCreated {
                     id: surface.id,
                     width_px: surface.width_px,
@@ -166,12 +102,7 @@ impl EngineCore {
                     surface.height_px
                 );
 
-                // A buffer we are currently holding is now the wrong size, but it is not dropped
-                // here: it goes back on the next `Present` and the driver recognises it as
-                // superseded. Rendering into it once more first is harmless and one frame
-                // cheaper than reaching for the new one mid-flight.
-                Self::route(self.render.advance(), out);
-
+                out.coordinator = Some(CoordinatorData::Advance);
                 out.app = Some(EngineEvent::Control(EngineEventControl::Resized {
                     id: surface.id,
                     width_px: surface.width_px,
@@ -290,31 +221,11 @@ impl Transducer for EngineCore {
                     refresh_interval,
                 }));
 
-                // The tick is also what retries a request that was dropped in transit.
-                Self::route(self.render.advance(), &mut out);
-            }
-            EngineData::RenderComplete(response) => {
-                // No staleness check here any more. Whether this buffer is still the one the
-                // driver wants is the driver's question, asked against state the driver owns —
-                // and it has to be asked there regardless, because a resize can land after this
-                // point too. Asking it in both places would be two answers that can disagree.
-                let Completed { present, next } = self.render.completed(response);
-                match present {
-                    Some((window, render_time)) => {
-                        self.present_cooked_frame(render_time, window, &mut out)
-                    }
-                    // The rasterizer was paused, so it handed the buffer back unrendered.
-                    // Presenting it would blit whatever stale pixels it still holds; keeping it
-                    // is the whole point of the frame coming back at all. The coordinator has
-                    // retained it.
-                    None => {
-                        log::debug!("Render skipped (paused); retaining the buffer unpresented")
-                    }
-                }
-                Self::route(next, &mut out);
+                // The tick is also what retries a request the coordinator dropped in transit.
+                out.coordinator = Some(CoordinatorData::Advance);
             }
             EngineData::WindowGranted(window) => {
-                Self::route(self.render.granted(window), &mut out);
+                out.coordinator = Some(CoordinatorData::Granted(window));
             }
         }
         Ok(out)
@@ -330,7 +241,7 @@ impl Transducer for EngineCore {
             // Handle-carrying: the shell intercepts this before the core ever sees it, since a
             // pure core has no field to hold the handle in. Only the type split arriving with
             // the port/wiring phase removes this arm.
-            EngineControl::VsyncActorReady(..) => {
+            EngineControl::GreenReady(..) => {
                 unreachable!("handled by the engine shell")
             }
             // A real port with a real consumer; policy later.
@@ -351,9 +262,6 @@ impl Transducer for EngineCore {
             // ever sees them, since a pure core has no field to hold a handle or an `Arc<dyn
             // Application>` in. Only the type split arriving with the port/wiring phase removes
             // these arms.
-            AppManagement::SetRasterizerForwardHandle(_) => {
-                unreachable!("handled by the engine shell")
-            }
             AppManagement::Configure(_) => {
                 unreachable!("handled by the engine shell")
             }
@@ -418,19 +326,23 @@ fn convert_mouse_button(button: u8) -> MouseButton {
 #[cfg(test)]
 mod tests {
     //! `EngineCore` in isolation — no handles, no threads, no scheduler. Mirrors
-    //! `vsync_actor.rs`'s `mod tests` for `VsyncCore` and `rasterizer/actor.rs`'s `core_tests`
-    //! for `RasterCore`.
+    //! `vsync_actor.rs`'s `mod tests` for `VsyncCore` and `coordinator_node.rs`'s `mod tests`
+    //! for `CoordinatorCore`.
+    //!
+    //! What used to live here and doesn't any more: everything about the render protocol itself
+    //! (request/render/present, resize races, `holds_buffer`) — that is `CoordinatorCore`'s
+    //! contract now, pinned in `coordinator_node.rs`. What is left is the relay: does the right
+    //! input produce the right `CoordinatorData` on the `coordinator` port.
 
     use super::*;
-    use crate::display::messages::{Generation, Surface};
+    use crate::display::messages::{Generation, Surface, Window, WindowMeta};
     use crate::platform::ColorCube;
     use pixelflow_core::{Discrete, Manifold};
-    use pixelflow_graphics::render::Frame;
-    use std::sync::Arc;
+    use std::time::{Duration, Instant};
 
     /// A constant black scene — these tests care about which port fires, not what is drawn.
-    fn manifold() -> Arc<dyn Manifold<Output = Discrete> + Send + Sync> {
-        Arc::new(ColorCube::default().at(0.0f32, 0.0f32, 0.0f32, 1.0f32))
+    fn manifold() -> std::sync::Arc<dyn Manifold<Output = Discrete> + Send + Sync> {
+        std::sync::Arc::new(ColorCube::default().at(0.0f32, 0.0f32, 0.0f32, 1.0f32))
     }
 
     fn surface(width_px: u32, height_px: u32) -> Surface {
@@ -446,7 +358,7 @@ mod tests {
 
     fn window(meta_size: (u32, u32)) -> Window {
         Window::rejoin(
-            Frame::new(meta_size.0, meta_size.1),
+            pixelflow_graphics::render::Frame::new(meta_size.0, meta_size.1),
             WindowMeta {
                 id: WindowId(1),
                 width_px: meta_size.0,
@@ -458,7 +370,7 @@ mod tests {
     }
 
     #[test]
-    fn a_vsync_tick_requests_a_frame_from_the_app() {
+    fn a_vsync_tick_requests_a_frame_from_the_app_and_nudges_the_coordinator() {
         let mut core = EngineCore::new();
         let out = core
             .step_data(EngineData::VSync {
@@ -474,6 +386,10 @@ mod tests {
                 Some(EngineEvent::Data(EngineEventData::RequestFrame { .. }))
             ),
             "every tick must ask the app for a frame"
+        );
+        assert!(
+            matches!(out.coordinator, Some(CoordinatorData::Advance)),
+            "every tick must also nudge the coordinator, in case a request was lost in transit"
         );
     }
 
@@ -520,7 +436,7 @@ mod tests {
     }
 
     #[test]
-    fn render_surface_returns_the_vsync_token() {
+    fn render_surface_returns_the_vsync_token_and_submits_to_the_coordinator() {
         let mut core = EngineCore::new();
         let out = core
             .step_data(EngineData::FromApp(AppData::RenderSurface(manifold())))
@@ -530,75 +446,56 @@ mod tests {
             matches!(out.vsync_control, Some(VsyncCommand::ReturnToken)),
             "submitting a scene must release the token so vsync can ask again"
         );
-    }
-
-    #[test]
-    fn a_granted_window_turns_a_submitted_scene_into_a_rasterizer_port() {
-        let mut core = EngineCore::new();
-        // A window must exist before the coordinator will ask for it.
-        core.step_data(EngineData::FromDriver(DisplayEvent::WindowCreated {
-            surface: surface(100, 100),
-        }))
-        .unwrap();
-
-        let out = core
-            .step_data(EngineData::FromApp(AppData::RenderSurface(manifold())))
-            .unwrap();
         assert!(
-            matches!(out.driver_mgmt, Some(DisplayMgmt::RequestWindow)),
-            "a scene with no buffer in hand must ask the driver for one"
-        );
-        core.request_delivered();
-
-        let out = core
-            .step_data(EngineData::WindowGranted(window((100, 100))))
-            .unwrap();
-        assert!(
-            out.rasterizer.is_some(),
-            "a granted window with a pending scene must render immediately"
-        );
-        assert!(
-            !core.holds_buffer(),
-            "the buffer left with the render request"
+            matches!(out.coordinator, Some(CoordinatorData::Submit(_))),
+            "a new scene must be forwarded to the coordinator"
         );
     }
 
     #[test]
-    fn render_complete_with_a_presentable_frame_emits_present_and_vsync_telemetry() {
-        use pixelflow_graphics::render::rasterizer::RenderResponse;
-
+    fn skipped_frame_returns_the_token_without_touching_the_coordinator() {
         let mut core = EngineCore::new();
-        core.step_data(EngineData::FromDriver(DisplayEvent::WindowCreated {
-            surface: surface(100, 100),
-        }))
-        .unwrap();
-        core.step_data(EngineData::FromApp(AppData::RenderSurface(manifold())))
+        let out = core
+            .step_data(EngineData::FromApp(AppData::Skipped))
             .unwrap();
-        core.request_delivered();
+
+        assert!(matches!(out.vsync_control, Some(VsyncCommand::ReturnToken)));
+        assert!(
+            out.coordinator.is_none(),
+            "nothing to draw, so the coordinator has nothing to hear about"
+        );
+    }
+
+    #[test]
+    fn window_granted_relays_to_the_coordinator() {
+        let mut core = EngineCore::new();
         let out = core
             .step_data(EngineData::WindowGranted(window((100, 100))))
             .unwrap();
-        let request = match out.rasterizer {
-            Some(request) => request,
-            None => panic!("expected a render request"),
-        };
+
+        assert!(
+            matches!(out.coordinator, Some(CoordinatorData::Granted(_))),
+            "a granted window must be forwarded to the coordinator"
+        );
+    }
+
+    #[test]
+    fn window_created_and_resized_nudge_the_coordinator_to_advance() {
+        let mut core = EngineCore::new();
 
         let out = core
-            .step_data(EngineData::RenderComplete(RenderResponse {
-                frame: request.frame,
-                render_time: Some(Duration::from_millis(1)),
-                meta: request.meta,
+            .step_data(EngineData::FromDriver(DisplayEvent::WindowCreated {
+                surface: surface(100, 100),
             }))
             .unwrap();
+        assert!(matches!(out.coordinator, Some(CoordinatorData::Advance)));
 
-        assert!(
-            matches!(out.driver_data, Some(DisplayData::Present { .. })),
-            "a drawn frame must be presented"
-        );
-        assert!(
-            out.vsync_data.is_some(),
-            "presenting a frame must report FPS telemetry to vsync"
-        );
+        let out = core
+            .step_data(EngineData::FromDriver(DisplayEvent::Resized {
+                surface: surface(200, 200),
+            }))
+            .unwrap();
+        assert!(matches!(out.coordinator, Some(CoordinatorData::Advance)));
     }
 
     #[test]

--- a/pixelflow-runtime/src/engine_troupe.rs
+++ b/pixelflow-runtime/src/engine_troupe.rs
@@ -5,9 +5,10 @@
 //! [`EngineOut`] word; `flush` is this file's hand-written `Wiring` — the one place that word
 //! meets real channels.
 
-use crate::api::private::{EngineControl, EngineData};
+use crate::api::private::{EngineControl, EngineData, GreenReadyBundle};
 use crate::api::public::{AppManagement, Application};
 use crate::config::EngineConfig;
+use crate::coordinator_node::{CoordinatorCore, CoordinatorData, CoordinatorWiring};
 use crate::display::driver::DriverActor;
 use crate::display::messages::{DisplayControl, DisplayData, DisplayMgmt, WindowMeta};
 use crate::display::platform::PlatformActor;
@@ -17,15 +18,13 @@ use crate::platform::{ActivePlatform, PlatformPixel};
 use crate::vsync_actor::{RenderedResponse, VsyncCommand, VsyncCore, VsyncManagement, VsyncWiring};
 use actor_scheduler::actors::{Schedule, Timer};
 use actor_scheduler::host::{GreenThread, Host, HostOut};
-use actor_scheduler::mealy::{Flush, Lanes, Node, Transducer, Wiring};
+use actor_scheduler::mealy::{Flush, Lanes, NoLane, Node, Transducer, Wiring};
 use actor_scheduler::{
     Actor, ActorBuilder, ActorHandle, ActorScheduler, ActorStatus, ActorTypes, GreenSender,
     HandlerError, HandlerResult, Message, SchedulerParams, SystemStatus, TroupeActor,
     TrySendError, green_channel,
 };
-use pixelflow_graphics::render::rasterizer::{
-    RasterizerActor, RasterizerHandle, RenderRequest, RenderResponse,
-};
+use pixelflow_graphics::render::rasterizer::{RasterizerActor, RasterizerHandle, RenderResponse};
 use std::convert::Infallible;
 use std::ops::ControlFlow;
 use std::sync::Arc;
@@ -49,28 +48,25 @@ fn expect_credit_bounded_send<T: std::fmt::Debug>(
 pub struct EngineHandler {
     /// Handle to the display driver actor.
     driver: ActorHandle<DisplayData, DisplayControl, DisplayMgmt>,
-    /// The vsync green node's data edge (rendered-frame feedback for FPS telemetry). `None`
-    /// until `EngineControl::VsyncActorReady` arrives.
-    vsync_data: Option<GreenSender<RenderedResponse>>,
     /// The vsync green node's control edge (`UpdateRefreshRate`, `ReturnToken`, ...).
     vsync_control: Option<GreenSender<VsyncCommand>>,
     /// A handle to the green host itself, for the shutdown cascade — sending it
-    /// `Message::Shutdown` stops the vsync node along with everything else the host owns.
+    /// `Message::Shutdown` stops both green nodes it hosts (vsync and the render coordinator)
+    /// along with everything else the host owns.
     vsync_host: Option<ActorHandle<Infallible, Infallible, Infallible>>,
-    /// Handle to the rasterizer actor (set after bootstrap completes).
-    rasterizer: Option<RasterizerHandle<PlatformPixel, WindowMeta>>,
+    /// The render coordinator's data lane (`coordinator_node.rs`): window grants, scene
+    /// submissions, and advance nudges, relayed from the driver/app/vsync edges below. `None`
+    /// until `EngineControl::GreenReady` arrives.
+    coordinator: Option<GreenSender<CoordinatorData>>,
     /// Handle to self (for shutdown).
     self_handle: Option<ActorHandle<EngineData, EngineControl, AppManagement>>,
-    /// Pre-created dedicated SPSC handle for rasterizer response forwarding thread.
-    /// Set via SetRasterizerForwardHandle management message before Configure.
-    rasterizer_forward_handle: Option<ActorHandle<EngineData, EngineControl, AppManagement>>,
-    /// Handle to the rasterizer response-forwarding actor (spawned alongside the rasterizer
-    /// in `spawn_rasterizer`; `None` until then, same as `rasterizer` itself).
+    /// Handle to the rasterizer response-forwarding actor (spawned in `with_config`, before the
+    /// green host, via the free `spawn_rasterizer` function; kept only for the shutdown
+    /// cascade — the rasterizer's own live handle belongs to the coordinator's wiring now, see
+    /// `GreenReadyBundle`'s doc).
     rasterizer_forwarder: Option<ActorHandle<Infallible, Infallible, Infallible>>,
     /// Handle to the application (for event forwarding).
     app_handle: Option<Arc<dyn Application + Send + Sync>>,
-    /// Number of render threads for work-stealing parallelism.
-    render_threads: usize,
     /// The pure mediator: decides what to do with each message and returns it as an
     /// [`EngineOut`] word for `flush` to deliver. Owns none of the handles above.
     core: EngineCore,
@@ -92,8 +88,12 @@ impl ActorTypes for DriverActor<ActivePlatform> {
 // Generate troupe structures using macro
 // Note: Rasterizer is NOT in the troupe - it uses a bootstrap handshake pattern
 // that enforces type-level guarantees about initialization order.
+//
+// `driver` is `[expose]` as well as `[main]` now: the render coordinator's own green node
+// (`coordinator_node.rs`, step 5c) needs a driver handle of its own, for `Present` and
+// `RequestWindow` — sends the engine no longer makes on its behalf.
 actor_scheduler::troupe! {
-    driver: DriverActor<ActivePlatform> [main],
+    driver: DriverActor<ActivePlatform> [main, expose],
     engine: EngineHandler [expose],
 }
 
@@ -109,11 +109,17 @@ impl Actor<EngineData, EngineControl, AppManagement> for EngineHandler {
         // Handle-carrying: intercepted before the core ever sees it, since a pure core has no
         // field to hold an `ActorHandle` in.
         let ctrl = match ctrl {
-            EngineControl::VsyncActorReady(triple) => {
-                let (data, control, host) = *triple;
-                self.vsync_data = Some(data);
-                self.vsync_control = Some(control);
+            EngineControl::GreenReady(bundle) => {
+                let GreenReadyBundle {
+                    vsync_control,
+                    coordinator,
+                    host,
+                    forwarder,
+                } = *bundle;
+                self.vsync_control = Some(vsync_control);
+                self.coordinator = Some(coordinator);
                 self.vsync_host = Some(host);
+                self.rasterizer_forwarder = Some(forwarder);
                 return Ok(());
             }
             other => other,
@@ -125,18 +131,18 @@ impl Actor<EngineData, EngineControl, AppManagement> for EngineHandler {
 
     fn handle_management(&mut self, mgmt: AppManagement) -> HandlerResult {
         // Handle-carrying / bootstrap messages: intercepted before the core ever sees them, for
-        // the same reason as `EngineControl::VsyncActorReady` above.
+        // the same reason as `EngineControl::GreenReady` above.
         let mgmt = match mgmt {
-            AppManagement::SetRasterizerForwardHandle(handle) => {
-                self.rasterizer_forward_handle = Some(handle);
-                return Ok(());
-            }
             AppManagement::Configure(config) => {
-                self.render_threads = config.performance.render_threads;
-                log::info!("Engine configured: {} render threads", self.render_threads);
-
-                // Spawn rasterizer with bootstrap pattern
-                self.spawn_rasterizer();
+                // The rasterizer is spawned by `with_config` itself now, before the green host —
+                // it needs the coordinator's management-lane sender as its forwarder's target,
+                // which does not exist until bootstrap builds it (`spawn_rasterizer`). Nothing
+                // engine-side to do with this any more but log; kept as a message rather than
+                // deleted outright in case a future engine-side setting wants to ride it.
+                log::info!(
+                    "Engine configured: {} render threads (rasterizer already spawned at bootstrap)",
+                    config.performance.render_threads
+                );
                 return Ok(());
             }
             AppManagement::RegisterApp(app) => {
@@ -157,12 +163,13 @@ impl Actor<EngineData, EngineControl, AppManagement> for EngineHandler {
     }
 }
 
-/// Bridges the rasterizer's response channel into the engine's own actor system.
+/// Bridges the rasterizer's response channel straight into the render coordinator's own green
+/// node — no engine round-trip (step 5c of the mesh migration doc).
 ///
 /// [`RasterizerActor`] hands completed frames back over a bare `mpsc::Sender` so
 /// pixelflow-graphics stays decoupled from any particular consumer's message enum. This actor
-/// is the one place that channel meets [`EngineData::RenderComplete`] — `handle_os` blocking on
-/// `response_rx.recv()` *is* the actor, the same way `PtyReader::handle_os` blocking on
+/// is the one place that channel meets the coordinator's management lane — `handle_os` blocking
+/// on `response_rx.recv()` *is* the actor, the same way `PtyReader::handle_os` blocking on
 /// `epoll_wait` is that actor's entire job.
 ///
 /// The scheduler only calls `handle_os` after the doorbell has woken at least once, so — same
@@ -172,7 +179,7 @@ impl Actor<EngineData, EngineControl, AppManagement> for EngineHandler {
 /// on the loop is self-sustaining.
 struct RasterizerForwarder {
     response_rx: std::sync::mpsc::Receiver<RenderResponse<PlatformPixel, WindowMeta>>,
-    engine: ActorHandle<EngineData, EngineControl, AppManagement>,
+    coordinator: GreenSender<RenderResponse<PlatformPixel, WindowMeta>>,
     /// Sends itself `Shutdown` once the rasterizer drops its sender, so the scheduler loop
     /// (and the OS thread underneath it) actually exits instead of parking on an empty
     /// doorbell forever. `Quit`/`AppManagement::Quit`/`CloseRequested` also send `Shutdown`
@@ -201,17 +208,20 @@ impl Actor<Infallible, Infallible, Infallible> for RasterizerForwarder {
 
     fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
         match self.response_rx.recv() {
-            Ok(response) => {
-                if let Err(e) = self
-                    .engine
-                    .send(Message::Data(EngineData::RenderComplete(response)))
-                {
-                    log::warn!("Failed to forward render response to engine: {}", e);
-                    self.shut_down();
-                    return Ok(ActorStatus::Idle);
+            Ok(response) => match self.coordinator.try_send(response) {
+                Ok(()) => Ok(ActorStatus::Busy),
+                // This is the render credit's reply edge: at most one render is ever in flight,
+                // so the ring can never fill from this edge alone — `Full` is a provisioning
+                // bug, not backpressure to wait out.
+                Err(TrySendError::Full(_)) => {
+                    panic!("coordinator management ring unexpectedly full: the render-complete edge is credit(1)-bounded")
                 }
-                Ok(ActorStatus::Busy)
-            }
+                Err(TrySendError::Disconnected(_)) => {
+                    log::warn!("Coordinator gone; rasterizer forwarder shutting down");
+                    self.shut_down();
+                    Ok(ActorStatus::Idle)
+                }
+            },
             Err(_) => {
                 // The rasterizer shut down and dropped its sender; there is nothing left to
                 // forward, so this actor's work is done too.
@@ -257,30 +267,13 @@ impl EngineHandler {
         }
 
         if let Some(mgmt) = out.driver_mgmt {
-            self.send_driver_mgmt(mgmt);
-        }
-
-        if let Some(request) = out.rasterizer {
-            self.send_render(request);
-        }
-
-        if let Some(data) = out.driver_data {
             self.driver
-                .send(Message::Data(data))
-                .expect("Failed to send window to driver for presentation");
+                .send(Message::Management(mgmt))
+                .expect("Failed to relay management to driver");
         }
 
-        if let Some(response) = out.vsync_data {
-            if let Some(tx) = &self.vsync_data {
-                // The ring is provisioned >= MAX_TOKENS worth of outstanding frames (bootstrap
-                // `with_config`), so `Full` here means that provisioning broke, not ordinary
-                // backpressure — same credit argument as `send_vsync_control` below (design doc
-                // §3.2).
-                expect_credit_bounded_send(
-                    tx.try_send(response),
-                    "vsync data ring unexpectedly full",
-                );
-            }
+        if let Some(data) = out.coordinator {
+            self.send_coordinator(data);
         }
 
         if let Some(cmd) = out.vsync_control {
@@ -292,32 +285,18 @@ impl EngineHandler {
         }
     }
 
-    /// The `driver_mgmt` port. `RequestWindow` needs the delivery-feedback seam described on
-    /// [`EngineCore::request_delivered`]; every other management message is a plain relay.
-    fn send_driver_mgmt(&mut self, mgmt: DisplayMgmt) {
-        match mgmt {
-            DisplayMgmt::RequestWindow => {
-                // A refused ask is not lost: the driver latches it and answers when a buffer
-                // frees. A send that fails leaves the latch clear, so the next tick retries —
-                // the latch only covers requests that actually arrived.
-                match self
-                    .driver
-                    .send(Message::Management(DisplayMgmt::RequestWindow))
-                {
-                    Ok(()) => self.core.request_delivered(),
-                    Err(e) => {
-                        log::debug!(
-                            "Window request not delivered ({e}); retrying on the next tick"
-                        );
-                    }
-                }
-            }
-            other => {
-                self.driver
-                    .send(Message::Management(other))
-                    .expect("Failed to relay management to driver");
-            }
-        }
+    /// The `coordinator` port: every window grant, scene submission, and advance nudge the
+    /// engine relays to the render coordinator's own green node.
+    ///
+    /// Submissions are bounded by the vsync token bucket (`MAX_TOKENS`, `vsync_actor.rs`) and
+    /// grants by the one-buffer-in-flight bound the driver already enforces, so this edge can
+    /// never see more outstanding sends than its ring holds — `Full` is therefore a provisioning
+    /// bug, the same credit argument `expect_credit_bounded_send` makes for `vsync_control`.
+    fn send_coordinator(&mut self, data: CoordinatorData) {
+        let Some(tx) = &self.coordinator else {
+            return; // Not configured yet, or the green host has already shut down.
+        };
+        expect_credit_bounded_send(tx.try_send(data), "coordinator ring unexpectedly full");
     }
 
     /// The `vsync_control` port — `ReturnToken` (a credit return: the ring holds `>= MAX_TOKENS`,
@@ -331,45 +310,28 @@ impl EngineHandler {
         expect_credit_bounded_send(tx.try_send(cmd), "vsync control ring unexpectedly full");
     }
 
-    /// Hand a bound frame to the rasterizer.
-    ///
-    /// NOTE: this send carries the framebuffer, and `ActorHandle::send` takes the message by
-    /// value while `SendError` carries nothing back — so a failure here destroys the driver's
-    /// only buffer and the display can never recover. Releasing the credit keeps the *edge*
-    /// usable, but there is no buffer left to use it with. Pre-existing, and deliberately left
-    /// as-is by the extraction that moved this code rather than changed mid-refactor; the
-    /// `Present` send takes the opposite stance (`.expect`) for the same hazard, so the two
-    /// disagree and one of them is wrong.
-    fn send_render(&mut self, request: RenderRequest<PlatformPixel, WindowMeta>) {
-        let Some(rasterizer) = &self.rasterizer else {
-            log::warn!("Rasterizer not initialized, dropping render request");
-            self.core.render_undeliverable();
-            return;
-        };
-        if let Err(e) = rasterizer.send(Message::Data(request)) {
-            log::warn!("Failed to send render request to rasterizer: {}", e);
-            self.core.render_undeliverable();
-        }
-    }
-
     /// The shutdown cascade all three quit paths (`EngineControl::Quit`,
-    /// `AppManagement::Quit`, `DisplayEvent::CloseRequested`) share: vsync, rasterizer,
-    /// forwarder, drop the app handle, driver, then self. Any app notification for a
+    /// `AppManagement::Quit`, `DisplayEvent::CloseRequested`) share: the green host, the
+    /// rasterizer forwarder, drop the app handle, driver, then self. Any app notification for a
     /// `CloseRequested` has already gone out via the `app` port earlier in [`Self::flush`].
+    ///
+    /// The rasterizer itself is *not* sent an explicit `Shutdown` here — it cannot be: its one
+    /// live handle belongs to the coordinator's wiring (see `GreenReadyBundle`'s doc), which
+    /// this cascade already reaches indirectly. Shutting down the green host drops `Host`, which
+    /// drops the coordinator `Node` and its `CoordinatorWiring` along with it — including that
+    /// sole rasterizer handle. The rasterizer's own scheduler sees every one of its lanes
+    /// disconnect and halts gracefully (the same "all disconnected ⇒ normal shutdown" path the
+    /// forwarder below already relies on one hop downstream), so the cascade still reaches it,
+    /// just by the handle dropping rather than a message arriving.
     fn shut_down(&mut self) {
         if let Some(host) = &self.vsync_host {
             host.send(Message::Shutdown)
-                .expect("Failed to shutdown vsync host on Quit");
+                .expect("Failed to shutdown green host on Quit");
         }
         // The host shutting down drops its lanes' receivers; drop our ends too so nothing
         // downstream mistakes a dead node for one still configured.
-        self.vsync_data = None;
         self.vsync_control = None;
-        if let Some(rasterizer) = &self.rasterizer {
-            rasterizer
-                .send(Message::Shutdown)
-                .expect("Failed to shutdown rasterizer on Quit");
-        }
+        self.coordinator = None;
         if let Some(forwarder) = &self.rasterizer_forwarder {
             forwarder
                 .send(Message::Shutdown)
@@ -385,64 +347,64 @@ impl EngineHandler {
                 .expect("Failed to shutdown engine on Quit");
         }
     }
+}
 
-    /// Spawn the rasterizer actor with bootstrap handshake.
-    ///
-    /// This sets up:
-    /// 1. The rasterizer actor thread
-    /// 2. A response channel for render results
-    /// 3. A forwarding thread that receives responses and sends them to the engine
-    fn spawn_rasterizer(&mut self) {
-        if self.rasterizer.is_some() {
-            log::warn!("Rasterizer already initialized");
-            return;
-        }
+/// Spawn the rasterizer actor with its bootstrap handshake, and the forwarder that turns its
+/// bare `mpsc` responses into direct sends on the coordinator's management lane.
+///
+/// A free function, not a method on `EngineHandler`: nothing here needs the engine any more once
+/// the forwarder's target is the coordinator instead of it (step 5c of the mesh migration doc).
+/// Called once from `Troupe::with_config`, before the green-host thread spawns — it needs only
+/// `render_threads` from config and the coordinator's already-built management-lane sender.
+///
+/// Returns the rasterizer's own handle (which goes straight into `CoordinatorWiring`, never to
+/// the engine — see `GreenReadyBundle`'s doc for why it can't be shared) and the forwarder's
+/// handle (which the engine keeps for its shutdown cascade).
+fn spawn_rasterizer(
+    render_threads: usize,
+    coordinator: GreenSender<RenderResponse<PlatformPixel, WindowMeta>>,
+) -> (
+    RasterizerHandle<PlatformPixel, WindowMeta>,
+    ActorHandle<Infallible, Infallible, Infallible>,
+) {
+    // Step 1: Spawn rasterizer with setup handle
+    let (setup_handle, _rasterizer_thread) =
+        RasterizerActor::<PlatformPixel, WindowMeta>::spawn_with_setup(render_threads);
 
-        let engine_handle = self
-            .rasterizer_forward_handle
-            .take()
-            .expect("SetRasterizerForwardHandle must be sent before Configure");
+    // Step 2: Create response channel (the forwarder receives render results here)
+    let (response_tx, response_rx) =
+        std::sync::mpsc::channel::<RenderResponse<PlatformPixel, WindowMeta>>();
 
-        // Step 1: Spawn rasterizer with setup handle
-        let (setup_handle, _rasterizer_thread) =
-            RasterizerActor::<PlatformPixel, WindowMeta>::spawn_with_setup(self.render_threads);
+    // Step 3: Run the forwarder as a real actor rather than a bare thread — it is addressable (a
+    // real Shutdown on the Quit paths, not an implicit exit whenever the rasterizer happens to
+    // drop its sender) and supervisable the same way the rest of the troupe is. Its lanes are
+    // `Infallible`: nothing but `Shutdown` and the doorbell ever reaches it, so
+    // `data_buffer_size` of 1 is a formality.
+    let mut builder = ActorBuilder::new(1, None);
+    let self_handle = builder.add_producer();
+    let forwarder_handle = builder.add_producer();
+    let mut forwarder_scheduler: ActorScheduler<Infallible, Infallible, Infallible> =
+        builder.build();
+    let mut forwarder = RasterizerForwarder {
+        response_rx,
+        coordinator,
+        self_handle: Some(self_handle),
+    };
+    std::thread::Builder::new()
+        .name("rasterizer-forwarder".into())
+        .spawn(move || {
+            forwarder_scheduler.run(&mut forwarder);
+        })
+        .expect("failed to spawn rasterizer forwarder thread");
+    // The scheduler blocks on its doorbell until woken; with `Infallible` lanes there is no
+    // message to send, so ring the doorbell directly to start the loop.
+    forwarder_handle.waker().wake();
 
-        // Step 2: Create response channel (engine receives render results here)
-        let (response_tx, response_rx) =
-            std::sync::mpsc::channel::<RenderResponse<PlatformPixel, WindowMeta>>();
+    // Step 4: Complete bootstrap - register response channel and get full handle
+    let rasterizer_handle = setup_handle.register(response_tx);
 
-        // Step 3: Run the forwarder as a real actor rather than a bare thread — it is now
-        // addressable (a real Shutdown on the Quit paths, not an implicit exit whenever the
-        // rasterizer happens to drop its sender) and supervisable the same way the rest of the
-        // troupe is. Its lanes are `Infallible`: nothing but `Shutdown` and the doorbell ever
-        // reaches it, so `data_buffer_size` of 1 is a formality.
-        let mut builder = ActorBuilder::new(1, None);
-        let self_handle = builder.add_producer();
-        let forwarder_handle = builder.add_producer();
-        let mut forwarder_scheduler: ActorScheduler<Infallible, Infallible, Infallible> =
-            builder.build();
-        let mut forwarder = RasterizerForwarder {
-            response_rx,
-            engine: engine_handle,
-            self_handle: Some(self_handle),
-        };
-        std::thread::Builder::new()
-            .name("rasterizer-forwarder".into())
-            .spawn(move || {
-                forwarder_scheduler.run(&mut forwarder);
-            })
-            .expect("failed to spawn rasterizer forwarder thread");
-        // The scheduler blocks on its doorbell until woken; with `Infallible` lanes there is no
-        // message to send, so ring the doorbell directly to start the loop.
-        forwarder_handle.waker().wake();
-
-        // Step 4: Complete bootstrap - register response channel and get full handle
-        let rasterizer_handle = setup_handle.register(response_tx);
-
-        log::info!("Rasterizer actor initialized via bootstrap");
-        self.rasterizer = Some(rasterizer_handle);
-        self.rasterizer_forwarder = Some(forwarder_handle);
-    }
+    log::info!("Rasterizer actor initialized via bootstrap");
+    (rasterizer_handle, forwarder_handle)
 }
 
 // Implement TroupeActor for EngineHandler — takes ownership of per-actor Directory
@@ -450,15 +412,12 @@ impl TroupeActor<Directory> for EngineHandler {
     fn new(dir: Directory) -> Self {
         Self {
             driver: dir.driver,
-            vsync_data: None, // Set via EngineControl::VsyncActorReady once the green host is up
-            vsync_control: None,
+            vsync_control: None, // Set via EngineControl::GreenReady once the green host is up
             vsync_host: None,
-            rasterizer: None, // Set up separately via bootstrap
+            coordinator: None, // Set via EngineControl::GreenReady once the green host is up
             self_handle: Some(dir.engine),
-            rasterizer_forward_handle: None, // Set via SetRasterizerForwardHandle message
-            rasterizer_forwarder: None,      // Set up separately via bootstrap
+            rasterizer_forwarder: None, // Set via EngineControl::GreenReady
             app_handle: None,
-            render_threads: 1, // Default, will be set by Configure message
             core: EngineCore::new(),
         }
     }
@@ -530,11 +489,12 @@ impl Wiring for EngineHostWiring {
 }
 
 impl Troupe {
-    /// Create troupe, configure the engine, and bring vsync up as the first green node
-    /// (docs/designs/actor-scheduler-mealy-transducer.md §5): one "green-host" thread runs a
-    /// [`Host`] hosting the vsync [`Node`], stepped by its own [`GreenThread`] rather than
-    /// living on a dedicated OS thread of its own. The one thread this bootstrap still spawns
-    /// for vsync is the [`Timer`] clock — a green actor may not block, and a clock has to wait.
+    /// Create troupe, configure the engine, and bring vsync *and the render coordinator* up as
+    /// green nodes (docs/designs/actor-scheduler-mealy-transducer.md §5, and step 5c of
+    /// `pixelflow-runtime-engine-mesh-migration.md` §8): one "green-host" thread runs a [`Host`]
+    /// hosting both [`Node`]s, stepped by its own [`GreenThread`] rather than either living on a
+    /// dedicated OS thread of its own. The one thread this bootstrap still spawns for vsync is
+    /// the [`Timer`] clock — a green actor may not block, and a clock has to wait.
     pub fn with_config(config: EngineConfig) -> Result<Self, RuntimeError> {
         // Create troupe with platform-specific waker for the main (driver) actor
         #[cfg(target_os = "macos")]
@@ -553,20 +513,12 @@ impl Troupe {
         #[cfg(not(any(target_os = "macos", target_os = "linux")))]
         let mut troupe = Self::new();
 
-        // Create SPSC handles for initialization (each exposed() creates unique channels)
-        let init = troupe.exposed(); // engine handle for sending config messages
-        let rasterizer_fwd = troupe.exposed(); // engine handle for rasterizer→engine
+        // Create SPSC handles for initialization (each exposed() creates unique channels).
+        // `init.driver` is the coordinator's own driver handle — grabbed here rather than with a
+        // separate `exposed()` call, since one call already mints every exposed actor's handle.
+        let init = troupe.exposed(); // engine: config messages; driver: the coordinator's handle
         let vsync_engine = troupe.exposed(); // dedicated engine producer for vsync ticks
         let host_engine = troupe.exposed(); // dedicated engine producer for host supervision
-
-        // Send rasterizer forwarding handle BEFORE Configure
-        init.engine
-            .send(Message::Management(
-                AppManagement::SetRasterizerForwardHandle(rasterizer_fwd.engine),
-            ))
-            .map_err(|e| {
-                RuntimeError::InitError(format!("Failed to set rasterizer fwd handle: {}", e))
-            })?;
 
         // Configure the engine with window settings
         init.engine
@@ -575,7 +527,7 @@ impl Troupe {
             )))
             .map_err(|e| RuntimeError::InitError(format!("Failed to configure engine: {}", e)))?;
 
-        // ── VSync: the first green node ─────────────────────────────────────────────────
+        // ── The green host: vsync AND the render coordinator ────────────────────────────
         //
         // A host has no lanes of its own (all three types are `Infallible`); work reaches it by
         // pushing straight into an adopted node's inbox with a `GreenSender` and ringing the
@@ -595,14 +547,36 @@ impl Troupe {
         let (vsync_control_tx, vsync_control_rx) = green_channel::<VsyncCommand>(128, waker.clone());
         // Capacity 1 is enough: a queued tick is as good as a fresh one, and the clock is the
         // only producer.
-        let (tick_tx, tick_rx) = green_channel::<VsyncManagement>(2, waker);
+        let (tick_tx, tick_rx) = green_channel::<VsyncManagement>(2, waker.clone());
+
+        // The coordinator's two lanes (§5c): data, fed by the engine shell
+        // (Submit/Granted/Advance) — 256 covers every vsync-token-bounded frame request plus
+        // every buffer grant that could be outstanding; management, fed directly by the
+        // rasterizer forwarder (`RenderResponse`) — bounded by the render credit (<=1 in
+        // flight), so its capacity is a formality, same as the forwarder's own ring.
+        let (coordinator_data_tx, coordinator_data_rx) =
+            green_channel::<CoordinatorData>(256, waker.clone());
+        let (coordinator_mgmt_tx, coordinator_mgmt_rx) =
+            green_channel::<RenderResponse<PlatformPixel, WindowMeta>>(8, waker);
+
+        // The rasterizer is spawned here now, not by the engine (§8 of the mesh migration doc):
+        // it needs only `render_threads` from config and the coordinator's management-lane
+        // sender as the forwarder's target, so the `SetRasterizerForwardHandle` round trip that
+        // used to gate `Configure` is gone entirely.
+        let (rasterizer, forwarder) =
+            spawn_rasterizer(config.performance.render_threads, coordinator_mgmt_tx);
 
         init.engine
-            .send(Message::Control(EngineControl::VsyncActorReady(Box::new(
-                (vsync_data_tx, vsync_control_tx, host_shutdown),
+            .send(Message::Control(EngineControl::GreenReady(Box::new(
+                GreenReadyBundle {
+                    vsync_control: vsync_control_tx,
+                    coordinator: coordinator_data_tx,
+                    host: host_shutdown,
+                    forwarder,
+                },
             ))))
             .map_err(|e| {
-                RuntimeError::InitError(format!("Failed to hand vsync handles to engine: {}", e))
+                RuntimeError::InitError(format!("Failed to hand green handles to engine: {}", e))
             })?;
 
         let refresh_rate = config.performance.target_fps as f64;
@@ -619,26 +593,51 @@ impl Troupe {
             }
         });
 
+        let coordinator_driver = init.driver;
+
         std::thread::Builder::new()
             .name("green-host".to_string())
             .spawn(move || {
                 let mut host = Host::new();
-                let core = VsyncCore::started(refresh_rate);
-                let wiring = VsyncWiring {
+
+                let vsync_core = VsyncCore::started(refresh_rate);
+                let vsync_wiring = VsyncWiring {
                     engine: vsync_engine.engine,
                     clock,
                 };
-                let node = Node::new_with_lanes(
-                    core,
+                let vsync_node = Node::new_with_lanes(
+                    vsync_core,
                     Lanes {
                         control: vsync_control_rx,
                         management: tick_rx,
                         data: vsync_data_rx,
                     },
-                    wiring,
+                    vsync_wiring,
                     SchedulerParams::DEFAULT,
                 );
-                host.adopt(node);
+                host.adopt(vsync_node);
+
+                // Adopted after vsync: sweep order between the two is not load-bearing here —
+                // vsync's tick still relays through the engine rather than the coordinator, so
+                // neither node's completion in one sweep depends on the other having already
+                // run in that same sweep.
+                let coordinator_core = CoordinatorCore::new();
+                let coordinator_wiring = CoordinatorWiring {
+                    rasterizer,
+                    driver: coordinator_driver,
+                    vsync: vsync_data_tx,
+                };
+                let coordinator_node = Node::new_with_lanes(
+                    coordinator_core,
+                    Lanes {
+                        control: NoLane::new(),
+                        management: coordinator_mgmt_rx,
+                        data: coordinator_data_rx,
+                    },
+                    coordinator_wiring,
+                    SchedulerParams::DEFAULT,
+                );
+                host.adopt(coordinator_node);
 
                 let mut green_thread = GreenThread::new(
                     host,
@@ -677,173 +676,67 @@ impl Troupe {
 
 #[cfg(test)]
 mod tests {
-    //! The render pipeline, driven directly.
+    //! `EngineHandler`, driven directly.
     //!
-    //! `EngineHandler` is exercised here without a troupe, a display, or a thread: the handles
-    //! it holds are real channel endpoints whose schedulers stay in the fixture, so every
-    //! message the engine emits is observable by polling the corresponding spy.
-    //!
-    //! The driver spy owns a **real [`WindowKeeper`]** rather than imitating one. Buffer
-    //! ownership is the driver's now, so a fixture that mocked it would be asserting against a
-    //! second implementation of the thing under test — and the resize races below are precisely
-    //! the interaction between the two sides, not the behaviour of either alone.
+    //! The render protocol itself — request/render/present, resize races, `holds_buffer` — no
+    //! longer runs through the engine at all, so those interaction tests moved to
+    //! `coordinator_node.rs`'s `node_tests` (see that module's doc for the full list and why
+    //! each one still exists). What is left here is what the engine still actually does: relay
+    //! driver/app/vsync events to the render coordinator's `CoordinatorData` port, plus its own
+    //! shutdown cascade.
 
     use super::*;
     use crate::api::public::{AppData, WindowId};
-    use crate::display::messages::{DisplayEvent, Surface, Window};
-    use crate::display::window_keeper::{Presented, WindowKeeper};
+    use crate::coordinator_node::CoordinatorData;
+    use crate::display::messages::{DisplayEvent, Surface};
     use crate::platform::ColorCube;
     use actor_scheduler::ActorScheduler;
+    use actor_scheduler::spsc::{SpscReceiver, spsc_channel};
     use pixelflow_core::{Discrete, Manifold};
-    use pixelflow_graphics::render::rasterizer::{RasterControl, RasterManagement};
-    use pixelflow_graphics::render::Frame;
-    use std::collections::VecDeque;
-    use std::time::{Duration, Instant};
+    use std::time::Instant;
 
-    /// Scheduler tuning for the fixture: nothing here approaches the buffer, and the burst
-    /// limit only has to be big enough that one `poll_once` drains a test's worth of messages.
+    /// Scheduler tuning for the fixture: small, since nothing here approaches a real ring.
     const LANE_BURST: usize = 16;
     const LANE_BUFFER: usize = 16;
 
-    /// A window size, as the tests talk about them.
-    type Size = (u32, u32);
-
-    #[derive(Default)]
-    struct RasterizerSpy {
-        requests: Vec<WindowMeta>,
+    /// A constant black scene — these tests care about which port fires, not what is drawn.
+    fn manifold() -> Arc<dyn Manifold<Output = Discrete> + Send + Sync> {
+        Arc::new(ColorCube::default().at(0.0f32, 0.0f32, 0.0f32, 1.0f32))
     }
 
-    impl Actor<RenderRequest<PlatformPixel, WindowMeta>, RasterControl, RasterManagement>
-        for RasterizerSpy
-    {
-        fn handle_data(&mut self, req: RenderRequest<PlatformPixel, WindowMeta>) -> HandlerResult {
-            self.requests.push(req.meta);
-            Ok(())
-        }
-        fn handle_control(&mut self, _msg: RasterControl) -> HandlerResult {
-            Ok(())
-        }
-        fn handle_management(&mut self, _msg: RasterManagement) -> HandlerResult {
-            Ok(())
-        }
-        fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
-            Ok(ActorStatus::Idle)
-        }
-    }
-
-    /// A driver, minus the platform: real buffer ownership, no blit.
-    #[derive(Default)]
-    struct DriverSpy {
-        keeper: WindowKeeper,
-        /// Buffers lent out, waiting to reach the engine. A real `PlatformActor` sends these
-        /// straight back over its engine handle; the fixture has no such handle, so `Rig` drains
-        /// this in `pump`.
-        granted: Vec<Window>,
-        /// Sizes actually blitted — excluding superseded buffers, which never reach a screen.
-        blitted: Vec<Size>,
-    }
-
-    impl DriverSpy {
-        /// What `PlatformActor::flush` does at the end of every handler: issue whatever grant
-        /// has come due.
-        fn grant(&mut self) {
-            if let Some(window) = self.keeper.pending_grant() {
-                self.granted.push(window);
-            }
-        }
-    }
-
-    impl Actor<DisplayData, DisplayControl, DisplayMgmt> for DriverSpy {
-        fn handle_data(&mut self, msg: DisplayData) -> HandlerResult {
-            let DisplayData::Present { window } = msg;
-            match self.keeper.presented(window) {
-                Presented::Blit(window) => {
-                    self.blitted.push((window.width_px, window.height_px));
-                    self.keeper.rest(window);
-                }
-                Presented::Superseded => {}
-            }
-            self.grant();
-            Ok(())
-        }
-        fn handle_control(&mut self, _msg: DisplayControl) -> HandlerResult {
-            Ok(())
-        }
-        fn handle_management(&mut self, msg: DisplayMgmt) -> HandlerResult {
-            if matches!(msg, DisplayMgmt::RequestWindow) {
-                self.keeper.request();
-                self.grant();
-            }
-            Ok(())
-        }
-        fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
-            Ok(ActorStatus::Idle)
-        }
-    }
-
+    /// `EngineHandler` wired to a real driver scheduler (so `driver_control`/`driver_mgmt`
+    /// relays are observable) and a held `coordinator` receiver (so `CoordinatorData` arrivals
+    /// are observable), with no green host, thread, or rasterizer in the loop.
     struct Rig {
         engine: EngineHandler,
-        raster_sched: ActorScheduler<
-            RenderRequest<PlatformPixel, WindowMeta>,
-            RasterControl,
-            RasterManagement,
-        >,
-        raster_spy: RasterizerSpy,
-        driver_sched: ActorScheduler<DisplayData, DisplayControl, DisplayMgmt>,
-        driver_spy: DriverSpy,
-        /// Never polled: vsync's token returns and FPS reports are not what these tests are
-        /// about. Held directly (no green host, no thread) only so the engine's sends have
-        /// somewhere to land — replaces the `ActorScheduler` spy the dedicated-thread
-        /// `VsyncActor` needed, since a `GreenSender`'s receiving end is a plain `SpscReceiver`.
-        _vsync_data_rx: actor_scheduler::spsc::SpscReceiver<RenderedResponse>,
-        _vsync_control_rx: actor_scheduler::spsc::SpscReceiver<VsyncCommand>,
-        /// Renders the rasterizer has been asked for and not yet answered, oldest first.
-        in_flight: VecDeque<WindowMeta>,
-        request_log: Vec<Size>,
+        coordinator_rx: SpscReceiver<CoordinatorData>,
     }
 
     impl Rig {
         fn new() -> Self {
-            let (driver, driver_sched) = ActorScheduler::new(LANE_BURST, LANE_BUFFER);
-            let (rasterizer, raster_sched) = ActorScheduler::new(LANE_BURST, LANE_BUFFER);
+            let (driver, _driver_sched) = ActorScheduler::new(LANE_BURST, LANE_BUFFER);
 
-            // A `Waker` with nobody listening is harmless (host.rs's own tests prove it), so a
-            // throwaway scheduler that is dropped immediately after minting one is enough — the
-            // green channels below never need a real host to wake.
             let waker = {
                 let (handle, _sched) = ActorScheduler::<Infallible, Infallible, Infallible>::new(1, 1);
                 handle.waker()
             };
-            // Same provisioning as the real bootstrap (>= MAX_TOKENS): the engine panics on a
-            // full vsync ring by the credit argument, so an undersized test ring would turn a
-            // long test into a spurious "provisioning broke" panic.
-            let (vsync_data, vsync_data_rx) = green_channel::<RenderedResponse>(128, waker.clone());
-            let (vsync_control, vsync_control_rx) = green_channel::<VsyncCommand>(128, waker);
+            let (coordinator_tx, coordinator_rx) = spsc_channel::<CoordinatorData>(64);
+            let coordinator = GreenSender::new(coordinator_tx, waker);
 
             let engine = EngineHandler {
                 driver,
-                vsync_data: Some(vsync_data),
-                vsync_control: Some(vsync_control),
+                vsync_control: None,
                 vsync_host: None,
-                rasterizer: Some(rasterizer),
+                coordinator: Some(coordinator),
                 self_handle: None,
-                rasterizer_forward_handle: None,
                 rasterizer_forwarder: None,
                 app_handle: None,
-                render_threads: 1,
                 core: EngineCore::new(),
             };
 
             Self {
                 engine,
-                raster_sched,
-                raster_spy: RasterizerSpy::default(),
-                driver_sched,
-                driver_spy: DriverSpy::default(),
-                _vsync_data_rx: vsync_data_rx,
-                _vsync_control_rx: vsync_control_rx,
-                in_flight: VecDeque::new(),
-                request_log: Vec::new(),
+                coordinator_rx,
             }
         }
 
@@ -852,333 +745,104 @@ mod tests {
                 .handle_data(data)
                 .expect("engine handled the message");
         }
+    }
 
-        /// Carry every message in flight to its destination, in both directions, until nothing
-        /// moves. The request → grant → render loop takes several hops, so a single pass would
-        /// leave the system mid-conversation and the assertions would read a partial state.
-        fn pump(&mut self) {
-            loop {
-                let _ = self.raster_sched.poll_once(&mut self.raster_spy);
-                for meta in self.raster_spy.requests.drain(..) {
-                    self.request_log.push((meta.width_px, meta.height_px));
-                    self.in_flight.push_back(meta);
-                }
+    #[test]
+    fn render_surface_relays_a_submit_to_the_coordinator() {
+        let mut rig = Rig::new();
+        rig.feed(EngineData::FromApp(AppData::RenderSurface(manifold())));
+        assert!(matches!(
+            rig.coordinator_rx.try_recv(),
+            Ok(CoordinatorData::Submit(_))
+        ));
+    }
 
-                let _ = self.driver_sched.poll_once(&mut self.driver_spy);
-                let granted: Vec<_> = self.driver_spy.granted.drain(..).collect();
-                if granted.is_empty() {
-                    return;
-                }
-                for window in granted {
-                    self.feed(EngineData::WindowGranted(window));
-                }
-            }
-        }
+    #[test]
+    fn skipped_frame_does_not_touch_the_coordinator() {
+        let mut rig = Rig::new();
+        rig.feed(EngineData::FromApp(AppData::Skipped));
+        assert!(rig.coordinator_rx.try_recv().is_err());
+    }
 
-        /// The platform reported a window at this geometry. Both halves of what
-        /// `PlatformActor::flush` does: the keeper builds the buffer, the engine is told the
-        /// size so it can relay it. Used for the initial window and for resizes alike, because
-        /// the driver treats them identically.
-        fn surface(&mut self, (width_px, height_px): Size) {
-            let surface = Surface {
+    #[test]
+    fn window_granted_relays_to_the_coordinator() {
+        use crate::display::messages::{Generation, Window, WindowMeta};
+
+        let mut rig = Rig::new();
+        let window = Window::rejoin(
+            pixelflow_graphics::render::Frame::new(100, 100),
+            WindowMeta {
                 id: WindowId(1),
-                width_px,
-                height_px,
-                frame_width: width_px,
-                frame_height: height_px,
+                width_px: 100,
+                height_px: 100,
                 scale: 1.0,
-            };
-            self.driver_spy.keeper.surface_changed(surface);
-            // A resize can answer a request that was refused while the old buffer was out, which
-            // is why `PlatformActor` flushes here too.
-            self.driver_spy.grant();
-            self.feed(EngineData::FromDriver(DisplayEvent::Resized { surface }));
-            self.pump();
-        }
-
-        /// Answer the oldest outstanding render, returning its `meta` untouched — which is the
-        /// rasterizer's actual contract.
-        fn complete_render(&mut self) {
-            self.pump();
-            let meta = self
-                .in_flight
-                .pop_front()
-                .expect("a render must be outstanding to complete");
-            self.feed(EngineData::RenderComplete(RenderResponse {
-                frame: Frame::new(meta.width_px, meta.height_px),
-                render_time: Some(Duration::from_millis(1)),
-                meta,
-            }));
-            self.pump();
-        }
-
-        fn app_frame(&mut self) {
-            self.queue_frame();
-            self.pump();
-        }
-
-        /// A frame, without letting anything be delivered. Two of these back to back is one
-        /// scheduler pass in which the engine reacts twice before the driver reacts once —
-        /// which is ordinary, since they are separate actors.
-        fn queue_frame(&mut self) {
-            self.feed(EngineData::FromApp(AppData::RenderSurface(manifold())));
-        }
-
-        /// A vsync tick, which is what re-drives a request the driver could not answer.
-        fn tick(&mut self) {
-            let now = Instant::now();
-            self.feed(EngineData::VSync {
-                timestamp: now,
-                target_timestamp: now,
-                refresh_interval: Duration::from_millis(16),
-            });
-            self.pump();
-        }
-
-        /// Render requests emitted since the last call.
-        fn render_requests(&mut self) -> Vec<Size> {
-            self.pump();
-            std::mem::take(&mut self.request_log)
-        }
-
-        /// Frames that actually reached the screen since the last call.
-        fn blitted(&mut self) -> Vec<Size> {
-            self.pump();
-            std::mem::take(&mut self.driver_spy.blitted)
-        }
+                generation: Generation::NONE,
+            },
+        );
+        rig.feed(EngineData::WindowGranted(window));
+        assert!(matches!(
+            rig.coordinator_rx.try_recv(),
+            Ok(CoordinatorData::Granted(_))
+        ));
     }
 
-    /// A constant black scene — these tests care about which buffer a render is aimed at, not
-    /// what is in it.
-    fn manifold() -> Arc<dyn Manifold<Output = Discrete> + Send + Sync> {
-        Arc::new(ColorCube::default().at(0.0f32, 0.0f32, 0.0f32, 1.0f32))
-    }
-
-    /// The steady state: the engine asks for the buffer only when it has something to draw,
-    /// draws, hands it straight back, and asks again next frame.
     #[test]
-    fn frames_circulate_through_request_render_and_present() {
+    fn vsync_tick_relays_advance_to_the_coordinator() {
         let mut rig = Rig::new();
-        rig.surface((100, 100));
-
-        rig.app_frame();
-        assert_eq!(rig.render_requests(), vec![(100, 100)]);
-
-        rig.complete_render();
-        assert_eq!(rig.blitted(), vec![(100, 100)]);
-
-        rig.app_frame();
-        assert_eq!(
-            rig.render_requests(),
-            vec![(100, 100)],
-            "Present returned the buffer to the driver, so the next frame can have it"
-        );
+        let now = Instant::now();
+        rig.feed(EngineData::VSync {
+            timestamp: now,
+            target_timestamp: now,
+            refresh_interval: Duration::from_millis(16),
+        });
+        assert!(matches!(
+            rig.coordinator_rx.try_recv(),
+            Ok(CoordinatorData::Advance)
+        ));
     }
 
-    /// Nothing is requested until there is something to draw. If the engine held the buffer
-    /// while idle, "who has the buffer" would stop meaning "who is drawing", and that
-    /// equivalence is the entire bound on the loop.
     #[test]
-    fn an_idle_engine_does_not_hold_the_buffer() {
+    fn window_created_and_resized_relay_advance_to_the_coordinator() {
         let mut rig = Rig::new();
-        rig.surface((100, 100));
+        let surface = Surface {
+            id: WindowId(1),
+            width_px: 100,
+            height_px: 100,
+            frame_width: 100,
+            frame_height: 100,
+            scale: 1.0,
+        };
 
-        rig.tick();
-        rig.tick();
-        assert!(rig.render_requests().is_empty());
-        assert!(
-            !rig.engine.core.holds_buffer(),
-            "no manifold to draw, so no reason to be holding the buffer"
-        );
-    }
+        rig.feed(EngineData::FromDriver(DisplayEvent::WindowCreated { surface }));
+        assert!(matches!(
+            rig.coordinator_rx.try_recv(),
+            Ok(CoordinatorData::Advance)
+        ));
 
-    /// Vsync keeps asking for frames at 60Hz regardless of how long a render takes, so a new
-    /// manifold routinely arrives while one is in flight. The refusal must keep it: dropping it
-    /// would leave the app's last state change unrendered with nothing following to correct it.
-    #[test]
-    fn a_manifold_arriving_mid_render_is_kept_not_dropped() {
-        let mut rig = Rig::new();
-        rig.surface((100, 100));
-
-        rig.app_frame();
-        assert_eq!(rig.render_requests(), vec![(100, 100)]);
-
-        rig.app_frame();
-        assert!(
-            rig.render_requests().is_empty(),
-            "the in-flight render holds the edge's only credit"
-        );
-
-        rig.complete_render();
-        assert_eq!(
-            rig.render_requests(),
-            vec![(100, 100)],
-            "the deferred manifold renders once the credit comes back"
-        );
-    }
-
-    /// The race the generation stamp exists for, end-to-end across both sides: a resize while
-    /// the buffer is out with the renderer. The old-size frame must not reach the screen, and
-    /// the next one must be at the new size.
-    #[test]
-    fn a_resize_mid_render_keeps_the_old_frame_off_the_screen() {
-        let mut rig = Rig::new();
-        rig.surface((100, 100));
-
-        rig.app_frame();
-        assert_eq!(rig.render_requests(), vec![(100, 100)]);
-
-        // Resize lands while that render is in flight.
-        rig.surface((200, 200));
-
-        rig.complete_render();
-        assert!(
-            rig.blitted().is_empty(),
-            "the old-size buffer is superseded and must not be blitted"
-        );
-
-        rig.app_frame();
-        assert_eq!(
-            rig.render_requests(),
-            vec![(200, 200)],
-            "and the driver's replacement buffer is what the next frame draws into"
-        );
-        rig.complete_render();
-        assert_eq!(rig.blitted(), vec![(200, 200)]);
-    }
-
-    /// A resize with nothing in flight: the next frame simply comes out at the new size.
-    #[test]
-    fn a_resize_between_frames_renders_at_the_new_size() {
-        let mut rig = Rig::new();
-        rig.surface((100, 100));
-
-        rig.app_frame();
-        rig.complete_render();
-        assert_eq!(rig.blitted(), vec![(100, 100)]);
-        let _ = rig.render_requests(); // drain, so the next assertion is about what follows
-
-        rig.surface((200, 200));
-        rig.app_frame();
-        assert_eq!(rig.render_requests(), vec![(200, 200)]);
-    }
-
-    /// A resize while a render is in flight, *with a frame already queued behind it*. The queued
-    /// frame makes the engine ask for a buffer it cannot yet use; the resize then allocates one,
-    /// so the ask is answered immediately and the engine is holding a second buffer while the
-    /// first is still out. The old completion then arrives with nowhere to go.
-    ///
-    /// In a debug build that trips the "one buffer" assertion. In release, a *paused*
-    /// completion — the arm that keeps its buffer rather than presenting it — overwrites the
-    /// replacement, and since the driver has already handed its only current buffer over, the
-    /// terminal never draws again.
-    #[test]
-    fn a_resize_does_not_grant_a_second_buffer_mid_render() {
-        let mut rig = Rig::new();
-        rig.surface((100, 100));
-
-        rig.app_frame();
-        assert_eq!(rig.render_requests(), vec![(100, 100)]);
-
-        // A second frame queues behind the in-flight render, and asks for a buffer.
-        rig.app_frame();
-        // The resize allocates one, which could answer that ask.
-        rig.surface((200, 200));
-
-        assert!(
-            !rig.engine.core.holds_buffer(),
-            "a buffer is already out with the renderer; a second one must not be granted"
-        );
-
-        // The original render completes into an engine that still has exactly one buffer's
-        // worth of state to reconcile.
-        rig.complete_render();
-        assert!(rig.blitted().is_empty(), "the old-size frame is superseded");
-        assert_eq!(
-            rig.render_requests(),
-            vec![(200, 200)],
-            "and the queued frame renders into the resize's buffer"
-        );
-    }
-
-    /// The same failure one step earlier in the conversation: two asks issued *before* the
-    /// driver has answered either. The credit guard cannot see this one — no render is in flight
-    /// yet, so both asks are legitimate at the moment they are made.
-    ///
-    /// The driver answers the first and has nothing for the second, which leaves its "somebody
-    /// is waiting" latch set with nobody actually waiting any more. The next buffer to appear —
-    /// a resize allocation, while the granted one is out being drawn into — is then handed over
-    /// unasked, and the engine is holding two.
-    #[test]
-    fn a_second_ask_before_the_first_is_answered_does_not_earn_a_second_grant() {
-        let mut rig = Rig::new();
-        rig.surface((100, 100));
-
-        // Two asks in one scheduler pass, before the driver reacts to either.
-        rig.queue_frame();
-        rig.queue_frame();
-        rig.pump();
-        assert_eq!(
-            rig.render_requests(),
-            vec![(100, 100)],
-            "the grant that did arrive is rendering"
-        );
-
-        // A resize now allocates a buffer that a stale ask would collect.
-        rig.surface((200, 200));
-        assert!(
-            !rig.engine.core.holds_buffer(),
-            "the buffer is out with the renderer; an unanswered duplicate ask must not \
-             collect the resize's replacement"
-        );
-
-        // The old buffer goes back and is discarded as superseded; the app answers the resize
-        // with a new frame, which asks properly and gets the replacement.
-        rig.complete_render();
-        rig.app_frame();
-        assert_eq!(
-            rig.render_requests(),
-            vec![(200, 200)],
-            "and the next frame draws into the replacement, asked for properly"
-        );
-    }
-
-    /// Two buffers can never be out at once — the old fixture had to model that possibility and
-    /// order the returns. It is now a property of ownership: the driver cannot lend what it is
-    /// not holding, so however many times it is asked, at most one buffer is out.
-    #[test]
-    fn the_driver_never_lends_a_second_buffer() {
-        let mut rig = Rig::new();
-        rig.surface((100, 100));
-
-        rig.app_frame();
-        assert_eq!(rig.render_requests(), vec![(100, 100)]);
-
-        // Ask repeatedly while the buffer is out with the renderer.
-        for _ in 0..5 {
-            rig.tick();
-        }
-        assert!(
-            !rig.engine.core.holds_buffer(),
-            "no grant can arrive while the buffer is out, however often it is requested"
-        );
-
-        rig.complete_render();
-        assert_eq!(rig.blitted(), vec![(100, 100)]);
+        rig.feed(EngineData::FromDriver(DisplayEvent::Resized { surface }));
+        assert!(matches!(
+            rig.coordinator_rx.try_recv(),
+            Ok(CoordinatorData::Advance)
+        ));
     }
 
     /// The forwarder's whole reason to exist: turn the rasterizer's bare `mpsc` responses into
-    /// real `EngineData::RenderComplete` sends on an addressable actor, rather than a bare
-    /// thread nobody could signal. Exercises the actual `RasterizerForwarder`, not a stand-in.
+    /// direct sends on the coordinator's management lane, rather than a bare thread nobody could
+    /// signal. Exercises the actual `RasterizerForwarder`, not a stand-in — simpler now than the
+    /// engine-routed version, since a `GreenSender`'s receiving end is a plain `SpscReceiver`
+    /// and no engine scheduler is needed to observe arrival.
     #[test]
     fn forwarder_relays_responses_and_exits_when_the_rasterizer_disconnects() {
         use crate::display::messages::Generation;
 
-        let (engine_handle, mut engine_sched) = ActorScheduler::<
-            EngineData,
-            EngineControl,
-            AppManagement,
-        >::new(LANE_BURST, LANE_BUFFER);
+        let waker = {
+            let (handle, _sched) = ActorScheduler::<Infallible, Infallible, Infallible>::new(1, 1);
+            handle.waker()
+        };
+        let (coordinator_tx, mut coordinator_rx) =
+            spsc_channel::<RenderResponse<PlatformPixel, WindowMeta>>(8);
+        let coordinator = GreenSender::new(coordinator_tx, waker);
+
         let (response_tx, response_rx) = std::sync::mpsc::channel();
 
         let mut builder = ActorBuilder::new(1, None);
@@ -1188,7 +852,7 @@ mod tests {
             builder.build();
         let mut forwarder = RasterizerForwarder {
             response_rx,
-            engine: engine_handle,
+            coordinator,
             self_handle: Some(self_handle),
         };
         let thread = std::thread::spawn(move || forwarder_sched.run(&mut forwarder));
@@ -1203,49 +867,26 @@ mod tests {
         };
         response_tx
             .send(RenderResponse {
-                frame: Frame::new(4, 4),
+                frame: pixelflow_graphics::render::Frame::new(4, 4),
                 render_time: Some(Duration::from_millis(1)),
                 meta,
             })
             .expect("forwarder thread should still be listening");
 
-        #[derive(Default)]
-        struct TargetSpy {
-            received: Vec<(u32, u32)>,
-        }
-        impl Actor<EngineData, EngineControl, AppManagement> for TargetSpy {
-            fn handle_data(&mut self, data: EngineData) -> HandlerResult {
-                if let EngineData::RenderComplete(response) = data {
-                    self.received
-                        .push((response.meta.width_px, response.meta.height_px));
-                }
-                Ok(())
-            }
-            fn handle_control(&mut self, _msg: EngineControl) -> HandlerResult {
-                Ok(())
-            }
-            fn handle_management(&mut self, _msg: AppManagement) -> HandlerResult {
-                Ok(())
-            }
-            fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
-                Ok(ActorStatus::Idle)
-            }
-        }
-
-        let mut spy = TargetSpy::default();
         // The forwarder thread runs concurrently; poll until its send lands rather than
         // asserting after a single pass.
+        let mut received = None;
         for _ in 0..10_000 {
-            let _ = engine_sched.poll_once(&mut spy);
-            if !spy.received.is_empty() {
+            if let Ok(response) = coordinator_rx.try_recv() {
+                received = Some((response.meta.width_px, response.meta.height_px));
                 break;
             }
             std::thread::yield_now();
         }
         assert_eq!(
-            spy.received,
-            vec![(4, 4)],
-            "the forwarder must translate the rasterizer's response into RenderComplete"
+            received,
+            Some((4, 4)),
+            "the forwarder must translate the rasterizer's response into a direct coordinator send"
         );
 
         // Dropping the sender is exactly what the real bootstrap path does when the rasterizer

--- a/pixelflow-runtime/src/lib.rs
+++ b/pixelflow-runtime/src/lib.rs
@@ -3,6 +3,7 @@ pub mod api;
 
 // Internal modules
 pub mod config;
+pub(crate) mod coordinator_node;
 pub mod display;
 pub(crate) mod engine_core;
 pub mod engine_troupe;


### PR DESCRIPTION
## Summary

Step 5c of the engine-mesh migration, executed through the mealy types: `RenderCoordinator` leaves `EngineCore` and runs as a second green node on the existing green-host thread — `CoordinatorCore` (coordinator + frame counter) with `CoordinatorWiring` sending **directly** to the rasterizer, the driver (`Present`/`RequestWindow`), and vsync's telemetry lane.

- **First true mesh edge**: render completions flow rasterizer-forwarder → coordinator with no engine round-trip; `EngineData::RenderComplete` is deleted. Lane choice is deliberate — Management (completions) outranks Data (submissions), so in-flight work finishes before new work is accepted, mirroring the continuation-first discipline.
- **The delivery-feedback seam dissolves**: `request_sent` is applied at decision time (delivery is guaranteed-or-parked under `Wiring`), and `render_send_failed` has no counterpart — a gone rasterizer surfaces as `Flush::Disconnected` → Host supervision → `GreenStuck`, buffer retained. The same park-and-retain on `Present` fixes the long-standing destroyed-on-failure hazard the old `send_render` carried a NOTE about.
- **Bootstrap simplification**: `spawn_rasterizer` moves into `with_config` as a free function; `AppManagement::SetRasterizerForwardHandle` and its round-trip die. The rasterizer's sole handle lives in the coordinator's wiring; shutdown reaches it by disconnect (host drops → wiring drops → all-lanes-disconnected → normal scheduler exit). `VsyncActorReady` → `GreenReady` with a named bundle struct.
- The Rig's eight render-protocol interaction tests (resize races, double-grant, buffer circulation) move with the logic they test — now driving a real `Node<CoordinatorCore, CoordinatorWiring>` against the real `WindowKeeper`, same names and intent.

## Test plan

- [x] `cargo test --workspace` — 1637 passed, 0 failed (net +17: CoordinatorCore port-mapping tests, moved Rig tests, retargeted forwarder test, engine relay tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] core-term builds; public API (`UnregisteredEngineHandle`, `Troupe::with_config`) unchanged in shape

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_015Y5cNzR9PnASfGfjBh5kJc

---
_Generated by [Claude Code](https://claude.ai/code/session_015Y5cNzR9PnASfGfjBh5kJc)_