### PR TITLE
fix(pixelflow-pipeline): exclude training CLI bins from `cargo bench --benches`

### DIFF
--- a/pixelflow-pipeline/Cargo.toml
+++ b/pixelflow-pipeline/Cargo.toml
@@ -44,33 +44,47 @@ harness = false
 name = "bench_jit_corpus"
 path = "src/bin/bench_jit_corpus.rs"
 required-features = ["training"]
+# libtest harness rejects Criterion's bencher flags under `cargo bench --benches`.
+bench = false
 
 [[bin]]
 name = "bootstrap_extraction_head"
 path = "src/bin/bootstrap_extraction_head.rs"
 required-features = ["training"]
+# libtest harness rejects Criterion's bencher flags under `cargo bench --benches`.
+bench = false
 
 [[bin]]
 name = "gen_bench_corpus"
 path = "src/bin/gen_bench_corpus.rs"
 required-features = ["training"]
+# libtest harness rejects Criterion's bencher flags under `cargo bench --benches`.
+bench = false
 
 [[bin]]
 name = "bench_jit_profile"
 path = "src/bin/bench_jit_profile.rs"
 required-features = ["training"]
+# libtest harness rejects Criterion's bencher flags under `cargo bench --benches`.
+bench = false
 
 [[bin]]
 name = "validate_corpus"
 path = "src/bin/validate_corpus.rs"
 required-features = ["training"]
+# libtest harness rejects Criterion's bencher flags under `cargo bench --benches`.
+bench = false
 
 [[bin]]
 name = "bench_extraction_3way"
 path = "src/bin/bench_extraction_3way.rs"
 required-features = ["training"]
+# libtest harness rejects Criterion's bencher flags under `cargo bench --benches`.
+bench = false
 
 [[bin]]
 name = "bench_jit_compile_cost"
 path = "src/bin/bench_jit_compile_cost.rs"
 required-features = ["training"]
+# libtest harness rejects Criterion's bencher flags under `cargo bench --benches`.
+bench = false


### PR DESCRIPTION
## What broke

`cargo bench --workspace --benches -- --output-format bencher` (the postsubmit Benchmark Regression Check's run step) now crashes:

```
Running unittests src/bin/bench_extraction_3way.rs (target/release/deps/bench_extraction_3way-a77dd7b7f34f523f)
error: Unrecognized option: 'output-format'
error: bench failed, to rerun pass `-p pixelflow-pipeline --bin bench_extraction_3way`
```

Root cause: 408a775 made `pixelflow-pipeline`'s `training` feature default-on (to get the value-head backward path exercised by presubmit's `--all-features` runs). That had a side effect nobody intended — `cargo bench --benches` selects **any target with `bench = true`**, which is the default for `[[bin]]` targets, not just declared `[[bench]]` targets. With `training` default-enabled, all seven of `pixelflow-pipeline`'s `required-features = ["training"]` CLI tools (`bench_jit_corpus`, `bootstrap_extraction_head`, `gen_bench_corpus`, `bench_jit_profile`, `validate_corpus`, `bench_extraction_3way`, `bench_jit_compile_cost`) now satisfy their required features and get pulled into the bench run. They're clap-based data-generation/training tools, not Criterion harnesses, so none of them understand `--output-format bencher`.

(This is unrelated to the `gh-pages`-branch-missing crash from #939/#951 — that's already fixed on `main` via a separately-landed "Ensure gh-pages branch exists" step. This branch was rebased onto current `main` to pick that up; my earlier redundant fix for it was dropped since main's version is equivalent.)

## The fix

Mark all seven bins `bench = false` in `pixelflow-pipeline/Cargo.toml` — the same treatment `xtask`, `core-term`, and `pixelflow-core`'s `calibrate_costs` bin already use, and the invariant `benchmark_regression.yaml` documents in a comment ("every `[lib]` in the workspace ... sets `bench = false`"; bins were simply missed). They still build and run normally as binaries — only `cargo bench --benches` skips them now.

Verified locally: `cargo bench -p pixelflow-pipeline --benches --no-run` now builds only the two real Criterion targets (`macro_bench`, `nnue_training_suite`); `cargo build -p pixelflow-pipeline --bin bench_extraction_3way --release` still builds the tool fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFebHVZqAyWk67zSts2DDF

---
_Generated by [Claude Code](https://claude.ai/code/session_01RFebHVZqAyWk67zSts2DDF)_