### PR TITLE
test: fix STYLE.md violations and mutation-test gaps (2026-08-01 audit)

### DIFF
--- a/actor-scheduler/src/host.rs
+++ b/actor-scheduler/src/host.rs
@@ -747,7 +747,7 @@ mod tests {
         });
 
         std::thread::sleep(Duration::from_millis(50));
-        tx_green.try_send(41).expect("green inbox has room");
+        tx_green.send(41).expect("green inbox has room");
 
         let deadline = Instant::now() + Duration::from_secs(5);
         let got = loop {
@@ -792,7 +792,7 @@ mod tests {
         // Let the host reach its doorbell and block before sending, so this exercises the
         // wake path rather than racing the host to its first sweep.
         std::thread::sleep(Duration::from_millis(50));
-        tx_green.try_send(41).expect("green inbox has room");
+        tx_green.send(41).expect("green inbox has room");
 
         let deadline = Instant::now() + Duration::from_secs(5);
         let got = loop {

--- a/actor-scheduler/src/lib.rs
+++ b/actor-scheduler/src/lib.rs
@@ -1845,6 +1845,7 @@ mod poll_once_tests {
 #[cfg(test)]
 mod try_send_tests {
     use super::*;
+    use crate::mealy::Flush;
 
     struct RecordActor {
         got: Option<i32>,
@@ -1869,7 +1870,9 @@ mod try_send_tests {
     #[test]
     fn try_send_succeeds_and_is_received() {
         let (tx, mut rx) = ActorScheduler::<i32, i32, i32>::new(10, 100);
-        tx.try_send(Message::Data(7)).expect("room in the ring");
+        let mut port = Some(Message::Data(7));
+        assert_eq!(mealy::send_port(&mut port, &tx), Flush::Done);
+        assert!(port.is_none(), "delivered ports are cleared");
 
         let mut actor = RecordActor { got: None };
         assert!(!rx.poll_once(&mut actor), "still connected");
@@ -1880,11 +1883,18 @@ mod try_send_tests {
     fn try_send_on_a_full_data_ring_returns_full_with_the_message_recoverable() {
         let (tx, _rx) = ActorScheduler::<i32, i32, i32>::new(10, 2);
         // Capacity rounds up to a power of 2 (minimum 2); fill it without a consumer draining.
-        while tx.try_send(Message::Data(1)).is_ok() {}
+        loop {
+            let mut port = Some(Message::Data(1));
+            if mealy::send_port(&mut port, &tx) != Flush::Done {
+                break;
+            }
+        }
 
-        match tx.try_send(Message::Data(99)) {
-            Err(TrySendError::Full(Message::Data(msg))) => assert_eq!(msg, 99),
-            other => panic!("expected Full(Message::Data(99)), got {other:?}"),
+        let mut port = Some(Message::Data(99));
+        assert_eq!(mealy::send_port(&mut port, &tx), Flush::Blocked);
+        match port {
+            Some(Message::Data(msg)) => assert_eq!(msg, 99),
+            other => panic!("expected a blocked port to keep Data(99), got {other:?}"),
         }
     }
 
@@ -1893,9 +1903,11 @@ mod try_send_tests {
         let (tx, rx) = ActorScheduler::<i32, i32, i32>::new(10, 100);
         drop(rx);
 
-        match tx.try_send(Message::Data(5)) {
-            Err(TrySendError::Disconnected(Message::Data(msg))) => assert_eq!(msg, 5),
-            other => panic!("expected Disconnected(Message::Data(5)), got {other:?}"),
+        let mut port = Some(Message::Data(5));
+        assert_eq!(mealy::send_port(&mut port, &tx), Flush::Disconnected);
+        match port {
+            Some(Message::Data(msg)) => assert_eq!(msg, 5),
+            other => panic!("expected a disconnected target to retain Data(5), got {other:?}"),
         }
     }
 }

--- a/actor-scheduler/src/mealy.rs
+++ b/actor-scheduler/src/mealy.rs
@@ -1569,20 +1569,17 @@ mod tests {
             node.poll_os(SystemStatus::Idle),
             (Step::Ran, ActorStatus::Busy)
         );
-        assert_eq!(
-            node.continuation,
-            Some(42),
-            "step_os's continuation lands in the same slot a lane's does"
-        );
 
-        // It resumes before any lane is even consulted, exactly like a lane-produced one.
+        // It resumes before any lane is even consulted, exactly like a lane-produced one —
+        // and the slot is drained by that resume, since a second `poll` would starve rather
+        // than re-run it (the lane holds nothing else).
         assert_eq!(node.poll(), Step::Ran);
         assert_eq!(
             node.actor().last_resumed,
             Some(42),
-            "the continuation actually reached step_data"
+            "step_os's continuation lands in the same slot a lane's does, and actually \
+             reached step_data"
         );
-        assert!(node.continuation.is_none());
     }
 
     #[test]
@@ -1790,16 +1787,20 @@ mod tests {
                 round,
                 "step_os runs at every burst boundary despite the endless chain"
             );
-            assert!(
-                node.continuation.is_some(),
-                "the chain's resume payload survived the OS turn"
-            );
             assert_eq!(
                 node.actor().resumed,
                 before,
                 "the OS turn advanced no lane work"
             );
         }
+        // One more poll proves round 3's continuation survived its OS turn too: the lane
+        // was fed exactly one message up front, so without a surviving continuation this
+        // would starve (`Step::Idle`) instead of resuming the chain.
+        assert_eq!(
+            node.poll(),
+            Step::Ran,
+            "the chain's resume payload survived the OS turn"
+        );
     }
 
     /// A lane step that yields a continuation *and* an output that parks: the continuation
@@ -1855,11 +1856,6 @@ mod tests {
 
         tx_in.try_send(1).expect("room in the lane");
         assert_eq!(node.poll(), Step::Ran);
-        assert_eq!(
-            node.continuation,
-            Some(2),
-            "the lane's continuation is stored"
-        );
 
         // Free the ring so poll_os's outbox flush succeeds — the hazard is what happens next.
         while rx_out.try_recv().is_ok() {}
@@ -1874,12 +1870,9 @@ mod tests {
             "step_os gets its turn — deferring it entirely would starve an OS bridge \
              behind an endless self-yielder"
         );
-        assert_eq!(
-            node.continuation,
-            Some(2),
-            "the continuation survived the OS turn intact"
-        );
 
+        // The continuation survived the OS turn intact: it resumes with the lane's value
+        // (2), not `step_os`'s own (empty) output overwriting the slot.
         assert_eq!(node.poll(), Step::Ran);
         assert_eq!(
             node.actor().last_resumed,
@@ -1985,15 +1978,14 @@ mod tests {
         );
 
         tx_in.try_send(3).unwrap();
-        while node.poll() == Step::Ran {
-            assert!(
-                node.continuation.is_none() || node.continuation.is_some(),
-                "slot is a single Option — it cannot hold two"
-            );
+        let mut last = Step::Ran;
+        while last == Step::Ran {
+            last = node.poll();
         }
-        assert!(
-            node.continuation.is_none(),
-            "the slot is empty once the machine finishes"
+        assert_eq!(
+            last,
+            Step::Idle,
+            "the slot is empty once the machine finishes — nothing left to run"
         );
     }
 
@@ -2013,12 +2005,14 @@ mod tests {
         tx_in.try_send(9).unwrap(); // queued behind the in-flight countdown
 
         assert_eq!(node.poll(), Step::Ran); // 2 → continuation 1
-        assert_eq!(node.continuation, Some(1));
         assert_eq!(node.poll(), Step::Ran); // resumes 1, not the queued 9
-        assert_eq!(node.continuation, Some(0));
         assert_eq!(node.poll(), Step::Ran); // 0 → done
-        assert_eq!(node.actor().finished, Some(0), "first unit finished first");
-        assert!(node.continuation.is_none());
+        assert_eq!(
+            node.actor().finished,
+            Some(0),
+            "first unit finished first — three steps, not interleaved with the queued 9, \
+             which needs its own nine steps to reach 0"
+        );
     }
 
     #[test]

--- a/core-term/src/terminal_app.rs
+++ b/core-term/src/terminal_app.rs
@@ -1088,40 +1088,115 @@ mod tests {
         assert_eq!(probe.data, vec![vec![b'a']]);
     }
 
+    /// Test double for the engine actor: records the scenes the app renders.
+    #[derive(Default)]
+    struct EngineProbe {
+        scenes: Vec<Scene>,
+    }
+
+    impl
+        Actor<
+            EngineData,
+            pixelflow_runtime::api::private::EngineControl,
+            pixelflow_runtime::api::public::AppManagement,
+        > for EngineProbe
+    {
+        fn handle_data(&mut self, msg: EngineData) -> HandlerResult {
+            if let EngineData::FromApp(AppData::RenderSurface(scene)) = msg {
+                self.scenes.push(scene);
+            }
+            Ok(())
+        }
+        fn handle_control(
+            &mut self,
+            _msg: pixelflow_runtime::api::private::EngineControl,
+        ) -> HandlerResult {
+            Ok(())
+        }
+        fn handle_management(
+            &mut self,
+            _msg: pixelflow_runtime::api::public::AppManagement,
+        ) -> HandlerResult {
+            Ok(())
+        }
+        fn handle_os(&mut self, _status: SystemStatus) -> Result<ActorStatus, HandlerError> {
+            Ok(ActorStatus::Idle)
+        }
+    }
+
+    /// Drain the frame(s) the app has sent to the engine so far.
+    fn drain_engine(
+        rx: &mut pixelflow_runtime::api::private::EngineActorScheduler,
+        probe: &mut EngineProbe,
+    ) {
+        for _ in 0..4 {
+            if rx.poll_once(probe) {
+                break;
+            }
+        }
+    }
+
+    fn request_frame() -> TerminalData {
+        let now = std::time::Instant::now();
+        TerminalData::Engine(EngineEventData::RequestFrame {
+            timestamp: now,
+            target_timestamp: now,
+            refresh_interval: std::time::Duration::from_millis(16),
+        })
+    }
+
     #[test]
     fn scene_paints_default_background_and_recompiles_on_resize() {
         use pixelflow_graphics::render::color::Bgra8;
         use pixelflow_graphics::render::frame::Frame;
 
-        let (mut app, _writer_rx, _tx, _scheduler) = match create_test_app() {
+        let (mut app, _writer_rx, _tx, mut engine_scheduler) = match create_test_app() {
             Some(v) => v,
             None => return,
         };
+        let (r, g, b, _) = app.config.colors.background.to_f32_rgba();
+        let close = |got: u8, want: f32| (got as f32 - want * 255.0).abs() <= 2.0;
 
-        // A blank 80x24 screen is spaces on the default background: the
-        // JIT cell-grid scene must rasterize to that color.
-        let scene = app.build_scene();
+        // A blank 80x24 screen is spaces on the default background: the JIT
+        // cell-grid scene the app sends the engine must rasterize to that
+        // color. Drive it through the actor's real entry point — a
+        // RequestFrame data message — rather than the private scene-builder.
+        app.handle_data(request_frame()).expect("request frame");
+        let mut probe = EngineProbe::default();
+        drain_engine(&mut engine_scheduler, &mut probe);
+        let scene = probe.scenes.pop().expect("app sent a frame");
         let mut frame = Frame::<Bgra8>::new(16, 16);
         scene.render(&mut frame, 1);
-        let (r, g, b, _) = app.config.colors.background.to_f32_rgba();
         let px = frame.data[8 * 16 + 8];
-        let close = |got: u8, want: f32| (got as f32 - want * 255.0).abs() <= 2.0;
         assert!(
             close(px.r(), r) && close(px.g(), g) && close(px.b(), b),
             "blank scene pixel {:?} != default background ({r}, {g}, {b})",
             (px.r(), px.g(), px.b()),
         );
 
-        // A resize is a recompile: the program's geometry must move with
-        // the grid dimensions.
-        let before = *app.program.as_ref().expect("compiled").geometry();
+        // A resize is a recompile: the cell buffer the next frame builds is
+        // always sized to the CURRENT terminal snapshot, so a program whose
+        // geometry failed to move with it would panic on the length
+        // mismatch the moment the next frame binds it. Rendering
+        // successfully after the resize is itself the proof.
         let resize = EngineEventControl::Resized {
             id: WindowId(0),
             width_px: 500,
             height_px: 320,
         };
         app.handle_control(resize).expect("resize");
-        let after = *app.program.as_ref().expect("recompiled").geometry();
-        assert_ne!(before, after, "resize must recompile the scene program");
+        app.handle_data(request_frame())
+            .expect("request frame after resize");
+        let mut probe = EngineProbe::default();
+        drain_engine(&mut engine_scheduler, &mut probe);
+        let scene = probe.scenes.pop().expect("app sent a post-resize frame");
+        let mut frame = Frame::<Bgra8>::new(16, 16);
+        scene.render(&mut frame, 1);
+        let px = frame.data[8 * 16 + 8];
+        assert!(
+            close(px.r(), r) && close(px.g(), g) && close(px.b(), b),
+            "post-resize scene pixel {:?} != default background ({r}, {g}, {b})",
+            (px.r(), px.g(), px.b()),
+        );
     }
 }

--- a/docs/bugs/2026-08-01-test-quality-audit-followup.md
+++ b/docs/bugs/2026-08-01-test-quality-audit-followup.md
@@ -1,0 +1,222 @@
+# Test quality control follow-up — 2026-08-01
+
+Scope: scheduled continuation of
+`docs/bugs/2026-07-28-test-quality-audit-followup.md`. Since that pass
+(commit `d7d33b8`), the tree picked up 33 commits and ~8,500 changed lines
+across actor-scheduler, core-term, and every `pixelflow-*` crate — the
+largest delta between audit passes to date, including a green-actor
+send-policy refactor (`actor-scheduler`'s `try_send` demoted to
+`pub(crate)` in favor of `send`/`send_port`), a brand-new JIT cell-grid
+lattice (`pixelflow-core/src/lattice/cell_grid.rs`) backing core-term's new
+cell-grid terminal scene, and a rewritten `pixelflow-runtime` engine/vsync
+troupe (`coordinator_node.rs`, `engine_troupe.rs`).
+
+## Static audit: two `Explore` sub-agents swept `git diff d7d33b8..HEAD`
+
+Split by area — actor-scheduler/core-term, and the `pixelflow-*` crates —
+against docs/STYLE.md's "Test Public API" rule, cross-checked against every
+prior audit's already-accepted exceptions (`pixelflow-graphics/src/spatial_bsp.rs`'s
+private `interiors[...]` indexing; core-term's `create_test_app()` using
+`new_registered`) so those weren't re-flagged.
+
+### Fixed this pass
+
+1. **`actor-scheduler/src/mealy.rs`** — the `Node` test module read the
+   private `continuation` field directly at ten call sites instead of
+   relying on `poll()`/`poll_os()`/`actor()`'s already-public signal. Every
+   one of these was redundant with an adjacent or easily-added
+   public-surface assertion:
+   - `step_os_continuation_lands_in_the_slot`: the field check was fully
+     subsumed by the following `poll()` call already asserting
+     `actor().last_resumed == Some(42)`.
+   - `an_endless_self_yielder_does_not_starve_step_os`: each round's
+     `continuation.is_some()` check is exactly what the *next* round's
+     `poll() == Step::Ran` already proves (the lane was fed only one
+     message up front, so a lost continuation would starve it). Added one
+     more `poll()` after the loop to cover round 3, which previously had no
+     following round to prove its own survival.
+   - `a_pending_continuation_survives_step_os`: both intermediate field
+     reads were subsumed by the test's own final
+     `actor().last_resumed == Some(2)` check.
+   - `the_continuation_slot_holds_at_most_one_message`: the loop body's
+     assertion was a literal tautology
+     (`is_none() || is_some()`, always true for any `Option`) — dead weight
+     regardless of privacy. Replaced with capturing the loop's final `Step`
+     and asserting it's `Step::Idle`, which is the actual public-observable
+     form of "the slot is empty once the machine finishes."
+   - `a_continuation_resumes_before_new_inbox_work`: the two intermediate
+     `continuation == Some(n)` checks were redundant with the final
+     `actor().finished == Some(0)` after exactly three `poll()` calls — a
+     scheduler that touched the queued message instead of the pending
+     continuation could not reach that state in three steps.
+
+   `cargo test -p actor-scheduler --lib mealy::`: 36/36 after the fix.
+
+2. **`actor-scheduler/src/host.rs`** — this pass's refactor demoted
+   `GreenSender::try_send` from `pub` to `pub(crate)` ("the scheduler owns
+   send policy... a handler pushing into another green actor's inbox from
+   outside a flush should use `Self::send` instead"), adding public `send`
+   as the replacement. Two tests
+   (`a_green_send_wakes_a_wired_host_too`,
+   `a_green_send_wakes_a_host_asleep_on_its_doorbell`) still called the
+   now-private `try_send` for what is, in both cases, a single message into
+   an otherwise-empty channel — `send`'s bounded backoff behaves
+   identically there. Swapped both to `.send(41)`.
+   `a_failed_send_reports_backpressure` and
+   `many_green_sends_coalesce_into_one_pending_wake` genuinely need the
+   non-blocking `Full` signal `send` doesn't expose; left as-is (same
+   Flexibility-clause carve-out as the actor-scheduler backoff internals in
+   2026-07-24's pass).
+
+   `cargo test -p actor-scheduler --lib host::`: 15/15 after the fix.
+
+3. **`actor-scheduler/src/lib.rs`** — the same refactor demoted
+   `ActorHandle::try_send` to `pub(crate)`. Three tests in
+   `try_send_tests` (`try_send_succeeds_and_is_received`,
+   `try_send_on_a_full_data_ring_returns_full_with_the_message_recoverable`,
+   `try_send_after_receiver_drop_returns_disconnected`) still called it
+   directly. Unlike `GreenSender`, there's an exact public replacement that
+   exercises the same code: `mealy::send_port(&mut Option<T>, &target)`,
+   returning `Flush::{Done,Blocked,Disconnected}`. Rewrote all three
+   through it (payload recovery on `Blocked`/`Disconnected` checked via
+   `match` — `Message` only derives `Debug`, not `PartialEq`).
+
+   `cargo test -p actor-scheduler --lib try_send_tests::`: 3/3 after the
+   fix; `cargo clippy -p actor-scheduler --lib --tests`: clean.
+
+4. **`core-term/src/terminal_app.rs`** —
+   `scene_paints_default_background_and_recompiles_on_resize` called the
+   private `app.build_scene()` directly and read the private `program`
+   field's geometry before/after a resize to prove the scene program
+   recompiles. Rewrote to drive the actor's real entry point
+   (`app.handle_data(TerminalData::Engine(EngineEventData::RequestFrame {
+   .. }))`) and observe the rendered output on a new `EngineProbe` test
+   double (mirroring the file's existing `WriterProbe`/`drain_writer`
+   pattern, and `pixelflow-runtime`'s own `testing::mock_engine`), draining
+   the engine scheduler's `poll_once`. The resize-recompiles claim no longer
+   needs to peek at `program`'s geometry at all: `CellGridProgram::frame`
+   asserts the cell buffer's length against its compiled geometry, and the
+   cell buffer is always rebuilt fresh from the *current* terminal
+   snapshot's dimensions — so a stale, un-recompiled program would panic on
+   the very next frame after a resize. Rendering successfully post-resize
+   is therefore itself the proof; kept the background-color pixel check
+   before and after for good measure.
+
+   `cargo test -p core-term --lib terminal_app::`: 4/4 after the fix;
+   `cargo clippy -p core-term --lib --tests`: clean.
+
+### Judged an acceptable exception, documented rather than changed
+
+5. **`pixelflow-graphics/src/render/scene.rs`** —
+   `chunked_bake_matches_whole_stripe` calls the private free function
+   `bake_and_pack_chunked` directly with an explicit `chunk_rows` no public
+   API exposes. Unlike the `#[cfg(test)] pub(crate) fn holds_buffer()`
+   test-only-window pattern already established elsewhere in this same
+   diff (`coordinator_node.rs`, `render_coordinator.rs`), this function
+   isn't a test seam — it's shared production logic
+   (`bake_and_pack_stripe` calls it on the real render path too), just with
+   a parameter (`chunk_rows`) that production always derives from
+   `PLANE_SCRATCH_BYTES`, which only forces a chunk boundary on frames far
+   larger than a unit test should render. `Scene::render`'s public surface
+   (`frame`, `num_threads`) has no way to reach that boundary
+   deterministically. Rather than invent a `pub(crate)` parameter on a
+   production function against CLAUDE.md's "do not change visibility of
+   internal APIs without explicit permission," added a comment on the test
+   documenting the Flexibility-clause exception — same judgment call the
+   2026-07-24 pass made for actor-scheduler's timing-internal backoff
+   arithmetic.
+
+Everything else in the diff — `dedicated_thread.rs`'s 598 new lines,
+`coordinator_node.rs`'s 871 new lines (`Transducer`-based, mirroring the
+already-accepted `VsyncCore`/`RasterCore` pattern), `engine_troupe.rs`'s
+rewrite, `fonts/atlas.rs`'s new tests, `tests/common/mod.rs`'s golden-image
+harness, `pixelflow-ir/tests/collapse_loop.rs` — drives its crate's genuine
+public API. No `raw_mul`/`raw_select`/`SimdVec`/lane access anywhere in the
+reviewed diff.
+
+## Mutation testing: `pixelflow-core/src/lattice/cell_grid.rs`
+
+Brand new this pass (637 lines, no prior audit had touched it) and the
+JIT-compiled backbone of core-term's new cell-grid terminal scene —
+self-contained, deterministic math with no actor/timing surface, so a good
+candidate to mutation-test cleanly (no timeout-class mutants the way
+actor-scheduler's sweep loops produced in 2026-07-28). Installed
+`cargo-mutants` fresh (v27.1.0, not present in this environment, consistent
+with every prior pass).
+
+**Before: 47 mutants — 9 missed, 34 caught, 4 unviable.**
+
+All nine were real coverage gaps, not equivalent mutants:
+
+1. **`CellGridGeometry::cells_len` (`*` → `/`)** — never called directly by
+   any test, only indirectly through a mismatch assertion that doesn't
+   care about the exact value. Added
+   `cells_len_and_atlas_len_match_declared_geometry` asserting both
+   accessors against hand-computed values.
+2. **`channel_arena`'s `bg_idx` offset (`6 + channel` → `6 - channel`)** —
+   every existing test only checked channels 0 (R) and 2 (B), where the
+   wrong offset happened to land on a field with a coincidentally
+   identical value. Added
+   `green_channel_reads_its_own_bg_field_not_a_neighboring_one`, which
+   checks channel 1 (G) specifically because its wrong-offset field (fg_a)
+   and correct field (bg_g) differ in `tiny_scene`'s fixture.
+3. **The vertical apron clamp (`tile_h as f32 + 0.5` → `-`/`*`)** — every
+   existing "cell bigger than its tile" test only varied the cell
+   horizontally; nothing exercised the row-direction apron clamp. Added
+   `cells_taller_than_their_tile_fade_to_background`, the vertical mirror
+   of the existing `cells_wider_than_their_tile_fade_to_background`.
+4. **`grid_w`/`grid_h`'s boundary math (`cols * cell_w` → `cols + cell_w`,
+   same for rows)** — the existing "outside the grid" test only sampled
+   points that were outside both the correct AND the wrong (`+`-computed)
+   boundary, so it couldn't tell them apart. Added
+   `grid_extent_is_cell_count_times_cell_size_not_their_sum`, sampling a
+   point inside the correct boundary but outside the smaller wrong one.
+5. **`CellGridFrame::padded_width`'s lane count (`/` → `*`)** — nothing
+   called `padded_width` directly and asserted its value; downstream code
+   recomputes the same lane count independently, so an inflated stride was
+   silently absorbed as wasted memory rather than a wrong answer. Added
+   `padded_width_rounds_up_to_whole_simd_batches`, asserting exact values
+   at and around a lane-count boundary.
+6. **`bake_channel_rows`'s pixel-center offset (`y0 as f32 + 0.5` → `-`/`*`)**
+   — every existing test baked from `y0 = 0`, and this class of mutation
+   shifts every row's absolute Y by the same constant, so a
+   self-consistency check (bake offset region, compare against a full bake
+   sliced at the same relative rows) can't see it — the shift cancels in
+   the comparison. First attempt at
+   `baking_a_row_offset_region_matches_the_same_rows_from_a_full_bake`
+   confirmed this empirically (it caught the `*` mutant but missed the `-`
+   one). Replaced it with
+   `baking_a_row_offset_region_samples_the_correct_absolute_row`, which
+   asserts a concrete expected pixel value tied to a specific `y0 > 0`
+   instead of comparing two bakes to each other.
+
+**After: 47 mutants — 0 missed, 43 caught, 4 unviable.**
+
+`cargo test -p pixelflow-core --lib lattice::cell_grid::`: 13/13 (was 7/7
+before this pass's additions). `cargo clippy -p pixelflow-core --lib
+--tests`: clean (one `identity_op` lint from an early draft of the vertical
+apron test, fixed before landing).
+
+## Verified
+
+- `cargo test --workspace --lib`: all 11 crates pass, 0 failures.
+- `cargo clippy --workspace --lib --tests`: clean.
+- `cargo fmt --check` on every touched crate: clean.
+- `cargo mutants -p pixelflow-core --file pixelflow-core/src/lattice/cell_grid.rs`:
+  0 missed (re-run after the fix, confirmed above).
+
+## Recommended next steps (not done here)
+
+1. `spatial_bsp.rs`'s private `interiors[...]` indexing (open since
+   2026-07-20) still needs a human design call — unchanged this pass.
+2. `core-term/src/terminal_app.rs`'s `create_test_app()` calling
+   `new_registered` instead of `spawn_terminal_app()` (open since
+   2026-07-24) — still judged an intentional seam, not re-litigated here.
+3. This pass only mutation-tested `cell_grid.rs`. The other large new
+   surfaces from this delta —
+   `pixelflow-runtime/src/coordinator_node.rs` (871 lines),
+   `engine_troupe.rs` (rewritten), and `actor-scheduler/src/mealy.rs`'s own
+   969-line rewrite around the `DedicatedThread`/`step_os` primitive — have
+   never been mutation-tested and are the highest-value next targets,
+   in roughly that order (coordinator_node.rs is the newest and least
+   exercised by any prior pass).

--- a/pixelflow-core/src/lattice/cell_grid.rs
+++ b/pixelflow-core/src/lattice/cell_grid.rs
@@ -634,4 +634,193 @@ mod tests {
         // Binding satisfies unused_must_use; the call panics first.
         let _refused = program.frame(Arc::new(alloc::vec![0.0; 3]), atlas);
     }
+
+    #[test]
+    fn cells_len_and_atlas_len_match_declared_geometry() {
+        let geom = CellGridGeometry {
+            cols: 3,
+            rows: 2,
+            cell_w: 4.0,
+            cell_h: 4.0,
+            density: 1.0,
+            atlas_width: 12,
+            atlas_height: 6,
+            tile_w: 4,
+            tile_h: 4,
+        };
+        assert_eq!(geom.cells_len(), 3 * 2 * CELL_STRIDE);
+        assert_eq!(geom.atlas_len(), 12 * 6);
+    }
+
+    #[test]
+    fn padded_width_rounds_up_to_whole_simd_batches() {
+        let lanes = pixelflow_ir::JIT_VECTOR_BYTES / core::mem::size_of::<f32>();
+        assert_eq!(CellGridFrame::padded_width(1), lanes);
+        assert_eq!(CellGridFrame::padded_width(lanes), lanes);
+        assert_eq!(CellGridFrame::padded_width(lanes + 1), lanes * 2);
+    }
+
+    #[test]
+    fn green_channel_reads_its_own_bg_field_not_a_neighboring_one() {
+        // In `tiny_scene`, cell 1 has fg_g = 1.0, bg_g = 0.0, coverage 0.5,
+        // so the correct blend is 0.5. Every neighboring field at cell 1
+        // (fg_a, bg_r, bg_b) is 1.0 or 0.0 in a way that a wrong bg-field
+        // offset would still coincidentally read 0.5-ish through cell 0's
+        // R/B channels the other tests already check — G is the one channel
+        // whose neighbors in the field layout (fg_a at offset 5, bg_r at
+        // offset 6) both read 1.0/0.0 in a way that distinguishes a bad
+        // offset from the correct one.
+        let (program, cells, atlas) = tiny_scene();
+        let frame = program.frame(cells, atlas);
+        let g = plane(&frame, 1, 8, 4);
+        assert!(
+            (g[px(1, 5)] - 0.5).abs() < 1e-5,
+            "cell1 G = {}",
+            g[px(1, 5)]
+        );
+    }
+
+    #[test]
+    fn cells_taller_than_their_tile_fade_to_background() {
+        // Mirrors `cells_wider_than_their_tile_fade_to_background` in the
+        // row direction: a 1x1 grid with a cell taller than its tile. The
+        // bottom half has no tile content; the vertical apron clamp must
+        // land those taps in the zero apron, never a neighboring slot.
+        let (aw, ah, slot) = (12usize, 6usize, 6usize);
+        let mut atlas = vec![0.0f32; aw * ah];
+        for r in 0..4 {
+            for c in 0..4 {
+                atlas[(1 + r) * aw + 1 + c] = 1.0; // tile 0: solid
+                atlas[(1 + r) * aw + slot + 1 + c] = 1.0; // tile 1: ALSO solid
+            }
+        }
+        let geom = CellGridGeometry {
+            cols: 1,
+            rows: 1,
+            cell_w: 4.0,
+            cell_h: 8.0,
+            density: 1.0,
+            atlas_width: aw as u32,
+            atlas_height: ah as u32,
+            tile_w: 4,
+            tile_h: 4,
+        };
+        let program = CellGridProgram::compile(geom, [0.0; 4]);
+        let cells = vec![
+            1.0, 1.0, /* fg */ 1.0, 1.0, 1.0, 1.0, /* bg */ 0.0, 0.0, 0.0, 1.0,
+        ];
+        let frame = program.frame(Arc::new(cells), Arc::new(atlas));
+        let r = plane(&frame, 0, 4, 8);
+        // Top half: tile content, fg. Bottom half: past the tile — if the
+        // clamp failed, taps would reach tile 1 (also solid) and read 1.0.
+        assert!((r[5] - 1.0).abs() < 1e-5, "tile content R = {}", r[5]);
+        for row in 5..8 {
+            assert!(
+                r[row * 4 + 1].abs() < 1e-5,
+                "cell past its tile must be background at row {row}, got {}",
+                r[row * 4 + 1]
+            );
+        }
+    }
+
+    #[test]
+    fn grid_extent_is_cell_count_times_cell_size_not_their_sum() {
+        // A 3x3 grid of 2x2 cells: grid_w = grid_h = 6.0. If the boundary
+        // check ever computed cols + cell_w (5.0) instead of cols * cell_w,
+        // the last row/column of real cells (spanning [4, 6)) would be
+        // wrongly treated as outside the grid.
+        let (aw, ah) = (6usize, 6usize);
+        let mut atlas = vec![0.0f32; aw * ah];
+        for r in 0..4 {
+            for c in 0..4 {
+                atlas[(1 + r) * aw + 1 + c] = 1.0; // solid tile
+            }
+        }
+        let geom = CellGridGeometry {
+            cols: 3,
+            rows: 3,
+            cell_w: 2.0,
+            cell_h: 2.0,
+            density: 1.0,
+            atlas_width: aw as u32,
+            atlas_height: ah as u32,
+            tile_w: 4,
+            tile_h: 4,
+        };
+        let program = CellGridProgram::compile(geom, [0.4; 4]);
+        let block: [f32; CELL_STRIDE] = [
+            1.0, 1.0, /* fg */ 1.0, 0.0, 0.0, 1.0, /* bg */ 0.0, 0.0, 0.0, 1.0,
+        ];
+        let mut cells = vec![];
+        for _ in 0..9 {
+            cells.extend_from_slice(&block);
+        }
+        let frame = program.frame(Arc::new(cells), Arc::new(atlas));
+        let r = plane(&frame, 0, 8, 8);
+        // (5.5, 5.5) is interior to the last (col 2, row 2) cell — must
+        // read pure fg (1.0), not the default background (0.4) a
+        // cols+cell_w-sized boundary would wrongly clip it to.
+        assert!(
+            (r[5 * 8 + 5] - 1.0).abs() < 1e-5,
+            "last cell R = {}",
+            r[5 * 8 + 5]
+        );
+    }
+
+    #[test]
+    fn baking_a_row_offset_region_samples_the_correct_absolute_row() {
+        // A 1x2 grid (one column, two rows) with visibly different content
+        // per row. Baking a region whose `PlaneRegion::y0` starts mid-grid
+        // must read the ABSOLUTE row that `y0` implies. A constant error in
+        // the pixel-center offset shifts every sampled row by the same
+        // amount, so a self-consistency check (comparing this bake against
+        // a full bake sliced at the same relative offset) can't see it —
+        // this asserts a concrete expected value instead.
+        let (aw, ah, slot) = (12usize, 6usize, 6usize);
+        let mut atlas = vec![0.0f32; aw * ah];
+        for r in 0..4 {
+            for c in 0..4 {
+                atlas[(1 + r) * aw + 1 + c] = 1.0; // tile 0: solid
+                atlas[(1 + r) * aw + slot + 1 + c] = 0.5; // tile 1: half
+            }
+        }
+        let geom = CellGridGeometry {
+            cols: 1,
+            rows: 2,
+            cell_w: 4.0,
+            cell_h: 4.0,
+            density: 1.0,
+            atlas_width: aw as u32,
+            atlas_height: ah as u32,
+            tile_w: 4,
+            tile_h: 4,
+        };
+        let program = CellGridProgram::compile(geom, [0.0; 4]);
+        let cells = vec![
+            1.0, 1.0, /* row0 fg */ 1.0, 0.0, 0.0, 1.0, /* bg */ 0.0, 0.0, 0.0, 1.0, 7.0,
+            1.0, /* row1 fg */ 0.0, 0.0, 1.0, 1.0, /* bg */ 1.0, 1.0, 1.0, 1.0,
+        ];
+        let frame = program.frame(Arc::new(cells), Arc::new(atlas));
+
+        let stride = CellGridFrame::padded_width(4);
+        let mut padded = vec![0.0f32; 4 * stride];
+        frame.bake_channel_rows(
+            0,
+            PlaneRegion {
+                width: 4,
+                y0: 4,
+                rows: 4,
+            },
+            &mut padded,
+        );
+        // y0 = 4 → the first baked row samples absolute y = 4.5, inside row
+        // 1's cell (coverage 0.5, R: bg 1.0 -> fg 0.0 blends to 0.5). An
+        // off-by-one-pixel-center bug would instead sample y = 3.5, still
+        // inside row 0's cell (solid fg, R = 1.0).
+        assert!(
+            (padded[1] - 0.5).abs() < 1e-5,
+            "row-offset bake read the wrong absolute row: R = {}",
+            padded[1]
+        );
+    }
 }

--- a/pixelflow-graphics/src/render/scene.rs
+++ b/pixelflow-graphics/src/render/scene.rs
@@ -235,6 +235,18 @@ mod tests {
     fn chunked_bake_matches_whole_stripe() {
         // Force chunk boundaries (3-row chunks over an 8-row band) and
         // require pixel identity with the unchunked bake.
+        //
+        // `bake_and_pack_chunked` is production logic (`bake_and_pack_stripe`
+        // calls it on the real render path too), not a test-only seam — but
+        // its `chunk_rows` argument is derived internally from
+        // `PLANE_SCRATCH_BYTES`, which only forces a chunk boundary on
+        // frames far larger than a unit test should render. Calling it
+        // directly with a small `chunk_rows` is the only way to exercise
+        // that boundary deterministically; going through `Scene::render`
+        // could only ever hit the always-one-chunk case. Flexibility-clause
+        // exception to docs/STYLE.md's public-API testing rule, same as the
+        // 2026-07-24 pass's call for actor-scheduler's timing-internal
+        // backoff arithmetic.
         let Scene::CellGrid(grid) = scene() else {
             unreachable!()
         };


### PR DESCRIPTION
## Summary

Scheduled test-quality-control pass, continuing `docs/bugs/2026-07-28-test-quality-audit-followup.md`. Full writeup: `docs/bugs/2026-08-01-test-quality-audit-followup.md`.

- Static-audited everything changed since the last pass (`d7d33b8..HEAD`, 33 commits) against `docs/STYLE.md`'s "Test Public API" rule and fixed 4 genuine violations:
  - `actor-scheduler/src/mealy.rs`: removed ten redundant reads of `Node`'s private `continuation` field, replacing them with (or confirming they were already subsumed by) public `poll()`/`poll_os()`/`actor()` assertions. Also killed a literal tautology assertion (`is_none() || is_some()`).
  - `actor-scheduler/src/host.rs` + `src/lib.rs`: this delta's send-policy refactor demoted `try_send` to `pub(crate)` on both `GreenSender` and `ActorHandle`; updated tests to go through the new public `send()`/`send_port()` paths instead.
  - `core-term/src/terminal_app.rs`: a resize-recompile test called the private `build_scene()` and read the private `program` field's geometry. Rewrote to drive the actor's real `RequestFrame` entry point and observe rendered output via a new `EngineProbe` test double.
  - `pixelflow-graphics/src/render/scene.rs`: one case judged an acceptable Flexibility-clause exception rather than fixed (the private function under test is shared production logic, not a test seam) — documented in a comment instead.
- Mutation-tested `pixelflow-core/src/lattice/cell_grid.rs` (brand new this delta, never audited before) with `cargo-mutants`: 9/47 mutants missed initially, all real coverage gaps. Added 6 tests; re-run confirms 0 missed.

## Test plan

- [x] `cargo test --workspace --lib` — all 11 crates pass
- [x] `cargo clippy --workspace --lib --tests` — clean
- [x] `cargo fmt --check` on every touched crate — clean
- [x] `cargo mutants -p pixelflow-core --file pixelflow-core/src/lattice/cell_grid.rs` — 0 missed (was 9)
- [x] `cargo test -p actor-scheduler --lib mealy:: / host:: / try_send_tests::` — 36/15/3 passing
- [x] `cargo test -p core-term --lib terminal_app::` — 4/4 passing

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01AW5FTT1BREJHwjgCzVqBm5

---
_Generated by [Claude Code](https://claude.ai/code/session_01AW5FTT1BREJHwjgCzVqBm5)_