### PR TITLE
chore(ci): enforce CL metadata tags

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -13,6 +13,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  cl-metadata:
+    name: CL metadata
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code and CL history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check CL title and commit subjects
+        env:
+          CL_TITLE: ${{ github.event.pull_request.title }}
+          BASE_COMMIT: ${{ github.event.pull_request.base.sha }}
+          HEAD_COMMIT: ${{ github.event.pull_request.head.sha }}
+        run: >-
+          bash scripts/check-cl-metadata.sh
+          "$CL_TITLE"
+          "$BASE_COMMIT"
+          "$HEAD_COMMIT"
+
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest

--- a/scripts/check-cl-metadata.sh
+++ b/scripts/check-cl-metadata.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+  echo "usage: $0 <cl-title> <base-commit> <head-commit>" >&2
+  exit 2
+fi
+
+cl_title=$1
+base_commit=$2
+head_commit=$3
+subject_pattern='^(fix|feat|chore|test|revert|docs|perf|refactor|ci)(\([[:alnum:]_.\/-]+\))?:[[:space:]]+[^[:space:]]'
+expected='(fix|feat|chore|test|revert|docs|perf|refactor|ci)(scope)?: description'
+
+check_subject() {
+  local kind=$1
+  local subject=$2
+
+  if [[ $subject =~ $subject_pattern ]]; then
+    return
+  fi
+
+  echo "invalid $kind: $subject" >&2
+  echo "expected: $expected" >&2
+  return 1
+}
+
+check_subject "CL title" "$cl_title"
+
+git cat-file -e "${base_commit}^{commit}" || {
+  echo "base is not a commit: $base_commit" >&2
+  exit 2
+}
+git cat-file -e "${head_commit}^{commit}" || {
+  echo "head is not a commit: $head_commit" >&2
+  exit 2
+}
+
+commit_list=$(mktemp)
+trap 'rm -f "$commit_list"' EXIT
+git log --format='%H%x09%s' "${base_commit}..${head_commit}" >"$commit_list" || {
+  echo "failed to enumerate CL commits: ${base_commit}..${head_commit}" >&2
+  exit 2
+}
+
+if [[ ! -s $commit_list ]]; then
+  echo "CL contains no commits: ${base_commit}..${head_commit}" >&2
+  exit 1
+fi
+
+invalid=0
+while IFS=$'\t' read -r commit subject; do
+  if ! check_subject "commit $commit" "$subject"; then
+    invalid=1
+  fi
+done <"$commit_list"
+
+if [[ $invalid -ne 0 ]]; then
+  exit 1
+fi
+
+echo "CL title and all commit subjects satisfy: $expected"


### PR DESCRIPTION
## What changed
- require every CL title to start with an approved category and optional scope
- require every commit introduced by the CL to follow the same grammar
- report every invalid commit instead of stopping after the first one

Allowed grammar: `^(fix|feat|chore|test|revert|docs|perf|refactor|ci)(\([[:alnum:]_.\/-]+\))?:`

Existing `main` history is not linted retroactively.

## Validation
- compliant unscoped title and commit
- compliant scoped title and commit
- invalid category rejection
- invalid scope rejection
- workflow YAML parse
- shell syntax and `git diff --check`