### PR TITLE
ci: require ABI and render behavior contracts

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -59,6 +59,38 @@ jobs:
       - name: Run Clippy
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
+  cross-target-abi:
+    name: Cross-target ABI (aarch64)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-unknown-linux-gnu
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-aarch64-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-aarch64-
+
+      # This integration target expands the public `kernel!` macro in a
+      # consumer crate. A host-only proc-macro check would miss generated code
+      # that disagrees with the second supported architecture's JIT ABI.
+      - name: Type-check default kernel routing on aarch64
+        run: >-
+          cargo check -p pixelflow-compiler
+          --test kernel_routing_parity
+          --target aarch64-unknown-linux-gnu
+
   test:
     name: Test on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -117,6 +149,66 @@ jobs:
       - name: Run doctests
         shell: bash
         run: cargo test --workspace --all-features --doc
+
+  behavior-contracts:
+    name: Behavior contracts
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-behavior-contracts-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-behavior-contracts-
+
+      # These are named public-behavior contracts, not an incidental subset of
+      # the workspace suite. nextest's explicit `--no-tests fail` makes deleting
+      # or renaming them a hard failure instead of a green zero-test run.
+      - name: Check default and arena kernel routing parity
+        shell: bash
+        run: |
+          cargo nextest run -p pixelflow-compiler --test kernel_routing_parity --no-tests fail
+          cargo nextest run -p pixelflow-compiler --test kernel_routing_parity --features arena-backend --no-tests fail
+
+      - name: Check JIT/interpreter glyph parity
+        shell: bash
+        run: >-
+          cargo nextest run -p pixelflow-graphics
+          --test kernel_glyph_golden
+          --no-tests fail
+
+      - name: Check scene color, reflection, and antialiasing contracts
+        shell: bash
+        run: >-
+          cargo nextest run -p pixelflow-graphics
+          --test scene3d_test
+          -E 'test(=color_chrome_sphere) | test(=floor_only) | test(=mullet_vs_3channel_comparison)'
+          --profile ci
+          --no-tests fail
+
+      - name: Check ray/surface composition contracts
+        shell: bash
+        run: >-
+          cargo nextest run -p pixelflow-graphics
+          --test raymarch_sphere
+          --profile ci
+          --no-tests fail
 
   isa-matrix:
     name: ISA matrix (SSE2/AVX2/AVX-512)

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -85,11 +85,16 @@ jobs:
       # This integration target expands the public `kernel!` macro in a
       # consumer crate. A host-only proc-macro check would miss generated code
       # that disagrees with the second supported architecture's JIT ABI.
-      - name: Type-check default kernel routing on aarch64
-        run: >-
-          cargo check -p pixelflow-compiler
-          --test kernel_routing_parity
-          --target aarch64-unknown-linux-gnu
+      - name: Type-check default and arena kernel routing on aarch64
+        shell: bash
+        run: |
+          cargo check -p pixelflow-compiler \
+            --test kernel_routing_parity \
+            --target aarch64-unknown-linux-gnu
+          cargo check -p pixelflow-compiler \
+            --test kernel_routing_parity \
+            --features arena-backend \
+            --target aarch64-unknown-linux-gnu
 
   test:
     name: Test on ${{ matrix.os }}
@@ -183,32 +188,76 @@ jobs:
       - name: Check default and arena kernel routing parity
         shell: bash
         run: |
-          cargo nextest run -p pixelflow-compiler --test kernel_routing_parity --no-tests fail
-          cargo nextest run -p pixelflow-compiler --test kernel_routing_parity --features arena-backend --no-tests fail
+          set -euo pipefail
+          tests=(
+            projection_kernels_stay_on_field_domain_semantics
+            routed_abs_recip_matches_truth
+            routed_arithmetic_matches_truth
+            routed_params_match_truth
+            routed_piecewise_matches_truth
+          )
+          for test_name in "${tests[@]}"; do
+            cargo nextest run -p pixelflow-compiler \
+              --test kernel_routing_parity \
+              -E "test(=$test_name)" \
+              --no-tests fail
+            cargo nextest run -p pixelflow-compiler \
+              --test kernel_routing_parity \
+              --features arena-backend \
+              -E "test(=$test_name)" \
+              --no-tests fail
+          done
 
       - name: Check JIT/interpreter glyph parity
         shell: bash
-        run: >-
-          cargo nextest run -p pixelflow-graphics
-          --test kernel_glyph_golden
-          --no-tests fail
+        run: |
+          set -euo pipefail
+          tests=(
+            descender_glyph_bake_matches_interpreter
+            double_counter_glyph_bake_matches_interpreter
+            round_glyph_bake_matches_interpreter
+            simple_glyph_bake_matches_interpreter
+          )
+          for test_name in "${tests[@]}"; do
+            cargo nextest run -p pixelflow-graphics \
+              --test kernel_glyph_golden \
+              -E "test(=$test_name)" \
+              --no-tests fail
+          done
 
       - name: Check scene color, reflection, and antialiasing contracts
         shell: bash
-        run: >-
-          cargo nextest run -p pixelflow-graphics
-          --test scene3d_test
-          -E 'test(=color_chrome_sphere) | test(=floor_only) | test(=mullet_vs_3channel_comparison)'
-          --profile ci
-          --no-tests fail
+        run: |
+          set -euo pipefail
+          tests=(
+            color_chrome_sphere
+            floor_only
+            mullet_vs_3channel_comparison
+          )
+          for test_name in "${tests[@]}"; do
+            cargo nextest run -p pixelflow-graphics \
+              --test scene3d_test \
+              -E "test(=$test_name)" \
+              --profile ci \
+              --no-tests fail
+          done
 
       - name: Check ray/surface composition contracts
         shell: bash
-        run: >-
-          cargo nextest run -p pixelflow-graphics
-          --test raymarch_sphere
-          --profile ci
-          --no-tests fail
+        run: |
+          set -euo pipefail
+          tests=(
+            chrome_sphere_on_checkerboard
+            sphere_on_floor
+            sphere_on_matte_floor
+          )
+          for test_name in "${tests[@]}"; do
+            cargo nextest run -p pixelflow-graphics \
+              --test raymarch_sphere \
+              -E "test(=$test_name)" \
+              --profile ci \
+              --no-tests fail
+          done
 
   isa-matrix:
     name: ISA matrix (SSE2/AVX2/AVX-512)


### PR DESCRIPTION
## What changed
- cross-compile the public `kernel!` consumer parity suite for the supported aarch64 JIT ABI
- make default-vs-arena routing parity and JIT-vs-interpreter glyph goldens explicit CI contracts
- make scene color/reflection/antialiasing and ray/surface render contracts fail loudly when deleted or renamed

## Why
PR #959 passed the broad workspace suite while deleting or weakening behavior coverage and changing architecture-sensitive routing. These named gates turn those behaviors into merge requirements instead of relying on test discovery alone.

## Local validation
- `cargo check -p pixelflow-compiler --test kernel_routing_parity --target aarch64-unknown-linux-gnu`
- default and `arena-backend` kernel routing parity: 10/10 passed
- JIT/interpreter glyph goldens: 4/4 passed
- selected scene behavior contracts: 3/3 passed
- ray/surface composition contracts: 3/3 passed
- `cargo fmt --all -- --check`
- workflow YAML parse and `git diff --check`