### PR TITLE
fix(ci): bootstrap gh-pages branch before benchmark publish

### DIFF
--- a/.github/workflows/benchmark_regression.yaml
+++ b/.github/workflows/benchmark_regression.yaml
@@ -71,6 +71,24 @@ jobs:
           path: benchmark_results/output.txt
           if-no-files-found: error
 
+      # github-action-benchmark's auto-push does `git fetch origin
+      # gh-pages:gh-pages` and fails outright if the branch has never been
+      # created. Bootstrap an empty orphan branch on first run only.
+      - name: Ensure gh-pages branch exists
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
+            echo "gh-pages already exists"
+            exit 0
+          fi
+          git config user.name "github-action-benchmark"
+          git config user.email "github@users.noreply.github.com"
+          git checkout --orphan gh-pages
+          git rm -rf . >/dev/null 2>&1 || true
+          git commit --allow-empty -m "Initialize gh-pages branch"
+          git push origin gh-pages:gh-pages
+          git checkout -
+
       - name: Compare against baseline and publish
         id: benchmark_check
         uses: benchmark-action/github-action-benchmark@v1


### PR DESCRIPTION
## Summary

- The Benchmark Regression Check CI job fails with `fatal: couldn't find remote ref gh-pages` because the repo has no `gh-pages` branch yet.
- `github-action-benchmark`'s `auto-push: true` step runs `git fetch origin gh-pages:gh-pages` internally, which hard-fails when the branch doesn't exist remotely.
- Added an "Ensure gh-pages branch exists" step that checks for the branch via `git ls-remote` and, if missing, creates and pushes an empty orphan `gh-pages` branch before the benchmark-publish step runs.

## Test plan

- [ ] Merge to `main` and confirm the `Benchmark Regression Check` workflow run creates/pushes the baseline to `gh-pages` successfully instead of failing on the fetch.

---
_Generated by [Claude Code](https://claude.ai/code/session_011CaT7RcXNJRBWSAQKy2CVN)_