### PR TITLE
ci: seed the gh-pages baseline branch so postsubmit benchmarks can publish

### DIFF
--- a/.github/workflows/benchmark_regression.yaml
+++ b/.github/workflows/benchmark_regression.yaml
@@ -71,6 +71,32 @@ jobs:
           path: benchmark_results/output.txt
           if-no-files-found: error
 
+      # github-action-benchmark hard-fails fetching a missing gh-pages
+      # branch and never creates one, so the compare step below died on
+      # `git fetch gh-pages` before any comparison ran — and the failure
+      # handler misfiled the crash as a performance regression (#939).
+      # Seed an empty baseline branch once; the action pushes real data
+      # onto it from then on.
+      - name: Seed benchmark baseline branch if missing
+        run: |
+          set -euo pipefail
+          status=0
+          git ls-remote --exit-code --heads origin gh-pages >/dev/null || status=$?
+          if [ "$status" -eq 0 ]; then
+            exit 0
+          fi
+          # ls-remote exits 2 for "no matching ref"; anything else is a
+          # transport error and must not be mistaken for a missing branch.
+          if [ "$status" -ne 2 ]; then
+            echo "Checking for the gh-pages baseline failed (git exit $status)" >&2
+            exit "$status"
+          fi
+          empty_tree=$(git hash-object -t tree /dev/null)
+          seed=$(git -c user.name=github-action-benchmark \
+                     -c user.email=github@users.noreply.github.com \
+                     commit-tree "$empty_tree" -m "Initialize benchmark baseline branch")
+          git push origin "$seed:refs/heads/gh-pages"
+
       - name: Compare against baseline and publish
         id: benchmark_check
         uses: benchmark-action/github-action-benchmark@v1


### PR DESCRIPTION
## What broke

Every run of the Benchmark Regression Check since the workflow overhaul in 9b4eee4 (runs 251–253) has failed at the compare step with:

```
git fetch ...github.com/jppittman/pixelflow.git gh-pages:gh-pages
fatal: couldn't find remote ref gh-pages
```

`benchmark-action/github-action-benchmark` fetches the `gh-pages` baseline branch before comparing and hard-fails when the branch doesn't exist — and it has **never** existed on this repo. The pre-9b4eee4 workflow checked for the branch and skipped comparison entirely when it was missing (runs 244–245 "succeeded" this way), so nothing ever seeded a baseline.

The `if: failure()` issue handler then misfiled each crash as a performance regression: issue #939 and both of its follow-up comments were produced by this git failure. No benchmark comparison has ever actually run.

## The fix

Add a step before the compare that seeds an empty orphan `gh-pages` branch when it's missing:

- Built with `git commit-tree` on the empty tree, so the working tree and checked-out ref are untouched.
- `git ls-remote --exit-code`'s "no matching ref" exit (2) is distinguished from transport errors, so a flaky network can't be mistaken for a missing branch.
- The existing `benchmark-baseline` concurrency group already serializes any create-push race between runs.

First post-merge push to `main` seeds the baseline and publishes the first data point; every run after that compares against it, so the regression gate finally does what it claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFebHVZqAyWk67zSts2DDF

---
_Generated by [Claude Code](https://claude.ai/code/session_01RFebHVZqAyWk67zSts2DDF)_