### PR TITLE
revert: restore pre-#959 graphics and compiler behavior

### DIFF
--- a/pixelflow-compiler/src/lib.rs
+++ b/pixelflow-compiler/src/lib.rs
@@ -132,11 +132,15 @@ pub fn kernel(input: TokenStream) -> TokenStream {
     // excludes derivative projections (see `is_transparent_routing_safe`) —
     // their `Field`-domain semantics intentionally differ between backends.
     // The default flips when the parity suite + font goldens say so.
-    // Default JIT routing (Phase 6): eligible closure kernels route to the JIT arena backend.
-    if jit_backend::is_transparent_routing_safe(&optimized)
-        && let Ok(tokens) = jit_backend::emit_jit(&optimized, jit_backend::ZeroParam::Closure)
+    #[cfg(feature = "arena-backend")]
     {
-        return tokens.into();
+        // A body the bridge cannot lower (Err) falls back to the combinator
+        // backend, same as ineligible signatures.
+        if jit_backend::is_transparent_routing_safe(&optimized)
+            && let Ok(tokens) = jit_backend::emit_jit(&optimized, jit_backend::ZeroParam::Closure)
+        {
+            return tokens.into();
+        }
     }
     codegen::emit(optimized).into()
 }

--- a/pixelflow-graphics/examples/chrome_asm.rs
+++ b/pixelflow-graphics/examples/chrome_asm.rs
@@ -1,41 +1,109 @@
-//! ASM inspection for JIT compiled 3D chrome sphere kernel.
+//! ASM inspection - mirrors the exact benchmark pattern
+//!
+//! Run: cargo-asm -p pixelflow-graphics --example chrome_asm eval_one_pixel --release
 
-use pixelflow_core::{Kernel, Lattice};
-use pixelflow_graphics::scene3d::kernel_3d;
+use pixelflow_compiler::ManifoldExpr;
+use pixelflow_core::combinators::At;
+use pixelflow_core::jet::Jet3;
+use pixelflow_core::{Discrete, Field, Manifold, ManifoldCompat};
+use pixelflow_graphics::render::color::RgbaColorCube;
+use pixelflow_graphics::scene3d::{
+    plane, ColorChecker, ColorReflect, ColorScreenToDir, ColorSky, ColorSurface,
+};
+
+type Field4 = (Field, Field, Field, Field);
+type Jet3_4 = (Jet3, Jet3, Jet3, Jet3);
 use std::hint::black_box;
 
-fn build_scene() -> Kernel {
-    let scale = 2.0 / 1080.0f32;
-    let sx = Kernel::x()
-        .sub(&Kernel::constant(1920.0 * 0.5))
-        .mul(&Kernel::constant(scale));
-    let sy = Kernel::constant(1080.0 * 0.5)
-        .sub(&Kernel::y())
-        .mul(&Kernel::constant(scale));
-
-    let (dx, dy, dz) = kernel_3d::screen_to_ray(&sx, &sy, 1.0);
-    let sky = kernel_3d::sky(&dy);
-
-    let (t_sphere, hit_mask) = kernel_3d::sphere_at((0.0, 0.0, 4.0), 1.0, &dx, &dy, &dz);
-    let px = dx.mul(&t_sphere);
-    let py = dy.mul(&t_sphere);
-    let pz = dz.mul(&t_sphere);
-
-    let (_nx, ny, _nz) = kernel_3d::surface_normal(&px, &py, &pz);
-
-    hit_mask.select(&ny, &sky)
+/// Sphere at given center with radius (local to this example).
+#[derive(Clone, Copy, ManifoldExpr)]
+struct SphereAt {
+    center: (f32, f32, f32),
+    radius: f32,
 }
 
+impl Manifold<Jet3_4> for SphereAt {
+    type Output = Jet3;
+
+    #[inline]
+    fn eval(&self, p: Jet3_4) -> Jet3 {
+        let (rx, ry, rz, _w) = p;
+        let cx = Jet3::constant(Field::from(self.center.0));
+        let cy = Jet3::constant(Field::from(self.center.1));
+        let cz = Jet3::constant(Field::from(self.center.2));
+
+        let d_dot_c = rx * cx + ry * cy + rz * cz;
+        let c_sq = cx * cx + cy * cy + cz * cz;
+        let r_sq = Jet3::constant(Field::from(self.radius * self.radius));
+        let discriminant = d_dot_c * d_dot_c - (c_sq - r_sq);
+
+        let epsilon_sq = Jet3::constant(Field::from(0.0001));
+        d_dot_c - (discriminant + epsilon_sq).sqrt()
+    }
+}
+
+// This is the EXACT pattern from the benchmark
+#[derive(Copy, Clone)]
+struct ColorScreenRemap<M> {
+    inner: M,
+    width: f32,
+    height: f32,
+}
+
+impl<M: ManifoldCompat<Field, Output = Discrete>> Manifold<Field4> for ColorScreenRemap<M> {
+    type Output = Discrete;
+
+    #[inline(always)]
+    fn eval(&self, p: Field4) -> Discrete {
+        let (x, y, z, w) = p;
+        let width = Field::from(self.width);
+        let height = Field::from(self.height);
+        let scale = Field::from(2.0) / height;
+        let sx = (x - width * Field::from(0.5)) * scale.clone();
+        let sy = (height * Field::from(0.5) - y) * scale;
+        // Use At combinator to evaluate at transformed coordinates
+        At {
+            inner: &self.inner,
+            x: sx,
+            y: sy,
+            z,
+            w,
+        }
+        .collapse()
+    }
+}
+
+/// Evaluate one pixel - this is what we want ASM for
 #[inline(never)]
-pub fn bake_chrome_scene() {
-    let scene = build_scene();
-    let lattice = Lattice::frame(1920, 1080, 0.0);
-    let baked = lattice.bake(&scene);
-    black_box(baked.buffer());
+#[must_use]
+pub fn eval_one_pixel(x: Field, y: Field) -> Discrete {
+    let world = ColorSurface {
+        geometry: plane(-1.0),
+        material: ColorChecker::<RgbaColorCube>::default(),
+        background: ColorSky::<RgbaColorCube>::default(),
+    };
+
+    let scene = ColorSurface {
+        geometry: SphereAt {
+            center: (0.0, 0.0, 4.0),
+            radius: 1.0,
+        },
+        material: ColorReflect { inner: world },
+        background: world,
+    };
+
+    let renderable = ColorScreenRemap {
+        inner: ColorScreenToDir { inner: scene },
+        width: 1920.0,
+        height: 1080.0,
+    };
+
+    renderable.eval((x, y, Field::from(0.0), Field::from(0.0)))
 }
 
 fn main() {
-    println!("Evaluating JIT compiled chrome scene...");
-    bake_chrome_scene();
-    println!("Done.");
+    let x = Field::sequential(960.0);
+    let y = Field::from(540.0);
+    let result = eval_one_pixel(black_box(x), black_box(y));
+    black_box(result);
 }

--- a/pixelflow-graphics/examples/subdivision_autodiff.rs
+++ b/pixelflow-graphics/examples/subdivision_autodiff.rs
@@ -1,76 +1,89 @@
-//! Subdivision surface rendering with JIT Kernel architecture (`kernel_3d`).
+//! Subdivision surface rendering with automatic differentiation.
+//!
+//! Demonstrates forward-mode AD for surface normals:
+//! - Generates a curved quad mesh procedurally
+//! - Evaluates Catmull-Clark limit surface with Jet3
+//! - Normals emerge from cross(dP/du, dP/dv) automatically
+//! - No finite differences, no extra evaluations
 
-use pixelflow_core::{Kernel, Lattice};
 use pixelflow_graphics::mesh::{Point3, QuadMesh};
-use pixelflow_graphics::scene3d::kernel_3d;
+use pixelflow_graphics::render::color::RgbaColorCube;
+use pixelflow_graphics::render::rasterizer::rasterize;
+use pixelflow_graphics::scene3d::{
+    ColorChecker, ColorReflect, ColorScreenToDir, ColorSky, ColorSurface,
+};
 use pixelflow_graphics::subdivision::{SubdivisionGeometry, SubdivisionPatch};
 use pixelflow_graphics::{Frame, Rgba8};
 
 fn main() {
-    println!("=== Subdivision Surface Demo (JIT Kernel) ===\n");
+    println!("=== Subdivision Surface Autodiff Demo ===\n");
 
+    // Create a simple curved quad mesh
     let mesh = create_curved_quad();
     println!("Generated mesh:");
     println!("  Vertices: {}", mesh.vertex_count());
     println!("  Faces: {}", mesh.face_count());
 
+    // Create subdivision geometry from first patch
     let patch = SubdivisionPatch::from_mesh(&mesh, 0).unwrap();
     println!("\nPatch info:");
     println!("  Corners: {:?}", patch.corners);
     println!("  Valences: {:?}", patch.corner_valences);
     println!("  Extraordinary: {}", patch.is_extraordinary());
 
-    let _geometry = SubdivisionGeometry::new(patch, &mesh, -1.0, 1.0, 0.0, 0.0);
+    let geometry = SubdivisionGeometry::new(
+        patch, &mesh, -1.0, // base_height (intersection plane)
+        1.0,  // uv_scale
+        0.0,  // center_x
+        0.0,  // center_z
+    );
 
+    // Build scene: subdivision surface with checker floor and sky
+    let floor = ColorSurface {
+        geometry: pixelflow_graphics::scene3d::plane(-2.0),
+        material: ColorChecker::<RgbaColorCube>::default(),
+        background: ColorSky::<RgbaColorCube>::default(),
+    };
+
+    let surface = ColorSurface {
+        geometry,
+        material: ColorReflect { inner: floor },
+        background: ColorSky::<RgbaColorCube>::default(),
+    };
+
+    let scene = ColorScreenToDir { inner: surface };
+
+    // Render
     let width = 800;
     let height = 600;
-    let scale = 2.0 / height as f32;
+    println!("\nRendering {}x{} image...", width, height);
 
-    let sx = Kernel::x()
-        .sub(&Kernel::constant(width as f32 * 0.5))
-        .mul(&Kernel::constant(scale));
-    let sy = Kernel::constant(height as f32 * 0.5)
-        .sub(&Kernel::y())
-        .mul(&Kernel::constant(scale));
+    let mut frame = Frame::<Rgba8>::new(width, height);
+    rasterize(&scene, &mut frame, 1);
 
-    let (dx, dy, dz) = kernel_3d::screen_to_ray(&sx, &sy, 1.0);
-    let sky = kernel_3d::sky(&dy);
-
-    let t_sphere = kernel_3d::unit_sphere(&dx, &dy, &dz);
-    let px = dx.mul(&t_sphere);
-    let py = dy.mul(&t_sphere);
-    let pz = dz.mul(&t_sphere);
-
-    let (_nx, ny, _nz) = kernel_3d::surface_normal(&px, &py, &pz);
-
-    let hit = t_sphere.gt(&Kernel::constant(0.0));
-    let scene = hit.select(&ny, &sky);
-
-    println!("\nRendering {}x{} image with JIT Kernel...", width, height);
-
-    let lattice = Lattice::frame(width, height, 0.0);
-    let baked = lattice.bake(&scene);
-    let buffer = baked.buffer();
-
-    let mut frame = Frame::<Rgba8>::new(width as u32, height as u32);
-    for (i, &val) in buffer.iter().enumerate() {
-        let b = (val.clamp(0.0, 1.0) * 255.0) as u8;
-        frame.data[i] = Rgba8::new(b, b, b, 255);
-    }
-
+    // Save to PPM (simple format, no dependencies)
     save_ppm("subdivision_autodiff.ppm", &frame);
+
     println!("\n✓ Rendered to subdivision_autodiff.ppm");
+    println!("\nKey insight: The smooth normals came from Jet3 autodiff.");
+    println!("No finite differences. No extra evaluations. Just algebra.");
 }
 
+/// Create a simple curved quad mesh for testing.
+///
+/// Returns a single quad with corners lifted to form a saddle surface.
 fn create_curved_quad() -> QuadMesh {
+    // Four corners of a quad, with Z displacement for curvature
     let vertices = vec![
-        Point3::new(-1.0, 0.0, -1.0),
-        Point3::new(1.0, 0.0, 1.0),
-        Point3::new(1.0, 0.0, -1.0),
-        Point3::new(-1.0, 0.0, 1.0),
+        Point3::new(-1.0, 0.0, -1.0), // Bottom-left
+        Point3::new(1.0, 0.0, 1.0),   // Bottom-right (lifted)
+        Point3::new(1.0, 0.0, -1.0),  // Top-right
+        Point3::new(-1.0, 0.0, 1.0),  // Top-left (lifted)
     ];
 
     let faces = vec![pixelflow_graphics::mesh::Quad::new(0, 1, 2, 3)];
+
+    // Valence computation
     let valence = vec![1, 1, 1, 1];
 
     QuadMesh {
@@ -80,15 +93,19 @@ fn create_curved_quad() -> QuadMesh {
     }
 }
 
+/// Save frame to PPM format (simple, no external dependencies).
 fn save_ppm(path: &str, frame: &Frame<Rgba8>) {
     use std::fs::File;
     use std::io::Write;
 
     let mut file = File::create(path).expect("Failed to create output file");
+
+    // PPM header
     writeln!(file, "P3").unwrap();
     writeln!(file, "{} {}", frame.width, frame.height).unwrap();
     writeln!(file, "255").unwrap();
 
+    // Pixel data (row-major)
     for y in 0..frame.height {
         for x in 0..frame.width {
             let idx = y * frame.width + x;
@@ -96,4 +113,6 @@ fn save_ppm(path: &str, frame: &Frame<Rgba8>) {
             writeln!(file, "{} {} {}", pixel.r(), pixel.g(), pixel.b()).unwrap();
         }
     }
+
+    println!("Saved to {}", path);
 }

--- a/pixelflow-graphics/src/lib.rs
+++ b/pixelflow-graphics/src/lib.rs
@@ -179,6 +179,7 @@ pub mod transform;
 pub use spatial_bsp::{Positioned, SpatialBSP};
 
 pub use baked::Baked;
+pub use transform::Scale;
 
 // Re-export fonts (user-facing types only)
 pub use fonts::{CachedGlyph, CachedText, Font, GlyphCache};

--- a/pixelflow-graphics/src/scene3d.rs
+++ b/pixelflow-graphics/src/scene3d.rs
@@ -1,201 +1,1147 @@
-//! 3D Scene Rendering Engine built on PixelFlow JIT [`Kernel`].
+//! Three-Layer Pull-Based Architecture:
+//! 1. Geometry: Returns `t` (Jet3)
+//! 2. Surface: Warps `P = ray * t` (Creates tangent frame via Chain Rule)
+//! 3. Material: Reconstructs Normal from `P` derivatives
 //!
-//! Provides coordinate mapping, 3D surface geometry, screen-space tangent frames,
-//! procedural RGB materials, and Householder reflection compiled via `Lattice::bake`.
+//! ## Architecture
+//!
+//! The "mullet" approach for full-color rendering:
+//! - **Front (serious)**: Geometry computed ONCE per pixel via Jet3
+//! - **Back (party)**: Colors flow as opaque `Discrete` (packed RGBA)
+//!
+//! This gives 3x speedup vs running geometry 3x (once per R,G,B channel).
+//!
+//! No iteration. Nesting is occlusion.
 
-use pixelflow_core::Kernel;
+use pixelflow_compiler::{kernel, ManifoldExpr};
+use pixelflow_core::jet::Jet3;
+use pixelflow_core::*;
 
-/// JIT Kernel 3D scene construction utilities.
+/// The standard 4D Field domain type.
+type Field4 = (Field, Field, Field, Field);
+
+/// The 4D Jet3 domain type for 3D ray tracing autodiff.
+type Jet3_4 = (Jet3, Jet3, Jet3, Jet3);
+
+/// The 4D PathJet domain type for recursive ray tracing.
+type PathJet4 = (PathJet<Jet3>, PathJet<Jet3>, PathJet<Jet3>, PathJet<Jet3>);
+
+// ============================================================================
+// LIFT: Field manifold → Jet3 manifold (explicit conversion)
+// ============================================================================
+
+/// Lifts a Field-based manifold to work with Jet3 inputs.
 ///
-/// Builds 3D scene graphs as pure [`Kernel`] values. Tangent frames and surface
-/// normals are derived symbolically via `Dwrt` (`.dx()` / `.dy()`), eliminating
-/// legacy `Jet3` combinators and enabling direct JIT compilation through `Lattice::bake`.
-pub mod kernel_3d {
-    use super::*;
+/// Uses `From<Jet3> for Field` to project jet coordinates to values,
+/// discarding derivatives. Use this for constant-valued manifolds
+/// (like Color) that don't need derivative information.
+#[derive(Clone, Copy, ManifoldExpr)]
+pub struct Lift<M>(pub M);
 
-    /// Screen-to-ray direction transformation for JIT `Kernel` scenes.
-    ///
-    /// Maps `(sx, sy)` screen coordinate kernels into a unit ray direction vector `(dx, dy, dz)`.
-    #[must_use]
-    pub fn screen_to_ray(sx: &Kernel, sy: &Kernel, focal_len: f32) -> (Kernel, Kernel, Kernel) {
-        let sz = Kernel::constant(focal_len);
-        let len_sq = sx.mul(sx).add(&sy.mul(sy)).add(&sz.mul(&sz));
+impl<M: ManifoldCompat<Field> + Send + Sync> Manifold<Jet3_4> for Lift<M> {
+    type Output = M::Output;
+
+    #[inline(always)]
+    fn eval(&self, p: Jet3_4) -> Self::Output {
+        let (x, y, z, w) = p;
+        self.0.eval_raw(x.into(), y.into(), z.into(), w.into())
+    }
+}
+
+// ============================================================================
+// HELPER: Lift Field mask to Jet3 manifold for Select conditions
+// ============================================================================
+
+// ============================================================================
+// ROOT: ScreenToDir
+// ============================================================================
+
+/// Converts screen coordinates to ray direction jets.
+///
+/// **CRITICAL**: This must seed the derivatives correctly.
+/// - Screen X changes by 1.0 per pixel (dx=1, dy=0)
+/// - Screen Y changes by 1.0 per pixel (dx=0, dy=1)
+/// - Direction is normalized(Screen X, Screen Y, 1.0)
+///
+/// The Chain Rule propagates these derivatives into the ray direction,
+/// allowing Materials to know "how the ray changes" across the pixel.
+#[derive(Clone, Copy, ManifoldExpr)]
+pub struct ScreenToDir<M> {
+    pub inner: M,
+}
+
+impl<M: ManifoldCompat<Jet3, Output = Field>> Manifold<Field4> for ScreenToDir<M> {
+    type Output = Field;
+
+    #[inline]
+    fn eval(&self, p: Field4) -> Field {
+        let (x, y, _z, w) = p;
+        // 1. Seed Jets from Screen Coords
+        // x: varies with screen x (dx=1, dy=0, dz=0)
+        let sx = Jet3::x(x);
+        // y: varies with screen y (dx=0, dy=1, dz=0)
+        let sy = Jet3::y(y);
+        // z: constant 1.0 (pinhole focal length, no derivatives)
+        let sz = Jet3::constant(Field::from(1.0));
+
+        // 2. Normalize to get Ray Direction
+        // The Jet math automatically computes d(dir)/dx and d(dir)/dy
+        let len_sq = sx * sx + sy * sy + sz * sz;
         let len = len_sq.sqrt();
-        (sx.div(&len), sy.div(&len), sz.div(&len))
+
+        let dx = sx / len;
+        let dy = sy / len;
+        let dz = sz / len;
+
+        // 3. Pass pure direction Jets to the scene
+        self.inner.eval_raw(dx, dy, dz, Jet3::constant(w))
     }
+}
 
-    /// Unit sphere geometry centered at origin for JIT `Kernel` scenes.
-    #[must_use]
-    pub fn unit_sphere(dx: &Kernel, dy: &Kernel, dz: &Kernel) -> Kernel {
-        let len_sq = dx.mul(dx).add(&dy.mul(dy)).add(&dz.mul(dz));
-        Kernel::constant(1.0).div(&len_sq.sqrt())
+/// Converts screen coordinates to ray direction jets, outputting Discrete.
+///
+/// Same as ScreenToDir but for color (Discrete) pipelines.
+#[derive(Clone, Copy, ManifoldExpr)]
+pub struct ColorScreenToDir<M> {
+    pub inner: M,
+}
+
+impl<M: ManifoldCompat<Jet3, Output = Discrete>> Manifold<Field4> for ColorScreenToDir<M> {
+    type Output = Discrete;
+
+    #[inline]
+    fn eval(&self, p: Field4) -> Discrete {
+        let (x, y, _z, w) = p;
+        let sx = Jet3::x(x);
+        let sy = Jet3::y(y);
+        let sz = Jet3::constant(Field::from(1.0));
+
+        let len_sq = sx * sx + sy * sy + sz * sz;
+        let len = len_sq.sqrt();
+
+        let dx = sx / len;
+        let dy = sy / len;
+        let dz = sz / len;
+
+        self.inner.eval_raw(dx, dy, dz, Jet3::constant(w))
     }
+}
 
-    /// Horizontal plane geometry at height `h` for JIT `Kernel` scenes.
-    #[must_use]
-    pub fn plane(height: f32, dy: &Kernel) -> Kernel {
-        Kernel::constant(height).div(dy)
+// ============================================================================
+// LAYER 1: Geometry (Returns t)
+// ============================================================================
+
+/// Unit sphere geometry kernel.
+///
+/// Computes t = 1/|ray| such that |t * ray| = 1.
+/// Returns Jet3 with value and partial derivatives.
+#[derive(Clone, Copy, Default, ManifoldExpr)]
+pub struct UnitSphere;
+
+impl Manifold<Jet3_4> for UnitSphere {
+    type Output = Jet3;
+
+    #[inline(always)]
+    fn eval(&self, (x, y, z, _w): Jet3_4) -> Jet3 {
+        let one = Jet3::constant(Field::from(1.0));
+        let len_sq = x * x + y * y + z * z;
+        one / len_sq.sqrt()
     }
+}
 
-    /// Sphere centered at `center` with radius `r` for JIT `Kernel` scenes.
-    ///
-    /// Returns `(t_sphere, hit_mask)` where `t_sphere` is the ray intersection distance
-    /// and `hit_mask` is a boolean mask indicating valid non-NaN hits.
-    #[must_use]
-    pub fn sphere_at(
-        center: (f32, f32, f32),
-        radius: f32,
-        dx: &Kernel,
-        dy: &Kernel,
-        dz: &Kernel,
-    ) -> (Kernel, Kernel) {
-        let cx = Kernel::constant(center.0);
-        let cy = Kernel::constant(center.1);
-        let cz = Kernel::constant(center.2);
-        let r_sq = Kernel::constant(radius * radius);
+/// Unit sphere centered at origin.
+/// Solves |t * ray| = 1  =>  t = 1 / |ray|
+#[inline]
+#[must_use]
+pub fn unit_sphere() -> UnitSphere {
+    UnitSphere
+}
 
-        let d_dot_c = dx.mul(&cx).add(&dy.mul(&cy)).add(&dz.mul(&cz));
-        let c_sq = cx.mul(&cx).add(&cy.mul(&cy)).add(&cz.mul(&cz));
+/// Horizontal plane geometry kernel.
+#[derive(Copy, Clone, ManifoldExpr)]
+pub struct PlaneKernel {
+    h: f32,
+}
 
-        let discriminant = d_dot_c.mul(&d_dot_c).sub(&c_sq.sub(&r_sq));
-        let zero = Kernel::constant(0.0);
-        let disc_valid = discriminant.ge(&zero);
-
-        // Clamp negative discriminant to 0.0 before sqrt to prevent NaN propagation
-        let safe_disc = disc_valid.select(&discriminant, &zero);
-        let t_sphere = d_dot_c.sub(&safe_disc.sqrt());
-        let hit = disc_valid.and(&t_sphere.gt(&zero));
-
-        (t_sphere, hit)
+impl Manifold<Jet3_4> for PlaneKernel {
+    type Output = Jet3;
+    #[inline(always)]
+    fn eval(&self, p: Jet3_4) -> Jet3 {
+        let h = Jet3::from(Field::from(self.h));
+        h / p.1 // h / Y
     }
+}
 
-    /// Computes unit surface normal `(Nx, Ny, Nz)` from hit position `(Px, Py, Pz)`.
-    ///
-    /// Derives screen-space tangent vectors `Tx = ∂P/∂X` and `Ty = ∂P/∂Y` using `Dwrt`
-    /// (`.dx()` and `.dy()`), and computes their normalized cross product `Tx × Ty`.
+/// Horizontal plane at y = height.
+/// Solves P.y = height => t * ry = height => t = height / ry
+#[allow(dead_code)]
+#[must_use]
+pub fn plane(height: f32) -> PlaneKernel {
+    PlaneKernel { h: height }
+}
+
+// ============================================================================
+// PATHJET GEOMETRY: Spheres with arbitrary ray origins
+// ============================================================================
+
+/// Sphere for PathJet rays (supports arbitrary ray origins).
+///
+/// Unlike the Jet3_4 sphere which assumes rays from camera at origin,
+/// this handles rays with explicit origin and direction components.
+///
+/// Ray equation: P(t) = O + t*D
+/// Sphere: |P - C|² = r²
+/// Solution: t = -(oc·D) - sqrt((oc·D)² - (|oc|² - r²))
+///   where oc = O - C (vector from center to ray origin)
+#[derive(Clone, Copy, ManifoldExpr)]
+pub struct PathJetSphere {
+    pub center: (f32, f32, f32),
+    pub radius: f32,
+}
+
+impl PathJetSphere {
     #[must_use]
-    pub fn surface_normal(px: &Kernel, py: &Kernel, pz: &Kernel) -> (Kernel, Kernel, Kernel) {
-        let tx_x = px.dx();
-        let tx_y = py.dx();
-        let tx_z = pz.dx();
-
-        let ty_x = px.dy();
-        let ty_y = py.dy();
-        let ty_z = pz.dy();
-
-        let nx = tx_y.mul(&ty_z).sub(&tx_z.mul(&ty_y));
-        let ny = tx_z.mul(&ty_x).sub(&tx_x.mul(&ty_z));
-        let nz = tx_x.mul(&ty_y).sub(&tx_y.mul(&ty_x));
-
-        let len_sq = nx.mul(&nx).add(&ny.mul(&ny)).add(&nz.mul(&nz));
-        let inv_len = len_sq.sqrt().recip();
-
-        (nx.mul(&inv_len), ny.mul(&inv_len), nz.mul(&inv_len))
+    pub fn new(center: (f32, f32, f32), radius: f32) -> Self {
+        Self { center, radius }
     }
+}
 
-    /// Sky gradient scalar material kernel.
-    #[must_use]
-    pub fn sky(dy: &Kernel) -> Kernel {
-        sky_rgb(dy).2
+impl Manifold<PathJet4> for PathJetSphere {
+    type Output = Jet3;
+
+    #[inline]
+    fn eval(&self, p: PathJet4) -> Jet3 {
+        let (x, y, z, _w) = p;
+        let cx = Jet3::constant(Field::from(self.center.0));
+        let cy = Jet3::constant(Field::from(self.center.1));
+        let cz = Jet3::constant(Field::from(self.center.2));
+        let r_sq = Jet3::constant(Field::from(self.radius * self.radius));
+        let eps = Jet3::constant(Field::from(0.0001));
+
+        // oc = O - C (origin minus center)
+        let oc_x = x.val - cx;
+        let oc_y = y.val - cy;
+        let oc_z = z.val - cz;
+
+        // Direction (assume normalized or will normalize later)
+        let dx = x.dir;
+        let dy = y.dir;
+        let dz = z.dir;
+
+        // oc·D (dot product)
+        let oc_dot_d = oc_x * dx + oc_y * dy + oc_z * dz;
+
+        // |oc|²
+        let oc_sq = oc_x * oc_x + oc_y * oc_y + oc_z * oc_z;
+
+        // discriminant = (oc·D)² - (|oc|² - r²)
+        let discriminant = oc_dot_d * oc_dot_d - (oc_sq - r_sq);
+
+        // t = -(oc·D) - sqrt(discriminant + epsilon)
+        let zero = Jet3::constant(Field::from(0.0));
+        let neg_oc_dot_d = zero - oc_dot_d;
+        neg_oc_dot_d - (discriminant + eps).sqrt()
     }
+}
 
-    /// Sky gradient RGB material kernel (deep horizon sky blue).
-    #[must_use]
-    pub fn sky_rgb(dy: &Kernel) -> (Kernel, Kernel, Kernel) {
-        let t = dy.mul(&Kernel::constant(0.5)).add(&Kernel::constant(0.5));
-        let clamped = t.max(&Kernel::constant(0.0)).min(&Kernel::constant(1.0));
+/// Also implement Jet3_4 for PathJetSphere (backwards compatibility).
+/// When used with Jet3_4, assumes origin = 0 (camera at origin).
+impl Manifold<Jet3_4> for PathJetSphere {
+    type Output = Jet3;
 
-        let r = Kernel::constant(0.7).sub(&clamped.mul(&Kernel::constant(0.5)));
-        let g = Kernel::constant(0.85).sub(&clamped.mul(&Kernel::constant(0.45)));
-        let b = Kernel::constant(1.0).sub(&clamped.mul(&Kernel::constant(0.2)));
+    #[inline]
+    fn eval(&self, p: Jet3_4) -> Jet3 {
+        let (rx, ry, rz, _w) = p;
+        let cx = Jet3::constant(Field::from(self.center.0));
+        let cy = Jet3::constant(Field::from(self.center.1));
+        let cz = Jet3::constant(Field::from(self.center.2));
+        let r_sq = Jet3::constant(Field::from(self.radius * self.radius));
+        let eps = Jet3::constant(Field::from(0.0001));
 
-        (r, g, b)
+        // For origin at 0: oc = -C
+        // oc·D = -C·D = -(D·C)
+        // So -(oc·D) = D·C
+        let d_dot_c = rx * cx + ry * cy + rz * cz;
+
+        // |oc|² = |C|²
+        let c_sq = cx * cx + cy * cy + cz * cz;
+
+        // discriminant = (D·C)² - (|C|² - r²)
+        let discriminant = d_dot_c * d_dot_c - (c_sq - r_sq);
+
+        // t = (D·C) - sqrt(discriminant + epsilon)
+        d_dot_c - (discriminant + eps).sqrt()
     }
+}
 
-    /// 2D procedural warm/cool checkerboard pattern RGB over `(px, pz)`.
-    #[must_use]
-    pub fn checker_rgb(px: &Kernel, pz: &Kernel, scale: f32) -> (Kernel, Kernel, Kernel) {
-        let inv_scale = Kernel::constant(1.0 / scale);
-        let cx = px.mul(&inv_scale).floor();
-        let cz = pz.mul(&inv_scale).floor();
+/// Height field geometry: z = base_height + scale * f(x, y)
+///
+/// Single-step intersection: hit base plane, sample height, adjust t.
+/// No iteration - just one evaluation of the height manifold.
+#[derive(Clone, Copy, ManifoldExpr)]
+pub struct HeightFieldGeometry<H> {
+    pub height_field: H,
+    pub base_height: f32,
+    pub scale: f32,
+    pub uv_scale: f32, // Maps world coords to (u, v) parameter space
+    pub center_x: f32, // World x offset (patch centered here)
+    pub center_z: f32, // World z offset (patch centered here)
+}
 
-        let two = Kernel::constant(2.0);
-        let x_even = cx.sub(&cx.div(&two).floor().mul(&two));
-        let z_even = cz.sub(&cz.div(&two).floor().mul(&two));
+impl<H: ManifoldCompat<Field, Output = Field>> Manifold<Jet3_4> for HeightFieldGeometry<H> {
+    type Output = Jet3;
 
-        let diff = x_even.sub(&z_even).abs();
-        let is_even = diff.lt(&Kernel::constant(0.5));
+    #[inline]
+    fn eval(&self, p: Jet3_4) -> Jet3 {
+        let (rx, ry, rz, _w) = p;
+        // Step 1: Hit base plane at y = base_height
+        let t_plane = Jet3::constant(Field::from(self.base_height)) / ry;
 
-        // Warm tile: (0.95, 0.90, 0.80), Cool tile: (0.20, 0.25, 0.30)
-        let r = is_even.select(&Kernel::constant(0.95), &Kernel::constant(0.20));
-        let g = is_even.select(&Kernel::constant(0.90), &Kernel::constant(0.25));
-        let b = is_even.select(&Kernel::constant(0.80), &Kernel::constant(0.30));
+        // Step 2: Get (x, z) world coords at plane hit (note: scene uses y-up)
+        let hit_x = rx * t_plane;
+        let hit_z = rz * t_plane;
 
-        (r, g, b)
-    }
+        // Step 3: Map to (u, v) centered on (center_x, center_z)
+        let uv_scale = Field::from(self.uv_scale);
+        let half = Field::from(0.5);
+        let u = ((hit_x.val - Field::from(self.center_x)) * uv_scale + half).constant();
+        let v = ((hit_z.val - Field::from(self.center_z)) * uv_scale + half).constant();
 
-    /// Householder reflection ray direction `(Rx, Ry, Rz)` from incident `(Dx, Dy, Dz)` and normal `(Nx, Ny, Nz)`.
-    #[must_use]
-    #[allow(clippy::too_many_arguments)]
-    pub fn reflect(
-        dx: &Kernel,
-        dy: &Kernel,
-        dz: &Kernel,
-        nx: &Kernel,
-        ny: &Kernel,
-        nz: &Kernel,
-    ) -> (Kernel, Kernel, Kernel) {
-        let d_dot_n = dx.mul(nx).add(&dy.mul(ny)).add(&dz.mul(nz));
-        let k = Kernel::constant(2.0).mul(&d_dot_n);
-        (dx.sub(&k.mul(nx)), dy.sub(&k.mul(ny)), dz.sub(&k.mul(nz)))
-    }
+        // Bounds check: (u, v) must be in [0, 1]
+        let zero = Field::from(0.0);
+        let one = Field::from(1.0);
+        let in_bounds = u.ge(zero) & u.le(one) & v.ge(zero) & v.le(one);
 
-    /// World scene background RGB (warm/cool checkerboard floor + sky gradient).
-    #[must_use]
-    pub fn world_rgb(dx: &Kernel, dy: &Kernel, dz: &Kernel) -> (Kernel, Kernel, Kernel) {
-        let floor_height = -1.0f32;
-        let t_floor = Kernel::constant(floor_height).div(dy);
+        // Sample height field
+        let h = self.height_field.eval_raw(u, v, zero, zero);
 
-        let px_floor = dx.mul(&t_floor);
-        let pz_floor = dz.mul(&t_floor);
+        // Step 4: Adjust t for height displacement
+        let effective_height =
+            (Field::from(self.base_height) + Field::from(self.scale) * h).constant();
+        let t_hit = Jet3::constant(effective_height) / ry;
 
-        let (fr, fg, fb) = checker_rgb(&px_floor, &pz_floor, 1.0);
-        let (sr, sg, sb) = sky_rgb(dy);
-
-        let hit_floor = dy.lt(&Kernel::constant(0.0));
-        (
-            hit_floor.select(&fr, &sr),
-            hit_floor.select(&fg, &sg),
-            hit_floor.select(&fb, &sb),
+        // Return valid t if in bounds, else negative (miss)
+        let miss = Field::from(-1.0);
+        Jet3::new(
+            in_bounds.select(t_hit.val, miss),
+            in_bounds.select(t_hit.dx, miss),
+            in_bounds.select(t_hit.dy, miss),
+            in_bounds.select(t_hit.dz, miss),
         )
     }
+}
 
-    /// Complete 3D reflective chrome sphere scene returning `(R, G, B)` Kernels over screen coordinates `(sx, sy)`.
-    #[must_use]
-    pub fn chrome_scene_rgb(
-        sx: &Kernel,
-        sy: &Kernel,
-        sphere_center: (f32, f32, f32),
-        radius: f32,
-    ) -> (Kernel, Kernel, Kernel) {
-        let (dx, dy, dz) = screen_to_ray(sx, sy, 1.0);
-        let (dr, dg, db) = world_rgb(&dx, &dy, &dz);
+// ============================================================================
+// LAYER 2: Surface (The Warp)
+// ============================================================================
 
-        let (t_sphere, hit_sphere) = sphere_at(sphere_center, radius, &dx, &dy, &dz);
+// The Glue. Combines Geometry, Material, and Background.
+//
+// Performs **The Warp**: `P = ray * t`.
+// Because `t` carries derivatives from Layer 1, and `ray` carries derivatives
+// from Root, `P` automatically contains the Surface Tangent Frame via the Chain Rule.
+//
+// Evaluates geometry to get t, computes hit point P = ray * t, then selects
+// between material (at P) and background based on hit validity.
+kernel!(pub struct Surface = |geometry: kernel, material: kernel, background: kernel| Jet3 -> Field {
+    // 1. Get distance t from geometry
+    let t = geometry;
 
-        let px = dx.mul(&t_sphere);
-        let py = dy.mul(&t_sphere);
-        let pz = dz.mul(&t_sphere);
+    // 2. Validate hit: t > 0, t < max, derivatives reasonable
+    let t_max = 1000000.0;
+    let deriv_max = 10000.0;
+    let valid_t = (V(t) > 0.0) & (V(t) < t_max);
+    let deriv_mag_sq = DX(t) * DX(t) + DY(t) * DY(t) + DZ(t) * DZ(t);
+    let valid_deriv = deriv_mag_sq < (deriv_max * deriv_max);
+    let mask = valid_t & valid_deriv;
 
-        let (nx, ny, nz) = surface_normal(&px, &py, &pz);
-        let (rx, ry, rz) = reflect(&dx, &dy, &dz, &nx, &ny, &nz);
+    // 3. Hit point: P = ray * t (always computed; Select short-circuits if mask is all-false)
+    let hx = X * t;
+    let hy = Y * t;
+    let hz = Z * t;
 
-        let (rr, rg, rb) = world_rgb(&rx, &ry, &rz);
+    // 4. Sample material at hit point, background at ray direction
+    let mat_val = material.at(hx, hy, hz, W);
+    let bg_val = background;
 
-        (
-            hit_sphere.select(&rr, &dr),
-            hit_sphere.select(&rg, &dg),
-            hit_sphere.select(&rb, &db),
-        )
+    // 5. Select based on hit validity (short-circuit avoids evaluating unused branch)
+    mask.select(mat_val, bg_val)
+});
+
+// Color Surface: geometry + material + background, outputs Discrete.
+kernel!(pub struct ColorSurface = |geometry: kernel, material: kernel, background: kernel| Jet3 -> Discrete {
+    // 1. Get distance t from geometry
+    let t = geometry;
+
+    // 2. Validate hit: t > 0, t < max, derivatives reasonable
+    let t_max = 1000000.0;
+    let deriv_max = 10000.0;
+    let valid_t = (V(t) > 0.0) & (V(t) < t_max);
+    let deriv_mag_sq = DX(t) * DX(t) + DY(t) * DY(t) + DZ(t) * DZ(t);
+    let valid_deriv = deriv_mag_sq < (deriv_max * deriv_max);
+    let mask = valid_t & valid_deriv;
+
+    // 3. Hit point: P = ray * t (always computed; Select short-circuits if mask is all-false)
+    let hx = X * t;
+    let hy = Y * t;
+    let hz = Z * t;
+
+    // 4. Sample material at hit point, background at ray direction
+    let mat_val = material.at(hx, hy, hz, W);
+    let bg_val = background;
+
+    // 5. Select based on hit validity (short-circuit avoids evaluating unused branch)
+    mask.select(mat_val, bg_val)
+});
+
+// ... SCENE COMPOSITION ...
+
+// ============================================================================
+// SCENE COMPOSITION: Union via priority order
+// ============================================================================
+
+/// A Scene separates hit detection (mask) from appearance (color).
+///
+/// This enables Union composition: check S1 first, if miss check S2.
+/// "First hit in scene graph wins" - not distance-based, but priority-based.
+pub trait Scene {
+    /// Mask manifold: evaluates to positive where ray hits this scene.
+    type Mask: ManifoldCompat<Jet3, Output = Field>;
+    /// Color manifold: evaluates to the color at the hit point.
+    type Color: ManifoldCompat<Jet3, Output = Discrete>;
+
+    fn mask(&self) -> Self::Mask;
+    fn color(&self) -> Self::Color;
+}
+
+/// Union of two scenes: first hit wins.
+///
+/// Evaluates S1's mask first. If hit, use S1's color.
+/// Otherwise, evaluate S2's mask. If hit, use S2's color.
+/// Otherwise, use background.
+#[derive(Clone, Copy, ManifoldExpr)]
+pub struct Union<S1, S2, B> {
+    pub first: S1,
+    pub second: S2,
+    pub background: B,
+}
+
+impl<S1, S2, B> Manifold<Jet3_4> for Union<S1, S2, B>
+where
+    S1: Scene + Send + Sync,
+    S2: Scene + Send + Sync,
+    B: ManifoldCompat<Jet3, Output = Discrete>,
+{
+    type Output = Discrete;
+
+    #[inline]
+    fn eval(&self, p: Jet3_4) -> Discrete {
+        let (rx, ry, rz, w) = p;
+        // First hit wins: nested Select
+        // Select(S1.mask, S1.color, Select(S2.mask, S2.color, background))
+        let m1 = self.first.mask();
+        let c1 = self.first.color();
+        let m2 = self.second.mask();
+        let c2 = self.second.color();
+
+        let mask1 = m1.eval_raw(rx, ry, rz, w);
+        let mask2 = m2.eval_raw(rx, ry, rz, w);
+
+        // Inner select: S2 vs background
+        let color2 = c2.eval_raw(rx, ry, rz, w);
+        let bg_color = self.background.eval_raw(rx, ry, rz, w);
+        let inner = Discrete::select(mask2, color2, bg_color);
+
+        // Outer select: S1 vs inner
+        let color1 = c1.eval_raw(rx, ry, rz, w);
+        Discrete::select(mask1, color1, inner)
+    }
+}
+
+/// Simple scene wrapper: geometry + material with explicit mask exposure.
+///
+/// Unlike ColorSurface which hides the mask, SceneObject exposes it
+/// for use in Union composition.
+#[derive(Clone, Copy, ManifoldExpr)]
+pub struct SceneObject<G, M> {
+    pub geometry: G,
+    pub material: M,
+}
+
+/// Color manifold for material evaluation at hit point.
+#[derive(Clone, Copy, ManifoldExpr)]
+pub struct GeometryColor<G, M> {
+    geometry: G,
+    material: M,
+}
+
+impl<G, M> Manifold<Jet3_4> for GeometryColor<G, M>
+where
+    G: ManifoldCompat<Jet3, Output = Jet3>,
+    M: ManifoldCompat<Jet3, Output = Discrete>,
+{
+    type Output = Discrete;
+
+    #[inline]
+    fn eval(&self, p: Jet3_4) -> Discrete {
+        let (rx, ry, rz, w) = p;
+        let t = self.geometry.eval_raw(rx, ry, rz, w);
+
+        // Compute hit point: P = ray * t
+        let hx = rx * t;
+        let hy = ry * t;
+        let hz = rz * t;
+
+        // Evaluate material at hit point
+        self.material.eval_raw(hx, hy, hz, w)
+    }
+}
+
+// Mask manifold for geometry hit detection.
+kernel!(pub struct GeometryMask = |geometry: kernel| Jet3 -> Field {
+    let t = geometry;
+    let t_max = 1000000.0;
+    let deriv_max = 10000.0;
+
+    // Valid if: t > 0, t < max, derivatives reasonable
+    let valid_t = (V(t) > 0.0) & (V(t) < t_max);
+    let deriv_mag_sq = DX(t) * DX(t) + DY(t) * DY(t) + DZ(t) * DZ(t);
+    let valid_deriv = deriv_mag_sq < (deriv_max * deriv_max);
+
+    valid_t & valid_deriv
+});
+
+impl<G, M> Scene for SceneObject<G, M>
+where
+    G: ManifoldCompat<Jet3, Output = Jet3> + ManifoldExpr + Clone + Copy + Send + Sync,
+    M: ManifoldCompat<Jet3, Output = Discrete> + ManifoldExpr + Clone + Copy + Send + Sync,
+{
+    type Mask = GeometryMask<G>;
+    type Color = GeometryColor<G, M>;
+
+    fn mask(&self) -> Self::Mask {
+        GeometryMask {
+            geometry: self.geometry,
+        }
+    }
+
+    fn color(&self) -> Self::Color {
+        GeometryColor {
+            geometry: self.geometry,
+            material: self.material,
+        }
+    }
+}
+
+// ============================================================================
+// LAYER 3: Materials
+// ============================================================================
+
+/// Reflect: The Crown Jewel.
+/// Reconstructs surface normal from the Tangent Frame implied by the Jet derivatives.
+#[derive(Clone, Copy, ManifoldExpr)]
+pub struct Reflect<M> {
+    pub inner: M,
+}
+
+impl<M: ManifoldCompat<Jet3, Output = Field>> Manifold<Jet3_4> for Reflect<M> {
+    type Output = Field;
+
+    #[inline]
+    fn eval(&self, p: Jet3_4) -> Field {
+        let (x, y, z, w) = p;
+        // The input (x, y, z) is the hit point P with derivatives dP/dscreen.
+        // We need to compute the reflected direction R with derivatives dR/dscreen.
+        //
+        // For a sphere, the normal N = normalize(P - center).
+        // Since center is constant, N = normalize(P) (for unit sphere at origin style).
+        // Actually for our warp, P = t * ray_dir, and we want N pointing outward.
+        //
+        // Key insight: The normal IS the normalized hit point direction for a sphere
+        // centered at origin. For SphereAt, we'd need (P - center), but our P already
+        // encodes the surface position.
+        //
+        // For a general surface, N comes from the tangent cross product.
+        // But the tangent vectors Tu, Tv ARE the derivatives dP/dx, dP/dy.
+        // So N = normalize(Tu × Tv) where Tu = (x.dx, y.dx, z.dx), Tv = (x.dy, y.dy, z.dy).
+
+        let p_len_sq = x * x + y * y + z * z;
+        let p_len = p_len_sq.sqrt();
+        let one = Jet3::constant(Field::from(1.0));
+        let inv_p_len = one / p_len;
+
+        // Extract tangent vectors (as scalars)
+        let tu = (x.dx, y.dx, z.dx);
+        let tv = (x.dy, y.dy, z.dy);
+
+        // Cross product Tv × Tu for outward normal
+        // Build expression tree, evaluate at Jet3 struct construction boundaries
+        let cross_x = tv.1 * tu.2 - tv.2 * tu.1;
+        let cross_y = tv.2 * tu.0 - tv.0 * tu.2;
+        let cross_z = tv.0 * tu.1 - tv.1 * tu.0;
+
+        // Build the normalized normal as a single expression tree
+        // All operations stay as AST nodes until final evaluation
+        let fzero = Field::from(0.0);
+        let n_len_sq = cross_x.clone() * cross_x.clone()
+            + cross_y.clone() * cross_y.clone()
+            + cross_z.clone() * cross_z.clone();
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+
+        // Normal components - evaluate at Jet3 construction boundary
+        let nx = (cross_x * inv_n_len.clone()).constant();
+        let ny = (cross_y * inv_n_len.clone()).constant();
+        let nz = (cross_z * inv_n_len).constant();
+
+        // Incident direction (normalized hit point direction from origin)
+        let d_x = (x.val * inv_p_len.val).constant();
+        let d_y = (y.val * inv_p_len.val).constant();
+        let d_z = (z.val * inv_p_len.val).constant();
+
+        // D·N (cosine of incidence angle) for curvature scaling
+        let d_dot_n_scalar = (d_x * nx + d_y * ny + d_z * nz).constant();
+
+        // Curvature-aware scaling: reflection magnifies angular spread
+        // Scale = 2 / |cos(incidence)|, clamped to avoid infinity
+        let cos_incidence = d_dot_n_scalar.abs().max(Field::from(0.1));
+        let curvature_scale = (Field::from(2.0) / cos_incidence).constant();
+
+        let n_jet_x = Jet3 {
+            val: nx,
+            dx: (x.dx * curvature_scale).constant(),
+            dy: (x.dy * curvature_scale).constant(),
+            dz: fzero,
+        };
+        let n_jet_y = Jet3 {
+            val: ny,
+            dx: (y.dx * curvature_scale).constant(),
+            dy: (y.dy * curvature_scale).constant(),
+            dz: fzero,
+        };
+        let n_jet_z = Jet3 {
+            val: nz,
+            dx: (z.dx * curvature_scale).constant(),
+            dy: (z.dy * curvature_scale).constant(),
+            dz: fzero,
+        };
+
+        // D as Jets (normalized P)
+        let d_jet_x = x * inv_p_len;
+        let d_jet_y = y * inv_p_len;
+        let d_jet_z = z * inv_p_len;
+
+        // Householder Reflection: R = D - 2(D·N)N
+        let d_dot_n = d_jet_x * n_jet_x + d_jet_y * n_jet_y + d_jet_z * n_jet_z;
+        let two = Jet3::constant(Field::from(2.0));
+        let k = two * d_dot_n;
+
+        let r_x = d_jet_x - k * n_jet_x;
+        let r_y = d_jet_y - k * n_jet_y;
+        let r_z = d_jet_z - k * n_jet_z;
+
+        // Recurse with curved reflected rays
+        self.inner.eval_raw(r_x, r_y, r_z, w)
+    }
+}
+
+/// Color Reflect: Householder reflection, wraps Discrete material.
+#[derive(Clone, Copy, ManifoldExpr)]
+pub struct ColorReflect<M> {
+    pub inner: M,
+}
+
+impl<M: ManifoldCompat<Jet3, Output = Discrete>> Manifold<Jet3_4> for ColorReflect<M> {
+    type Output = Discrete;
+
+    #[inline(always)]
+    fn eval(&self, p: Jet3_4) -> Discrete {
+        let (x, y, z, w) = p;
+        let p_len_sq = x * x + y * y + z * z;
+        let p_len = p_len_sq.sqrt();
+        let one = Jet3::constant(Field::from(1.0));
+        let inv_p_len = one / p_len;
+
+        let tu = (x.dx, y.dx, z.dx);
+        let tv = (x.dy, y.dy, z.dy);
+
+        // Cross product Tv × Tu for outward normal - build expression tree
+        let cross_x = tv.1 * tu.2 - tv.2 * tu.1;
+        let cross_y = tv.2 * tu.0 - tv.0 * tu.2;
+        let cross_z = tv.0 * tu.1 - tv.1 * tu.0;
+
+        // Build normalized normal as expression tree, evaluate at boundaries
+        let fzero = Field::from(0.0);
+        let n_len_sq = cross_x.clone() * cross_x.clone()
+            + cross_y.clone() * cross_y.clone()
+            + cross_z.clone() * cross_z.clone();
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+
+        // Normal components - evaluate at Jet3 construction boundary
+        let nx = (cross_x * inv_n_len.clone()).constant();
+        let ny = (cross_y * inv_n_len.clone()).constant();
+        let nz = (cross_z * inv_n_len).constant();
+
+        // Incident direction (normalized hit point direction from origin)
+        let d_x = (x.val * inv_p_len.val).constant();
+        let d_y = (y.val * inv_p_len.val).constant();
+        let d_z = (z.val * inv_p_len.val).constant();
+
+        // D·N (cosine of incidence angle) for curvature scaling
+        let d_dot_n_scalar = (d_x * nx + d_y * ny + d_z * nz).constant();
+
+        // Curvature-aware scaling: reflection magnifies angular spread
+        // Scale = 2 / |cos(incidence)|, clamped to avoid infinity
+        let cos_incidence = d_dot_n_scalar.abs().max(Field::from(0.1));
+        let curvature_scale = (Field::from(2.0) / cos_incidence).constant();
+
+        let n_jet_x = Jet3 {
+            val: nx,
+            dx: (x.dx * curvature_scale).constant(),
+            dy: (x.dy * curvature_scale).constant(),
+            dz: fzero,
+        };
+        let n_jet_y = Jet3 {
+            val: ny,
+            dx: (y.dx * curvature_scale).constant(),
+            dy: (y.dy * curvature_scale).constant(),
+            dz: fzero,
+        };
+        let n_jet_z = Jet3 {
+            val: nz,
+            dx: (z.dx * curvature_scale).constant(),
+            dy: (z.dy * curvature_scale).constant(),
+            dz: fzero,
+        };
+
+        let d_jet_x = x * inv_p_len;
+        let d_jet_y = y * inv_p_len;
+        let d_jet_z = z * inv_p_len;
+
+        let d_dot_n = d_jet_x * n_jet_x + d_jet_y * n_jet_y + d_jet_z * n_jet_z;
+        let two = Jet3::constant(Field::from(2.0));
+        let k = two * d_dot_n;
+
+        let r_x = d_jet_x - k * n_jet_x;
+        let r_y = d_jet_y - k * n_jet_y;
+        let r_z = d_jet_z - k * n_jet_z;
+
+        self.inner.eval_raw(r_x, r_y, r_z, w)
+    }
+}
+
+// ============================================================================
+// PATHJET-BASED REFLECTION: Generic reflection for any surface
+// ============================================================================
+
+use pixelflow_core::jet::PathJet;
+
+/// Generalized Reflect for PathJet coordinates.
+///
+/// This implementation works with ANY surface - it extracts the normal from
+/// the hit point's tangent frame (derivatives) and reflects the ray direction.
+///
+/// ## Input Contract
+///
+/// The PathJet coordinates encode:
+/// - `val`: The hit point P on a surface (Jet3 with screen derivatives)
+/// - `dir`: The incoming ray direction D (Jet3)
+///
+/// The hit point's derivatives (`val.dx`, `val.dy`) form the tangent frame,
+/// from which we compute the surface normal via cross product.
+///
+/// ## Output
+///
+/// Creates a reflected ray:
+/// - `val`: Same hit point (new ray origin)
+/// - `dir`: Reflected direction R = D - 2(D·N)N
+impl<M> Manifold<PathJet4> for Reflect<M>
+where
+    M: ManifoldCompat<PathJet<Jet3>, Output = Field>,
+{
+    type Output = Field;
+
+    #[inline]
+    fn eval(&self, p: PathJet4) -> Field {
+        let (x, y, z, w) = p;
+        // ====================================================================
+        // 1. Extract surface normal from hit point's tangent frame
+        // ====================================================================
+
+        // Hit point P = (x.val, y.val, z.val) with screen derivatives
+        // Tangent vectors: Tu = dP/dscreen_x, Tv = dP/dscreen_y
+        let tu = (x.val.dx, y.val.dx, z.val.dx);
+        let tv = (x.val.dy, y.val.dy, z.val.dy);
+
+        // Normal = Tv × Tu (cross product, ordering for outward normal)
+        let cross_x = tv.1 * tu.2 - tv.2 * tu.1;
+        let cross_y = tv.2 * tu.0 - tv.0 * tu.2;
+        let cross_z = tv.0 * tu.1 - tv.1 * tu.0;
+
+        // Normalize - build expression tree, clone for reuse
+        let n_len_sq = cross_x.clone() * cross_x.clone()
+            + cross_y.clone() * cross_y.clone()
+            + cross_z.clone() * cross_z.clone();
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+
+        let nx = (cross_x * inv_n_len.clone()).constant();
+        let ny = (cross_y * inv_n_len.clone()).constant();
+        let nz = (cross_z * inv_n_len).constant();
+
+        // ====================================================================
+        // 2. Get incoming direction D (from PathJet.dir)
+        // ====================================================================
+
+        // Normalize the incoming direction
+        let d_len_sq = x.dir * x.dir + y.dir * y.dir + z.dir * z.dir;
+        let inv_d_len = Jet3::constant(Field::from(1.0)) / d_len_sq.sqrt();
+
+        let dx = x.dir * inv_d_len;
+        let dy = y.dir * inv_d_len;
+        let dz = z.dir * inv_d_len;
+
+        // ====================================================================
+        // 3. Curvature-aware derivative scaling for AA
+        // ====================================================================
+
+        // Compute D·N for curvature scaling
+        let d_dot_n_scalar = (dx.val * nx + dy.val * ny + dz.val * nz).constant();
+        let cos_incidence = d_dot_n_scalar.abs().max(Field::from(0.1));
+        let curvature_scale = (Field::from(2.0) / cos_incidence).constant();
+
+        // Normal as Jet3 with scaled derivatives
+        let fzero = Field::from(0.0);
+        let n_jet_x = Jet3 {
+            val: nx,
+            dx: (x.val.dx * curvature_scale).constant(),
+            dy: (x.val.dy * curvature_scale).constant(),
+            dz: fzero,
+        };
+        let n_jet_y = Jet3 {
+            val: ny,
+            dx: (y.val.dx * curvature_scale).constant(),
+            dy: (y.val.dy * curvature_scale).constant(),
+            dz: fzero,
+        };
+        let n_jet_z = Jet3 {
+            val: nz,
+            dx: (z.val.dx * curvature_scale).constant(),
+            dy: (z.val.dy * curvature_scale).constant(),
+            dz: fzero,
+        };
+
+        // ====================================================================
+        // 4. Householder reflection: R = D - 2(D·N)N
+        // ====================================================================
+
+        let d_dot_n = dx * n_jet_x + dy * n_jet_y + dz * n_jet_z;
+        let two = Jet3::constant(Field::from(2.0));
+        let k = two * d_dot_n;
+
+        let r_x = dx - k * n_jet_x;
+        let r_y = dy - k * n_jet_y;
+        let r_z = dz - k * n_jet_z;
+
+        // ====================================================================
+        // 5. Create reflected ray and recurse
+        // ====================================================================
+
+        // New ray: origin = hit point, direction = reflected
+        let reflected_x = PathJet {
+            val: x.val,
+            dir: r_x,
+        };
+        let reflected_y = PathJet {
+            val: y.val,
+            dir: r_y,
+        };
+        let reflected_z = PathJet {
+            val: z.val,
+            dir: r_z,
+        };
+        let reflected_w = PathJet {
+            val: w.val,
+            dir: w.dir,
+        };
+
+        self.inner
+            .eval_raw(reflected_x, reflected_y, reflected_z, reflected_w)
+    }
+}
+
+/// Generalized ColorReflect for PathJet coordinates.
+///
+/// Same as Reflect but outputs Discrete (packed RGBA) for color pipelines.
+impl<M> Manifold<PathJet4> for ColorReflect<M>
+where
+    M: ManifoldCompat<PathJet<Jet3>, Output = Discrete>,
+{
+    type Output = Discrete;
+
+    #[inline]
+    fn eval(&self, p: PathJet4) -> Discrete {
+        let (x, y, z, w) = p;
+        // Same algorithm as Reflect<M> for PathJet<Jet3>
+
+        // 1. Extract normal from tangent frame
+        let tu = (x.val.dx, y.val.dx, z.val.dx);
+        let tv = (x.val.dy, y.val.dy, z.val.dy);
+
+        let cross_x = tv.1 * tu.2 - tv.2 * tu.1;
+        let cross_y = tv.2 * tu.0 - tv.0 * tu.2;
+        let cross_z = tv.0 * tu.1 - tv.1 * tu.0;
+
+        // Build normalized normal as expression tree, clone for reuse
+        let n_len_sq = cross_x.clone() * cross_x.clone()
+            + cross_y.clone() * cross_y.clone()
+            + cross_z.clone() * cross_z.clone();
+        let inv_n_len = n_len_sq.max(Field::from(1e-10)).sqrt().rsqrt();
+
+        let nx = (cross_x * inv_n_len.clone()).constant();
+        let ny = (cross_y * inv_n_len.clone()).constant();
+        let nz = (cross_z * inv_n_len).constant();
+
+        // 2. Normalize incoming direction
+        let d_len_sq = x.dir * x.dir + y.dir * y.dir + z.dir * z.dir;
+        let inv_d_len = Jet3::constant(Field::from(1.0)) / d_len_sq.sqrt();
+
+        let dx = x.dir * inv_d_len;
+        let dy = y.dir * inv_d_len;
+        let dz = z.dir * inv_d_len;
+
+        // 3. Curvature scaling
+        let d_dot_n_scalar = (dx.val * nx + dy.val * ny + dz.val * nz).constant();
+        let cos_incidence = d_dot_n_scalar.abs().max(Field::from(0.1));
+        let curvature_scale = (Field::from(2.0) / cos_incidence).constant();
+
+        let fzero = Field::from(0.0);
+        let n_jet_x = Jet3 {
+            val: nx,
+            dx: (x.val.dx * curvature_scale).constant(),
+            dy: (x.val.dy * curvature_scale).constant(),
+            dz: fzero,
+        };
+        let n_jet_y = Jet3 {
+            val: ny,
+            dx: (y.val.dx * curvature_scale).constant(),
+            dy: (y.val.dy * curvature_scale).constant(),
+            dz: fzero,
+        };
+        let n_jet_z = Jet3 {
+            val: nz,
+            dx: (z.val.dx * curvature_scale).constant(),
+            dy: (z.val.dy * curvature_scale).constant(),
+            dz: fzero,
+        };
+
+        // 4. Householder reflection
+        let d_dot_n = dx * n_jet_x + dy * n_jet_y + dz * n_jet_z;
+        let two = Jet3::constant(Field::from(2.0));
+        let k = two * d_dot_n;
+
+        let r_x = dx - k * n_jet_x;
+        let r_y = dy - k * n_jet_y;
+        let r_z = dz - k * n_jet_z;
+
+        // 5. Reflected ray
+        let reflected_x = PathJet {
+            val: x.val,
+            dir: r_x,
+        };
+        let reflected_y = PathJet {
+            val: y.val,
+            dir: r_y,
+        };
+        let reflected_z = PathJet {
+            val: z.val,
+            dir: r_z,
+        };
+        let reflected_w = PathJet {
+            val: w.val,
+            dir: w.dir,
+        };
+
+        self.inner
+            .eval_raw(reflected_x, reflected_y, reflected_z, reflected_w)
+    }
+}
+
+// Checkerboard pattern based on X/Z coordinates.
+// Uses Jet3 derivatives for automatic antialiasing at edges.
+kernel!(pub struct Checker = || Jet3 -> Field {
+    // Which checker cell are we in?
+    let cell_x = V(X).floor();
+    let cell_z = V(Z).floor();
+    let sum = cell_x + cell_z;
+    let half = sum * 0.5;
+    let fract_half = half - half.floor();
+    let is_even = fract_half.abs() < 0.25;
+
+    // Colors
+    let color_a = 0.9;
+    let color_b = 0.2;
+    let base_color = is_even.select(color_a, color_b);
+
+    // AA: distance to nearest grid line in X and Z
+    let fx = V(X) - cell_x;
+    let fz = V(Z) - cell_z;
+
+    // Distance to nearest edge (0.0 or 1.0 boundary)
+    let dx_edge = (fx - 0.5).abs();
+    let dz_edge = (fz - 0.5).abs();
+    let dist_to_edge = (0.5 - dx_edge).min(0.5 - dz_edge);
+
+    // Gradient magnitude from Jet3 derivatives
+    let grad_x = (DX(X) * DX(X) + DY(X) * DY(X) + DZ(X) * DZ(X)).sqrt();
+    let grad_z = (DX(Z) * DX(Z) + DY(Z) * DY(Z) + DZ(Z) * DZ(Z)).sqrt();
+    let pixel_size = grad_x.max(grad_z) + 0.001;
+
+    // Coverage: how much of the pixel is in this cell vs neighbor
+    let coverage = (dist_to_edge / pixel_size).min(1.0).max(0.0);
+
+    // Blend with neighbor color at edges
+    let neighbor_color = is_even.select(color_b, color_a);
+    base_color * coverage + neighbor_color * (1.0 - coverage)
+});
+
+/// Simple Sky Gradient based on Y direction.
+///
+/// Uses Lift to project Jet3 → Field (discards derivatives - sky doesn't need AA).
+#[must_use]
+pub fn sky() -> Lift<impl Manifold<Field4, Output = Field> + Clone> {
+    Lift(kernel!(|| {
+        let t = (Y * 0.5 + 0.5).max(0.0).min(1.0);
+        t * 0.8 + 0.1
+    })())
+}
+
+/// Color Sky: Blue gradient, takes a color cube for platform-specific byte order.
+///
+/// Manual struct implementation because the color_cube parameter needs
+/// `Manifold<Field4>` (Field coordinates from V() extraction), not the kernel's
+/// Jet3_4 domain.
+#[derive(Clone, Copy, ManifoldExpr)]
+pub struct ColorSky<C> {
+    pub color_cube: C,
+}
+
+impl<C> ColorSky<C> {
+    pub fn new(color_cube: C) -> Self {
+        Self { color_cube }
+    }
+}
+
+impl<C: Default> Default for ColorSky<C> {
+    fn default() -> Self {
+        Self::new(C::default())
+    }
+}
+
+impl<C: ManifoldCompat<Field, Output = Discrete>> Manifold<Jet3_4> for ColorSky<C> {
+    type Output = Discrete;
+
+    #[inline]
+    fn eval(&self, p: Jet3_4) -> Discrete {
+        let (_x, y, _z, _w) = p;
+
+        // t = (V(Y) * 0.5 + 0.5).max(0.0).min(1.0)
+        let y_val: Field = y.into();
+        let half = Field::from(0.5);
+        let zero = Field::from(0.0);
+        let one = Field::from(1.0);
+        let t = (y_val * half + half).max(zero).min(one).constant();
+
+        // Gradient colors - collapse to Field with .constant()
+        let r = (Field::from(0.7) - t * Field::from(0.5)).constant();
+        let g = (Field::from(0.85) - t * Field::from(0.45)).constant();
+        let b = (one - t * Field::from(0.2)).constant();
+
+        self.color_cube.eval_raw(r, g, b, one)
+    }
+}
+
+/// Color Checker: Warm/cool checker with AA, takes a color cube for platform-specific byte order.
+///
+/// Manual struct implementation because the color_cube parameter needs
+/// `Manifold<Field4>` (Field coordinates), not the kernel's Jet3_4 domain.
+#[derive(Clone, Copy, ManifoldExpr)]
+pub struct ColorChecker<C> {
+    pub color_cube: C,
+}
+
+impl<C> ColorChecker<C> {
+    pub fn new(color_cube: C) -> Self {
+        Self { color_cube }
+    }
+}
+
+impl<C: Default> Default for ColorChecker<C> {
+    fn default() -> Self {
+        Self::new(C::default())
+    }
+}
+
+impl<C: ManifoldCompat<Field, Output = Discrete>> Manifold<Jet3_4> for ColorChecker<C> {
+    type Output = Discrete;
+
+    #[inline]
+    fn eval(&self, p: Jet3_4) -> Discrete {
+        let (x, _y, z, _w) = p;
+
+        // Extract Field values from Jet3
+        let x_val: Field = x.val;
+        let z_val: Field = z.val;
+
+        // Which checker cell are we in?
+        let cell_x = x_val.floor();
+        let cell_z = z_val.floor();
+        let sum = (cell_x.clone() + cell_z.clone()).constant();
+        let half = Field::from(0.5);
+        let sum_half = (sum * half).constant();
+        let fract_half = (sum_half - sum_half.floor()).constant();
+        let is_even = fract_half.abs().lt(Field::from(0.25));
+
+        // Colors (warm and cool)
+        let ra = Field::from(0.95);
+        let ga = Field::from(0.9);
+        let ba = Field::from(0.8);
+        let rb = Field::from(0.2);
+        let gb = Field::from(0.25);
+        let bb = Field::from(0.3);
+
+        // AA: distance to nearest grid line in X and Z
+        let fx = (x_val - cell_x).constant();
+        let fz = (z_val - cell_z).constant();
+
+        // Distance to nearest edge (0.0 or 1.0 boundary)
+        let dx_edge = (fx - half).abs().constant();
+        let dz_edge = (fz - half).abs().constant();
+        let dist_to_edge = (half - dx_edge).min(half - dz_edge).constant();
+
+        // Gradient magnitude from Jet3 derivatives
+        let grad_x = (x.dx * x.dx + x.dy * x.dy + x.dz * x.dz).sqrt().constant();
+        let grad_z = (z.dx * z.dx + z.dy * z.dy + z.dz * z.dz).sqrt().constant();
+        let pixel_size = (grad_x.max(grad_z) + Field::from(0.001)).constant();
+
+        // Coverage: how much of the pixel is in this cell vs neighbor
+        let zero = Field::from(0.0);
+        let one = Field::from(1.0);
+        let coverage = (dist_to_edge / pixel_size).min(one).max(zero).constant();
+
+        // Select and blend colors
+        let r_base = is_even.select(ra, rb);
+        let g_base = is_even.select(ga, gb);
+        let b_base = is_even.select(ba, bb);
+
+        let r_neighbor = is_even.select(rb, ra);
+        let g_neighbor = is_even.select(gb, ga);
+        let b_neighbor = is_even.select(bb, ba);
+
+        let inv_coverage = (one - coverage).constant();
+        let r = (r_base * coverage + r_neighbor * inv_coverage).constant();
+        let g = (g_base * coverage + g_neighbor * inv_coverage).constant();
+        let b = (b_base * coverage + b_neighbor * inv_coverage).constant();
+
+        // Sample the color cube
+        self.color_cube.eval_raw(r, g, b, one)
     }
 }

--- a/pixelflow-graphics/src/transform.rs
+++ b/pixelflow-graphics/src/transform.rs
@@ -1,33 +1,32 @@
 //! Coordinate transformations for manifolds.
 //!
-//! Provides composable coordinate warping using [`Kernel`].
+//! Provides composable coordinate warping using the `At` combinator.
 
-use pixelflow_core::{At, Div, Field, Kernel, Manifold, Sub, W, X, Y, Z};
+use pixelflow_compiler::kernel;
+use pixelflow_core::jet::Jet2;
+use pixelflow_core::ops::{Div, Sub};
+use pixelflow_core::{At, Field, Manifold, W, X, Y, Z};
 
 /// The standard 4D Field domain type.
 type Field4 = (Field, Field, Field, Field);
 
+// =============================================================================
+// Scale transformation
+// =============================================================================
+
 /// Alias for the scaled manifold type.
 pub type Scaled<M> = At<Div<X, f32>, Div<Y, f32>, Z, W, M>;
 
-/// Alias for the translated manifold type.
-pub type Translated<M> = At<Sub<X, f32>, Sub<Y, f32>, Z, W, M>;
-
-/// Uniform scaling of a [`Kernel`] domain by `factor`.
-#[inline]
-#[must_use]
-pub fn scale_kernel(k: &Kernel, factor: f32) -> Kernel {
-    k.scale(factor)
-}
-
-/// Translation of a [`Kernel`] domain by `(dx, dy)`.
-#[inline]
-#[must_use]
-pub fn translate_kernel(k: &Kernel, dx: f32, dy: f32) -> Kernel {
-    k.translate(dx, dy)
-}
-
-/// Uniform scaling of a combinator manifold domain.
+/// Uniform scaling of the manifold domain.
+///
+/// Effectively scales the object size by `factor`.
+/// Internally, coordinates are divided by `factor`.
+///
+/// # Example
+/// ```ignore
+/// let circle = kernel!(|| (X * X + Y * Y).sqrt() - 1.0);
+/// let big_circle = scale(circle, 2.0);  // radius 2 circle
+/// ```
 pub fn scale<M>(inner: M, factor: f32) -> Scaled<M>
 where
     M: Manifold<Field4, Output = Field>,
@@ -41,7 +40,23 @@ where
     }
 }
 
-/// Translation of a combinator manifold domain.
+// =============================================================================
+// Translate transformation
+// =============================================================================
+
+/// Alias for the translated manifold type.
+pub type Translated<M> = At<Sub<X, f32>, Sub<Y, f32>, Z, W, M>;
+
+/// Translation of the manifold domain.
+///
+/// Shifts the object by `(dx, dy)`.
+/// Internally, coordinates are subtracted by the offset.
+///
+/// # Example
+/// ```ignore
+/// let circle = kernel!(|| (X * X + Y * Y).sqrt() - 1.0);
+/// let moved = translate(circle, 10.0, 5.0);  // circle centered at (10, 5)
+/// ```
 pub fn translate<M>(inner: M, dx: f32, dy: f32) -> Translated<M>
 where
     M: Manifold<Field4, Output = Field>,
@@ -55,19 +70,215 @@ where
     }
 }
 
+// =============================================================================
+// Legacy types (for backwards compatibility)
+// =============================================================================
+
+/// Uniform scaling transformation struct (legacy).
+///
+/// Prefer using `scale()` function which returns a composable `At` combinator.
+#[derive(Clone, Debug)]
+pub struct Scale<M> {
+    pub manifold: M,
+    pub factor: f32,
+}
+
+/// Translation transformation struct (legacy).
+///
+/// Prefer using `translate()` function which returns a composable `At` combinator.
+#[derive(Clone, Debug)]
+pub struct Translate<M> {
+    pub manifold: M,
+    pub offset: [f32; 2],
+}
+
+// Manifold implementations for legacy types use At directly
+
+impl<M> Manifold<Field4> for Scale<M>
+where
+    M: Manifold<Field4, Output = Field>,
+{
+    type Output = Field;
+
+    #[inline(always)]
+    fn eval(&self, p: Field4) -> Field {
+        // Create At combinator with coordinate expressions
+        let at = At {
+            inner: &self.manifold,
+            x: X / self.factor,
+            y: Y / self.factor,
+            z: Z,
+            w: W,
+        };
+        at.eval(p)
+    }
+}
+
+// Translate is domain-generic (one kernel body per domain, see the note in
+// fonts/ttf_curve_analytical.rs): raw `f32` coordinate offsets always evaluate
+// to `Field`, so `X - offset` would be ill-typed over `Jet2`; the kernel lifts
+// the offset into the evaluation domain instead.
+macro_rules! impl_translate_manifold {
+    ($n:ty) => {
+        impl<M> Manifold<($n, $n, $n, $n)> for Translate<M>
+        where
+            M: Manifold<($n, $n, $n, $n), Output = Field>,
+        {
+            type Output = Field;
+
+            #[inline(always)]
+            fn eval(&self, p: ($n, $n, $n, $n)) -> Field {
+                let shift_x = kernel!(|d: f32| -> $n { X - d });
+                let shift_y = kernel!(|d: f32| -> $n { Y - d });
+                // Create At combinator with coordinate expressions
+                let at = At {
+                    inner: &self.manifold,
+                    x: shift_x(self.offset[0]),
+                    y: shift_y(self.offset[1]),
+                    z: Z,
+                    w: W,
+                };
+                at.eval(p)
+            }
+        }
+    };
+}
+
+impl_translate_manifold!(Field);
+impl_translate_manifold!(Jet2);
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pixelflow_core::Field;
 
     #[test]
-    fn kernel_scale_and_translate_work() {
-        let circle = Kernel::x()
-            .mul(&Kernel::x())
-            .add(&Kernel::y().mul(&Kernel::y()))
-            .sqrt()
-            .sub(&Kernel::constant(1.0));
-        let scaled = scale_kernel(&circle, 2.0);
-        let moved = translate_kernel(&scaled, 10.0, 5.0);
-        let _ = moved;
+    fn scale_function_works() {
+        let scaled = scale(X, 2.0);
+        let zero = Field::from(0.0);
+        let two = Field::from(2.0);
+
+        // At x=2, scaled should give x/2 = 1
+        let result = scaled.eval((two, zero, zero, zero));
+        let _ = result;
+    }
+
+    #[test]
+    fn translate_function_works() {
+        let translated = translate(X, 1.0, 0.0);
+        let zero = Field::from(0.0);
+        let two = Field::from(2.0);
+
+        // At x=2, translated should give x-1 = 1
+        let result = translated.eval((two, zero, zero, zero));
+        let _ = result;
+    }
+
+    #[test]
+    fn scale_and_translate_compose() {
+        let scaled = scale(X, 2.0);
+        let composed = translate(scaled, 1.0, 0.0);
+
+        let zero = Field::from(0.0);
+        let four = Field::from(4.0);
+
+        let result = composed.eval((four, zero, zero, zero));
+        let _ = result;
+    }
+
+    #[test]
+    fn scale_creation_and_eval() {
+        let scaled = Scale {
+            manifold: X,
+            factor: 2.0,
+        };
+
+        let zero = Field::from(0.0);
+        let one = Field::from(1.0);
+
+        let _ = scaled.eval((one, zero, zero, zero));
+    }
+
+    #[test]
+    fn scale_with_various_factors() {
+        for factor in [0.5, 1.0, 2.0, 10.0] {
+            let scaled = Scale {
+                manifold: X,
+                factor,
+            };
+            let zero = Field::from(0.0);
+            let one = Field::from(1.0);
+            let _ = scaled.eval((one, one, zero, zero));
+        }
+    }
+
+    #[test]
+    fn scale_is_clone() {
+        let scaled = Scale {
+            manifold: X,
+            factor: 2.0,
+        };
+        let cloned = scaled.clone();
+        assert_eq!(cloned.factor, 2.0);
+    }
+
+    #[test]
+    fn translate_creation_and_eval() {
+        let translated = Translate {
+            manifold: X,
+            offset: [1.0, 2.0],
+        };
+
+        let zero = Field::from(0.0);
+        let one = Field::from(1.0);
+
+        let _ = translated.eval((one, one, zero, zero));
+    }
+
+    #[test]
+    fn translate_with_various_offsets() {
+        for offset in [[0.0, 0.0], [1.0, 1.0], [-5.0, 5.0], [100.0, -100.0]] {
+            let translated = Translate {
+                manifold: X,
+                offset,
+            };
+            let zero = Field::from(0.0);
+            let one = Field::from(1.0);
+            let _ = translated.eval((one, one, zero, zero));
+        }
+    }
+
+    #[test]
+    fn struct_scale_and_translate_compose() {
+        let scaled = Scale {
+            manifold: X,
+            factor: 2.0,
+        };
+        let composed = Translate {
+            manifold: scaled,
+            offset: [1.0, 1.0],
+        };
+
+        let zero = Field::from(0.0);
+        let one = Field::from(1.0);
+
+        let _ = composed.eval((one, one, zero, zero));
+    }
+
+    #[test]
+    fn struct_translate_and_scale_compose() {
+        let translated = Translate {
+            manifold: Y,
+            offset: [1.0, 2.0],
+        };
+        let composed = Scale {
+            manifold: translated,
+            factor: 0.5,
+        };
+
+        let zero = Field::from(0.0);
+        let one = Field::from(1.0);
+
+        let _ = composed.eval((one, one, zero, zero));
     }
 }

--- a/pixelflow-graphics/tests/e2e_render_to_file.rs
+++ b/pixelflow-graphics/tests/e2e_render_to_file.rs
@@ -4,12 +4,13 @@
 //! through rasterization to file output.
 
 use pixelflow_compiler::kernel;
-use pixelflow_core::{Discrete, Field, Manifold, ManifoldCompat, ManifoldExt};
+use pixelflow_core::{Discrete, Field, Manifold, ManifoldCompat, ManifoldExt, X, Y};
 use pixelflow_graphics::render::color::{Grayscale, NamedColor, Rgba8};
 
 type Field4 = (Field, Field, Field, Field);
 use pixelflow_graphics::render::frame::Frame;
 use pixelflow_graphics::render::rasterizer::rasterize;
+use pixelflow_graphics::transform::{Scale, Translate};
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;
@@ -162,33 +163,47 @@ fn e2e_render_radial_gradient() {
     println!("Radial gradient saved to: {}", output_path.display());
 }
 
+/// A unit circle manifold (returns 1.0 inside, 0.0 outside).
+/// Uses proper manifold composition with ManifoldExt.
+#[derive(Clone, Copy)]
+struct UnitCircle;
+
+impl Manifold<Field4> for UnitCircle {
+    type Output = Field;
+
+    fn eval(&self, p: Field4) -> Field {
+        // Build the manifold expression: x² + y² < 1 ? 1.0 : 0.0
+        // Using ManifoldExt's lt() and select()
+        let dist_sq = X * X + Y * Y;
+        let mask = dist_sq.lt(1.0f32);
+        let result = mask.select(1.0f32, 0.0f32);
+
+        // Evaluate the composed manifold at the given coordinates
+        result.eval(p)
+    }
+}
+
 #[test]
 fn e2e_render_circle() {
-    use pixelflow_core::{Kernel, Lattice};
-
     const SIZE: u32 = 100;
 
-    // Unit circle at origin, scaled and translated to center of image using Kernel methods
+    // Unit circle at origin, scaled and translated to center of image
     let radius = SIZE as f32 / 2.0 - 5.0;
-    let dist_sq = Kernel::x()
-        .mul(&Kernel::x())
-        .add(&Kernel::y().mul(&Kernel::y()));
-    let circle_kernel = dist_sq
-        .lt(&Kernel::constant(1.0))
-        .select(&Kernel::constant(1.0), &Kernel::constant(0.0));
-    let centered = circle_kernel
-        .scale(radius)
-        .translate(SIZE as f32 / 2.0, SIZE as f32 / 2.0);
+    let scaled = Scale {
+        manifold: UnitCircle,
+        factor: radius,
+    };
+    let centered = Translate {
+        manifold: scaled,
+        offset: [SIZE as f32 / 2.0, SIZE as f32 / 2.0],
+    };
 
-    let lattice = Lattice::frame(SIZE as usize, SIZE as usize, 0.0);
-    let baked = lattice.bake(&centered);
-    let buffer = baked.buffer();
+    // Grayscale conversion
+    let scene = Grayscale(centered);
 
     let mut frame = Frame::<Rgba8>::new(SIZE, SIZE);
-    for (i, &val) in buffer.iter().enumerate() {
-        let byte = (val.clamp(0.0, 1.0) * 255.0) as u8;
-        frame.data[i] = Rgba8::new(byte, byte, byte, 255);
-    }
+
+    rasterize(&scene, &mut frame, 1);
 
     // Center should be white (inside circle = 1.0)
     let center_idx = (SIZE / 2) as usize * SIZE as usize + (SIZE / 2) as usize;

--- a/pixelflow-graphics/tests/raymarch_sphere.rs
+++ b/pixelflow-graphics/tests/raymarch_sphere.rs
@@ -1,53 +1,264 @@
-//! Test: 3D scene rendering with sphere + floor using JIT Kernel architecture (`kernel_3d`)
+//! Test: 3D scene rendering with sphere + floor using the scene3d architecture
 
-use pixelflow_core::{Kernel, Lattice};
-use pixelflow_graphics::render::color::Rgba8;
+use pixelflow_compiler::ManifoldExpr;
+use pixelflow_core::combinators::At;
+use pixelflow_core::jet::Jet3;
+use pixelflow_core::{Discrete, Field, Manifold, ManifoldCompat};
+
+type Field4 = (Field, Field, Field, Field);
+type Jet3_4 = (Jet3, Jet3, Jet3, Jet3);
+use pixelflow_graphics::render::color::{Rgba8, RgbaColorCube};
 use pixelflow_graphics::render::frame::Frame;
-use pixelflow_graphics::scene3d::kernel_3d;
+use pixelflow_graphics::render::rasterizer::rasterize;
+use pixelflow_graphics::scene3d::{
+    plane, ColorChecker, ColorReflect, ColorScreenToDir, ColorSky, ColorSurface,
+};
+
+/// Sphere at given center with radius (local to this test).
+#[derive(Clone, Copy, ManifoldExpr)]
+struct SphereAt {
+    center: (f32, f32, f32),
+    radius: f32,
+}
+
+impl Manifold<Jet3_4> for SphereAt {
+    type Output = Jet3;
+
+    #[inline]
+    fn eval(&self, p: Jet3_4) -> Jet3 {
+        let (rx, ry, rz, _w) = p;
+        let cx = Jet3::constant(Field::from(self.center.0));
+        let cy = Jet3::constant(Field::from(self.center.1));
+        let cz = Jet3::constant(Field::from(self.center.2));
+
+        let d_dot_c = rx * cx + ry * cy + rz * cz;
+        let c_sq = cx * cx + cy * cy + cz * cz;
+        let r_sq = Jet3::constant(Field::from(self.radius * self.radius));
+        let discriminant = d_dot_c * d_dot_c - (c_sq - r_sq);
+
+        let epsilon_sq = Jet3::constant(Field::from(0.0001));
+        d_dot_c - (discriminant + epsilon_sq).sqrt()
+    }
+}
 use std::fs::File;
 use std::io::Write;
+
+/// Remap pixel coordinates to normalized screen coordinates.
+/// Transforms [0, width] × [0, height] → normalized coordinates
+struct ColorScreenRemap<M> {
+    inner: M,
+    width: f32,
+    height: f32,
+}
+
+impl<M: ManifoldCompat<Field, Output = Discrete>> Manifold<Field4> for ColorScreenRemap<M> {
+    type Output = Discrete;
+
+    fn eval(&self, p: Field4) -> Discrete {
+        let (px, py, z, w) = p;
+        let width = Field::from(self.width);
+        let height = Field::from(self.height);
+        let scale = Field::from(2.0) / height;
+
+        // Map pixel coords to normalized screen coordinates (flip y)
+        let x = (px - width * Field::from(0.5)) * scale.clone();
+        let y = (height * Field::from(0.5) - py) * scale;
+
+        At {
+            inner: &self.inner,
+            x,
+            y,
+            z,
+            w,
+        }
+        .collapse()
+    }
+}
 
 #[test]
 fn sphere_on_floor() {
     const W: usize = 400;
     const H: usize = 300;
-    let w_f32 = W as f32;
-    let h_f32 = H as f32;
-    let scale = 2.0 / h_f32;
 
-    let sx = Kernel::x()
-        .sub(&Kernel::constant(w_f32 * 0.5))
-        .mul(&Kernel::constant(scale));
-    let sy = Kernel::constant(h_f32 * 0.5)
-        .sub(&Kernel::y())
-        .mul(&Kernel::constant(scale));
+    // Floor + sky as the world (background)
+    let world = ColorSurface {
+        geometry: plane(-0.5),
+        material: ColorChecker::<RgbaColorCube>::default(),
+        background: ColorSky::<RgbaColorCube>::default(),
+    };
 
-    let (dx, dy, dz) = kernel_3d::screen_to_ray(&sx, &sy, 1.0);
-    let sky = kernel_3d::sky(&dy);
+    // Chrome sphere at (0.0, 0.5, 4.0) with radius 1.0, reflecting the world
+    let scene = ColorSurface {
+        geometry: SphereAt {
+            center: (0.0, 0.5, 4.0),
+            radius: 1.0,
+        },
+        material: ColorReflect { inner: world },
+        background: world,
+    };
 
-    let (t_sphere, hit_sphere) = kernel_3d::sphere_at((0.0, 0.5, 4.0), 1.0, &dx, &dy, &dz);
-    let px = dx.mul(&t_sphere);
-    let py = dy.mul(&t_sphere);
-    let pz = dz.mul(&t_sphere);
-
-    let (_nx, ny, _nz) = kernel_3d::surface_normal(&px, &py, &pz);
-    let scene = hit_sphere.select(&ny, &sky);
-
-    let lattice = Lattice::frame(W, H, 0.0);
-    let baked = lattice.bake(&scene);
-    let buffer = baked.buffer();
+    // Wrap with screen coordinate transformation
+    let renderable = ColorScreenRemap {
+        inner: ColorScreenToDir { inner: scene },
+        width: W as f32,
+        height: H as f32,
+    };
 
     let mut frame = Frame::<Rgba8>::new(W as u32, H as u32);
-    for (i, &val) in buffer.iter().enumerate() {
-        let b = (val.clamp(0.0, 1.0) * 255.0) as u8;
-        frame.data[i] = Rgba8::new(b, b, b, 255);
-    }
+    rasterize(&renderable, &mut frame, 1);
 
-    let path = std::env::temp_dir().join("raymarch_sphere_jit.ppm");
+    // Save PPM
+    let path = std::env::temp_dir().join("pixelflow_raymarch_sh.ppm");
     let mut file = File::create(&path).unwrap();
     writeln!(file, "P6\n{} {}\n255", W, H).unwrap();
     for p in &frame.data {
         file.write_all(&[p.r(), p.g(), p.b()]).unwrap();
     }
-    assert!(path.exists());
+    println!("Saved: {}", path.display());
+
+    // Basic sanity: center should hit something (not pure sky)
+    let center = &frame.data[(H / 2) * W + (W / 2)];
+    // Sky is blue-ish, sphere reflection should be different
+    assert!(
+        center.r() > 10 || center.g() > 10 || center.b() > 10,
+        "Center pixel should have some color"
+    );
+}
+
+/// Test with solid gray material (non-reflective)
+#[test]
+fn sphere_on_matte_floor() {
+    const W: usize = 400;
+    const H: usize = 300;
+
+    // Simple solid gray material
+    #[derive(Copy, Clone, ManifoldExpr)]
+    struct SolidGray;
+
+    impl pixelflow_core::Manifold<Jet3_4> for SolidGray {
+        type Output = Discrete;
+
+        fn eval(&self, _p: Jet3_4) -> Discrete {
+            let gray = Field::from(0.5);
+            Discrete::pack(gray, gray, gray, Field::from(1.0))
+        }
+    }
+
+    // Floor + sky as the world (background)
+    let world = ColorSurface {
+        geometry: plane(-0.5),
+        material: SolidGray,
+        background: ColorSky::<RgbaColorCube>::default(),
+    };
+
+    // Matte gray sphere at (0.0, 0.5, 4.0) with radius 1.0
+    let scene = ColorSurface {
+        geometry: SphereAt {
+            center: (0.0, 0.5, 4.0),
+            radius: 1.0,
+        },
+        material: SolidGray,
+        background: world,
+    };
+
+    let renderable = ColorScreenRemap {
+        inner: ColorScreenToDir { inner: scene },
+        width: W as f32,
+        height: H as f32,
+    };
+
+    let mut frame = Frame::<Rgba8>::new(W as u32, H as u32);
+    rasterize(&renderable, &mut frame, 1);
+
+    // Save PPM
+    let path = std::env::temp_dir().join("pixelflow_raymarch_matte.ppm");
+    let mut file = File::create(&path).unwrap();
+    writeln!(file, "P6\n{} {}\n255", W, H).unwrap();
+    for p in &frame.data {
+        file.write_all(&[p.r(), p.g(), p.b()]).unwrap();
+    }
+    println!("Saved: {}", path.display());
+
+    // Center should hit geometry (gray sphere)
+    let center = &frame.data[(H / 2) * W + (W / 2)];
+    // Should be grayish (around 127-128 for 0.5 * 255)
+    assert!(
+        center.r() > 100 && center.r() < 150,
+        "Center pixel should be gray: r={}",
+        center.r()
+    );
+}
+
+/// Chrome sphere on checkerboard floor
+#[test]
+fn chrome_sphere_on_checkerboard() {
+    const WIDTH: usize = 400;
+    const HEIGHT: usize = 300;
+
+    // Floor with checkerboard pattern + sky background
+    let world = ColorSurface {
+        geometry: plane(-0.5),
+        material: ColorChecker::<RgbaColorCube>::default(),
+        background: ColorSky::<RgbaColorCube>::default(),
+    };
+
+    // Chrome sphere at (0.0, 0.5, 4.0) reflecting the checkerboard floor
+    let scene = ColorSurface {
+        geometry: SphereAt {
+            center: (0.0, 0.5, 4.0),
+            radius: 1.0,
+        },
+        material: ColorReflect { inner: world },
+        background: world,
+    };
+
+    let renderable = ColorScreenRemap {
+        inner: ColorScreenToDir { inner: scene },
+        width: WIDTH as f32,
+        height: HEIGHT as f32,
+    };
+
+    let mut frame = Frame::<Rgba8>::new(WIDTH as u32, HEIGHT as u32);
+    rasterize(&renderable, &mut frame, 1);
+
+    // Save PPM
+    let path = std::env::temp_dir().join("pixelflow_chrome_checker.ppm");
+    let mut file = File::create(&path).unwrap();
+    writeln!(file, "P6\n{} {}\n255", WIDTH, HEIGHT).unwrap();
+    for p in &frame.data {
+        file.write_all(&[p.r(), p.g(), p.b()]).unwrap();
+    }
+    println!("Saved: {}", path.display());
+
+    // Debug: print some pixel values
+    let center = &frame.data[(HEIGHT / 2) * WIDTH + (WIDTH / 2)];
+    println!(
+        "Center pixel (sphere): r={} g={} b={}",
+        center.r(),
+        center.g(),
+        center.b()
+    );
+    let bottom = &frame.data[(HEIGHT * 3 / 4) * WIDTH + (WIDTH / 2)];
+    println!(
+        "Bottom pixel (floor): r={} g={} b={}",
+        bottom.r(),
+        bottom.g(),
+        bottom.b()
+    );
+    let top = &frame.data[(HEIGHT / 4) * WIDTH + (WIDTH / 2)];
+    println!("Top pixel (sky): r={} g={} b={}", top.r(), top.g(), top.b());
+
+    // Verify: center should be chrome sphere (reflective)
+    let center = &frame.data[(HEIGHT / 2) * WIDTH + (WIDTH / 2)];
+    assert!(
+        center.r() > 10 || center.g() > 10 || center.b() > 10,
+        "Center pixel should hit chrome sphere"
+    );
+
+    // Verify: bottom should be checkerboard floor
+    let bottom = &frame.data[(HEIGHT * 3 / 4) * WIDTH + (WIDTH / 2)];
+    assert!(
+        bottom.r() > 10 || bottom.g() > 10 || bottom.b() > 10,
+        "Bottom pixel should hit floor"
+    );
 }

--- a/pixelflow-graphics/tests/scene3d_test.rs
+++ b/pixelflow-graphics/tests/scene3d_test.rs
@@ -1,74 +1,681 @@
-//! Test: Analytic 3D rendering with JIT Kernel architecture (`kernel_3d`).
+//! Test: Analytic 3D rendering with three-layer architecture
+//!
+//! Three Layers:
+//! 1. Geometry: Returns `t` (Jet3) - UnitSphere, PlaneGeometry
+//! 2. Surface: Warps `P = ray * t` - creates tangent frame via chain rule
+//! 3. Material: Reconstructs normal from derivatives - Reflect, Checker, Sky
 
-use pixelflow_core::{Kernel, Lattice};
-use pixelflow_graphics::scene3d::kernel_3d;
+use pixelflow_compiler::ManifoldExpr;
+use pixelflow_core::combinators::At;
+use pixelflow_core::jet::Jet3;
+use pixelflow_core::{Discrete, Field, Manifold, ManifoldCompat, ManifoldExt};
 
-#[test]
-fn jit_kernel_3d_sky_and_normal() {
-    const W: f32 = 32.0;
-    const H: f32 = 32.0;
-    let scale = 2.0 / H;
+type Field4 = (Field, Field, Field, Field);
+type Jet3_4 = (Jet3, Jet3, Jet3, Jet3);
+use pixelflow_graphics::render::color::{Rgba8, RgbaColorCube};
+use pixelflow_graphics::render::frame::Frame;
+use pixelflow_graphics::render::rasterizer::rasterize;
+use pixelflow_graphics::scene3d::{
+    plane, sky, Checker, ColorChecker, ColorReflect, ColorScreenToDir, ColorSky, ColorSurface,
+    Reflect, ScreenToDir, Surface,
+};
+use std::fs::File;
+use std::io::Write;
 
-    let sx = Kernel::x()
-        .sub(&Kernel::constant(W * 0.5))
-        .mul(&Kernel::constant(scale));
-    let sy = Kernel::constant(H * 0.5)
-        .sub(&Kernel::y())
-        .mul(&Kernel::constant(scale));
-
-    let (dx, dy, dz) = kernel_3d::screen_to_ray(&sx, &sy, 1.0);
-    let sky = kernel_3d::sky(&dy);
-
-    let t_sphere = kernel_3d::unit_sphere(&dx, &dy, &dz);
-    let px = dx.mul(&t_sphere);
-    let py = dy.mul(&t_sphere);
-    let pz = dz.mul(&t_sphere);
-
-    let (_nx, ny, _nz) = kernel_3d::surface_normal(&px, &py, &pz);
-
-    let lattice = Lattice::frame(32, 32, 0.0);
-    let baked_sky = lattice.bake(&sky);
-    assert_eq!(baked_sky.buffer().len(), 1024);
-
-    let top_sample = baked_sky.buffer()[16];
-    let bot_sample = baked_sky.buffer()[31 * 32 + 16];
-    assert!(
-        bot_sample > top_sample,
-        "Horizon sky ({bot_sample}) should be brighter than zenith sky ({top_sample})"
-    );
-
-    let baked_ny = lattice.bake(&ny);
-    assert_eq!(baked_ny.buffer().len(), 1024);
+/// Sphere at given center with radius (local to this test).
+#[derive(Clone, Copy, ManifoldExpr)]
+struct SphereAt {
+    center: (f32, f32, f32),
+    radius: f32,
 }
 
+impl Manifold<Jet3_4> for SphereAt {
+    type Output = Jet3;
+
+    #[inline]
+    fn eval(&self, p: Jet3_4) -> Jet3 {
+        let (rx, ry, rz, _w) = p;
+        let cx = Jet3::constant(Field::from(self.center.0));
+        let cy = Jet3::constant(Field::from(self.center.1));
+        let cz = Jet3::constant(Field::from(self.center.2));
+
+        let d_dot_c = rx * cx + ry * cy + rz * cz;
+        let c_sq = cx * cx + cy * cy + cz * cz;
+        let r_sq = Jet3::constant(Field::from(self.radius * self.radius));
+        let discriminant = d_dot_c * d_dot_c - (c_sq - r_sq);
+
+        let epsilon_sq = Jet3::constant(Field::from(0.0001));
+        d_dot_c - (discriminant + epsilon_sq).sqrt()
+    }
+}
+
+/// Convert grayscale Field to Discrete RGBA
+struct GrayToRgba<M> {
+    inner: M,
+}
+
+impl<M: ManifoldCompat<Field, Output = Field>> Manifold<Field4> for GrayToRgba<M> {
+    type Output = Discrete;
+
+    fn eval(&self, p: Field4) -> Discrete {
+        let (x, y, z, w) = p;
+        let gray = self.inner.eval_raw(x, y, z, w);
+        Discrete::pack(gray, gray, gray, Field::from(1.0))
+    }
+}
+
+/// Remap pixel coordinates to normalized screen coordinates for ~60° FOV.
+/// Transforms [0, width] × [0, height] → [-aspect, aspect] × [-1, 1]
+/// where the values represent tan(angle) from optical axis.
+struct ScreenRemap<M> {
+    inner: M,
+    width: f32,
+    height: f32,
+}
+
+impl<M: ManifoldCompat<Field, Output = Field> + ManifoldExt> Manifold<Field4> for ScreenRemap<M> {
+    type Output = Field;
+
+    fn eval(&self, p: Field4) -> Field {
+        let (px, py, z, w) = p;
+        let width = Field::from(self.width);
+        let height = Field::from(self.height);
+
+        // Scale so that screen Y range is [-1, 1]
+        // This gives ~53° vertical FOV (since atan(1) = 45°, the full range is 90°)
+        let scale = Field::from(2.0) / height;
+        let x = (px - width * Field::from(0.5)) * scale.clone();
+        let y = (height * Field::from(0.5) - py) * scale; // Flip Y
+
+        self.inner.eval_at(x, y, z, w)
+    }
+}
+
+// ============================================================================
+// TESTS
+// ============================================================================
+
+/// Test: Chrome sphere at z=4 reflecting floor and sky.
+/// Uses the new three-layer architecture:
+/// - ScreenToDir: seeds jets with screen derivatives, normalizes direction
+/// - Surface<SphereAt, Reflect<world>, world>: sphere reflecting world
+/// - world = Surface<plane, Checker, Sky>: floor + sky
 #[test]
-fn jit_kernel_3d_sphere_on_plane() {
-    const W: usize = 64;
-    const H: usize = 48;
-    let w_f32 = W as f32;
-    let h_f32 = H as f32;
-    let scale = 2.0 / h_f32;
+fn chrome_unit_sphere() {
+    const W: usize = 400;
+    const H: usize = 300;
 
-    let sx = Kernel::x()
-        .sub(&Kernel::constant(w_f32 * 0.5))
-        .mul(&Kernel::constant(scale));
-    let sy = Kernel::constant(h_f32 * 0.5)
-        .sub(&Kernel::y())
-        .mul(&Kernel::constant(scale));
+    // World = floor + sky
+    // PlaneGeometry at y=-1: returns t = -1 / ry (negative plane)
+    let world = Surface {
+        geometry: plane(-1.0),
+        material: Checker,
+        background: sky(),
+    };
 
-    let (dx, dy, dz) = kernel_3d::screen_to_ray(&sx, &sy, 1.0);
-    let sky = kernel_3d::sky(&dy);
+    // Scene = chrome sphere at (0, 0, 4) + world background
+    // SphereAt solves quadratic for intersection distance
+    let scene = Surface {
+        geometry: SphereAt {
+            center: (0.0, 0.0, 4.0),
+            radius: 1.0,
+        },
+        material: Reflect {
+            inner: world.clone(),
+        },
+        background: world,
+    };
 
-    let (t_sphere, hit_sphere) = kernel_3d::sphere_at((0.0, 0.0, 4.0), 1.0, &dx, &dy, &dz);
+    // ScreenToDir: pixel coords → direction jets with derivatives
+    let screen = ScreenRemap {
+        inner: ScreenToDir { inner: scene },
+        width: W as f32,
+        height: H as f32,
+    };
 
-    let px = dx.mul(&t_sphere);
-    let py = dy.mul(&t_sphere);
-    let pz = dz.mul(&t_sphere);
-    let (_nx, ny, _nz) = kernel_3d::surface_normal(&px, &py, &pz);
+    // Wrap in GrayToRgba for rendering
+    let renderable = GrayToRgba { inner: screen };
 
-    let scene = hit_sphere.select(&ny, &sky);
+    // Render
+    let mut frame = Frame::<Rgba8>::new(W as u32, H as u32);
+    rasterize(&renderable, &mut frame, 1);
 
-    let lattice = Lattice::frame(W, H, 0.0);
-    let baked = lattice.bake(&scene);
-    assert_eq!(baked.buffer().len(), W * H);
+    // Save PPM
+    let path = std::env::temp_dir().join("pixelflow_chrome_unit_sphere.ppm");
+    let mut file = File::create(&path).unwrap();
+    writeln!(file, "P6\n{} {}\n255", W, H).unwrap();
+    for p in &frame.data {
+        file.write_all(&[p.r(), p.g(), p.b()]).unwrap();
+    }
+    println!("Saved: {}", path.display());
+
+    // Debug: print some pixel values
+    let center = &frame.data[(H / 2) * W + (W / 2)];
+    let bottom_sphere = &frame.data[(H * 5 / 8) * W + (W / 2)]; // Lower part
+    let top_sphere = &frame.data[(H * 3 / 8) * W + (W / 2)]; // Upper part
+    let corner = &frame.data[0]; // Top-left (sky)
+
+    println!("Chrome center: r={}", center.r());
+    println!("Chrome bottom: r={}", bottom_sphere.r());
+    println!("Chrome top: r={}", top_sphere.r());
+    println!("Corner (sky): r={}", corner.r());
+
+    // Sanity checks
+    assert!(
+        center.r() > 10,
+        "Center should not be black: r={}",
+        center.r()
+    );
+    // Sky gradient goes from 0.1 (dark) to 0.9 (bright) = 25 to 229
+    assert!(
+        corner.r() > 20,
+        "Corner should be sky (not black): r={}",
+        corner.r()
+    );
+}
+
+/// Test: Just the sky (no geometry)
+#[test]
+fn sky_only() {
+    const W: usize = 200;
+    const H: usize = 150;
+
+    // Sky as the only "scene" - wraps it in a dummy Surface that always misses
+    struct SkyOnly;
+
+    impl Manifold<Jet3_4> for SkyOnly {
+        type Output = Field;
+
+        fn eval(&self, p: Jet3_4) -> Field {
+            let (_x, y, _z, _w) = p;
+            // Same as Sky: gradient based on Y direction
+            let t = (y.val * Field::from(0.5) + Field::from(0.5))
+                .max(Field::from(0.0))
+                .min(Field::from(1.0));
+            (Field::from(0.1) + t * Field::from(0.8)).constant()
+        }
+    }
+
+    let screen = ScreenRemap {
+        inner: ScreenToDir { inner: SkyOnly },
+        width: W as f32,
+        height: H as f32,
+    };
+
+    let renderable = GrayToRgba { inner: screen };
+
+    let mut frame = Frame::<Rgba8>::new(W as u32, H as u32);
+    rasterize(&renderable, &mut frame, 1);
+
+    // Save
+    let path = std::env::temp_dir().join("pixelflow_sky_only.ppm");
+    let mut file = File::create(&path).unwrap();
+    writeln!(file, "P6\n{} {}\n255", W, H).unwrap();
+    for p in &frame.data {
+        file.write_all(&[p.r(), p.g(), p.b()]).unwrap();
+    }
+    println!("Saved: {}", path.display());
+
+    // Top should be brighter than bottom (gradient)
+    let top = &frame.data[(H / 4) * W + (W / 2)];
+    let bottom = &frame.data[(3 * H / 4) * W + (W / 2)];
+    println!("Sky top: r={}", top.r());
+    println!("Sky bottom: r={}", bottom.r());
+
+    // Top looks "up" (positive y direction), should be brighter
+    assert!(top.r() > bottom.r(), "Sky should be brighter at top");
+}
+
+/// Test: Floor only (plane with checker pattern)
+#[test]
+fn floor_only() {
+    const W: usize = 400;
+    const H: usize = 300;
+
+    // Just floor + sky (no sphere)
+    let scene = Surface {
+        geometry: plane(-1.0),
+        material: Checker,
+        background: sky(),
+    };
+
+    let screen = ScreenRemap {
+        inner: ScreenToDir { inner: scene },
+        width: W as f32,
+        height: H as f32,
+    };
+
+    let renderable = GrayToRgba { inner: screen };
+
+    let mut frame = Frame::<Rgba8>::new(W as u32, H as u32);
+    rasterize(&renderable, &mut frame, 1);
+
+    // Save
+    let path = std::env::temp_dir().join("pixelflow_floor_only.ppm");
+    let mut file = File::create(&path).unwrap();
+    writeln!(file, "P6\n{} {}\n255", W, H).unwrap();
+    for p in &frame.data {
+        file.write_all(&[p.r(), p.g(), p.b()]).unwrap();
+    }
+    println!("Saved: {}", path.display());
+
+    // Bottom half should hit floor, top half should hit sky
+    let floor_pixel = &frame.data[(3 * H / 4) * W + (W / 2)];
+    let sky_pixel = &frame.data[(H / 4) * W + (W / 2)];
+    println!("Floor: r={}", floor_pixel.r());
+    println!("Sky: r={}", sky_pixel.r());
+
+    // Floor should have checkerboard values (either light or dark)
+    assert!(
+        floor_pixel.r() < 80 || floor_pixel.r() > 180,
+        "Floor should be checker (dark or light): r={}",
+        floor_pixel.r()
+    );
+}
+
+/// Test: Color chrome sphere with blue sky (MULLET ARCHITECTURE)
+/// Geometry runs ONCE, colors flow as packed RGBA. 3x speedup!
+#[test]
+fn color_chrome_sphere() {
+    const W: usize = 1920;
+    const H: usize = 1080;
+
+    // World = floor + sky (using Color* types that output Discrete)
+    let world = ColorSurface {
+        geometry: plane(-1.0),
+        material: ColorChecker::<RgbaColorCube>::default(),
+        background: ColorSky::<RgbaColorCube>::default(),
+    };
+
+    // Scene = chrome sphere reflecting world
+    let scene = ColorSurface {
+        geometry: SphereAt {
+            center: (0.0, 0.0, 4.0),
+            radius: 1.0,
+        },
+        material: ColorReflect { inner: world },
+        background: world,
+    };
+
+    // ScreenRemap but for Discrete output
+    struct ColorScreenRemap<M> {
+        inner: M,
+        width: f32,
+        height: f32,
+    }
+
+    impl<M: ManifoldCompat<Field, Output = Discrete>> Manifold<Field4> for ColorScreenRemap<M> {
+        type Output = Discrete;
+
+        fn eval(&self, p: Field4) -> Discrete {
+            let (px, py, z, w) = p;
+            let width = Field::from(self.width);
+            let height = Field::from(self.height);
+            let scale = Field::from(2.0) / height;
+            let x = (px - width * Field::from(0.5)) * scale.clone();
+            let y = (height * Field::from(0.5) - py) * scale;
+            At {
+                inner: &self.inner,
+                x,
+                y,
+                z,
+                w,
+            }
+            .collapse()
+        }
+    }
+
+    let renderable = ColorScreenRemap {
+        inner: ColorScreenToDir { inner: scene },
+        width: W as f32,
+        height: H as f32,
+    };
+
+    // Render
+    let mut frame = Frame::<Rgba8>::new(W as u32, H as u32);
+    let start = std::time::Instant::now();
+    rasterize(&renderable, &mut frame, 1);
+    let elapsed = start.elapsed();
+    let mpps = (W * H) as f64 / elapsed.as_secs_f64() / 1_000_000.0;
+    println!("Color render (mullet): {:?} ({:.2} Mpix/s)", elapsed, mpps);
+
+    // Save PPM
+    let path = std::env::temp_dir().join("pixelflow_color_chrome.ppm");
+    let mut file = File::create(&path).unwrap();
+    writeln!(file, "P6\n{} {}\n255", W, H).unwrap();
+    for p in &frame.data {
+        file.write_all(&[p.r(), p.g(), p.b()]).unwrap();
+    }
+    println!("Saved: {}", path.display());
+
+    // Debug pixels
+    let center = &frame.data[(H / 2) * W + (W / 2)];
+    let sky = &frame.data[0];
+    println!("Center: r={} g={} b={}", center.r(), center.g(), center.b());
+    println!("Sky: r={} g={} b={}", sky.r(), sky.g(), sky.b());
+
+    // Sky should be blue-ish (B > R)
+    assert!(
+        sky.b() > sky.r(),
+        "Sky should be blue: r={} b={}",
+        sky.r(),
+        sky.b()
+    );
+}
+
+/// Test: Compare 3-channel vs mullet rendering to ensure they match.
+/// This verifies the mullet architecture produces identical results.
+#[test]
+fn mullet_vs_3channel_comparison() {
+    const W: usize = 200;
+    const H: usize = 150;
+
+    // ============================================================
+    // OLD APPROACH: Run geometry 3 times (once per channel)
+    // ============================================================
+
+    /// Per-channel sky (inline version since we deleted BlueSky)
+    #[derive(Clone, Copy, ManifoldExpr)]
+    struct ChannelSky {
+        channel: u8,
+    }
+    impl Manifold<Jet3_4> for ChannelSky {
+        type Output = Field;
+        fn eval(&self, p: Jet3_4) -> Field {
+            let (_x, y, _z, _w) = p;
+            let t = y.val * Field::from(0.5) + Field::from(0.5);
+            let t = t.max(Field::from(0.0)).min(Field::from(1.0)).constant();
+            match self.channel {
+                0 => (Field::from(0.7) - t * Field::from(0.5)).constant(),
+                1 => (Field::from(0.85) - t * Field::from(0.45)).constant(),
+                _ => (Field::from(1.0) - t * Field::from(0.2)).constant(),
+            }
+        }
+    }
+
+    /// Per-channel checker (inline version)
+    #[derive(Clone, Copy, ManifoldExpr)]
+    struct ChannelChecker {
+        channel: u8,
+    }
+    impl Manifold<Jet3_4> for ChannelChecker {
+        type Output = Field;
+        fn eval(&self, p: Jet3_4) -> Field {
+            let (x, _y, z, _w) = p;
+            let cell_x = x.val.floor().constant();
+            let cell_z = z.val.floor().constant();
+            let sum = (cell_x + cell_z).constant();
+            let half = (sum * Field::from(0.5)).constant();
+            let fract_half = (half - half.floor()).constant();
+            let is_even = fract_half.abs().lt(Field::from(0.25));
+
+            let (a, b) = match self.channel {
+                0 => (0.95, 0.2),
+                1 => (0.9, 0.25),
+                _ => (0.8, 0.3),
+            };
+
+            let color_a = Field::from(a);
+            let color_b = Field::from(b);
+            let base_color = is_even.select(color_a, color_b);
+
+            let fx = (x.val - cell_x).constant();
+            let fz = (z.val - cell_z).constant();
+            let dx_edge = (fx - Field::from(0.5)).abs();
+            let dz_edge = (fz - Field::from(0.5)).abs();
+            let dist_to_edge = (Field::from(0.5) - dx_edge).min(Field::from(0.5) - dz_edge);
+
+            let grad_x = (x.dx * x.dx + x.dy * x.dy + x.dz * x.dz).sqrt().constant();
+            let grad_z = (z.dx * z.dx + z.dy * z.dy + z.dz * z.dz).sqrt().constant();
+            let pixel_size = (grad_x.max(grad_z) + Field::from(0.001)).constant();
+
+            let coverage = (dist_to_edge / pixel_size)
+                .min(Field::from(1.0))
+                .max(Field::from(0.0));
+            let neighbor_color = is_even.select(color_b, color_a);
+            (base_color * coverage.clone() + neighbor_color * (Field::from(1.0) - coverage))
+                .constant()
+        }
+    }
+
+    fn build_channel_scene(channel: u8) -> impl Manifold<Output = Field> {
+        let world = Surface {
+            geometry: plane(-1.0),
+            material: ChannelChecker { channel },
+            background: ChannelSky { channel },
+        };
+
+        ScreenRemap {
+            inner: ScreenToDir {
+                inner: Surface {
+                    geometry: SphereAt {
+                        center: (0.0, 0.0, 4.0),
+                        radius: 1.0,
+                    },
+                    material: Reflect { inner: world },
+                    background: world,
+                },
+            },
+            width: W as f32,
+            height: H as f32,
+        }
+    }
+
+    struct ThreeChannelRenderer<R, G, B> {
+        r: R,
+        g: G,
+        b: B,
+    }
+    impl<R, G, B> Manifold<Field4> for ThreeChannelRenderer<R, G, B>
+    where
+        R: ManifoldCompat<Field, Output = Field>,
+        G: ManifoldCompat<Field, Output = Field>,
+        B: ManifoldCompat<Field, Output = Field>,
+    {
+        type Output = Discrete;
+        fn eval(&self, p: Field4) -> Discrete {
+            let (x, y, z, w) = p;
+            let r = self.r.eval_raw(x, y, z, w);
+            let g = self.g.eval_raw(x, y, z, w);
+            let b = self.b.eval_raw(x, y, z, w);
+            Discrete::pack(r, g, b, Field::from(1.0))
+        }
+    }
+
+    let old_renderer = ThreeChannelRenderer {
+        r: build_channel_scene(0),
+        g: build_channel_scene(1),
+        b: build_channel_scene(2),
+    };
+
+    let mut old_frame = Frame::<Rgba8>::new(W as u32, H as u32);
+    let old_start = std::time::Instant::now();
+    rasterize(&old_renderer, &mut old_frame, 1);
+    let old_elapsed = old_start.elapsed();
+
+    // ============================================================
+    // NEW APPROACH: Mullet architecture (geometry once, Discrete colors)
+    // ============================================================
+
+    struct ColorScreenRemap<M> {
+        inner: M,
+        width: f32,
+        height: f32,
+    }
+    impl<M: ManifoldCompat<Field, Output = Discrete>> Manifold<Field4> for ColorScreenRemap<M> {
+        type Output = Discrete;
+        fn eval(&self, p: Field4) -> Discrete {
+            let (px, py, z, w) = p;
+            let width = Field::from(self.width);
+            let height = Field::from(self.height);
+            let scale = Field::from(2.0) / height;
+            let x = (px - width * Field::from(0.5)) * scale.clone();
+            let y = (height * Field::from(0.5) - py) * scale;
+            At {
+                inner: &self.inner,
+                x,
+                y,
+                z,
+                w,
+            }
+            .collapse()
+        }
+    }
+
+    let world = ColorSurface {
+        geometry: plane(-1.0),
+        material: ColorChecker::<RgbaColorCube>::default(),
+        background: ColorSky::<RgbaColorCube>::default(),
+    };
+
+    let new_renderer = ColorScreenRemap {
+        inner: ColorScreenToDir {
+            inner: ColorSurface {
+                geometry: SphereAt {
+                    center: (0.0, 0.0, 4.0),
+                    radius: 1.0,
+                },
+                material: ColorReflect { inner: world },
+                background: world,
+            },
+        },
+        width: W as f32,
+        height: H as f32,
+    };
+
+    let mut new_frame = Frame::<Rgba8>::new(W as u32, H as u32);
+    let new_start = std::time::Instant::now();
+    rasterize(&new_renderer, &mut new_frame, 1);
+    let new_elapsed = new_start.elapsed();
+
+    // ============================================================
+    // COMPARE
+    // ============================================================
+
+    println!("3-channel: {:?}", old_elapsed);
+    println!("Mullet:    {:?}", new_elapsed);
+    println!(
+        "Speedup:   {:.2}x",
+        old_elapsed.as_secs_f64() / new_elapsed.as_secs_f64()
+    );
+
+    // Compare all pixels
+    let mut max_diff = 0i32;
+    let mut diff_count = 0usize;
+    for (i, (old_p, new_p)) in old_frame.data.iter().zip(new_frame.data.iter()).enumerate() {
+        let dr = (old_p.r() as i32 - new_p.r() as i32).abs();
+        let dg = (old_p.g() as i32 - new_p.g() as i32).abs();
+        let db = (old_p.b() as i32 - new_p.b() as i32).abs();
+        let d = Ord::max(Ord::max(dr, dg), db);
+        if d > max_diff {
+            max_diff = d;
+            let x = i % W;
+            let y = i / W;
+            println!(
+                "New max diff {} at ({}, {}): old=({},{},{}) new=({},{},{})",
+                d,
+                x,
+                y,
+                old_p.r(),
+                old_p.g(),
+                old_p.b(),
+                new_p.r(),
+                new_p.g(),
+                new_p.b()
+            );
+        }
+        if d > 0 {
+            diff_count += 1;
+        }
+    }
+
+    println!("Max diff: {} (out of 255)", max_diff);
+    println!("Pixels with diff: {} / {}", diff_count, W * H);
+
+    // Allow small differences due to FP ordering, but they should be identical
+    assert!(
+        max_diff <= 1,
+        "Max diff too large: {} (expected 0-1 for FP rounding)",
+        max_diff
+    );
+}
+
+/// Benchmark: Compare work-stealing vs single-threaded at 1080p
+#[test]
+fn work_stealing_benchmark() {
+    const W: usize = 1920;
+    const H: usize = 1080;
+
+    // Build scene
+    let world = ColorSurface {
+        geometry: plane(-1.0),
+        material: ColorChecker::<RgbaColorCube>::default(),
+        background: ColorSky::<RgbaColorCube>::default(),
+    };
+
+    let scene = ColorSurface {
+        geometry: SphereAt {
+            center: (0.0, 0.0, 4.0),
+            radius: 1.0,
+        },
+        material: ColorReflect { inner: world },
+        background: world,
+    };
+
+    struct ColorScreenRemap<M> {
+        inner: M,
+        width: f32,
+        height: f32,
+    }
+    impl<M: ManifoldCompat<Field, Output = Discrete>> Manifold<Field4> for ColorScreenRemap<M> {
+        type Output = Discrete;
+        fn eval(&self, p: Field4) -> Discrete {
+            let (px, py, z, w) = p;
+            let width = Field::from(self.width);
+            let height = Field::from(self.height);
+            let scale = Field::from(2.0) / height;
+            let x = (px - width * Field::from(0.5)) * scale.clone();
+            let y = (height * Field::from(0.5) - py) * scale;
+            At {
+                inner: &self.inner,
+                x,
+                y,
+                z,
+                w,
+            }
+            .collapse()
+        }
+    }
+
+    let renderable = ColorScreenRemap {
+        inner: ColorScreenToDir { inner: scene },
+        width: W as f32,
+        height: H as f32,
+    };
+
+    // Single-threaded baseline
+    let mut frame1 = Frame::<Rgba8>::new(W as u32, H as u32);
+    let start1 = std::time::Instant::now();
+    rasterize(&renderable, &mut frame1, 1);
+    let single = start1.elapsed();
+
+    // Work-stealing with 12 threads
+    let mut frame2 = Frame::<Rgba8>::new(W as u32, H as u32);
+    let start2 = std::time::Instant::now();
+    rasterize(&renderable, &mut frame2, 12);
+    let parallel = start2.elapsed();
+
+    let speedup = single.as_secs_f64() / parallel.as_secs_f64();
+    let mpps = (W * H) as f64 / parallel.as_secs_f64() / 1_000_000.0;
+
+    println!("Single-threaded: {:?}", single);
+    println!("Work-stealing (12 threads): {:?}", parallel);
+    println!("Speedup: {:.2}x", speedup);
+    println!("Throughput: {:.2} Mpix/s", mpps);
+
+    // Verify correctness
+    assert_eq!(
+        frame1.data, frame2.data,
+        "Parallel output must match single-threaded"
+    );
 }

--- a/pixelflow-ir/src/kernel.rs
+++ b/pixelflow-ir/src/kernel.rs
@@ -574,29 +574,6 @@ impl Kernel {
         Self::wrap(arena, root)
     }
 
-    /// Scale `self` uniformly in 2D by `factor`.
-    #[must_use]
-    pub fn scale(&self, factor: f32) -> Self {
-        let inv = Self::constant(1.0 / factor);
-        self.at(
-            &Self::x().mul(&inv),
-            &Self::y().mul(&inv),
-            &Self::z(),
-            &Self::w(),
-        )
-    }
-
-    /// Translate `self` in 2D by `(dx, dy)`.
-    #[must_use]
-    pub fn translate(&self, dx: f32, dy: f32) -> Self {
-        self.at(
-            &Self::x().sub(&Self::constant(dx)),
-            &Self::y().sub(&Self::constant(dy)),
-            &Self::z(),
-            &Self::w(),
-        )
-    }
-
     /// The derivative `∂self/∂var` (0=X, 1=Y, 2=Z), resolved symbolically at
     /// compile time. The building block of screen-space antialiasing: no jet
     /// domain, just an expression the calculus differentiates.
@@ -701,18 +678,5 @@ mod tests {
         let (out, oroot) = lower_dwrt_owned(arena, root).expect("calculus");
         let got = eval_scalar(&out, oroot, &[3.0, 4.0, 0.0, 0.0], &BindingTable::empty());
         assert!((got - 0.6).abs() < 1e-5);
-    }
-
-    #[test]
-    fn scale_and_translate_kernel_methods() {
-        // x · y scaled by 2 => (x/2) · (y/2)
-        let expr = Kernel::x().mul(&Kernel::y());
-        let scaled = expr.scale(2.0);
-        assert_eq!(eval(&scaled, 4.0, 6.0), 2.0 * 3.0);
-
-        // x + y translated by (1, 2) => (x - 1) + (y - 2)
-        let expr2 = Kernel::x().add(&Kernel::y());
-        let shifted = expr2.translate(1.0, 2.0);
-        assert_eq!(eval(&shifted, 5.0, 7.0), 4.0 + 5.0);
     }
 }

--- a/pixelflow-runtime/examples/animated_sphere.rs
+++ b/pixelflow-runtime/examples/animated_sphere.rs
@@ -1,14 +1,30 @@
-//! Animated Chrome Sphere - windowed animation using JIT Kernel.
+//! Animated Chrome Sphere - windowed animation using the runtime.
+//!
+//! Demonstrates the **pull-based rendering model**:
+//! - Engine sends `RequestFrame` events when ready for a new frame
+//! - App responds with a manifold computed at the requested timestamp
+//! - No busy loops, no sleeps - vsync drives the cadence
+//!
+//! Animation approach:
+//! - Each frame, a new scene is built with the sphere at the animated position
+//! - The position is computed using sin(t * freq) * amplitude at the app level
+//!
+//! Resize handling:
+//! - App receives Resized events and updates stored dimensions
+//! - Scene is rebuilt with new dimensions on next frame
 
 use actor_scheduler::Message;
-use pixelflow_core::{Discrete, Kernel, Lattice, Manifold};
-use pixelflow_graphics::scene3d::kernel_3d;
-use pixelflow_graphics::Grayscale;
+use pixelflow_compiler::ManifoldExpr;
+use pixelflow_core::combinators::At;
+use pixelflow_core::jet::Jet3;
+use pixelflow_core::{Discrete, Field, Manifold, ManifoldCompat};
+use pixelflow_graphics::scene3d::{
+    plane, ColorChecker, ColorReflect, ColorScreenToDir, ColorSky, ColorSurface,
+};
 use pixelflow_runtime::api::private::EngineData;
 use pixelflow_runtime::api::public::{AppData, EngineEvent, EngineEventControl, EngineEventData};
-use pixelflow_runtime::{
-    Application, EngineConfig, EngineTroupe, RuntimeError, WindowConfig, WindowDescriptor,
-};
+use pixelflow_runtime::platform::ColorCube;
+use pixelflow_runtime::{Application, EngineConfig, EngineTroupe, RuntimeError, WindowConfig};
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
@@ -16,59 +32,172 @@ use std::time::Instant;
 const WIDTH: u32 = 1920;
 const HEIGHT: u32 = 1080;
 
+type Field4 = (Field, Field, Field, Field);
+type Jet3_4 = (Jet3, Jet3, Jet3, Jet3);
+
+// ============================================================================
+// GEOMETRY PRIMITIVES (manual struct like chrome_sphere)
+// ============================================================================
+
+/// Sphere at given center with radius.
+#[derive(Clone, Copy, ManifoldExpr)]
+struct SphereAt {
+    center: (f32, f32, f32),
+    radius: f32,
+}
+
+impl Manifold<Jet3_4> for SphereAt {
+    type Output = Jet3;
+
+    #[inline]
+    fn eval(&self, p: Jet3_4) -> Jet3 {
+        let (rx, ry, rz, _w) = p;
+        let cx = Jet3::constant(Field::from(self.center.0));
+        let cy = Jet3::constant(Field::from(self.center.1));
+        let cz = Jet3::constant(Field::from(self.center.2));
+
+        let d_dot_c = rx * cx + ry * cy + rz * cz;
+        let c_sq = cx * cx + cy * cy + cz * cz;
+        let r_sq = Jet3::constant(Field::from(self.radius * self.radius));
+        let discriminant = d_dot_c * d_dot_c - (c_sq - r_sq);
+
+        // Smooth fix for grazing angles
+        let epsilon_sq = Jet3::constant(Field::from(0.0001));
+        d_dot_c - (discriminant + epsilon_sq).sqrt()
+    }
+}
+
+// ============================================================================
+// SCREEN COORDINATE REMAPPING
+// ============================================================================
+
+/// Remap pixel coordinates to normalized screen coordinates for ~60° FOV.
+#[derive(Clone, ManifoldExpr)]
+struct ColorScreenRemap<M> {
+    inner: M,
+    width: f32,
+    height: f32,
+}
+
+impl<M: ManifoldCompat<Field, Output = Discrete>> Manifold<Field4> for ColorScreenRemap<M> {
+    type Output = Discrete;
+
+    fn eval(&self, p: Field4) -> Discrete {
+        let (px, py, z, w) = p;
+        let width = Field::from(self.width);
+        let height = Field::from(self.height);
+
+        let scale = Field::from(2.0) / height;
+        let x = (px - width * Field::from(0.5)) * scale.clone();
+        let y = (height * Field::from(0.5) - py) * scale;
+
+        At {
+            inner: &self.inner,
+            x,
+            y,
+            z,
+            w,
+        }
+        .collapse()
+    }
+}
+
+// ============================================================================
+// SCENE CONSTRUCTION - Compositional Animation
+// ============================================================================
+
+/// Animation parameters for the oscillating sphere.
 const BASE_CENTER: (f32, f32, f32) = (0.0, 0.0, 4.0);
-const AMPLITUDE: f32 = 2.0;
-const FREQUENCY: f32 = 1.0;
+const AMPLITUDE: f32 = 2.0; // Oscillate ±2 units in X
+const FREQUENCY: f32 = 1.0; // 1 rad/s
 const RADIUS: f32 = 1.0;
 
-fn build_scene_kernel(t: f32, width: u32, height: u32) -> Kernel {
+/// Build scene with sphere at the given animated position.
+///
+/// The animation offset is precomputed at the application level using
+/// sin(t * frequency) * amplitude, then baked into the sphere's center.
+fn build_scene_at_time(
+    t: f32,
+    width: u32,
+    height: u32,
+) -> impl Manifold<Output = Discrete> + Clone {
+    // Compute the animated X offset
     let x_offset = (t * FREQUENCY).sin() * AMPLITUDE;
     let cx = BASE_CENTER.0 + x_offset;
     let cy = BASE_CENTER.1;
     let cz = BASE_CENTER.2;
 
-    let scale = 2.0 / height as f32;
-    let sx = Kernel::x()
-        .sub(&Kernel::constant(width as f32 * 0.5))
-        .mul(&Kernel::constant(scale));
-    let sy = Kernel::constant(height as f32 * 0.5)
-        .sub(&Kernel::y())
-        .mul(&Kernel::constant(scale));
+    // Background: floor with checkerboard
+    let color_cube = ColorCube::default();
+    let world = ColorSurface {
+        geometry: plane(-1.0),
+        material: ColorChecker::new(color_cube),
+        background: ColorSky::new(color_cube),
+    };
 
-    let (dx, dy, dz) = kernel_3d::screen_to_ray(&sx, &sy, 1.0);
-    let sky = kernel_3d::sky(&dy);
+    // Sphere at the computed animated position
+    let sphere = SphereAt {
+        center: (cx, cy, cz),
+        radius: RADIUS,
+    };
 
-    let (t_sphere, hit_mask) = kernel_3d::sphere_at((cx, cy, cz), RADIUS, &dx, &dy, &dz);
-    let px = dx.mul(&t_sphere);
-    let py = dy.mul(&t_sphere);
-    let pz = dz.mul(&t_sphere);
+    let scene = ColorSurface {
+        geometry: sphere,
+        material: ColorReflect { inner: world },
+        background: world,
+    };
 
-    let (_nx, ny, _nz) = kernel_3d::surface_normal(&px, &py, &pz);
-
-    hit_mask.select(&ny, &sky)
+    ColorScreenRemap {
+        inner: ColorScreenToDir { inner: scene },
+        width: width as f32,
+        height: height as f32,
+    }
 }
 
+// ============================================================================
+// APPLICATION - Pull-based rendering
+// ============================================================================
+
+/// The animated sphere application.
+///
+/// Implements the pull-based rendering model:
+/// - Receives `RequestFrame` events from the engine
+/// - Responds with a manifold at the requested timestamp
+/// - Handles resize events to update dimensions
 struct AnimatedSphereApp {
+    /// Animation start time
     start: Instant,
+    /// Handle to send frames back to the engine.
+    /// Mutex satisfies Sync for Arc<dyn Application + Send + Sync>.
+    /// No contention — only the engine actor thread calls send().
     engine_handle: std::sync::Mutex<pixelflow_runtime::api::private::EngineActorHandle>,
+    /// Current width (atomic for interior mutability)
     width: AtomicU32,
+    /// Current height (atomic for interior mutability)
     height: AtomicU32,
 }
 
 impl Application for AnimatedSphereApp {
     fn send(&self, event: EngineEvent) -> Result<(), RuntimeError> {
         match event {
+            // Engine is ready for a frame - this is the pull!
             EngineEvent::Data(EngineEventData::RequestFrame { timestamp, .. }) => {
+                log::debug!("App received RequestFrame");
+
+                // Compute elapsed time from animation start
                 let t = timestamp.duration_since(self.start).as_secs_f32();
+
+                // Get current dimensions
                 let width = self.width.load(Ordering::Relaxed);
                 let height = self.height.load(Ordering::Relaxed);
 
-                let scene_kernel = build_scene_kernel(t, width, height);
-                let lattice = Lattice::frame(width as usize, height as usize, 0.0);
-                let baked = lattice.bake(&scene_kernel);
-                let arc: Arc<dyn Manifold<Output = Discrete> + Send + Sync> =
-                    Arc::new(Grayscale(baked));
+                // Build the scene at this moment in time with current dimensions
+                let scene = build_scene_at_time(t, width, height);
 
+                let arc: Arc<dyn Manifold<Output = Discrete> + Send + Sync> = Arc::new(scene);
+
+                // Send the frame back to the engine
+                log::debug!("App sending RenderSurface");
                 self.engine_handle
                     .lock()
                     .unwrap()
@@ -77,27 +206,47 @@ impl Application for AnimatedSphereApp {
                     ))))
                     .map_err(|e| RuntimeError::EventSendError(e.to_string()))?;
             }
+            // Handle resize events
             EngineEvent::Control(EngineEventControl::Resized {
                 width_px,
                 height_px,
                 ..
             }) => {
+                log::info!("App: Window resized to {}x{}", width_px, height_px);
                 self.width.store(width_px, Ordering::Relaxed);
                 self.height.store(height_px, Ordering::Relaxed);
             }
-            _ => {}
+            EngineEvent::Control(EngineEventControl::WindowCreated {
+                width_px,
+                height_px,
+                ..
+            }) => {
+                log::info!("App: Window created {}x{}", width_px, height_px);
+                self.width.store(width_px, Ordering::Relaxed);
+                self.height.store(height_px, Ordering::Relaxed);
+            }
+            EngineEvent::Control(ctrl) => {
+                log::debug!("App received Control event: {:?}", ctrl);
+            }
+            _ => {
+                log::debug!("App received other event");
+            }
         }
         Ok(())
     }
 }
 
 fn main() -> anyhow::Result<()> {
-    println!("Animated Chrome Sphere Demo (JIT Kernel)");
-    println!("--------------------------------------");
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    println!("Animated Chrome Sphere (Pull-based)");
+    println!("====================================");
+    println!("Resolution: {}x{}", WIDTH, HEIGHT);
+    println!();
 
     let config = EngineConfig {
         window: WindowConfig {
-            title: "PixelFlow JIT Animated Chrome Sphere".to_string(),
+            title: "Animated Sphere".to_string(),
             width: WIDTH,
             height: HEIGHT,
         },
@@ -107,8 +256,12 @@ fn main() -> anyhow::Result<()> {
     let mut troupe = EngineTroupe::with_config(config)?;
     let unregistered_handle = troupe.engine_handle();
     let start = Instant::now();
+
+    // Get the raw engine handle for sending frames back
+    // This must be obtained before registration (app needs it to respond to RequestFrame)
     let engine_handle_for_app = troupe.raw_engine_handle();
 
+    // Create the pull-based app (scene is built per-frame with animation)
     let app = AnimatedSphereApp {
         start,
         engine_handle: std::sync::Mutex::new(engine_handle_for_app),
@@ -116,14 +269,19 @@ fn main() -> anyhow::Result<()> {
         height: AtomicU32::new(HEIGHT),
     };
 
+    // Register app and create window
+    use pixelflow_runtime::WindowDescriptor;
     let window = WindowDescriptor {
         width: WIDTH,
         height: HEIGHT,
-        title: "Animated Chrome Sphere".into(),
+        title: "Animated Sphere".into(),
         resizable: true,
     };
     let _engine_handle = unregistered_handle.register(Arc::new(app), window)?;
 
+    println!("Running... (close window to exit)");
     troupe.play().map_err(|e| anyhow::anyhow!("{}", e))?;
+
+    println!("Done!");
     Ok(())
 }

--- a/pixelflow-runtime/examples/chrome_sphere.rs
+++ b/pixelflow-runtime/examples/chrome_sphere.rs
@@ -1,12 +1,50 @@
-//! Chrome Sphere JIT Rendering Demo
+//! Chrome Sphere Parallel Rendering Demo
 //!
-//! Renders the 3D chrome sphere scene (with warm/cool checkerboard floor, sky gradient, and Householder reflections)
-//! JIT-compiled via `Lattice::bake`.
+//! Compares single-threaded vs parallel rasterization of the 3D chrome sphere scene.
+//! Uses the mullet architecture: geometry once, colors as packed Discrete.
 
-use pixelflow_core::{Kernel, Lattice};
+use pixelflow_compiler::ManifoldExpr;
+use pixelflow_core::combinators::At;
+use pixelflow_core::jet::Jet3;
+use pixelflow_core::{Discrete, Field, Manifold, ManifoldCompat};
+
+type Field4 = (Field, Field, Field, Field);
+type Jet3_4 = (Jet3, Jet3, Jet3, Jet3);
 use pixelflow_graphics::render::color::Rgba8;
 use pixelflow_graphics::render::frame::Frame;
-use pixelflow_graphics::scene3d::kernel_3d;
+use pixelflow_graphics::render::rasterizer::rasterize;
+use pixelflow_graphics::scene3d::{
+    plane, ColorChecker, ColorReflect, ColorScreenToDir, ColorSky, ColorSurface,
+};
+use pixelflow_runtime::platform::ColorCube;
+
+/// Sphere at given center with radius (local to this example).
+#[derive(Clone, Copy, ManifoldExpr)]
+struct SphereAt {
+    center: (f32, f32, f32),
+    radius: f32,
+}
+
+impl Manifold<Jet3_4> for SphereAt {
+    type Output = Jet3;
+
+    #[inline]
+    fn eval(&self, p: Jet3_4) -> Jet3 {
+        let (rx, ry, rz, _w) = p;
+        let cx = Jet3::constant(Field::from(self.center.0));
+        let cy = Jet3::constant(Field::from(self.center.1));
+        let cz = Jet3::constant(Field::from(self.center.2));
+
+        let d_dot_c = rx * cx + ry * cy + rz * cz;
+        let c_sq = cx * cx + cy * cy + cz * cz;
+        let r_sq = Jet3::constant(Field::from(self.radius * self.radius));
+        let discriminant = d_dot_c * d_dot_c - (c_sq - r_sq);
+
+        // Smooth fix for grazing angles
+        let epsilon_sq = Jet3::constant(Field::from(0.0001));
+        d_dot_c - (discriminant + epsilon_sq).sqrt()
+    }
+}
 use std::fs::File;
 use std::io::Write;
 use std::time::Instant;
@@ -14,21 +52,66 @@ use std::time::Instant;
 const W: usize = 1920;
 const H: usize = 1080;
 
-fn build_scene() -> (Kernel, Kernel, Kernel) {
-    let scale = 2.0 / H as f32;
-    let sx = Kernel::x()
-        .sub(&Kernel::constant(W as f32 * 0.5))
-        .mul(&Kernel::constant(scale));
-    let sy = Kernel::constant(H as f32 * 0.5)
-        .sub(&Kernel::y())
-        .mul(&Kernel::constant(scale));
+/// Remap pixel coordinates to normalized screen coordinates for ~60° FOV.
+#[derive(Clone, ManifoldExpr)]
+struct ColorScreenRemap<M> {
+    inner: M,
+    width: f32,
+    height: f32,
+}
 
-    kernel_3d::chrome_scene_rgb(&sx, &sy, (0.0, 0.0, 4.0), 1.0)
+impl<M: ManifoldCompat<Field, Output = Discrete>> Manifold<Field4> for ColorScreenRemap<M> {
+    type Output = Discrete;
+
+    fn eval(&self, p: Field4) -> Discrete {
+        let (px, py, z, w) = p;
+        let width = Field::from(self.width);
+        let height = Field::from(self.height);
+
+        let scale = Field::from(2.0) / height;
+        let x = (px - width * Field::from(0.5)) * scale.clone();
+        let y = (height * Field::from(0.5) - py) * scale;
+
+        At {
+            inner: &self.inner,
+            x,
+            y,
+            z,
+            w,
+        }
+        .collapse()
+    }
+}
+
+/// Build the color scene using the mullet architecture.
+/// Geometry runs once, colors flow as packed RGBA.
+fn build_scene() -> impl Manifold<Output = Discrete> + Clone {
+    let color_cube = ColorCube::default();
+    let world = ColorSurface {
+        geometry: plane(-1.0),
+        material: ColorChecker::new(color_cube),
+        background: ColorSky::new(color_cube),
+    };
+
+    let scene = ColorSurface {
+        geometry: SphereAt {
+            center: (0.0, 0.0, 4.0),
+            radius: 1.0,
+        },
+        material: ColorReflect { inner: world },
+        background: world,
+    };
+
+    ColorScreenRemap {
+        inner: ColorScreenToDir { inner: scene },
+        width: W as f32,
+        height: H as f32,
+    }
 }
 
 fn main() {
-    println!("Chrome Sphere JIT Rendering Demo");
-    println!("================================");
+    println!("Chrome Sphere Parallel Rendering Demo");
+    println!("=====================================");
     println!(
         "Resolution: {}x{} ({:.1}M pixels)",
         W,
@@ -37,42 +120,85 @@ fn main() {
     );
     println!();
 
-    let (rk, gk, bk) = build_scene();
-    let lattice = Lattice::frame(W, H, 0.0);
+    // Build the scene using mullet architecture (geometry once, colors as packed Discrete)
+    let scene = build_scene();
 
-    let start = Instant::now();
-    let baked_r = lattice.bake(&rk);
-    let baked_g = lattice.bake(&gk);
-    let baked_b = lattice.bake(&bk);
-    let elapsed = start.elapsed();
+    let num_cpus = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1);
 
-    let buf_r = baked_r.buffer();
-    let buf_g = baked_g.buffer();
-    let buf_b = baked_b.buffer();
+    println!("Available CPU threads: {}", num_cpus);
+    println!();
 
-    let mpps = (W * H) as f64 / elapsed.as_secs_f64() / 1_000_000.0;
-    let fps = 1.0 / elapsed.as_secs_f64();
-    println!(
-        "JIT Baked render: {:>7.2}ms ({:>5.1} Mpix/s, {:>5.1} FPS)",
-        elapsed.as_secs_f64() * 1000.0,
-        mpps,
-        fps
-    );
-
-    let mut frame = Frame::<Rgba8>::new(W as u32, H as u32);
-    for i in 0..(W * H) {
-        let r = (buf_r[i].clamp(0.0, 1.0) * 255.0) as u8;
-        let g = (buf_g[i].clamp(0.0, 1.0) * 255.0) as u8;
-        let b = (buf_b[i].clamp(0.0, 1.0) * 255.0) as u8;
-        frame.data[i] = Rgba8::new(r, g, b, 255);
+    // Warm-up run
+    {
+        let mut frame = Frame::<Rgba8>::new(W as u32, H as u32);
+        rasterize(&scene, &mut frame, 1);
     }
 
-    let path = std::env::temp_dir().join("chrome_sphere_jit.ppm");
-    let mut file = File::create(&path).unwrap();
-    writeln!(file, "P6\n{} {}\n255", W, H).unwrap();
-    for p in &frame.data {
-        file.write_all(&[p.r(), p.g(), p.b()]).unwrap();
+    // Single-threaded benchmark
+    let single_time = {
+        let mut frame = Frame::<Rgba8>::new(W as u32, H as u32);
+        let start = Instant::now();
+        rasterize(&scene, &mut frame, 1);
+        let elapsed = start.elapsed();
+
+        let mpps = (W * H) as f64 / elapsed.as_secs_f64() / 1_000_000.0;
+        let fps = 1.0 / elapsed.as_secs_f64();
+        println!(
+            "Single-threaded: {:>7.2}ms ({:>5.1} Mpix/s, {:>5.1} FPS)",
+            elapsed.as_secs_f64() * 1000.0,
+            mpps,
+            fps
+        );
+
+        // Save the image
+        let path = std::env::temp_dir().join("chrome_sphere_single.ppm");
+        let mut file = File::create(&path).unwrap();
+        writeln!(file, "P6\n{} {}\n255", W, H).unwrap();
+        for p in &frame.data {
+            file.write_all(&[p.r(), p.g(), p.b()]).unwrap();
+        }
+        println!("  Saved: {}", path.display());
+
+        elapsed
+    };
+
+    println!();
+
+    // Parallel benchmarks with different thread counts
+    for threads in [2, 4, 8, num_cpus].iter().filter(|&&t| t <= num_cpus) {
+        let mut frame = Frame::<Rgba8>::new(W as u32, H as u32);
+
+        let start = Instant::now();
+        rasterize(&scene, &mut frame, *threads);
+        let elapsed = start.elapsed();
+
+        let mpps = (W * H) as f64 / elapsed.as_secs_f64() / 1_000_000.0;
+        let fps = 1.0 / elapsed.as_secs_f64();
+        let speedup = single_time.as_secs_f64() / elapsed.as_secs_f64();
+
+        println!(
+            "{:>2}-threaded:      {:>7.2}ms ({:>5.1} Mpix/s, {:>5.1} FPS) - {:.2}x speedup",
+            threads,
+            elapsed.as_secs_f64() * 1000.0,
+            mpps,
+            fps,
+            speedup
+        );
+
+        if *threads == num_cpus {
+            // Save the parallel result
+            let path = std::env::temp_dir().join("chrome_sphere_parallel.ppm");
+            let mut file = File::create(&path).unwrap();
+            writeln!(file, "P6\n{} {}\n255", W, H).unwrap();
+            for p in &frame.data {
+                file.write_all(&[p.r(), p.g(), p.b()]).unwrap();
+            }
+            println!("  Saved: {}", path.display());
+        }
     }
-    println!("Saved: {}", path.display());
-    println!("Done!");
+
+    println!();
+    println!("Done! Images saved to /tmp/");
 }

--- a/pixelflow-runtime/examples/image_viewer.rs
+++ b/pixelflow-runtime/examples/image_viewer.rs
@@ -1,117 +1,175 @@
-//! Simple Image Viewer - displays the chrome sphere in a window using JIT Kernel.
+//! Simple Image Viewer - displays the chrome sphere in a window.
+//!
+//! This demonstrates the minimal pixelflow-runtime usage:
+//! 1. Create EngineTroupe with config
+//! 2. Get engine handle
+//! 3. Send a manifold to render
+//! 4. Run the event loop
 
-use actor_scheduler::Message;
-use pixelflow_core::{Discrete, Kernel, Lattice, Manifold};
-use pixelflow_graphics::scene3d::kernel_3d;
-use pixelflow_graphics::Grayscale;
-use pixelflow_runtime::api::private::EngineData;
-use pixelflow_runtime::api::public::{AppData, EngineEvent, EngineEventControl, EngineEventData};
-use pixelflow_runtime::{Application, EngineConfig, EngineTroupe, WindowConfig, WindowDescriptor};
-use std::sync::atomic::{AtomicU32, Ordering};
+use pixelflow_compiler::ManifoldExpr;
+use pixelflow_core::combinators::At;
+use pixelflow_core::jet::Jet3;
+use pixelflow_core::{Discrete, Field, Manifold, ManifoldCompat};
+use pixelflow_runtime::{api::public::AppData, EngineConfig, EngineTroupe, WindowConfig};
 use std::sync::Arc;
+
+type Field4 = (Field, Field, Field, Field);
+type Jet3_4 = (Jet3, Jet3, Jet3, Jet3);
 
 const W: u32 = 1920;
 const H: u32 = 1080;
 
-fn build_scene() -> Kernel {
-    let scale = 2.0 / H as f32;
-    let sx = Kernel::x()
-        .sub(&Kernel::constant(W as f32 * 0.5))
-        .mul(&Kernel::constant(scale));
-    let sy = Kernel::constant(H as f32 * 0.5)
-        .sub(&Kernel::y())
-        .mul(&Kernel::constant(scale));
+// Import scene3d types
+use pixelflow_graphics::scene3d::{
+    plane, ColorChecker, ColorReflect, ColorScreenToDir, ColorSky, ColorSurface,
+};
+use pixelflow_runtime::platform::ColorCube;
 
-    let (dx, dy, dz) = kernel_3d::screen_to_ray(&sx, &sy, 1.0);
-    let sky = kernel_3d::sky(&dy);
-
-    let (t_sphere, hit_mask) = kernel_3d::sphere_at((0.0, 0.0, 4.0), 1.0, &dx, &dy, &dz);
-    let px = dx.mul(&t_sphere);
-    let py = dy.mul(&t_sphere);
-    let pz = dz.mul(&t_sphere);
-
-    let (_nx, ny, _nz) = kernel_3d::surface_normal(&px, &py, &pz);
-
-    hit_mask.select(&ny, &sky)
+/// Sphere at given center with radius (local to this example).
+#[derive(Clone, Copy, ManifoldExpr)]
+struct SphereAt {
+    center: (f32, f32, f32),
+    radius: f32,
 }
 
-struct ImageViewerApp {
-    engine_handle: std::sync::Mutex<pixelflow_runtime::api::private::EngineActorHandle>,
-    width: AtomicU32,
-    height: AtomicU32,
+impl Manifold<Jet3_4> for SphereAt {
+    type Output = Jet3;
+
+    #[inline]
+    fn eval(&self, p: Jet3_4) -> Jet3 {
+        let (rx, ry, rz, _w) = p;
+        let cx = Jet3::constant(Field::from(self.center.0));
+        let cy = Jet3::constant(Field::from(self.center.1));
+        let cz = Jet3::constant(Field::from(self.center.2));
+
+        let d_dot_c = rx * cx + ry * cy + rz * cz;
+        let c_sq = cx * cx + cy * cy + cz * cz;
+        let r_sq = Jet3::constant(Field::from(self.radius * self.radius));
+        let discriminant = d_dot_c * d_dot_c - (c_sq - r_sq);
+
+        let epsilon_sq = Jet3::constant(Field::from(0.0001));
+        d_dot_c - (discriminant + epsilon_sq).sqrt()
+    }
 }
 
-impl Application for ImageViewerApp {
-    fn send(&self, event: EngineEvent) -> Result<(), pixelflow_runtime::RuntimeError> {
-        match event {
-            EngineEvent::Data(EngineEventData::RequestFrame { .. }) => {
-                let width = self.width.load(Ordering::Relaxed);
-                let height = self.height.load(Ordering::Relaxed);
+/// Screen coordinate remapper for Discrete output.
+#[derive(Clone, Copy, ManifoldExpr)]
+struct ScreenRemap<M> {
+    inner: M,
+    width: f32,
+    height: f32,
+}
 
-                let scene_kernel = build_scene();
-                let lattice = Lattice::frame(width as usize, height as usize, 0.0);
-                let baked = lattice.bake(&scene_kernel);
-                let arc: Arc<dyn Manifold<Output = Discrete> + Send + Sync> =
-                    Arc::new(Grayscale(baked));
+impl<M: ManifoldCompat<Field, Output = Discrete>> Manifold<Field4> for ScreenRemap<M> {
+    type Output = Discrete;
 
-                self.engine_handle
-                    .lock()
-                    .unwrap()
-                    .send(Message::Data(EngineData::FromApp(AppData::RenderSurface(
-                        arc,
-                    ))))
-                    .map_err(|e| pixelflow_runtime::RuntimeError::EventSendError(e.to_string()))?;
-            }
-            EngineEvent::Control(EngineEventControl::Resized {
-                width_px,
-                height_px,
-                ..
-            }) => {
-                self.width.store(width_px, Ordering::Relaxed);
-                self.height.store(height_px, Ordering::Relaxed);
-            }
-            _ => {}
+    fn eval(&self, p: Field4) -> Discrete {
+        let (x, y, z, w) = p;
+        let scale = 2.0 / self.height;
+        let sx = (x - Field::from(self.width * 0.5)) * Field::from(scale);
+        let sy = (Field::from(self.height * 0.5) - y) * Field::from(scale);
+        At {
+            inner: &self.inner,
+            x: sx,
+            y: sy,
+            z,
+            w,
         }
-        Ok(())
+        .collapse()
+    }
+}
+
+/// Build the chrome sphere scene.
+fn build_scene() -> impl Manifold<Output = Discrete> + Clone {
+    let color_cube = ColorCube::default();
+    let world = ColorSurface {
+        geometry: plane(-1.0),
+        material: ColorChecker::new(color_cube),
+        background: ColorSky::new(color_cube),
+    };
+
+    let scene = ColorSurface {
+        geometry: SphereAt {
+            center: (0.0, 0.0, 4.0),
+            radius: 1.0,
+        },
+        material: ColorReflect { inner: world },
+        background: world,
+    };
+
+    ScreenRemap {
+        inner: ColorScreenToDir { inner: scene },
+        width: W as f32,
+        height: H as f32,
     }
 }
 
 fn main() -> anyhow::Result<()> {
+    // Initialize logging
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
 
-    println!("Chrome Sphere JIT Image Viewer");
-    println!("==============================");
+    println!("Chrome Sphere + Bezier Patch");
+    println!("=============================");
     println!("Resolution: {}x{}", W, H);
+    println!();
 
+    // Configure the engine
     let config = EngineConfig {
         window: WindowConfig {
-            title: "Chrome Sphere JIT Image Viewer".to_string(),
+            title: "Chrome Sphere + Bezier Patch".to_string(),
             width: W,
             height: H,
         },
         ..Default::default()
     };
 
+    // Phase 1: Create the troupe
     let mut troupe = EngineTroupe::with_config(config)?;
+
+    // Phase 2: Get unregistered engine handle
     let unregistered_handle = troupe.engine_handle();
-    let engine_handle_for_app = troupe.raw_engine_handle();
 
-    let app = ImageViewerApp {
-        engine_handle: std::sync::Mutex::new(engine_handle_for_app),
-        width: AtomicU32::new(W),
-        height: AtomicU32::new(H),
-    };
+    // Create a dummy app that ignores events
+    struct DummyApp;
+    impl pixelflow_runtime::Application for DummyApp {
+        fn send(
+            &self,
+            _event: pixelflow_runtime::EngineEvent,
+        ) -> Result<(), pixelflow_runtime::RuntimeError> {
+            Ok(())
+        }
+    }
 
+    // Register app and create window
+    use pixelflow_runtime::WindowDescriptor;
     let window = WindowDescriptor {
         width: W,
         height: H,
         title: "Image Viewer".into(),
         resizable: false,
     };
-    let _engine_handle = unregistered_handle.register(Arc::new(app), window)?;
+    let engine_handle = unregistered_handle.register(Arc::new(DummyApp), window)?;
+
+    // Build our scene manifold
+    let scene = build_scene();
+    let scene_arc: Arc<dyn Manifold<Output = Discrete> + Send + Sync> = Arc::new(scene);
+
+    // Send initial frame
+    use actor_scheduler::Message;
+    use pixelflow_runtime::api::private::EngineData;
+
+    engine_handle
+        .send(Message::Data(EngineData::FromApp(AppData::RenderSurface(
+            scene_arc.clone(),
+        ))))
+        .map_err(|e| anyhow::anyhow!("Failed to send initial frame: {}", e))?;
 
     println!("Sent initial frame to engine");
+    println!("Running event loop... (close window to exit)");
+
+    // Phase 3: Run the event loop (blocks)
     troupe.play().map_err(|e| anyhow::anyhow!("{}", e))?;
 
+    println!("Exited cleanly.");
     Ok(())
 }


### PR DESCRIPTION
## What changed

Reverts #959 in full, restoring the exact tracked tree from immediately before its squash merge.

## Why

The second automated review completed after the PR had already merged and left eight actionable threads unresolved, including three P1 findings. Confirmed regressions include:

- default `kernel!` JIT routing breaks supported non-JIT targets and contradicts the retained polymorphism contract;
- `subdivision_autodiff` discards its subdivision geometry and renders a unit sphere instead;
- the chrome examples regress to grayscale normal visualizations and lose the reflected floor/sky material;
- `sphere_at` mishandles NaN discriminants and interior-camera roots;
- checkerboard footprint filtering was removed, reintroducing shimmer and moiré;
- the static viewer re-bakes a 1080p scene on every frame request.

The local post-merge follow-up commits are intentionally not included; they were never part of `main`.

## Validation

- The revert branch tree is byte-for-byte identical to the parent of merge commit `5a1a1b20481791cb72272f384ec36f12acdd6725`.
- `cargo fmt --all -- --check` passes locally.
- Full presubmit CI is required before merge.

Follow-up CI-hardening work will be submitted separately so this rollback stays mechanical and easy to audit.
