### PR TITLE
feat(render): kernel-native frame lane with a collapse-baked cell grid

### DIFF
--- a/actor-scheduler/src/spsc.rs
+++ b/actor-scheduler/src/spsc.rs
@@ -22,7 +22,7 @@
 use std::cell::{Cell, UnsafeCell};
 use std::mem::MaybeUninit;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 /// Cache line size for padding. 64 bytes on x86, conservative default.
 const CACHE_LINE: usize = 64;
@@ -76,6 +76,14 @@ struct RingBuffer<T> {
     head: PaddedAtomic,
     /// Producer's write position. Only the producer stores to this.
     tail: PaddedAtomic,
+    /// Set (Release) by the producer's Drop, AFTER its last `tail` publish.
+    /// The consumer reads it with Acquire, so observing `true` makes every
+    /// message the producer ever published visible — which is what makes
+    /// "disconnected AND empty" a drain guarantee instead of a race.
+    /// (`Arc::strong_count` cannot serve here: its Relaxed load orders
+    /// nothing, so a consumer could see the count drop before the final
+    /// tail store and abandon buffered messages.)
+    producer_gone: AtomicBool,
 }
 
 // Safety: RingBuffer is shared between exactly one producer thread and one
@@ -102,6 +110,7 @@ impl<T> RingBuffer<T> {
             mask,
             head: PaddedAtomic::new(0),
             tail: PaddedAtomic::new(0),
+            producer_gone: AtomicBool::new(false),
         }
     }
 }
@@ -247,11 +256,21 @@ impl<T> SpscReceiver<T> {
             // Refresh tail from the producer's atomic
             self.cached_tail = self.ring.tail.value.load(Ordering::Acquire);
             if head == self.cached_tail {
-                // Empty — check if producer is gone
-                if Arc::strong_count(&self.ring) == 1 {
-                    return Err(TryRecvError::Disconnected);
+                // Empty — check if producer is gone. The Acquire load pairs
+                // with the Release store in SpscSender::drop, which runs
+                // after the producer's last publish; re-check the tail so a
+                // disconnect never outruns messages already sent (the CI-
+                // caught race: 256 of 100k lost at teardown).
+                if self.ring.producer_gone.load(Ordering::Acquire) {
+                    self.cached_tail = self.ring.tail.value.load(Ordering::Acquire);
+                    if head == self.cached_tail {
+                        return Err(TryRecvError::Disconnected);
+                    }
+                    // Messages landed between the checks: fall through and
+                    // read them; Disconnected is only ever "gone AND drained".
+                } else {
+                    return Err(TryRecvError::Empty);
                 }
-                return Err(TryRecvError::Empty);
             }
         }
 
@@ -274,7 +293,7 @@ impl<T> SpscReceiver<T> {
     /// Returns true if the producer has been dropped.
     #[must_use]
     pub fn is_disconnected(&self) -> bool {
-        Arc::strong_count(&self.ring) == 1
+        self.ring.producer_gone.load(Ordering::Acquire)
     }
 
     /// Returns the number of messages currently in the buffer.
@@ -296,8 +315,10 @@ impl<T> SpscReceiver<T> {
 
 impl<T> Drop for SpscSender<T> {
     fn drop(&mut self) {
-        // No special action needed — the RingBuffer's Drop handles cleanup.
-        // The consumer will see Disconnected on next try_recv when empty.
+        // Release-publish the disconnect AFTER every tail store this thread
+        // made, so a consumer that Acquire-observes it also observes the
+        // final messages. The RingBuffer's Drop handles slot cleanup.
+        self.ring.producer_gone.store(true, Ordering::Release);
     }
 }
 

--- a/core-term/src/terminal_app.rs
+++ b/core-term/src/terminal_app.rs
@@ -11,7 +11,8 @@ use actor_scheduler::{
     Actor, ActorBuilder, ActorHandle, ActorStatus, HandlerError, HandlerResult, Message,
     SystemStatus,
 };
-use pixelflow_core::{At, CellGridGeometry, CellGridProgram, Discrete, Manifold};
+use pixelflow_core::{At, CellGridGeometry, CellGridProgram};
+use pixelflow_graphics::render::scene::Scene;
 
 /// Adapter to send PTY commands to TerminalApp actor.
 pub struct TerminalAppSender {
@@ -221,20 +222,20 @@ impl TerminalApp {
     /// A resize therefore IS a recompile — four channel kernels, sized
     /// independently of the grid — which replaces the old per-frame tree of
     /// boxed combinators entirely.
-    fn build_scene(&mut self) -> Arc<dyn Manifold<Output = Discrete> + Send + Sync> {
+    fn build_scene(&mut self) -> Scene {
         let (dbg_r, dbg_g, dbg_b, dbg_a) = self.config.colors.background.to_f32_rgba();
 
         // Get terminal snapshot
         let snapshot = match self.emulator.get_render_snapshot() {
             Some(s) => s,
             None => {
-                return Arc::new(At {
+                return Scene::Surface(Arc::new(At {
                     inner: ColorCube::default(),
                     x: dbg_r,
                     y: dbg_g,
                     z: dbg_b,
                     w: dbg_a,
-                });
+                }));
             }
         };
 
@@ -286,12 +287,16 @@ impl TerminalApp {
         // (Re)compile the scene program when the geometry moved: resize,
         // density change, atlas growth. Compile cost is independent of the
         // grid size, so this is the entire cost of a dynamic resize.
+        // Scene::CellGrid renders in DEVICE-PIXEL space (the runtime does
+        // not contramap it): cell extents scale by the display density, and
+        // the atlas — baked at `density` texels per point — is exactly one
+        // texel per device pixel.
         let geom = CellGridGeometry {
             cols: cols as u32,
             rows: rows as u32,
-            cell_w: cell_width,
-            cell_h: cell_height,
-            density: self.density,
+            cell_w: cell_width * self.density,
+            cell_h: cell_height * self.density,
+            density: 1.0,
             atlas_width: self.atlas.width() as u32,
             atlas_height: self.atlas.height() as u32,
             tile_w: self.atlas.tile_px() as u32,
@@ -310,15 +315,7 @@ impl TerminalApp {
             self.program = Some(CellGridProgram::compile(geom, [dbg_r, dbg_g, dbg_b, dbg_a]));
         }
         let program = self.program.as_ref().expect("program compiled above");
-        let frame = program.frame(Arc::new(cells), self.atlas.buffer());
-
-        Arc::new(At {
-            inner: ColorCube::default(),
-            x: frame.channel(0),
-            y: frame.channel(1),
-            z: frame.channel(2),
-            w: frame.channel(3),
-        })
+        Scene::CellGrid(program.frame(Arc::new(cells), self.atlas.buffer()))
     }
 
     /// Send a rendered frame to the engine.
@@ -1095,7 +1092,6 @@ mod tests {
     fn scene_paints_default_background_and_recompiles_on_resize() {
         use pixelflow_graphics::render::color::Bgra8;
         use pixelflow_graphics::render::frame::Frame;
-        use pixelflow_graphics::render::rasterizer::rasterize;
 
         let (mut app, _writer_rx, _tx, _scheduler) = match create_test_app() {
             Some(v) => v,
@@ -1106,7 +1102,7 @@ mod tests {
         // JIT cell-grid scene must rasterize to that color.
         let scene = app.build_scene();
         let mut frame = Frame::<Bgra8>::new(16, 16);
-        rasterize(&scene, &mut frame, 1);
+        scene.render(&mut frame, 1);
         let (r, g, b, _) = app.config.colors.background.to_f32_rgba();
         let px = frame.data[8 * 16 + 8];
         let close = |got: u8, want: f32| (got as f32 - want * 255.0).abs() <= 2.0;

--- a/docs/plans/2026-07-20-kernel-unification.md
+++ b/docs/plans/2026-07-20-kernel-unification.md
@@ -310,6 +310,23 @@ to-be-retired backend, tracked until that backend dies.
   lane in pixelflow-runtime (bake channel planes via the collapse loop +
   LICM, pack to RGBA) is the natural next cut and would retire that too.
 
+  **P6 progress 2026-07-29 (second): the frame lane is Kernel-native.**
+  The rasterizer's input is now `pixelflow_graphics::render::scene::Scene`:
+  `Surface` (an arbitrary color manifold, dense per-batch evaluation — the
+  generic lane examples and the no-snapshot background still use) or
+  `CellGrid` (a `CellGridFrame` rendered by ONE 2D-collapse call per channel
+  per stripe — the internal pixel loop, both LICM prologue scopes active —
+  then packed via `Pixel::from_rgba`). `CellGridProgram` compiles
+  collapse-mode kernels only; the per-batch `CellGridChannel` manifolds are
+  deleted with their `At`+`ColorCube` composition in core-term — the
+  terminal's render path now contains no combinator evaluation at all.
+  `Scene::CellGrid` renders in device-pixel space by contract (the
+  coordinator's DPI contramap applies only to `Surface`; the cell grid
+  carries its scale in its geometry, which makes atlas texels ≡ device
+  pixels). `AppData::RenderSurfaceU32` — documented as u32-coordinate
+  rendering but treated identically to `RenderSurface` by the engine, with
+  zero senders — deleted per subtract-before-add.
+
 ## Beyond P6 — the language the totality axiom demands
 
 P0–P6 unify the *pipeline*. These phases grow the *language* to cover the AO /

--- a/pixelflow-core/src/lattice/cell_grid.rs
+++ b/pixelflow-core/src/lattice/cell_grid.rs
@@ -54,19 +54,31 @@ use pixelflow_ir::{ExprArena, ExprId, JitManifold, OpKind};
 pub const CELL_STRIDE: usize = 10;
 
 /// The compiled-against shape of a [`CellGridProgram`]: grid dimensions,
-/// cell extent in points, atlas extents in texels, and the atlas sample
-/// density (texels per point). Changing any field means recompiling.
+/// cell extents, atlas extents in texels, and the atlas sample density.
+/// Changing any field means recompiling.
+///
+/// ## Coordinate units
+///
+/// Cell extents and `density` are in the CALLER'S sampling space — the
+/// coordinates the compiled kernels will be evaluated at. The program
+/// applies no unit conversion of its own, so whoever drives the bake
+/// decides what a coordinate means and must express every field in that
+/// one space. In particular, `pixelflow-runtime` renders cell-grid scenes
+/// on the frame buffer's DEVICE-PIXEL grid without any DPI contramap: a
+/// scene destined for the runtime bakes its display scale in here
+/// (extents × scale, density in texels per device pixel), as core-term
+/// does.
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct CellGridGeometry {
     /// Grid width in cells.
     pub cols: u32,
     /// Grid height in cells.
     pub rows: u32,
-    /// Cell width in points.
+    /// Cell width, in sampling-space coordinate units (see the type docs).
     pub cell_w: f32,
-    /// Cell height in points.
+    /// Cell height, in sampling-space coordinate units.
     pub cell_h: f32,
-    /// Atlas texels per point.
+    /// Atlas texels per sampling-space coordinate unit.
     pub density: f32,
     /// Atlas width in texels.
     pub atlas_width: u32,

--- a/pixelflow-core/src/lattice/cell_grid.rs
+++ b/pixelflow-core/src/lattice/cell_grid.rs
@@ -46,7 +46,7 @@ use alloc::sync::Arc;
 use alloc::vec::Vec;
 
 use super::JitVec;
-use crate::{Field, Manifold};
+use crate::Field;
 use pixelflow_ir::arena::BufferDecl;
 use pixelflow_ir::{ExprArena, ExprId, JitManifold, OpKind};
 
@@ -265,10 +265,11 @@ impl CellGridProgram {
         );
         let jits = core::array::from_fn(|c| {
             let (arena, root) = channel_arena(&geom, c, default_bg[c]);
-            // Bound-memory arenas are uncacheable (the code bakes buffer
-            // slot metadata); compile_cached recognizes that and compiles
-            // fresh.
-            pixelflow_ir::jit_cache::compile_cached(&arena, root)
+            // Collapse-mode (internal 2D loop): one call bakes a whole run
+            // of rows for a channel. Bound-memory arenas are uncacheable
+            // (the code bakes buffer slot metadata); the cache recognizes
+            // that and compiles fresh.
+            pixelflow_ir::jit_cache::compile_collapse_cached(&arena, root)
                 .expect("cell-grid channel failed to compile")
         });
         Self { geom, jits }
@@ -320,52 +321,73 @@ pub struct CellGridFrame {
 }
 
 impl CellGridFrame {
-    /// The manifold for one color channel (0 = R, 1 = G, 2 = B, 3 = A).
+    /// The padded row stride (in `f32`s) that [`CellGridFrame::bake_channel_rows`]
+    /// writes: `width` rounded up to whole SIMD batches. Planes are laid out
+    /// at this stride; the padding lanes hold whatever the kernel computed
+    /// past the right edge (out-of-grid pixels — the default background) and
+    /// are simply not read back.
+    #[must_use]
+    pub fn padded_width(width: usize) -> usize {
+        let lanes = pixelflow_ir::JIT_VECTOR_BYTES / core::mem::size_of::<f32>();
+        width.div_ceil(lanes).max(1) * lanes
+    }
+
+    /// Bake one color channel (0 = R, 1 = G, 2 = B, 3 = A) over the pixel
+    /// rows `y0 .. y0 + rows` at pixel-center coordinates, into a plane of
+    /// [`CellGridFrame::padded_width`]`(width)`-stride rows.
+    ///
+    /// ONE call into the channel's 2D collapse kernel per invocation: the
+    /// loop over batches and rows lives inside the JIT, with the two-level
+    /// LICM prologues (per-call and per-row) active. This is the production
+    /// render path — a frame is four of these per stripe, then a pack.
     ///
     /// # Panics
     ///
-    /// Panics if `channel >= 4`.
-    #[must_use]
-    pub fn channel(&self, channel: usize) -> CellGridChannel {
-        CellGridChannel {
-            jit: self.jits[channel].clone(),
-            cells: self.cells.clone(),
-            atlas: self.atlas.clone(),
+    /// Panics if `channel >= 4`, `width == 0`, or `out` is shorter than
+    /// `rows * padded_width(width)`.
+    pub fn bake_channel_rows(
+        &self,
+        channel: usize,
+        width: usize,
+        y0: usize,
+        rows: usize,
+        out: &mut [f32],
+    ) {
+        assert!(width > 0, "bake_channel_rows: zero width");
+        let stride = Self::padded_width(width);
+        assert!(
+            out.len() >= rows * stride,
+            "bake_channel_rows: plane of {} f32s cannot hold {rows} rows at stride {stride}",
+            out.len()
+        );
+        if rows == 0 {
+            return;
         }
-    }
-}
-
-/// One color channel of a [`CellGridFrame`], as a manifold. Evaluation is a
-/// single call into the channel's JIT-compiled program with the frame's two
-/// buffers bound.
-#[derive(Clone)]
-pub struct CellGridChannel {
-    jit: Arc<JitManifold>,
-    cells: Arc<Vec<f32>>,
-    atlas: Arc<Vec<f32>>,
-}
-
-impl crate::ext::ManifoldExpr for CellGridChannel {}
-
-impl Manifold<(Field, Field, Field, Field)> for CellGridChannel {
-    type Output = Field;
-
-    #[inline(always)]
-    fn eval(&self, (x, y, z, w): (Field, Field, Field, Field)) -> Field {
+        let groups = stride / (pixelflow_ir::JIT_VECTOR_BYTES / core::mem::size_of::<f32>());
         let ctx = [self.cells.as_ptr(), self.atlas.as_ptr()];
+        // Pixel centers: the rasterizer convention (x + ½, y + ½).
+        let x0 = Field::sequential(0.5);
+        let y = Field::from(y0 as f32 + 0.5);
+        let zero = Field::from(0.0);
         // SAFETY: `compile` checked size_of::<Field>() == JIT_VECTOR_BYTES;
         // the kernel was compiled from an arena declaring exactly the two
         // buffers whose lengths `CellGridProgram::frame` asserted against
-        // the same geometry, and `ctx` binds their live base pointers (in
-        // declaration order) for the duration of the call.
+        // the same geometry; `ctx` binds their live base pointers (in
+        // declaration order) for the duration of the call; and `out` holds
+        // `rows` full rows of `groups` batches (asserted above) with no
+        // scalar tail (row_skip = 0 — the stride IS whole batches).
         unsafe {
-            core::mem::transmute::<JitVec, Field>(self.jit.call_bound(
+            self.jits[channel].call_collapse(
                 ctx.as_ptr(),
-                core::mem::transmute::<Field, JitVec>(x),
+                out.as_mut_ptr(),
+                groups,
+                rows,
+                0,
+                core::mem::transmute::<Field, JitVec>(x0),
                 core::mem::transmute::<Field, JitVec>(y),
-                core::mem::transmute::<Field, JitVec>(z),
-                core::mem::transmute::<Field, JitVec>(w),
-            ))
+                core::mem::transmute::<Field, JitVec>(zero),
+                core::mem::transmute::<Field, JitVec>(zero),
+            );
         }
     }
 }
@@ -373,7 +395,6 @@ impl Manifold<(Field, Field, Field, Field)> for CellGridChannel {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Lattice;
     use alloc::vec;
 
     /// A 2×1 grid over a 2-tile atlas: tile A solid coverage 1, tile B a
@@ -417,13 +438,16 @@ mod tests {
         row * 8 + col
     }
 
-    /// Evaluate one channel over a pixel-center lattice.
+    /// Bake one channel over pixel centers and unpad to a dense w×h plane.
     fn plane(frame: &CellGridFrame, channel: usize, w: usize, h: usize) -> alloc::vec::Vec<f32> {
-        let lattice = Lattice {
-            extent: [w as u32, h as u32, 1, 1],
-            origin: [0.5, 0.5, 0.0, 0.0],
-        };
-        lattice.collapse(&frame.channel(channel)).into_buffer()
+        let stride = CellGridFrame::padded_width(w);
+        let mut padded = vec![0.0f32; h * stride];
+        frame.bake_channel_rows(channel, w, 0, h, &mut padded);
+        let mut dense = alloc::vec::Vec::with_capacity(w * h);
+        for row in 0..h {
+            dense.extend_from_slice(&padded[row * stride..row * stride + w]);
+        }
+        dense
     }
 
     #[test]
@@ -474,21 +498,43 @@ mod tests {
 
     #[test]
     fn misaligned_samples_fade_through_the_apron_not_into_neighbors() {
-        let (program, cells, atlas) = tiny_scene();
-        let frame = program.frame(cells, atlas);
-        // Sample pixel centers shifted by +0.4 point: x = 3.9 in cell 0 taps
-        // its last content texel (weight 0.6) and its APRON (weight 0.4) —
-        // coverage 0.6. If the tap bled into tile 1's 0.5 coverage instead,
-        // this would read 0.6 + 0.4·0.5 = 0.8.
-        let lattice = Lattice {
-            extent: [8, 4, 1, 1],
-            origin: [0.9, 0.5, 0.0, 0.0],
+        // Density 0.8 over a 5-point cell: pixel centers land BETWEEN texel
+        // centers, so the bilinear filter engages. The last pixel of the
+        // cell (x = 4.5 → tile-space 3.6) taps the last content texel
+        // (weight 0.9) and the zero APRON (weight 0.1) — never the next
+        // slot's content, which sits two texels further.
+        let (aw, ah, slot) = (12usize, 6usize, 6usize);
+        let mut atlas = vec![0.0f32; aw * ah];
+        for r in 0..4 {
+            for c in 0..4 {
+                atlas[(1 + r) * aw + 1 + c] = 1.0; // tile 0: solid
+                atlas[(1 + r) * aw + slot + 1 + c] = 1.0; // tile 1: ALSO solid
+            }
+        }
+        let geom = CellGridGeometry {
+            cols: 1,
+            rows: 1,
+            cell_w: 5.0,
+            cell_h: 5.0,
+            density: 0.8,
+            atlas_width: aw as u32,
+            atlas_height: ah as u32,
+            tile_w: 4,
+            tile_h: 4,
         };
-        let r = lattice.collapse(&frame.channel(0)).into_buffer();
+        let program = CellGridProgram::compile(geom, [0.0; 4]);
+        let cells = vec![
+            1.0, 1.0, /* fg */ 1.0, 1.0, 1.0, 1.0, /* bg */ 0.0, 0.0, 0.0, 1.0,
+        ];
+        let frame = program.frame(Arc::new(cells), Arc::new(atlas));
+        let r = plane(&frame, 0, 5, 5);
+        // Row 2 (tile-space y = 2.0·... = interior): x = 4.5 → 0.9 content,
+        // 0.1 apron. If the tap bled into tile 1's solid content instead,
+        // this would read 1.0.
         assert!(
-            (r[px(1, 3)] - 0.6).abs() < 1e-5,
-            "cell0 apron R = {}",
-            r[11]
+            (r[2 * 5 + 4] - 0.9).abs() < 1e-5,
+            "fractional edge sample R = {}",
+            r[2 * 5 + 4]
         );
     }
 

--- a/pixelflow-core/src/lattice/cell_grid.rs
+++ b/pixelflow-core/src/lattice/cell_grid.rs
@@ -320,6 +320,18 @@ pub struct CellGridFrame {
     atlas: Arc<Vec<f32>>,
 }
 
+/// A horizontal band of pixel rows to bake: `width` pixels across, rows
+/// `y0 .. y0 + rows`.
+#[derive(Clone, Copy, Debug)]
+pub struct PlaneRegion {
+    /// Pixels per row.
+    pub width: usize,
+    /// First pixel row.
+    pub y0: usize,
+    /// Number of rows.
+    pub rows: usize,
+}
+
 impl CellGridFrame {
     /// The padded row stride (in `f32`s) that [`CellGridFrame::bake_channel_rows`]
     /// writes: `width` rounded up to whole SIMD batches. Planes are laid out
@@ -343,16 +355,10 @@ impl CellGridFrame {
     ///
     /// # Panics
     ///
-    /// Panics if `channel >= 4`, `width == 0`, or `out` is shorter than
-    /// `rows * padded_width(width)`.
-    pub fn bake_channel_rows(
-        &self,
-        channel: usize,
-        width: usize,
-        y0: usize,
-        rows: usize,
-        out: &mut [f32],
-    ) {
+    /// Panics if `channel >= 4`, the region's width is zero, or `out` is
+    /// shorter than `rows * padded_width(width)`.
+    pub fn bake_channel_rows(&self, channel: usize, region: PlaneRegion, out: &mut [f32]) {
+        let PlaneRegion { width, y0, rows } = region;
         assert!(width > 0, "bake_channel_rows: zero width");
         let stride = Self::padded_width(width);
         assert!(
@@ -442,7 +448,15 @@ mod tests {
     fn plane(frame: &CellGridFrame, channel: usize, w: usize, h: usize) -> alloc::vec::Vec<f32> {
         let stride = CellGridFrame::padded_width(w);
         let mut padded = vec![0.0f32; h * stride];
-        frame.bake_channel_rows(channel, w, 0, h, &mut padded);
+        frame.bake_channel_rows(
+            channel,
+            PlaneRegion {
+                width: w,
+                y0: 0,
+                rows: h,
+            },
+            &mut padded,
+        );
         let mut dense = alloc::vec::Vec::with_capacity(w * h);
         for row in 0..h {
             dense.extend_from_slice(&padded[row * stride..row * stride + w]);

--- a/pixelflow-core/src/lib.rs
+++ b/pixelflow-core/src/lib.rs
@@ -243,9 +243,7 @@ pub use manifold::Differentiable;
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub use lattice::BilinearSampler;
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-pub use lattice::cell_grid::{
-    CELL_STRIDE, CellGridChannel, CellGridFrame, CellGridGeometry, CellGridProgram,
-};
+pub use lattice::cell_grid::{CELL_STRIDE, CellGridFrame, CellGridGeometry, CellGridProgram};
 pub use lattice::{DiscreteManifold, Lattice, ReduceOp};
 
 // ============================================================================

--- a/pixelflow-core/src/lib.rs
+++ b/pixelflow-core/src/lib.rs
@@ -243,7 +243,9 @@ pub use manifold::Differentiable;
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub use lattice::BilinearSampler;
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-pub use lattice::cell_grid::{CELL_STRIDE, CellGridFrame, CellGridGeometry, CellGridProgram};
+pub use lattice::cell_grid::{
+    CELL_STRIDE, CellGridFrame, CellGridGeometry, CellGridProgram, PlaneRegion,
+};
 pub use lattice::{DiscreteManifold, Lattice, ReduceOp};
 
 // ============================================================================

--- a/pixelflow-graphics/src/render/mod.rs
+++ b/pixelflow-graphics/src/render/mod.rs
@@ -2,6 +2,7 @@ pub mod color;
 pub mod frame;
 pub mod pixel;
 pub mod rasterizer;
+pub mod scene;
 
 #[cfg(test)]
 mod pict; // PICT-style pairwise covering-array generator (POC)

--- a/pixelflow-graphics/src/render/rasterizer/actor.rs
+++ b/pixelflow-graphics/src/render/rasterizer/actor.rs
@@ -36,7 +36,6 @@ use super::messages::{
     RasterConfig, RasterControl, RasterManagement, RasterSetup, RasterizerSetupHandle,
     RenderRequest, RenderResponse,
 };
-use super::rasterize;
 use crate::render::Pixel;
 use actor_scheduler::mealy::Transducer;
 use actor_scheduler::{
@@ -102,7 +101,7 @@ impl<P: Pixel, Meta> RasterCore<P, Meta> {
     /// path carrying no frame.
     fn render(&mut self, request: RenderRequest<P, Meta>) -> RenderResponse<P, Meta> {
         let RenderRequest {
-            manifold,
+            scene,
             mut frame,
             meta,
         } = request;
@@ -117,7 +116,7 @@ impl<P: Pixel, Meta> RasterCore<P, Meta> {
         }
 
         let start = Instant::now();
-        rasterize(&manifold, &mut frame, self.num_threads);
+        scene.render(&mut frame, self.num_threads);
         let render_time = start.elapsed();
 
         log::trace!(
@@ -215,7 +214,7 @@ mod core_tests {
 
     fn request(size: u32) -> RenderRequest<Rgba8> {
         RenderRequest {
-            manifold: Arc::new(Color::Rgb(255, 0, 0)),
+            scene: crate::render::scene::Scene::Surface(Arc::new(Color::Rgb(255, 0, 0))),
             frame: Frame::new(size, size),
             meta: (),
         }
@@ -236,7 +235,7 @@ mod core_tests {
         let mut core = RasterCore::<Rgba8, WindowMeta>::new(1);
         let out = core
             .step_data(RenderRequest {
-                manifold: Arc::new(Color::Rgb(0, 255, 0)),
+                scene: crate::render::scene::Scene::Surface(Arc::new(Color::Rgb(0, 255, 0))),
                 frame: Frame::new(8, 8),
                 meta: WindowMeta {
                     id: 42,
@@ -482,7 +481,7 @@ mod tests {
         let red = Color::Rgb(255, 0, 0);
 
         let request = RenderRequest {
-            manifold: Arc::new(red),
+            scene: crate::render::scene::Scene::Surface(Arc::new(red)),
             frame,
             meta: (),
         };
@@ -569,7 +568,7 @@ mod tests {
         let blue = Color::Rgb(0, 0, 255);
 
         let request = RenderRequest {
-            manifold: Arc::new(blue),
+            scene: crate::render::scene::Scene::Surface(Arc::new(blue)),
             frame,
             meta: (),
         };

--- a/pixelflow-graphics/src/render/rasterizer/messages.rs
+++ b/pixelflow-graphics/src/render/rasterizer/messages.rs
@@ -16,11 +16,10 @@
 //! - **Management**: Configuration updates (thread count, etc.)
 
 use crate::render::frame::Frame;
+use crate::render::scene::Scene;
 use crate::render::Pixel;
 use actor_scheduler::ActorHandle;
-use pixelflow_core::{Discrete, Manifold};
 use std::sync::mpsc::{self, Sender, SyncSender};
-use std::sync::Arc;
 use std::time::Duration;
 
 /// Frame rendering request (Data lane - high throughput, backpressure).
@@ -28,8 +27,9 @@ use std::time::Duration;
 /// The Data lane is designed for high-volume work items and will block
 /// senders when the buffer is full, providing natural backpressure.
 pub struct RenderRequest<P: Pixel, Meta = ()> {
-    /// The color manifold to render.
-    pub manifold: Arc<dyn Manifold<Output = Discrete> + Send + Sync>,
+    /// The scene to render (an arbitrary color manifold, or a JIT
+    /// cell-grid frame on the collapse-baked fast lane).
+    pub scene: Scene,
     /// The frame buffer to render into.
     pub frame: Frame<P>,
     /// Caller-owned payload, returned untouched in the [`RenderResponse`].

--- a/pixelflow-graphics/src/render/scene.rs
+++ b/pixelflow-graphics/src/render/scene.rs
@@ -1,0 +1,206 @@
+//! # Scene: what the rasterizer renders
+//!
+//! The rasterizer's input is either an arbitrary color manifold — rendered
+//! by dense per-batch evaluation through the `Manifold` trait — or a JIT
+//! cell-grid frame ([`pixelflow_core::CellGridFrame`]), whose four channel
+//! planes are baked by ONE internal-loop collapse call per channel per
+//! stripe and then packed to pixels. The cell-grid lane is the production
+//! frame path: no per-batch FFI boundary, no virtual dispatch, and the
+//! collapse kernel's two-level LICM prologues (per-call, per-row) active.
+
+use crate::render::frame::Frame;
+use crate::render::Pixel;
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+use pixelflow_core::CellGridFrame;
+use pixelflow_core::{Discrete, Manifold};
+use std::sync::Arc;
+
+/// A renderable scene. See the module docs for the two lanes.
+#[derive(Clone)]
+pub enum Scene {
+    /// Dense per-batch evaluation of an arbitrary color manifold.
+    Surface(Arc<dyn Manifold<Output = Discrete> + Send + Sync>),
+    /// A JIT cell-grid frame: channel planes baked by the 2D collapse
+    /// kernel, packed to pixels per stripe.
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    CellGrid(CellGridFrame),
+}
+
+impl From<Arc<dyn Manifold<Output = Discrete> + Send + Sync>> for Scene {
+    fn from(manifold: Arc<dyn Manifold<Output = Discrete> + Send + Sync>) -> Self {
+        Self::Surface(manifold)
+    }
+}
+
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+impl From<CellGridFrame> for Scene {
+    fn from(frame: CellGridFrame) -> Self {
+        Self::CellGrid(frame)
+    }
+}
+
+impl core::fmt::Debug for Scene {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Surface(_) => f.debug_tuple("Scene::Surface").finish(),
+            #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+            Self::CellGrid(_) => f.debug_tuple("Scene::CellGrid").finish(),
+        }
+    }
+}
+
+impl Scene {
+    /// Render this scene into `frame` with up to `num_threads` workers.
+    ///
+    /// Surfaces go through the work-stealing per-batch rasterizer; cell
+    /// grids bake channel planes stripe-parallel through the collapse
+    /// kernels and pack via [`Pixel::from_rgba`].
+    pub fn render<P: Pixel + Send>(&self, frame: &mut Frame<P>, num_threads: usize) {
+        match self {
+            Self::Surface(manifold) => {
+                crate::render::rasterizer::rasterize(manifold, frame, num_threads);
+            }
+            #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+            Self::CellGrid(grid) => render_cell_grid(grid, frame, num_threads),
+        }
+    }
+}
+
+/// Bake and pack a cell-grid frame, stripe-parallel.
+///
+/// Each worker owns a contiguous run of rows: it bakes the four channel
+/// planes for its stripe (one collapse call per channel — the pixel loop
+/// lives inside the JIT) and packs them row by row.
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+fn render_cell_grid<P: Pixel + Send>(
+    grid: &CellGridFrame,
+    frame: &mut Frame<P>,
+    num_threads: usize,
+) {
+    let (width, height) = (frame.width, frame.height);
+    if width == 0 || height == 0 {
+        return;
+    }
+    let workers = num_threads.max(1).min(height);
+    let rows_per = height.div_ceil(workers);
+    let mut bands: Vec<(usize, &mut [P])> = Vec::with_capacity(workers);
+    {
+        let mut rest: &mut [P] = &mut frame.data[..width * height];
+        let mut y = 0usize;
+        while y < height {
+            let rows = rows_per.min(height - y);
+            let (band, tail) = rest.split_at_mut(rows * width);
+            bands.push((y, band));
+            rest = tail;
+            y += rows;
+        }
+    }
+
+    std::thread::scope(|scope| {
+        for (y0, band) in bands {
+            scope.spawn(move || bake_and_pack_stripe(grid, width, y0, band));
+        }
+    });
+}
+
+/// Bake the four channel planes for rows `y0..y0 + band.len()/width` and
+/// pack them into `band`.
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+fn bake_and_pack_stripe<P: Pixel>(grid: &CellGridFrame, width: usize, y0: usize, band: &mut [P]) {
+    let rows = band.len() / width;
+    let stride = CellGridFrame::padded_width(width);
+    let mut planes = vec![0.0f32; 4 * rows * stride];
+    {
+        let (r, rest) = planes.split_at_mut(rows * stride);
+        let (g, rest) = rest.split_at_mut(rows * stride);
+        let (b, a) = rest.split_at_mut(rows * stride);
+        grid.bake_channel_rows(0, width, y0, rows, r);
+        grid.bake_channel_rows(1, width, y0, rows, g);
+        grid.bake_channel_rows(2, width, y0, rows, b);
+        grid.bake_channel_rows(3, width, y0, rows, a);
+    }
+    let plane = |c: usize| &planes[c * rows * stride..(c + 1) * rows * stride];
+    let (r, g, b, a) = (plane(0), plane(1), plane(2), plane(3));
+    for row in 0..rows {
+        let p = row * stride;
+        let o = row * width;
+        for i in 0..width {
+            band[o + i] = P::from_rgba(r[p + i], g[p + i], b[p + i], a[p + i]);
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+mod tests {
+    use super::*;
+    use crate::render::color::Rgba8;
+    use pixelflow_core::{CellGridGeometry, CellGridProgram};
+
+    /// A 2×2 grid of solid/half tiles; oracle is the scalar blend math.
+    fn scene() -> Scene {
+        let (aw, ah, slot) = (12usize, 6usize, 6usize);
+        let mut atlas = vec![0.0f32; aw * ah];
+        for r in 0..4 {
+            for c in 0..4 {
+                atlas[(1 + r) * aw + 1 + c] = 1.0; // tile 0: solid
+                atlas[(1 + r) * aw + slot + 1 + c] = 0.5; // tile 1: half
+            }
+        }
+        let geom = CellGridGeometry {
+            cols: 2,
+            rows: 2,
+            cell_w: 4.0,
+            cell_h: 4.0,
+            density: 1.0,
+            atlas_width: aw as u32,
+            atlas_height: ah as u32,
+            tile_w: 4,
+            tile_h: 4,
+        };
+        let program = CellGridProgram::compile(geom, [0.25, 0.25, 0.25, 1.0]);
+        #[rustfmt::skip]
+        let cells = vec![
+            // (0,0): solid tile, red on black
+            1.0, 1.0,  1.0, 0.0, 0.0, 1.0,  0.0, 0.0, 0.0, 1.0,
+            // (1,0): half tile, white on blue
+            7.0, 1.0,  1.0, 1.0, 1.0, 1.0,  0.0, 0.0, 1.0, 1.0,
+            // (0,1): half tile, green on black
+            7.0, 1.0,  0.0, 1.0, 0.0, 1.0,  0.0, 0.0, 0.0, 1.0,
+            // (1,1): solid tile, black on white
+            1.0, 1.0,  0.0, 0.0, 0.0, 1.0,  1.0, 1.0, 1.0, 1.0,
+        ];
+        Scene::CellGrid(program.frame(Arc::new(cells), Arc::new(atlas)))
+    }
+
+    #[test]
+    fn cell_grid_scene_packs_blended_channels() {
+        let scene = scene();
+        // 10×10 frame: the 8×8 grid plus a margin of default background.
+        let mut frame = Frame::<Rgba8>::new(10, 10);
+        scene.render(&mut frame, 2);
+
+        let px = |x: usize, y: usize| frame.data[y * 10 + x];
+        // Cell (0,0) interior: coverage 1 → pure red.
+        assert_eq!((px(1, 1).r(), px(1, 1).g(), px(1, 1).b()), (255, 0, 0));
+        // Cell (1,0) interior: coverage ½ of white over blue → (128, 128, 255)ish.
+        let p = px(5, 1);
+        assert!(p.r() >= 126 && p.r() <= 129, "half blend r = {}", p.r());
+        assert_eq!(p.b(), 255);
+        // Cell (1,1) interior: black over white at coverage 1 → black.
+        assert_eq!(px(5, 5).r(), 0);
+        // Outside the grid: the default background (0.25 → ~64).
+        let m = px(9, 9);
+        assert!(m.r() >= 62 && m.r() <= 66, "margin r = {}", m.r());
+    }
+
+    #[test]
+    fn stripe_split_matches_single_threaded() {
+        let scene = scene();
+        let mut one = Frame::<Rgba8>::new(9, 8);
+        let mut many = Frame::<Rgba8>::new(9, 8);
+        scene.render(&mut one, 1);
+        scene.render(&mut many, 4);
+        assert_eq!(one.data, many.data, "thread count must not change pixels");
+    }
+}

--- a/pixelflow-graphics/src/render/scene.rs
+++ b/pixelflow-graphics/src/render/scene.rs
@@ -103,31 +103,67 @@ fn render_cell_grid<P: Pixel + Send>(
     });
 }
 
+/// Scratch budget per worker for the four channel planes. Bounds the
+/// bake-and-pack working set to cache-friendly chunks instead of sizing
+/// temporaries to the whole stripe (a 4K frame would otherwise stage
+/// ~127 MiB of planes per render).
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+const PLANE_SCRATCH_BYTES: usize = 1 << 20;
+
 /// Bake the four channel planes for rows `y0..y0 + band.len()/width` and
-/// pack them into `band`.
+/// pack them into `band`, in bounded-height chunks reusing one scratch
+/// allocation.
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 fn bake_and_pack_stripe<P: Pixel>(grid: &CellGridFrame, width: usize, y0: usize, band: &mut [P]) {
+    let stride = CellGridFrame::padded_width(width);
+    let chunk_rows = PLANE_SCRATCH_BYTES / (4 * stride * core::mem::size_of::<f32>());
+    bake_and_pack_chunked(grid, width, y0, band, chunk_rows);
+}
+
+/// [`bake_and_pack_stripe`] with an explicit chunk height (rows of plane
+/// scratch per pass) — split out so tests can force chunk boundaries that
+/// the production budget would only hit on very large frames.
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+fn bake_and_pack_chunked<P: Pixel>(
+    grid: &CellGridFrame,
+    width: usize,
+    y0: usize,
+    band: &mut [P],
+    chunk_rows: usize,
+) {
     let rows = band.len() / width;
     let stride = CellGridFrame::padded_width(width);
-    let mut planes = vec![0.0f32; 4 * rows * stride];
-    {
-        let (r, rest) = planes.split_at_mut(rows * stride);
-        let (g, rest) = rest.split_at_mut(rows * stride);
-        let (b, a) = rest.split_at_mut(rows * stride);
-        let region = PlaneRegion { width, y0, rows };
-        grid.bake_channel_rows(0, region, r);
-        grid.bake_channel_rows(1, region, g);
-        grid.bake_channel_rows(2, region, b);
-        grid.bake_channel_rows(3, region, a);
-    }
-    let plane = |c: usize| &planes[c * rows * stride..(c + 1) * rows * stride];
-    let (r, g, b, a) = (plane(0), plane(1), plane(2), plane(3));
-    for row in 0..rows {
-        let p = row * stride;
-        let o = row * width;
-        for i in 0..width {
-            band[o + i] = P::from_rgba(r[p + i], g[p + i], b[p + i], a[p + i]);
+    let chunk_rows = chunk_rows.clamp(1, rows.max(1));
+    let mut planes = vec![0.0f32; 4 * chunk_rows * stride];
+
+    let mut done = 0usize;
+    while done < rows {
+        let n = chunk_rows.min(rows - done);
+        {
+            let (r, rest) = planes.split_at_mut(chunk_rows * stride);
+            let (g, rest) = rest.split_at_mut(chunk_rows * stride);
+            let (b, a) = rest.split_at_mut(chunk_rows * stride);
+            let region = PlaneRegion {
+                width,
+                y0: y0 + done,
+                rows: n,
+            };
+            grid.bake_channel_rows(0, region, r);
+            grid.bake_channel_rows(1, region, g);
+            grid.bake_channel_rows(2, region, b);
+            grid.bake_channel_rows(3, region, a);
         }
+        let plane =
+            |c: usize| &planes[c * chunk_rows * stride..c * chunk_rows * stride + n * stride];
+        let (r, g, b, a) = (plane(0), plane(1), plane(2), plane(3));
+        for row in 0..n {
+            let p = row * stride;
+            let o = (done + row) * width;
+            for i in 0..width {
+                band[o + i] = P::from_rgba(r[p + i], g[p + i], b[p + i], a[p + i]);
+            }
+        }
+        done += n;
     }
 }
 
@@ -193,6 +229,21 @@ mod tests {
         // Outside the grid: the default background (0.25 → ~64).
         let m = px(9, 9);
         assert!(m.r() >= 62 && m.r() <= 66, "margin r = {}", m.r());
+    }
+
+    #[test]
+    fn chunked_bake_matches_whole_stripe() {
+        // Force chunk boundaries (3-row chunks over an 8-row band) and
+        // require pixel identity with the unchunked bake.
+        let Scene::CellGrid(grid) = scene() else {
+            unreachable!()
+        };
+        let (w, h) = (9usize, 8usize);
+        let mut whole = vec![Rgba8::from_u32(0); w * h];
+        let mut chunked = vec![Rgba8::from_u32(0); w * h];
+        super::bake_and_pack_chunked(&grid, w, 0, &mut whole, h);
+        super::bake_and_pack_chunked(&grid, w, 0, &mut chunked, 3);
+        assert_eq!(whole, chunked, "chunk boundaries must not change pixels");
     }
 
     #[test]

--- a/pixelflow-graphics/src/render/scene.rs
+++ b/pixelflow-graphics/src/render/scene.rs
@@ -11,7 +11,7 @@
 use crate::render::frame::Frame;
 use crate::render::Pixel;
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-use pixelflow_core::CellGridFrame;
+use pixelflow_core::{CellGridFrame, PlaneRegion};
 use pixelflow_core::{Discrete, Manifold};
 use std::sync::Arc;
 
@@ -114,10 +114,11 @@ fn bake_and_pack_stripe<P: Pixel>(grid: &CellGridFrame, width: usize, y0: usize,
         let (r, rest) = planes.split_at_mut(rows * stride);
         let (g, rest) = rest.split_at_mut(rows * stride);
         let (b, a) = rest.split_at_mut(rows * stride);
-        grid.bake_channel_rows(0, width, y0, rows, r);
-        grid.bake_channel_rows(1, width, y0, rows, g);
-        grid.bake_channel_rows(2, width, y0, rows, b);
-        grid.bake_channel_rows(3, width, y0, rows, a);
+        let region = PlaneRegion { width, y0, rows };
+        grid.bake_channel_rows(0, region, r);
+        grid.bake_channel_rows(1, region, g);
+        grid.bake_channel_rows(2, region, b);
+        grid.bake_channel_rows(3, region, a);
     }
     let plane = |c: usize| &planes[c * rows * stride..(c + 1) * rows * stride];
     let (r, g, b, a) = (plane(0), plane(1), plane(2), plane(3));

--- a/pixelflow-runtime/examples/animated_sphere.rs
+++ b/pixelflow-runtime/examples/animated_sphere.rs
@@ -202,7 +202,7 @@ impl Application for AnimatedSphereApp {
                     .lock()
                     .unwrap()
                     .send(Message::Data(EngineData::FromApp(AppData::RenderSurface(
-                        arc,
+                        arc.into(),
                     ))))
                     .map_err(|e| RuntimeError::EventSendError(e.to_string()))?;
             }

--- a/pixelflow-runtime/examples/image_viewer.rs
+++ b/pixelflow-runtime/examples/image_viewer.rs
@@ -160,7 +160,7 @@ fn main() -> anyhow::Result<()> {
 
     engine_handle
         .send(Message::Data(EngineData::FromApp(AppData::RenderSurface(
-            scene_arc.clone(),
+            scene_arc.clone().into(),
         ))))
         .map_err(|e| anyhow::anyhow!("Failed to send initial frame: {}", e))?;
 

--- a/pixelflow-runtime/examples/psychedelic_shader.rs
+++ b/pixelflow-runtime/examples/psychedelic_shader.rs
@@ -121,7 +121,7 @@ impl Application for PsychedelicApp {
                     .lock()
                     .unwrap()
                     .send(Message::Data(EngineData::FromApp(AppData::RenderSurface(
-                        arc,
+                        arc.into(),
                     ))))
                     .map_err(|e| RuntimeError::EventSendError(e.to_string()))?;
             }

--- a/pixelflow-runtime/src/api/public.rs
+++ b/pixelflow-runtime/src/api/public.rs
@@ -286,47 +286,50 @@ pub enum EngineEventData {
 /// The pixel type `P` is kept for API compatibility but is unused in practice.
 /// All rendering is done via manifolds that produce `Discrete` (packed RGBA u32 pixels).
 pub enum AppData {
-    /// Render a manifold (continuous surface) to the window.
+    /// Render a [`Scene`](pixelflow_graphics::render::scene::Scene) to the
+    /// window.
     ///
     /// # Contract
     ///
-    /// **Sender** (Application): Provides a color manifold that produces `Discrete` pixels.
-    /// The manifold is evaluated at sequential x-coordinates and writes pixels to the framebuffer.
+    /// **Sender** (Application): Provides the scene — either
+    /// `Scene::Surface` (an `Arc<dyn Manifold<Output = Discrete>>`; `.into()`
+    /// converts one directly) or `Scene::CellGrid` (a JIT cell-grid frame,
+    /// rendered by the collapse-baked fast lane).
     ///
-    /// **Receiver** (Engine): Materializes the manifold and presents it to the window.
-    /// The manifold is evaluated fresh for each frame, so it can be animated or interactive.
+    /// **Receiver** (Engine): Renders the scene into the frame buffer and
+    /// presents it. The scene is rendered fresh for each submission, so it
+    /// can be animated or interactive.
     ///
-    /// # Arguments
+    /// # Coordinate spaces
     ///
-    /// - A `Manifold<Output = Discrete>` wrapped in `Arc<dyn ...>` for type erasure
+    /// `Surface` scenes are authored in point space: on HiDPI displays the
+    /// engine contramaps them by points/pixels so the author stays
+    /// scale-agnostic. `CellGrid` scenes are DEVICE-PIXEL space by
+    /// contract — their geometry carries any display scale (see
+    /// `CellGridGeometry`'s docs), and the engine applies no transform.
     ///
     /// # Example
     ///
     /// ```ignore
     /// use pixelflow_graphics::Color;
-    /// use pixelflow_core::ManifoldExt;
     /// use std::sync::Arc;
     ///
-    /// // Build a red rectangle
+    /// // A solid color as the generic surface lane.
     /// let red = Color::Named(NamedColor::Red);
     /// let manifold = Arc::new(red) as Arc<dyn Manifold<Output = Discrete> + Send + Sync>;
+    /// tx.send(Message::Data(AppData::RenderSurface(manifold.into())))?;
     ///
-    /// tx.send(Message::Data(AppData::RenderSurface(manifold)))?;
+    /// // A cell-grid frame takes the fast lane.
+    /// tx.send(Message::Data(AppData::RenderSurface(Scene::CellGrid(frame))))?;
     /// ```
     ///
     /// # Performance Notes
     ///
-    /// - The manifold is evaluated for every frame, every pixel (no caching)
-    /// - Use simple, closed-form expressions for good performance
-    /// - The evaluation happens in the render thread; expensive computations will cause frame drops
-    /// - Consider composing manifolds rather than using `map` callbacks
-    ///
-    /// # Type Erasure
-    ///
-    /// The manifold is stored as `dyn Manifold`, which erases the static type.
-    /// This allows different manifold types to be sent without recompiling.
-    /// Performance cost: no dynamic dispatch at the algebra level (monomorphization still works),
-    /// but you lose some inlining opportunities across the Arc boundary.
+    /// - `Surface`: evaluated per batch through the `Manifold` trait, every
+    ///   frame, every pixel — keep expressions closed-form; expensive
+    ///   evaluation causes frame drops.
+    /// - `CellGrid`: one internal-loop JIT call per channel per stripe plus
+    ///   a pack — the production path for grid-shaped content.
     RenderSurface(pixelflow_graphics::render::scene::Scene),
 
     /// Skip this frame (no rendering needed).

--- a/pixelflow-runtime/src/api/public.rs
+++ b/pixelflow-runtime/src/api/public.rs
@@ -327,44 +327,7 @@ pub enum AppData {
     /// This allows different manifold types to be sent without recompiling.
     /// Performance cost: no dynamic dispatch at the algebra level (monomorphization still works),
     /// but you lose some inlining opportunities across the Arc boundary.
-    RenderSurface(
-        std::sync::Arc<
-            dyn pixelflow_core::Manifold<Output = pixelflow_core::Discrete> + Send + Sync,
-        >,
-    ),
-
-    /// Render a manifold at u32 coordinates (pixel-aligned).
-    ///
-    /// # Contract
-    ///
-    /// **Sender** (Application): Provides a color manifold to be evaluated at pixel-aligned coordinates.
-    ///
-    /// **Receiver** (Engine): Materializes the manifold using integer u32 coordinates (no floating-point).
-    /// This is identical to `RenderSurface` except for the coordinate type passed to evaluation.
-    ///
-    /// # When to Use
-    ///
-    /// - When your manifold is designed to work with integer coordinates (e.g., per-pixel patterns)
-    /// - For pixel-perfect rendering without sub-pixel interpolation
-    /// - When aliasing is acceptable or desirable
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// // A checkerboard pattern using u32 coordinates
-    /// let checkerboard = (X & 16u32).eq(0.0).select(black, white);
-    /// tx.send(Message::Data(AppData::RenderSurfaceU32(checkerboard)))?;
-    /// ```
-    ///
-    /// # Performance
-    ///
-    /// Slightly more efficient than `RenderSurface` if your manifold naturally works
-    /// with integer coordinates, but the difference is usually negligible.
-    RenderSurfaceU32(
-        std::sync::Arc<
-            dyn pixelflow_core::Manifold<Output = pixelflow_core::Discrete> + Send + Sync,
-        >,
-    ),
+    RenderSurface(pixelflow_graphics::render::scene::Scene),
 
     /// Skip this frame (no rendering needed).
     ///
@@ -392,7 +355,6 @@ impl std::fmt::Debug for AppData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::RenderSurface(_) => f.debug_tuple("RenderSurface").finish(),
-            Self::RenderSurfaceU32(_) => f.debug_tuple("RenderSurfaceU32").finish(),
             Self::Skipped => f.debug_tuple("Skipped").finish(),
         }
     }

--- a/pixelflow-runtime/src/coordinator_node.rs
+++ b/pixelflow-runtime/src/coordinator_node.rs
@@ -41,9 +41,7 @@ use crate::render_coordinator::{Completed, RenderCoordinator, Step};
 use crate::vsync_actor::RenderedResponse;
 use actor_scheduler::mealy::{all, send_port, Flush, Transducer, Wiring};
 use actor_scheduler::{ActorHandle, GreenSender, HandlerError, Message};
-use pixelflow_core::{Discrete, Manifold};
 use pixelflow_graphics::render::rasterizer::{RasterizerHandle, RenderRequest, RenderResponse};
-use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 /// A manifold as it travels between the app and the rasterizer.
@@ -52,7 +50,7 @@ use std::time::{Duration, Instant};
 /// it: that module's `Scene` is deliberately not part of even this crate's wider surface, and
 /// re-exporting it just to share one line would widen `RenderCoordinator`'s API for a type
 /// alias, not a capability.
-type Scene = Arc<dyn Manifold<Output = Discrete> + Send + Sync>;
+use pixelflow_graphics::render::scene::Scene;
 
 /// Frame counter logging cadence — moved verbatim from the old `EngineCore` copy: the telemetry
 /// edge (`rendered`, below) is a coordinator → vsync edge now, so the counter that stamps it
@@ -275,7 +273,9 @@ mod tests {
     use crate::platform::ColorCube;
 
     fn manifold() -> Scene {
-        Arc::new(ColorCube::default().at(0.0f32, 0.0f32, 0.0f32, 1.0f32))
+        Scene::Surface(std::sync::Arc::new(
+            ColorCube::default().at(0.0f32, 0.0f32, 0.0f32, 1.0f32),
+        ))
     }
 
     fn one_to_one_window() -> Window {
@@ -651,7 +651,9 @@ mod node_tests {
     /// A constant black scene — these tests care about which buffer a render is aimed at, not
     /// what is in it.
     fn manifold() -> Scene {
-        Arc::new(ColorCube::default().at(0.0f32, 0.0f32, 0.0f32, 1.0f32))
+        Scene::Surface(std::sync::Arc::new(
+            ColorCube::default().at(0.0f32, 0.0f32, 0.0f32, 1.0f32),
+        ))
     }
 
     /// The steady state: the coordinator asks for the buffer only when it has something to

--- a/pixelflow-runtime/src/engine_core.rs
+++ b/pixelflow-runtime/src/engine_core.rs
@@ -57,12 +57,12 @@ impl EngineCore {
 
     fn step_app_data(&mut self, app_data: AppData, out: &mut EngineOut) {
         match app_data {
-            AppData::RenderSurface(manifold) | AppData::RenderSurfaceU32(manifold) => {
+            AppData::RenderSurface(scene) => {
                 log::debug!("Engine: Received RenderSurface from app");
                 // The app has provided its compute graph, so permit VSync to request another
                 // frame without waiting for rasterization to finish.
                 out.vsync_control = Some(VsyncCommand::ReturnToken);
-                out.coordinator = Some(CoordinatorData::Submit(manifold));
+                out.coordinator = Some(CoordinatorData::Submit(scene));
             }
             AppData::Skipped => {
                 // App says nothing to render - return token anyway
@@ -337,8 +337,10 @@ mod tests {
     use std::time::{Duration, Instant};
 
     /// A constant black scene — these tests care about which port fires, not what is drawn.
-    fn manifold() -> std::sync::Arc<dyn Manifold<Output = Discrete> + Send + Sync> {
-        std::sync::Arc::new(ColorCube::default().at(0.0f32, 0.0f32, 0.0f32, 1.0f32))
+    fn manifold() -> pixelflow_graphics::render::scene::Scene {
+        pixelflow_graphics::render::scene::Scene::Surface(std::sync::Arc::new(
+            ColorCube::default().at(0.0f32, 0.0f32, 0.0f32, 1.0f32),
+        ))
     }
 
     fn surface(width_px: u32, height_px: u32) -> Surface {

--- a/pixelflow-runtime/src/engine_core.rs
+++ b/pixelflow-runtime/src/engine_core.rs
@@ -333,7 +333,6 @@ mod tests {
     use super::*;
     use crate::display::messages::{Generation, Surface, Window, WindowMeta};
     use crate::platform::ColorCube;
-    use pixelflow_core::{Discrete, Manifold};
     use std::time::{Duration, Instant};
 
     /// A constant black scene — these tests care about which port fires, not what is drawn.

--- a/pixelflow-runtime/src/engine_troupe.rs
+++ b/pixelflow-runtime/src/engine_troupe.rs
@@ -666,8 +666,10 @@ mod tests {
     const LANE_BUFFER: usize = 16;
 
     /// A constant black scene — these tests care about which port fires, not what is drawn.
-    fn manifold() -> Arc<dyn Manifold<Output = Discrete> + Send + Sync> {
-        Arc::new(ColorCube::default().at(0.0f32, 0.0f32, 0.0f32, 1.0f32))
+    fn manifold() -> pixelflow_graphics::render::scene::Scene {
+        pixelflow_graphics::render::scene::Scene::Surface(Arc::new(
+            ColorCube::default().at(0.0f32, 0.0f32, 0.0f32, 1.0f32),
+        ))
     }
 
     /// `EngineHandler` wired to a real driver scheduler (so `driver_control`/`driver_mgmt`

--- a/pixelflow-runtime/src/engine_troupe.rs
+++ b/pixelflow-runtime/src/engine_troupe.rs
@@ -658,7 +658,6 @@ mod tests {
     use crate::platform::ColorCube;
     use actor_scheduler::spsc::{spsc_channel, SpscReceiver};
     use actor_scheduler::ActorScheduler;
-    use pixelflow_core::{Discrete, Manifold};
     use std::time::Instant;
 
     /// Scheduler tuning for the fixture: small, since nothing here approaches a real ring.

--- a/pixelflow-runtime/src/render_coordinator.rs
+++ b/pixelflow-runtime/src/render_coordinator.rs
@@ -15,13 +15,13 @@
 use crate::display::messages::{Window, WindowMeta};
 use crate::platform::PlatformPixel;
 use actor_scheduler::mealy::Credit;
-use pixelflow_core::{At, Discrete, Manifold, W, X, Y, Z};
+use pixelflow_core::{At, W, X, Y, Z};
 use pixelflow_graphics::render::rasterizer::{RenderRequest, RenderResponse};
 use std::sync::Arc;
 use std::time::Duration;
 
-/// A manifold as it travels between the app and the rasterizer.
-type Scene = Arc<dyn Manifold<Output = Discrete> + Send + Sync>;
+/// A scene as it travels between the app and the rasterizer.
+use pixelflow_graphics::render::scene::Scene;
 
 /// What the coordinator wants delivered, having decided everything it can on its own.
 ///
@@ -259,23 +259,28 @@ fn bind(scene: Scene, window: Window) -> RenderRequest<PlatformPixel, WindowMeta
     );
     let point_per_px_x = width_px as f32 / frame.width as f32;
     let point_per_px_y = height_px as f32 / frame.height as f32;
-    let manifold: Scene = if point_per_px_x == 1.0 && point_per_px_y == 1.0 {
-        scene
-    } else {
-        Arc::new(At {
-            inner: scene,
-            x: X * point_per_px_x,
-            y: Y * point_per_px_y,
-            z: Z,
-            w: W,
-        })
+    let scene: Scene = match scene {
+        // Point-space surfaces are contramapped into the denser device grid.
+        Scene::Surface(manifold) => {
+            if point_per_px_x == 1.0 && point_per_px_y == 1.0 {
+                Scene::Surface(manifold)
+            } else {
+                Scene::Surface(Arc::new(At {
+                    inner: manifold,
+                    x: X * point_per_px_x,
+                    y: Y * point_per_px_y,
+                    z: Z,
+                    w: W,
+                }))
+            }
+        }
+        // A cell-grid scene is device-pixel space by contract: its geometry
+        // (cell extents, atlas density) already carries any DPI scale, so
+        // the collapse kernels sample the buffer's own pixel grid directly.
+        Scene::CellGrid(grid) => Scene::CellGrid(grid),
     };
 
-    RenderRequest {
-        manifold,
-        frame,
-        meta,
-    }
+    RenderRequest { scene, frame, meta }
 }
 
 #[cfg(test)]
@@ -292,6 +297,7 @@ mod tests {
     use crate::display::messages::Surface;
     use crate::display::window_keeper::WindowKeeper;
     use pixelflow_core::Field;
+    use pixelflow_core::{Discrete, Manifold};
     use pixelflow_graphics::render::rasterizer::RenderResponse;
 
     /// A manifold that ignores its input — the coordinator never samples it, it only decides
@@ -312,7 +318,7 @@ mod tests {
     }
 
     fn scene() -> Scene {
-        Arc::new(Flat)
+        Scene::Surface(Arc::new(Flat))
     }
 
     /// A keeper holding one buffer at the given logical size, sampled 1:1.
@@ -513,24 +519,30 @@ mod tests {
         // 1:1 — the scene must arrive at the rasterizer untouched.
         let mut coord = RenderCoordinator::new();
         let flat = scene();
-        assert_requests_window(coord.submit(Arc::clone(&flat)));
+        assert_requests_window(coord.submit(flat.clone()));
         coord.request_sent();
         let request = expect_render(coord.granted(one_to_one_window()));
+        let (Scene::Surface(got), Scene::Surface(sent)) = (&request.scene, &flat) else {
+            panic!("surface scenes in, surface scenes out");
+        };
         assert!(
-            Arc::ptr_eq(&request.manifold, &flat),
+            Arc::ptr_eq(got, sent),
             "a 1:1 frame needs no warp, so the scene should pass through unwrapped"
         );
 
         // 2:1 — 100 points across a 200-pixel frame.
         let mut coord = RenderCoordinator::new();
         let flat = scene();
-        assert_requests_window(coord.submit(Arc::clone(&flat)));
+        assert_requests_window(coord.submit(flat.clone()));
         coord.request_sent();
         let retina = grant_from(&mut keeper_at((100, 100), (200, 200), 2.0));
         let request = expect_render(coord.granted(retina));
         assert_eq!((request.frame.width, request.frame.height), (200, 200));
+        let (Scene::Surface(got), Scene::Surface(sent)) = (&request.scene, &flat) else {
+            panic!("surface scenes in, surface scenes out");
+        };
         assert!(
-            !Arc::ptr_eq(&request.manifold, &flat),
+            !Arc::ptr_eq(got, sent),
             "a Retina frame must be contramapped by points/pixels, not forwarded as authored"
         );
     }


### PR DESCRIPTION
The next cut after #956 and the 2D collapse (#961): the render path itself goes through the JIT's internal loop. The rasterizer's input is now `pixelflow_graphics::render::scene::Scene`, with two lanes:

- **`Scene::Surface`** — an arbitrary color manifold, dense per-batch evaluation through the `Manifold` trait. The generic lane; the runtime examples and core-term's no-snapshot background use it, and the coordinator's DPI contramap applies here.
- **`Scene::CellGrid`** — a `CellGridFrame` rendered by **one 2D-collapse call per channel per stripe**: the pixel loop lives inside the JIT with both LICM prologue scopes active (per-call and per-row), then the four planes pack via `Pixel::from_rgba`, stripe-parallel across the worker pool. No per-batch `extern "C"` boundary, no virtual dispatch, no combinator evaluation.

## What changed

- **pixelflow-core**: `CellGridProgram` compiles collapse-mode kernels only; `CellGridFrame::bake_channel_rows` bakes a channel plane at padded-batch stride (one `call_collapse` per invocation). The per-batch `CellGridChannel` manifolds are **deleted** — one implementation per job. Cell-grid tests re-anchor on the plane-bake path; the misaligned-sample apron test moves to a fractional density probe (the bake API owns the pixel-center origin).
- **pixelflow-graphics**: `render::scene::Scene` + the stripe-parallel bake-and-pack; `RenderRequest.manifold` → `RenderRequest.scene`. New tests: packed-channel blending against scalar oracles, and thread-count invariance of the stripe split.
- **pixelflow-runtime**: the coordinator's `Scene` alias becomes the graphics `Scene`; the DPI contramap (`At { x: X·points/px }`) wraps only `Surface` scenes — **`Scene::CellGrid` is device-pixel space by contract**, carrying its scale in its geometry. `AppData::RenderSurfaceU32` deleted per subtract-before-add: documented as u32-coordinate rendering, treated identically to `RenderSurface` by the engine, zero senders.
- **core-term**: `build_scene` returns `Scene::CellGrid` with device-pixel geometry (cell extents × density; atlas texels ≡ device pixels, sample density 1). The `At`+`ColorCube` frame-root composition is gone — the terminal's render path now contains no combinator evaluation at all.

## Testing

- pixelflow-core `cell_grid`: 7/7 on the plane-bake path (lossless aligned reads, fractional-density apron fade, neighbor isolation, out-of-grid background, oversized-buffer refusal).
- pixelflow-graphics: full lib suite (149) including the new scene tests; rasterizer actor suite on the `Scene` shape.
- pixelflow-runtime: full suite including the coordinator's 1:1/Retina contramap identity tests restated on `Scene::Surface`.
- core-term: full suite; the end-to-end scene test now renders a blank screen to the default background **through the collapse lane** and still proves resize-recompiles.
- Full workspace test + clippy `-D warnings` run in flight at time of opening; will confirm on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PHPBWpn4HqSDpo1DoqcTWW

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHPBWpn4HqSDpo1DoqcTWW)_