### PR TITLE
feat(pixelflow): the terminal screen as ONE packed JIT kernel (3.05x steady-state)

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -397,6 +397,55 @@ jobs:
         shell: bash
         run: cargo run -p xtask -- isa-matrix --clippy --build-only
 
+  # The `test` job above runs `cargo test` on macos-latest, but that never
+  # exercises a real LaunchServices bundle launch -- `cargo run`/`cargo test`
+  # spawn the binary directly, bypassing the app-bundle launch path entirely.
+  # A prior bug (background threads calling into AppKit unsynchronized with
+  # MetalOps's hand-pumped event queue, fixed via CocoaWaker's dispatch_async
+  # hop onto the main thread -- see pixelflow-runtime/src/platform/waker.rs)
+  # crashed ~2 out of 3 raw launches, 14-22s after startup, and was invisible
+  # to every job above: Linux runners have no window server at all, and even
+  # on macOS, only a real `open`/LaunchServices launch reproduced it. This
+  # job is what would have caught it, and is what stops it from silently
+  # coming back.
+  macos-launch-stability:
+    name: macOS launch stability
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-launch-stability-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-launch-stability-
+
+      - name: Launch the bundled app repeatedly and check for crash reports
+        run: cargo run -p xtask --release -- launch-stability-check
+
+      # The stability check above already fails the job on a crash; this
+      # step exists purely to attach the .ips content to the log so a
+      # failure is diagnosable without re-running locally.
+      - name: Dump any crash reports (only runs if a launch crashed)
+        if: failure()
+        run: |
+          shopt -s nullglob
+          for f in "$HOME/Library/Logs/DiagnosticReports"/CoreTerm-*.ips; do
+            echo "::group::$f"
+            cat "$f"
+            echo "::endgroup::"
+          done
+
   # Every display driver's cfg (use_cocoa_display, use_x11_display,
   # use_web_display) should be verifiably exercised *somewhere* in CI, or its
   # buildability is a total blind spot -- exactly how the now-deleted headless

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -409,7 +409,11 @@ jobs:
   # job is what would have caught it, and is what stops it from silently
   # coming back.
   macos-launch-stability:
-    name: macOS launch stability
+    # Informational while the harness is tuned against real runner timing —
+    # same policy as the WASM status job: keep the signal, don't gate merges
+    # on an unproven check. Flip to blocking once it has a green history.
+    name: macOS launch stability (informational, non-blocking)
+    continue-on-error: true
     runs-on: macos-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -419,6 +419,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # The app's font is LFS-tracked (.gitattributes), and this is the
+          # only job that runs the real bundle — without the smudge it ships
+          # a 131-byte pointer and the app dies parsing it. Tests escape this
+          # by include_bytes!-ing the fallback font, which .gitattributes
+          # exempts from LFS for exactly that reason.
+          lfs: true
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,8 @@ Use the stable Rust toolchain from `rust-toolchain.toml`.
 - `cargo bench -p pixelflow-core` or `cargo bench -p actor-scheduler`: run focused benchmarks.
 
 ## Coding Style & Naming Conventions
+Design denotationally: decide what a thing *means* as a mathematical object, and encode that meaning in the type system, before writing the code that manipulates it (see "Denote before you build" in `CLAUDE.md`). A rule that lives only in a doc comment — "this operand must be a constant", "these bits are a mask, not a number", "these coordinates are in the caller's space" — is an invariant some later pass will break, and the repair always costs more than the type would have.
+
 Follow `docs/STYLE.md`. Prefer clear names over explanatory comments; use Rustdoc for public APIs and regular comments only for design rationale. Keep control flow flat with guard clauses, prefer `match` over long `else if` chains, and avoid boolean parameters when an enum or separate function is clearer. Use `snake_case` for functions/modules/files, `CamelCase` for types, and named constants instead of unexplained numeric literals.
 
 ## Testing Guidelines

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Minimal public API** - Do NOT change visibility of internal APIs without explicit permission. Keep `pub(crate)` and private items encapsulated. Use Manifold composition instead of exposing internals.
 - **Subtract before you add.** The good version of a primitive is reached by removing machinery, not stacking it. If a type's signature already refuses the wrong shape, you don't need a macro, a lint, or a doc to forbid it — the opinion lives in the types. Reach for a new dependency or a new abstraction only after subtraction has failed.
 
+- **Denote before you build.** Say what a thing *means* — as a mathematical object, in the type system — before writing the code that manipulates it. Design is choosing the denotation; the implementation is then obliged to it. Where this codebase is good, it already works this way: `Lattice`/`DiscreteManifold` are a representable functor whose law is written down (`index(collapse(f)) = f`), and that law is *why* a buffer can BE a manifold rather than merely back one.
+
+  Where it is bad, the meaning lives in a comment instead of a type, and every such place has cost us a bug. One `f32` lane carries continuous values, integers, and bit patterns at once — `OpKind::is_bitwise_domain()` exists to recover at runtime what a type would have given for free, and a mask (all-ones, i.e. NaN read as a number) is one careless fold away from corruption. `Var(u8)` means a coordinate axis, a reduce binder, or a manifold-param slot depending on magic ranges. `push_reduce` encodes an `OpKind` as a `Const(f32)`. Each convention held right up until the optimizer grew strong enough to violate it — **a convention written in a comment is an invariant something else will eventually break.**
+
+  So: **when you extend a type's meaning, extend its type.** The escape hatch — "reinterpret is free", "this operand must be a literal", "these coordinates are in the caller's space" — is the moment to pay. Afterwards it is a bug hunt rather than a refactor, and the fix arrives as a runtime guard defending what a type should have made unrepresentable. Prioritize by whether a wrong value would be *silently* representable: a domain confusion produces plausible pixels and deserves a type; an out-of-range index that panics on the next line does not.
+
 ### Floating point at the edges
 
 **Rust already ships reasonably fast IEEE-754 arithmetic.** `f32::min`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,7 @@ Behavior that differs by target, because the instructions do:
 | `Round` (`-0.5 ≤ x ≤ -0.0`) | `-0.0` (sign preserved) | `-0.0` | `+0.0` |
 | `Recip`, `Rsqrt` | `rcpps` ~12 bits; `vrcp14ps` ~14 | `FRECPE` + one `FRECPS` step | estimate + NR |
 | `MulAdd` | **one** rounding with `+fma`, **two** without (`mulps`+`addps`) | one (`FMLA`) | one |
+| `TruncToInt` (invalid: non-finite or outside i32) | `cvttps2dq` → **`i32::MIN`** (integer indefinite) | `FCVTZS` **saturates**; NaN → 0 | saturates (Rust `as`) |
 
 The last two rows are the reminder that "target" is finer than "architecture":
 `Recip` and `MulAdd` differ between *ISA levels of the same machine*, which is

--- a/core-term/src/terminal_app.rs
+++ b/core-term/src/terminal_app.rs
@@ -11,7 +11,7 @@ use actor_scheduler::{
     Actor, ActorBuilder, ActorHandle, ActorStatus, HandlerError, HandlerResult, Message,
     SystemStatus,
 };
-use pixelflow_core::{At, CellGridGeometry, CellGridProgram};
+use pixelflow_core::{At, CellGridGeometry, CellGridPackedProgram};
 use pixelflow_graphics::render::scene::Scene;
 
 /// Adapter to send PTY commands to TerminalApp actor.
@@ -109,12 +109,14 @@ pub struct TerminalApp {
     loaded_font: Arc<LoadedFont<MmapSource>>,
     /// Baked glyph coverage tiles, gathered by the scene kernel.
     atlas: GlyphAtlas,
-    /// The compiled cell-grid scene (four channel kernels). Recompiled
-    /// whenever the geometry it was compiled against — grid dimensions,
-    /// cell size, density, atlas extents — changes; `None` until the first
-    /// frame. This is the JIT answer to dynamic resize: the program's size
-    /// and compile time are independent of the grid's.
-    program: Option<CellGridProgram>,
+    /// The compiled cell-grid scene: ONE packed kernel producing finished
+    /// `u32` pixels, byte order bound by the platform's ColorCube inside
+    /// pixelflow-graphics. Recompiled whenever the geometry it was compiled
+    /// against — grid dimensions, cell size, density, atlas extents —
+    /// changes; `None` until the first frame. This is the JIT answer to
+    /// dynamic resize: the program's size and compile time are independent
+    /// of the grid's.
+    program: Option<CellGridPackedProgram>,
     /// Whether any scene has been submitted yet. Synchronized output holds
     /// the last frame, which only exists once this is true; before that, the
     /// solid background is the only honest thing to show.
@@ -345,7 +347,7 @@ impl TerminalApp {
             tile_w: self.atlas.tile_px() as u32,
             tile_h: self.atlas.tile_px() as u32,
         };
-        if self.program.as_ref().map(CellGridProgram::geometry) != Some(&geom) {
+        if self.program.as_ref().map(CellGridPackedProgram::geometry) != Some(&geom) {
             log::info!(
                 "Compiling cell-grid scene: {}x{} cells, cell {}x{} pt, atlas {}x{} texels",
                 cols,
@@ -355,7 +357,12 @@ impl TerminalApp {
                 geom.atlas_width,
                 geom.atlas_height
             );
-            self.program = Some(CellGridProgram::compile(geom, [dbg_r, dbg_g, dbg_b, dbg_a]));
+            self.program = Some(
+                pixelflow_graphics::render::scene::compile_platform_cell_grid(
+                    geom,
+                    [dbg_r, dbg_g, dbg_b, dbg_a],
+                ),
+            );
         }
         let program = self.program.as_ref().expect("program compiled above");
         Some(Scene::CellGrid(

--- a/core-term/src/terminal_app.rs
+++ b/core-term/src/terminal_app.rs
@@ -173,7 +173,30 @@ impl TerminalApp {
             panic!("Failed to open font file at {}: {}", font_path.display(), e)
         });
 
-        let loaded_font = Arc::new(LoadedFont::new(source).expect("Failed to parse font"));
+        let loaded_font = Arc::new(LoadedFont::new(source).unwrap_or_else(|| {
+            // `expect("Failed to parse font")` discarded the path and the
+            // size — and cost a CI round-trip with a bespoke diagnostic
+            // harness to learn that the "font" was a 131-byte Git LFS
+            // pointer. The parse returns no error of its own, so what the
+            // file actually IS is the only signal available; report it.
+            let size = std::fs::metadata(&font_path).map(|m| m.len());
+            let lfs_pointer = std::fs::read(&font_path)
+                .is_ok_and(|b| b.starts_with(b"version https://git-lfs.github.com/spec/v1"));
+            panic!(
+                "Failed to parse font at {} ({}){}",
+                font_path.display(),
+                match size {
+                    Ok(n) => format!("{n} bytes"),
+                    Err(e) => format!("size unknown: {e}"),
+                },
+                if lfs_pointer {
+                    " — this file is a Git LFS pointer, not a font. Run \
+                     `git lfs pull` (or check out with LFS enabled)."
+                } else {
+                    ""
+                }
+            )
+        }));
 
         // Bake the ASCII set into the atlas. Density 1.0 until the platform
         // reports the real backing scale via WindowCreated.

--- a/core-term/src/terminal_app.rs
+++ b/core-term/src/terminal_app.rs
@@ -1213,7 +1213,10 @@ mod tests {
 
     #[test]
     fn scene_paints_default_background_and_recompiles_on_resize() {
-        use pixelflow_graphics::render::color::Bgra8;
+        // The app compiles its kernel for the PLATFORM's pixel format, so
+        // the frame must be that format too — a hardcoded one was correct
+        // only while rendering converted per pixel.
+        use pixelflow_graphics::render::color::PlatformPixel;
         use pixelflow_graphics::render::frame::Frame;
 
         let (mut app, _writer_rx, _tx, mut engine_scheduler) = match create_test_app() {
@@ -1231,7 +1234,7 @@ mod tests {
         let mut probe = EngineProbe::default();
         drain_engine(&mut engine_scheduler, &mut probe);
         let scene = probe.scenes.pop().expect("app sent a frame");
-        let mut frame = Frame::<Bgra8>::new(16, 16);
+        let mut frame = Frame::<PlatformPixel>::new(16, 16);
         scene.render(&mut frame, 1);
         let px = frame.data[8 * 16 + 8];
         assert!(
@@ -1256,7 +1259,7 @@ mod tests {
         let mut probe = EngineProbe::default();
         drain_engine(&mut engine_scheduler, &mut probe);
         let scene = probe.scenes.pop().expect("app sent a post-resize frame");
-        let mut frame = Frame::<Bgra8>::new(16, 16);
+        let mut frame = Frame::<PlatformPixel>::new(16, 16);
         scene.render(&mut frame, 1);
         let px = frame.data[8 * 16 + 8];
         assert!(

--- a/docs/plans/2026-08-08-egraph-constant-domain-spike.md
+++ b/docs/plans/2026-08-08-egraph-constant-domain-spike.md
@@ -1,0 +1,461 @@
+# Spike: `ENode` constant representation for the dyadic-exact fold
+
+**Status:** Reconnaissance only — no source changes. Recommendation for whoever implements.
+**Date:** 2026-08-08
+**Scope:** `pixelflow-search` (primary), `pixelflow-compiler`, `pixelflow-ir` (read-only —
+`dyadic.rs`/`fold_exactness.rs`/`arena.rs` were under concurrent edit by other agents during
+this spike and were not modified here).
+
+---
+
+## TL;DR recommendation
+
+Split `ENode::Const(u32)` into **two variants**, `ENode::Num(Dyadic)` and `ENode::Bits(u32)`
+(option **a** in the brief). Keep `ENode::constant(val: f32) -> Self` as the single, unchanged,
+f32-taking constructor everyone already calls — it auto-classifies via `Dyadic::from_f32`
+(`Some` → `Num`, `None` for NaN/±inf → `Bits`). Keep `ENode::as_f32(&self) -> Option<f32>`
+with its current signature and behavior for `Num` (now `Dyadic::to_f32`, one correctly-rounded
+conversion) and `Bits` (unchanged bit-reinterpretation).
+
+That combination means **the great majority of the census below needs zero or
+compiler-mechanical changes.** Of the 72 real, live call sites found:
+
+- **~46 are pure construction** (`ENode::constant(f32)` / `ENode::Op{..}` builders) — untouched,
+  because the constructor signature doesn't change.
+- **15 are shape-only matches** (`ENode::Const(_)` wildcard, "is this a constant leaf") — these
+  need a second match arm (`Num(_) | Bits(_)`), which `rustc` finds for you: `ENode` is not
+  `#[non_exhaustive]`, so every one of these is a compile error until fixed, not a silent bug.
+- **~9 read `.as_f32()`/`.is_const()`** — zero caller-visible change, because those methods'
+  signatures don't change.
+- **A genuinely small set — about 10 sites — need real design thought**: the two hash-consing
+  impls in `node.rs` (this is the whole point of the migration), the `ConstantFold` rewrite's
+  arg-gather and result-construction in `math/algebra.rs`, the freshly-added `const_fact` side
+  table in `graph.rs` (7 sub-edits, see below), and 6 sites that pattern-match `ENode::Const(bits)`
+  with a **bound** variable and must decide what to do with each variant.
+
+Full reasoning, the rejected alternative (a single fused variant), and an ordered
+implementation sketch are below.
+
+---
+
+## 1. Measured site census
+
+**Raw grep count** (`ENode::Const|ENode::constant\(|\.as_f32\(|\.is_const\(`, all four patterns,
+`--type rust`, whole workspace) as of this spike: **76 matches in 17 files.** The brief's
+estimate ("~71 in ~17 files") was close but not exact; here is the reconciliation:
+
+| Adjustment | Count | Why |
+|---|---|---|
+| Raw matches | 76 | `rg` count, all 4 patterns, 17 files |
+| − dead code | −2 | `pixelflow-search/src/egraph/algebra.rs` is **not declared as a module** anywhere (`egraph/mod.rs` has no `mod algebra;`/`pub mod algebra;`) — it does not compile into the crate. It duplicates `InverseAnnihilation<T>` byte-for-byte from `math/algebra.rs`. See §3. |
+| − false positives | −2 | `nnue/factored.rs` (`v.is_const()`) and `egraph/deps.rs` (`child_v.is_const()`) both call **`Variance::is_const()`** (`pixelflow-ir/src/variance.rs`), an unrelated method on an unrelated type. Not `ENode` at all. |
+| **Live, real total** | **72** | across **16 compiled files** |
+
+`pixelflow-pipeline` was checked and has **zero** references to `ENode` — it operates one
+layer up, on `pixelflow_ir::ExprArena`/`ExprNode` (plain `f32`), which this change does not
+touch. Out of scope, confirmed by grep, not asserted.
+
+### Per-file counts (live, compiled files only)
+
+| File | Raw sites | Construction | Read (bound) | Read (shape-only wildcard) | Notes |
+|---|---:|---:|---:|---:|---|
+| `pixelflow-search/src/egraph/node.rs` | 6 | 1 (ctor def) | 3 (`as_f32`, `is_const`, + PartialEq/Hash below) | 1 | **Defines the type + hash-consing.** See §2.1. |
+| `pixelflow-search/src/egraph/graph.rs` | 25 | 21 (incl. `add_arena` widen, derivative helpers, tests) | 2 (`as_f32` in `add()`'s `const_fact` hook, `is_const` in `any_const_eq`) | 2 | Also owns the **union refusal valve** and new `const_fact` table — see §2.2. |
+| `pixelflow-search/src/egraph/extract.rs` | 8 | 1 (test) | 1 (`choices_to_arena` narrowing — **the** extraction funnel) | 6 (incl. new `pin_shift_counts`, see §2.4) | |
+| `pixelflow-search/src/egraph/deps.rs` | 8 (7 real) | 5 (tests) | 0 | 2 | Variance classification only; never reads the value. |
+| `pixelflow-search/src/math/algebra.rs` | 7 | 5 (incl. `ConstantFold` result) | 2 (`ConstantFold` arg-gather, 1 test) | 0 | **`ConstantFold::apply` — the crux.** See §2.3. |
+| `pixelflow-compiler/src/optimize.rs` | 4 | 3 | 1 (egraph→AST codegen) | 0 | Cross-crate: `ENode` is `pub`, matched from outside `pixelflow-search`. |
+| `pixelflow-search/src/nnue/factored.rs` | 3 (2 real) | 0 | 0 | 2 | Shape/`OpKind` classification only — **no numeric value ever reaches NNUE features.** Reassuring finding, see §3. |
+| `pixelflow-search/src/math/trig.rs` | 2 | 2 | 0 | 0 | Pythagorean identity → literal `1.0`. |
+| `pixelflow-search/src/math/power.rs` | 2 | 1 | 1 (`eclass_const`, epsilon-compared) | 0 | See §3 (epsilon-vs-exact risk). |
+| `pixelflow-search/src/egraph/saturate.rs` | 2 | 2 (tests) | 0 | 0 | |
+| `pixelflow-search/src/math/mod.rs` | 2 | 1 (test-local widen) | 1 (test-local narrow) | 0 | **Duplicates the arena-boundary logic** in test code instead of calling `add_arena`/`choices_to_arena`. |
+| `pixelflow-search/src/math/fusion.rs` | 1 | 0 | 1 (`is_one`, epsilon-compared, manually unpacks bits instead of using `.as_f32()`) | 0 | |
+| `pixelflow-search/src/math/pict_rewrite_tests.rs` | 1 | 1 (test-local widen, same duplication as above) | 0 | 0 | |
+| `pixelflow-search/src/egraph/codegen.rs` | 1 | 0 | 1 (`format_const` — string-codegen numeric literal emission) | 0 | |
+| `pixelflow-search/src/egraph/cost.rs` | 1 | 0 | 0 | 1 | |
+| `pixelflow-search/src/runtime.rs` | 1 | 1 | 0 | 0 | **Second, independent** arena→egraph widening implementation (memoized), parallel to `add_arena`. Must be kept in sync by hand — pre-existing risk, not created by this change. |
+| **`pixelflow-search/src/egraph/algebra.rs`** | 2 | — | — | — | **DEAD CODE**, not compiled. Excluded from all totals above. Flagging for cleanup (separate task). |
+
+Total live real sites: 1+21+2+1(node.rs shape)... — see the "Live, real total: 72" figure above;
+the table's per-file breakdown sums to it (72 across the 16 compiled files, i.e. 76 raw − 2 dead
+− 2 false-positive).
+
+**Caveat on line numbers:** two other agents were actively editing `pixelflow-ir/src/arena.rs`,
+`pixelflow-search/src/egraph/extract.rs`, `pixelflow-search/src/egraph/graph.rs`, and
+`pixelflow-search/tests/fold_exactness.rs` during this spike (a real, unrelated correctness fix —
+see §2.2). Line numbers cited below were re-verified against the working tree at time of writing
+but **will drift further**; re-grep before acting. `git diff` those four files first to see
+what already landed.
+
+---
+
+## 2. Deep dives on the sites that actually matter
+
+### 2.1 `node.rs` — the type definition and hash-consing (the whole point)
+
+```rust
+pub enum ENode {
+    Var(u8),
+    Const(u32),              // stored as f32 bits
+    Buffer(BufferDecl),
+    Op { op: &'static dyn Op, children: Vec<EClassId> },
+}
+
+pub fn constant(val: f32) -> Self { ENode::Const(val.to_bits()) }      // ctor
+pub fn as_f32(&self) -> Option<f32> { ... f32::from_bits(*bits) ... } // numeric read
+pub fn is_const(&self, val: f32) -> bool { self.as_f32() == Some(val) }
+
+impl PartialEq for ENode {
+    (ENode::Const(a), ENode::Const(b)) => a == b,   // bit-exact — the hash-consing key
+}
+impl Hash for ENode {
+    ENode::Const(bits) => { 1u8.hash(state); bits.hash(state); }
+}
+```
+
+This `PartialEq`/`Hash` pair, together with `EGraph`'s `memo: HashMap<ENode, EClassId>`
+(`graph.rs`), **is** hash-consing: two constants are the same e-node today iff their f32 bits
+are identical. This is exactly what constraint 1 in the brief breaks — a dyadic fold result with
+no f32 form has no bits to hash. This is the site the whole migration exists to fix; everything
+else downstream is bookkeeping.
+
+`ENode` is `pub`, not `#[non_exhaustive]`, and re-exported (`egraph/mod.rs:52`,
+`pub use node::{EClassId, ENode};`) — and it is pattern-matched **outside the crate**, in
+`pixelflow-compiler/src/optimize.rs` (imports `pixelflow_search::egraph::ENode` directly, line
+~30). Any variant-shape change is a breaking change for that crate too, not just internal
+`pixelflow-search` code — already counted in its 4 sites above.
+
+### 2.2 `graph.rs` — the union refusal valve, and a just-landed `const_fact` table
+
+The refusal valve the brief calls out (`EGraph::union`) is real and load-bearing. **While this
+spike was in progress, another agent fixed a genuine bug in it** (visible via `git diff
+pixelflow-search/src/egraph/graph.rs` at time of writing): the old implementation scanned
+`EClass::nodes` to find a class's constant, but `rebuild()` drains `nodes` with `mem::take`
+*before* performing congruence unions — so a node-scanning guard was blind at exactly the moment
+congruence closure does its merging, and a contradictory merge could slip through during
+rebuild. The fix adds a class-indexed side table:
+
+```rust
+/// The constant each class is known to equal, as f32 bits, indexed by class id —
+/// maintained independently of `EClass::nodes` on purpose. [...] The fact must
+/// outlive the nodes.
+const_fact: Vec<Option<u32>>,
+```
+
+populated in `add()` (`self.const_fact.push(node.as_f32().map(f32::to_bits));`) and consulted —
+not the node vector — in `union()`. **This table is a new, permanent piece of state that must
+also become domain-aware.** Under the recommended design it becomes
+`Vec<Option<ConstFact>>` where `ConstFact` mirrors the `Num`/`Bits` split (or two parallel
+`Vec<Option<Dyadic>>` / `Vec<Option<u32>>`), touching: the field declaration, `Clone` impl,
+both `new()`/`with_rules()` constructors, `add()`, and `union()`'s comparison — 7 mechanical
+edits, all in one file, none individually hard.
+
+For the refusal valve itself, the recommended semantics (see §5) are:
+- Two `Num` facts compare via `Dyadic`'s derived, normalized `Eq` — exact, no more `ca != cb &&
+  ca.to_bits() != cb.to_bits()` double-check needed (that dance existed only to admit ±0.0 and
+  identical-NaN-bits under `f32`; `Dyadic` has one zero and no NaN by construction, so the
+  double-check collapses to a single `!=`).
+- Two `Bits` facts compare via raw bit equality — unchanged from today (still admits identical
+  NaN/mask patterns, which is correct — an all-ones comparison mask must be unionable with
+  itself).
+- A `Num` fact and a `Bits` fact are **never** unioned — see §4 ("mixed reading") — refuse and
+  journal it the same way, which doubles as a new diagnostic for a rewrite rule that
+  accidentally crosses domains (arguably a bug worth catching, not just tolerating).
+
+`canonical_op` (`graph.rs`, `ENode::Const(_) => pixelflow_ir::OpKind::Const`) is shape-only —
+both new variants still map to `OpKind::Const`, no behavior change, no ambiguity.
+
+### 2.3 `math/algebra.rs` — `ConstantFold::apply`: the site where exactness is actually decided
+
+```rust
+fn apply(&self, egraph: &EGraph, _id: EClassId, node: &ENode) -> Option<RewriteAction> {
+    let ENode::Op { op, children } = node else { return None };
+    let kind = op.kind();
+    let mut args = Vec::with_capacity(children.len());
+    for &child_id in children {
+        let mut found_const = None;
+        for child_node in egraph.nodes(child_id) {
+            if let Some(val) = child_node.as_f32() { found_const = Some(val); break; }
+        }
+        args.push(found_const?);
+    }
+    if kind.fold_is_platform_specific(&args) { return None; }
+    let result = match args.len() {
+        1 => kind.eval_unary(args[0])?,
+        2 => kind.eval_binary(args[0], args[1])?,
+        3 => kind.eval_ternary(args[0], args[1], args[2])?,
+        _ => return None,
+    };
+    if !result.is_finite() && !kind.is_bitwise_domain() { return None; }
+    Some(RewriteAction::Create(ENode::constant(result)))
+}
+```
+
+`OpKind::eval_unary/binary/ternary` (`pixelflow-ir/src/kind.rs`) already dispatch two
+categorically different kinds of computation through the *same* `f32`-typed function:
+arithmetic (`Add`/`Sub`/`Mul`/`Div`/`Min`/`Max`/...) and bit-domain ops
+(`Lt/Le/Gt/Ge/Eq/Ne/Select/BitAnd/BitOr/TruncToInt/IntToFloat/IAdd/Shl/Shr`, exactly
+`OpKind::is_bitwise_domain()`'s membership). The bit-domain arms already operate via
+`.to_bits()`/`f32::from_bits()` internally — i.e. they are **already exact**, because bit
+reinterpretation through `f32` never rounds. That is a reassuring finding: **the bit domain does
+not need new arithmetic machinery in `pixelflow-ir::OpKind` at all**, as long as
+`ENode::as_f32()` keeps returning the exact reinterpreted value for `Bits` — which it does under
+the recommended design (`Bits(b) => Some(f32::from_bits(b))`, unchanged).
+
+What genuinely needs new work, and is **not** just a representation change:
+1. **Result routing** (line ~964, `Some(RewriteAction::Create(ENode::constant(result)))`): must
+   become `if kind.is_bitwise_domain() { ENode::Bits(result.to_bits()) } else { /* dyadic path,
+   see below */ }`. This alone (still computing `result: f32` exactly as today) already satisfies
+   constraint 2 — a mask can never again be hash-consed as if it were a number.
+2. **Exactness** (constraint 1) requires the non-bitwise branch to stop computing `result` via
+   f32 arithmetic and instead gather `Dyadic` args (a new accessor, `as_dyadic(&self) ->
+   Option<Dyadic>`, succeeding only on `Num`, refusing on `Bits` — correctly declining to do
+   arithmetic on a bit pattern) and evaluate via new dyadic-native counterparts to
+   `eval_unary/binary/ternary` in `pixelflow-ir::OpKind` (not present today — `Dyadic::add/
+   sub/mul/try_div/try_sqrt` exist in `dyadic.rs` as of this spike but are all still `todo!()`,
+   being implemented by a concurrent agent). **This second piece is genuinely out of this
+   spike's scope** (it's fold-algorithm work, not `ENode`-representation work) but is the
+   follow-up that actually buys the "no more f32-vs-algebra contradiction" property the brief's
+   background section motivates. Recommend sequencing it as a separate phase (see §6).
+
+The two duplicate `InverseAnnihilation<T>` sites (`math/algebra.rs` lines ~303/314, mirrored in
+the dead `egraph/algebra.rs`) and the `Annihilator` site (line ~707) construct
+`ENode::constant(T::identity())` where `identity()` is always `0.0` or `1.0` — always exactly
+dyadic-representable, zero risk.
+
+### 2.4 The arena boundary: two widen implementations, one narrow funnel, plus a live example of why `Const` shape-matching matters independent of value
+
+**Widen** (`ExprNode::Const(f32)` from `pixelflow_ir::ExprArena` → `ENode`): there are **two
+independent, hand-synchronized implementations**:
+- `EGraph::add_arena` (`graph.rs`, production, non-memoized): `ExprNode::Const(v) => self.add(ENode::constant(*v))`.
+- A second one in `pixelflow-search/src/runtime.rs` (memoized, used on a different call path):
+  `&ExprNode::Const(val) => { let class = egraph.add(ENode::constant(val)); ... }`.
+
+Both are pure construction, unaffected by the representation change if `ENode::constant(f32)`
+keeps its signature — **but the fact that two implementations exist at all is a standing
+maintenance risk** independent of this migration (worth flagging separately; not blocking).
+
+Two more **test-local** reimplementations of the same widening logic exist:
+`math/mod.rs`'s `expr_to_egraph` (`ExprNode::Const(val) => egraph.add(ENode::Const(val.to_bits()))`
+— note: hand-rolled, doesn't even call `ENode::constant`) and
+`math/pict_rewrite_tests.rs`'s equivalent. These need the same one-line fix and would ideally be
+deleted in favor of calling the real `add_arena`, but that's a pre-existing duplication, not
+something this migration must fix.
+
+**Narrow** (`ENode` → `ExprArena`'s `ExprNode::Const(f32)`, at extraction): there is exactly
+**one** production funnel, `choices_to_arena` (`extract.rs`, called by both `extract_dag` and
+`extract_neural_to_arena`):
+
+```rust
+ENode::Const(bits) => {
+    let expr_id = arena.push_const(f32::from_bits(*bits));
+    ...
+}
+```
+
+Under the new design: `Num(d) => arena.push_const(d.to_f32())` (the one designed, correctly-
+rounded conversion — this is where dyadic exactness legitimately ends, because `ExprArena` is
+and remains f32-only; that's fine, it's the documented contract of `Dyadic::to_f32`, not a
+regression) and `Bits(b) => arena.push_const(f32::from_bits(b))` (unchanged). One function to
+touch, well-isolated. `pixelflow-search/src/math/mod.rs`'s test-local `eclass_to_arena` duplicates
+this narrowing too and needs the parallel fix.
+
+**A live example of why the `Const` shape matters independent of its value** surfaced during
+this spike: `extract.rs` gained a new function, `pin_shift_counts`, while this spike was in
+progress (`git diff` shows it was added concurrently). It re-pins every `Shl`/`Shr` shift-count
+child's extraction choice to a node that `matches!(n, ENode::Const(_))`, because the emitter
+requires shift counts to be hardware immediates and a cost model could otherwise pick an
+uncollapsed `Add` in the same e-class. This is a **shape-only** read (doesn't care whether the
+constant is `Num` or `Bits` — a shift count is, semantically, closer to `Bits`/an integer, but
+the pinning logic itself never inspects the value) — it costs one extra match arm under option
+(a) (already counted in the 15 shape-only sites) and nothing under a design that keeps a single
+outer `Const`-shaped pattern.
+
+---
+
+## 3. Risks found
+
+1. **Result-routing correctness in `ConstantFold` is the load-bearing change; everything else is
+   plumbing.** Get `is_bitwise_domain()`-based routing right at the one result-construction site
+   (§2.3) and constraint 2 (no mask-as-number corruption) is satisfied immediately, independent
+   of whether the dyadic-exact arithmetic follow-up ever lands. Get it wrong and this migration
+   doesn't fix the bug it exists to fix.
+
+2. **Epsilon-tolerant numeric matching against exact special values.** Two read sites compare a
+   constant's `f32` value against a target with a fixed tolerance rather than exact equality:
+   `math/power.rs`'s `eclass_const`/`const_eq` (`EPSILON = 1e-6`, matching `pow(x, 0/1/2/0.5/-1/
+   -0.5)`) and `math/fusion.rs`'s `is_one` (`1e-10`, matching `recip(sqrt(x))` → `rsqrt(x)` only
+   when the exponent is "close enough" to 1). All of the target values here (0, 1, 2, 0.5, -1,
+   -0.5) are exactly dyadic *and* exactly f32-representable, so switching these two sites to
+   exact `Dyadic` comparison would be strictly more correct and never break a currently-passing
+   case — but it is a **behavior change** (a value that today matches "close enough" would stop
+   matching if it isn't exactly one of those constants), so flag it for the implementer to decide
+   deliberately rather than fold it in silently as part of "just changing the representation."
+
+3. **"Mixed reading" is a real, not hypothetical, design question**, not just a hedge in the
+   brief. See §4 — recommend resolving it explicitly (never unify) rather than leaving it
+   implicit, because the natural implementation of option (b) resolves it *wrong* by default
+   (silently unifies same-bit-pattern values regardless of domain provenance) unless it
+   re-invents a domain tag, at which point it has stopped being simpler than option (a).
+
+4. **The `const_fact` side table (§2.2) is new, not something this spike introduced, but it must
+   not be forgotten** — it's easy to design the `Num`/`Bits` split against `node.rs` and
+   `math/algebra.rs` and miss that `graph.rs` now carries a *second* place that stores "this
+   class's constant, as bits" and must be updated in lockstep or the refusal valve regresses to
+   the bug that was just fixed.
+
+5. **Two hand-synchronized arena-widening implementations** (`graph.rs::add_arena` and
+   `runtime.rs`'s memoized version) and **two hand-synchronized narrowing implementations in test
+   code** (`math/mod.rs`, `math/pict_rewrite_tests.rs`, duplicating `extract.rs::choices_to_arena`)
+   mean the same one-line fix must be applied in 4 places by hand, with no compiler help catching
+   a missed one (they're free functions with their own `match`, not shared code) — **except**
+   that the shape-only-match-forces-a-compile-error property (§2.1) does still apply to each of
+   these individually, so a missed *arm* fails to compile; a missed *file* just silently keeps
+   the old f32-bits behavior in a code path this spike didn't find. Grep for
+   `ENode::Const` and `ExprNode::Const` together one more time immediately before landing the
+   change, since new call sites may have appeared (four files changed under the census's feet
+   during this very spike).
+
+6. **NNUE feature extraction is unaffected — verified, not assumed.** `pixelflow-search/src/nnue/
+   factored.rs`'s two real `ENode::Const` sites are both shape/`OpKind` classification
+   (`ENode::Const(_) => OpKind::Const`); no numeric constant value ever flows into
+   `EdgeAccumulator`/`GraphAccumulator` features at the `ENode` level. (`nnue/mod.rs` does
+   epsilon-compare constants, but operates entirely on `pixelflow_ir::ExprNode`/`ExprArena`, a
+   layer up, untouched by this change.) This means training/inference correctness is not at risk
+   from this migration — a genuine relief given the file's size and centrality.
+
+---
+
+## 4. The "mixed reading" question, resolved
+
+A dyadic `Num` and a `Bits` pattern can, for a finite value, decode to numerically identical
+`f32` — e.g. `Num(Dyadic::from_f32(1.0))` and `Bits(0x3F800000)` both read as `1.0f32`. Should
+they be the same e-node?
+
+**No.** Recommend: never unify across domains, by construction (different variant ⇒ different
+hash-cons key ⇒ never memo-collide) and by policy (the union refusal valve should refuse, and
+journal, an explicit attempt to union a `Num` class with a `Bits` class, the same way it already
+refuses two unequal `Num`s). Reasoning:
+
+- This is exactly constraint 2's contract, extended: "a mask is not a number" must hold even
+  when the mask's bit pattern happens to coincide with some number's bits. If arithmetic
+  rewrites (associativity, distributivity, `ConstantFold`'s own arithmetic branch) could ever see
+  a `Bits` value as if it were `Num(1.0)`, the entire point of separating the domains is
+  defeated — the corruption constraint 2 exists to prevent doesn't require the bit pattern to be
+  NaN, just to be read as a number when it wasn't meant as one. A `Bits` value with a **finite**
+  reinterpretation (e.g. a `Select`/`BitAnd` result that happens to decode to a normal float) is
+  exactly the dangerous case, since it wouldn't be caught by "refuse non-finite" guards.
+- The alternative — unify when they coincide — requires deciding *which* provenance wins when a
+  rewrite rule later wants to do arithmetic on the unified class, and silently allows a
+  `Select`/`BitAnd`/shift result to participate in `Add`/`Mul` folding. That's a correctness
+  regression relative to today's `is_bitwise_domain()` exemption logic, not a neutral choice.
+  If a kernel genuinely needs to bridge domains (reinterpret a bit pattern as a number, or vice
+  versa), that's what `TruncToInt`/`IntToFloat` are *for* — an explicit op, not implicit
+  hash-consing.
+
+---
+
+## 5. Candidate shapes evaluated
+
+### (a) Two variants — `Num(Dyadic)` / `Bits(u32)` — RECOMMENDED
+
+- **Hash-consing key**: variant tag + payload. `Num` keys off `Dyadic`'s own normalized
+  `(mantissa, exp)` — exact-by-construction per `dyadic.rs`'s module docs ("two dyadics denoting
+  the same number must have identical fields"). `Bits` keys off raw `u32`, unchanged. Never
+  cross-domain equal (§4).
+- **Arena boundary**: widen = `Dyadic::from_f32(v).map_or_else(|| Bits(v.to_bits()), Num)` inside
+  `ENode::constant`, so every one of the ~46 construction call sites is unchanged text.
+  Narrow = per-variant, one function (`choices_to_arena`) plus 3 test-local duplicates (§2.4).
+- **Mixed reading**: resolved by never unifying (§4) — the variant split makes "never" the
+  default/free behavior rather than something to enforce with extra logic.
+- **Churn**: ~46 construction sites untouched; 15 shape-only sites get a compiler-forced second
+  arm (mechanical, ~15 one-line edits, zero design judgment needed per site); ~9
+  `.as_f32()`/`.is_const()` reads untouched; **the real work is ~10 sites**: `node.rs`'s
+  `PartialEq`/`Hash`/`as_f32`/`constant` (4, this is the actual point of the exercise),
+  `math/algebra.rs`'s `ConstantFold` arg-gather + result (2, §2.3), `graph.rs`'s `const_fact`
+  table (7 sub-edits in 1 file, §2.2), and the 6 bound-pattern reads that must decide per-variant
+  behavior (`extract.rs::choices_to_arena`, `egraph/codegen.rs::format_const`,
+  `pixelflow-compiler/src/optimize.rs`'s AST-literal site, `math/fusion.rs::is_one`,
+  `math/power.rs::eclass_const`, plus the test-local duplicates in `math/mod.rs`/
+  `pict_rewrite_tests.rs`).
+
+### (b) One variant carrying both representations — REJECTED
+
+E.g. `Const { num: Option<Dyadic>, bits: u32 }`, always populated with at least one field. Looks
+appealing because the 15 shape-only sites (`Const(_)` wildcard) need zero changes — a real
+advantage over (a). But it fails on the two properties that matter most:
+
+- **Hash-consing must still pick a key**, and the honest key is "which domain is this value
+  living in" — which is exactly the tag that (a) already has for free via the variant.
+  Implementing (b) correctly requires adding that tag back inside the struct (`domain:
+  ConstDomain` or equivalent), at which point (b) is isomorphic to (a) but with extra always-
+  carried, usually-meaningless payload (every `Bits`-provenance value wastefully carries a `num`
+  field that's either `None` or, worse, a `Some` nobody asked for; every non-f32-representable
+  `Num` has no natural `bits` value to put there — `0`? the nearest rounding's bits, silently
+  reintroducing the very rounding this migration exists to avoid?).
+- **Implementing it incorrectly** (keying hash-consing off `(num, bits)` jointly, or off
+  whichever field is populated, without a domain tag) **silently resolves §4's mixed-reading
+  question the wrong way**: a `Num(1.0)` and a `Bits(0x3F800000)` would naturally serialize to
+  the same `(Some(Dyadic::ONE), 0x3F800000)` payload and hash-cons together, exactly the
+  corruption constraint 2 warns against. This is the decisive argument against (b): the design
+  that looks like less churn achieves it by making the dangerous case easy to reach by accident.
+
+### (c) Nothing better identified
+
+A three-way split (`Num`/`Bits`/`Unrepresentable`) was considered and rejected: `Dyadic` already
+*is* the "unrepresentable in f32 but exact" case (that's the entire premise of the module docs —
+"`2^24 + 128/255` is exactly a dyadic but is not representable in f32"), so a third variant would
+just be `Num` with extra steps, adding a distinction with no behavioral difference at any of the
+72 sites.
+
+---
+
+## 6. Ordered implementation sketch
+
+Phased so each phase compiles and is independently testable; phase 1 alone already fixes
+constraint 2 (the more urgent, cheaper-to-fix half of the bug) without waiting on `Dyadic`'s
+arithmetic (`add`/`sub`/`mul`/`try_div`/`try_sqrt`) to be finished by the concurrent
+implementation effort.
+
+1. **Land `Dyadic`** (concurrent work, not this spike) — `from_f32`/`to_f32` at minimum;
+   `add`/`sub`/`mul` needed before phase 4.
+2. **Split the type** (`node.rs`): `ENode::Const(u32)` → `ENode::Num(Dyadic)` /
+   `ENode::Bits(u32)`. Rewrite `constant()` (auto-classify via `Dyadic::from_f32`), `as_f32()`
+   (per-variant: `to_f32()` / `from_bits()`), `is_const()` (unchanged, delegates), `children()`
+   (add arm), `PartialEq`/`Hash` (derive-friendly once `Dyadic: Eq + Hash`, per-variant tag +
+   payload — this is the hash-consing fix, the actual point).
+3. **Fix every compile error** `rustc` now reports — this mechanically finds the 15 shape-only
+   sites plus `canonical_op`/`node_op_cost`/`node_deps`/etc. Expect ~15-20 one-line arm additions
+   across `graph.rs`, `extract.rs`, `cost.rs`, `deps.rs`, `factored.rs`.
+4. **Fix the 6 bound-pattern read sites by hand** (§2.1's list) — each needs a real per-variant
+   decision (usually: `Num(d) => ... d.to_f32() ...`, `Bits(b) => ... f32::from_bits(b) ...`,
+   matching what `as_f32()` now does internally, but some sites — e.g. `codegen.rs::format_const`
+   — could eventually special-case `Num` to emit an exact dyadic-derived literal instead of a
+   rounded one; not required for correctness, worth a `// TODO` at minimum).
+5. **Fix `ConstantFold::apply`'s result routing** (§2.3, item 1): branch on
+   `kind.is_bitwise_domain()` and construct `Bits`/`Num` accordingly, **still computing via f32
+   arithmetic for now** — this alone satisfies constraint 2 end-to-end and is independently
+   testable/shippable.
+6. **Fix `graph.rs`'s `const_fact` table** (§2.2) to carry the same domain split; re-derive the
+   union refusal valve's `Num`-vs-`Num` (exact `Dyadic` compare), `Bits`-vs-`Bits` (bit compare,
+   unchanged), and `Num`-vs-`Bits` (always refuse, §4) cases.
+7. **Fix the 4 duplicate boundary implementations** (`runtime.rs`'s memoized widen; `math/mod.rs`
+   and `math/pict_rewrite_tests.rs`'s test-local widen+narrow) — same one-line pattern as steps
+   2-4, applied by hand since nothing forces finding them (§3, risk 5). Consider deleting the
+   test-local duplicates in favor of calling `add_arena`/`choices_to_arena` directly, as a
+   follow-up cleanup (not required for this migration).
+8. **(Follow-up phase, separate from this migration's minimum bar)** Add dyadic-native
+   `eval_unary`/`eval_binary`/`eval_ternary` counterparts in `pixelflow-ir::OpKind` for the
+   non-bitwise-domain ops, and switch `ConstantFold`'s arithmetic branch (only) to gather `Dyadic`
+   args via a new `ENode::as_dyadic() -> Option<Dyadic>` (succeeds only on `Num`) and evaluate
+   exactly. This is what actually delivers constraint 1 (no more f32-vs-algebra contradiction);
+   phases 1-7 deliver constraint 2 and the exact-hash-consing infrastructure it depends on.
+9. Re-run the full-workspace grep from §1 (`ENode::Const|ENode::constant\(|\.as_f32\(|
+   \.is_const\(` plus, now, `ENode::Num|ENode::Bits`) one more time before landing, since this
+   spike found the codebase moving under it — new call sites may exist by the time this is
+   implemented.
+
+Separately, flag `pixelflow-search/src/egraph/algebra.rs` (dead code, §3 of the census table) for
+deletion or wiring-up in an unrelated follow-up — it is out of scope for this migration either
+way, since it never compiles.

--- a/pixelflow-codegen/src/emit/mod.rs
+++ b/pixelflow-codegen/src/emit/mod.rs
@@ -4321,6 +4321,7 @@ mod tests {
         use pixelflow_ir::arena::BufferDecl;
         let mut a = ExprArena::new();
         let buf = a.declare_buffer(BufferDecl {
+            id: pixelflow_ir::arena::BufferIdentity::mint(),
             width: 2,
             height: 1,
         });
@@ -5062,6 +5063,7 @@ mod tests {
             let buf: Vec<f32> = (0..(w * h)).map(|i| i as f32 * 2.0 - 3.0).collect();
             let mut a = ExprArena::new();
             let b = a.declare_buffer(pixelflow_ir::arena::BufferDecl {
+                id: pixelflow_ir::arena::BufferIdentity::mint(),
                 width: w as u32,
                 height: h as u32,
             });
@@ -5080,6 +5082,7 @@ mod tests {
             let buf: Vec<f32> = (0..(w * h)).map(|i| (i as f32).sin()).collect();
             let mut a = ExprArena::new();
             let b = a.declare_buffer(pixelflow_ir::arena::BufferDecl {
+                id: pixelflow_ir::arena::BufferIdentity::mint(),
                 width: w as u32,
                 height: h as u32,
             });
@@ -5102,10 +5105,12 @@ mod tests {
             let buf_b: Vec<f32> = (0..(w * h)).map(|i| -(i as f32) * 0.5).collect();
             let mut a = ExprArena::new();
             let ba = a.declare_buffer(pixelflow_ir::arena::BufferDecl {
+                id: pixelflow_ir::arena::BufferIdentity::mint(),
                 width: w as u32,
                 height: h as u32,
             });
             let bb = a.declare_buffer(pixelflow_ir::arena::BufferDecl {
+                id: pixelflow_ir::arena::BufferIdentity::mint(),
                 width: w as u32,
                 height: h as u32,
             });
@@ -5139,10 +5144,12 @@ mod tests {
 
             let mut a = ExprArena::new();
             let wb = a.declare_buffer(pixelflow_ir::arena::BufferDecl {
+                id: pixelflow_ir::arena::BufferIdentity::mint(),
                 width: in_dim as u32,
                 height: out_dim as u32,
             });
             let ib = a.declare_buffer(pixelflow_ir::arena::BufferDecl {
+                id: pixelflow_ir::arena::BufferIdentity::mint(),
                 width: in_dim as u32,
                 height: 1,
             });
@@ -5308,6 +5315,7 @@ mod tests {
             let buf: Vec<f32> = (0..(w * h)).map(|i| i as f32 * 2.0 - 3.0).collect();
             let mut a = ExprArena::new();
             let b = a.declare_buffer(pixelflow_ir::arena::BufferDecl {
+                id: pixelflow_ir::arena::BufferIdentity::mint(),
                 width: w as u32,
                 height: h as u32,
             });
@@ -5326,6 +5334,7 @@ mod tests {
             let buf: Vec<f32> = (0..(w * h)).map(|i| (i as f32).sin()).collect();
             let mut a = ExprArena::new();
             let b = a.declare_buffer(pixelflow_ir::arena::BufferDecl {
+                id: pixelflow_ir::arena::BufferIdentity::mint(),
                 width: w as u32,
                 height: h as u32,
             });
@@ -5348,10 +5357,12 @@ mod tests {
             let buf_b: Vec<f32> = (0..(w * h)).map(|i| -(i as f32) * 0.5).collect();
             let mut a = ExprArena::new();
             let ba = a.declare_buffer(pixelflow_ir::arena::BufferDecl {
+                id: pixelflow_ir::arena::BufferIdentity::mint(),
                 width: w as u32,
                 height: h as u32,
             });
             let bb = a.declare_buffer(pixelflow_ir::arena::BufferDecl {
+                id: pixelflow_ir::arena::BufferIdentity::mint(),
                 width: w as u32,
                 height: h as u32,
             });
@@ -5385,10 +5396,12 @@ mod tests {
 
             let mut a = ExprArena::new();
             let wb = a.declare_buffer(pixelflow_ir::arena::BufferDecl {
+                id: pixelflow_ir::arena::BufferIdentity::mint(),
                 width: in_dim as u32,
                 height: out_dim as u32,
             });
             let ib = a.declare_buffer(pixelflow_ir::arena::BufferDecl {
+                id: pixelflow_ir::arena::BufferIdentity::mint(),
                 width: in_dim as u32,
                 height: 1,
             });

--- a/pixelflow-codegen/src/jit_manifold.rs
+++ b/pixelflow-codegen/src/jit_manifold.rs
@@ -14,6 +14,13 @@ pub struct JitManifold {
 }
 
 impl JitManifold {
+    /// The emitted machine code, for offline inspection (disassembly,
+    /// profiler correlation). The bytes are the artifact, not an ABI.
+    #[must_use]
+    pub fn code_bytes(&self) -> &[u8] {
+        self.code.as_bytes()
+    }
+
     /// Wrap compiled executable code.
     #[must_use]
     pub fn new(code: ExecutableCode) -> Self {

--- a/pixelflow-codegen/tests/collapse_loop.rs
+++ b/pixelflow-codegen/tests/collapse_loop.rs
@@ -375,6 +375,7 @@ fn gather_reads_ctx_every_iteration() {
 
     let mut a = ExprArena::new();
     let b = a.declare_buffer(BufferDecl {
+        id: pixelflow_ir::arena::BufferIdentity::mint(),
         width: w as u32,
         height: 2,
     });
@@ -408,10 +409,12 @@ fn matmul_reduce_one_call_fills_output() {
 
     let mut a = ExprArena::new();
     let wb = a.declare_buffer(BufferDecl {
+        id: pixelflow_ir::arena::BufferIdentity::mint(),
         width: in_dim as u32,
         height: out_dim as u32,
     });
     let ib = a.declare_buffer(BufferDecl {
+        id: pixelflow_ir::arena::BufferIdentity::mint(),
         width: in_dim as u32,
         height: 1,
     });

--- a/pixelflow-codegen/tests/packed_pixel_shape_optimizes.rs
+++ b/pixelflow-codegen/tests/packed_pixel_shape_optimizes.rs
@@ -1,0 +1,69 @@
+//! The packed-pixel kernel shape must optimize, not bail: four channel
+//! lanes (gather → scale → `TruncToInt` → `Shl` → or-fold) share their
+//! coordinate geometry only if the integer-domain ops are representable in
+//! the runtime e-graph. This bailed silently before the int ops joined
+//! `runtime_op_from_kind` — and the frame benchmark read 1.01x against the
+//! four-plane path because BOTH compiled unoptimized.
+use pixelflow_ir::OpKind;
+use pixelflow_ir::arena::{BufferDecl, BufferIdentity, ExprArena, ExprId};
+
+fn reachable(arena: &ExprArena, root: ExprId) -> usize {
+    let mut seen = vec![false; arena.nodes_raw().len()];
+    let mut stack = vec![root];
+    let mut n = 0;
+    while let Some(id) = stack.pop() {
+        if std::mem::replace(&mut seen[id.0 as usize], true) {
+            continue;
+        }
+        n += 1;
+        stack.extend(arena.children(id));
+    }
+    n
+}
+
+#[test]
+fn packed_shape_gets_cse() {
+    // Four channel fragments sharing geometry, spliced into one root —
+    // the packed kernel's shape at reduced scale.
+    let mut a = ExprArena::new();
+    let cells = a.declare_buffer(BufferDecl {
+        id: BufferIdentity::mint(),
+        width: 100,
+        height: 10,
+    });
+    let x = a.push_var(0);
+    let y = a.push_var(1);
+    let ten = a.push_const(10.0);
+    let mut lanes = Vec::new();
+    for c in 0..4u32 {
+        // each lane duplicates the shared geometry (col = floor(x/10)*10 …)
+        let inv = a.push_const(0.1);
+        let xc = a.push_binary(OpKind::Mul, x, inv);
+        let col = a.push_unary(OpKind::Floor, xc);
+        let cx = a.push_binary(OpKind::Mul, col, ten);
+        let off = a.push_const(2.0 + c as f32);
+        let idx = a.push_binary(OpKind::Add, cx, off);
+        let g = a.push_gather(cells, idx, y);
+        let f255 = a.push_const(255.0);
+        let scaled = a.push_binary(OpKind::Mul, g, f255);
+        let t = a.push_unary(OpKind::TruncToInt, scaled);
+        let sh = a.push_const((c * 8) as f32);
+        let shifted = a.push_binary(OpKind::Shl, t, sh);
+        lanes.push(shifted);
+    }
+    let or1 = a.push_binary(OpKind::BitOr, lanes[0], lanes[1]);
+    let or2 = a.push_binary(OpKind::BitOr, or1, lanes[2]);
+    let root = a.push_binary(OpKind::BitOr, or2, lanes[3]);
+
+    let before = reachable(&a, root);
+    let out = pixelflow_search::runtime::optimize_runtime_arena(&a, root);
+    match out {
+        None => panic!("optimizer BAILED on the packed shape ({before} nodes)"),
+        Some(res) => {
+            let (oa, or_) = (&res.0, res.1);
+            let after = reachable(oa, or_);
+            println!("before={before} after={after}");
+            assert!(after < before, "no CSE: {before} -> {after}");
+        }
+    }
+}

--- a/pixelflow-codegen/tests/transcendental_jit.rs
+++ b/pixelflow-codegen/tests/transcendental_jit.rs
@@ -378,3 +378,39 @@ fn eq_ne_are_exact_not_epsilon() {
     // against here — the folder IS the consumer that was wrong, and these
     // assertions are what pins it.
 }
+
+/// An INVALID float->int conversion has three answers, so the folder must
+/// decline it: x86 `cvttps2dq` produces the "integer indefinite"
+/// `0x8000_0000` for every invalid input, aarch64 `FCVTZS` saturates (NaN to
+/// 0), and Rust's `as i32` — which `eval_unary` uses — saturates like aarch64.
+/// So `+inf` would fold to `i32::MAX`'s bit pattern but execute as `i32::MIN`
+/// on x86: optimizing would change the program's output.
+#[test]
+fn invalid_trunc_to_int_is_platform_specific() {
+    for x in [
+        f32::INFINITY,
+        f32::NEG_INFINITY,
+        f32::NAN,
+        3e9,
+        -3e9,
+        // 2^31 is the first f32 ABOVE i32::MAX. `i32::MAX as f32` rounds up to
+        // exactly this value, so a naive `x > i32::MAX as f32` bound would
+        // wrongly admit it.
+        2_147_483_648.0,
+        -2_147_483_904.0, // first representable f32 below i32::MIN
+    ] {
+        assert!(
+            pixelflow_ir::OpKind::TruncToInt.fold_is_platform_specific(&[x]),
+            "invalid conversion of {x} must not fold"
+        );
+    }
+
+    // Value-aware: a conversion that IS in range agrees on every target and
+    // still folds. i32::MIN is exactly representable and is a valid input.
+    for x in [0.0, -0.0, 1.9, -1.9, 2_147_483_520.0, -2_147_483_648.0] {
+        assert!(
+            !pixelflow_ir::OpKind::TruncToInt.fold_is_platform_specific(&[x]),
+            "in-range conversion of {x} should still fold"
+        );
+    }
+}

--- a/pixelflow-compiler/src/optimize.rs
+++ b/pixelflow-compiler/src/optimize.rs
@@ -1017,6 +1017,15 @@ impl EGraphContext {
 
             ENode::Const(bits) => make_literal(f32::from_bits(*bits) as f64, span),
 
+            // Buffer leaves exist only in runtime-built arenas (there is no
+            // surface syntax for one); the macro tier's representability gate
+            // refuses memory ops before the e-graph is ever built, so one
+            // reaching AST emission is a pipeline-order bug.
+            ENode::Buffer(decl) => panic!(
+                "eclass_to_expr: ENode::Buffer({decl:?}) in the macro tier — \
+                 buffer-bearing kernels are runtime-JIT only"
+            ),
+
             ENode::Op { op, children } => {
                 let name = op.name();
                 let child_exprs: Vec<Expr> = children

--- a/pixelflow-core/src/lattice/cell_grid.rs
+++ b/pixelflow-core/src/lattice/cell_grid.rs
@@ -97,15 +97,46 @@ pub struct CellGridGeometry {
 
 impl CellGridGeometry {
     /// Cell-data buffer length this geometry implies.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the product overflows `usize`. A wrapped length would be
+    /// SMALL, so `frame` would accept a correspondingly small buffer while
+    /// the compiled kernel still declared the true row width — and the
+    /// gathers would read billions of elements past the end through an
+    /// entirely safe API.
     #[must_use]
     pub fn cells_len(&self) -> usize {
-        self.cols as usize * self.rows as usize * CELL_STRIDE
+        (self.cols as usize)
+            .checked_mul(self.rows as usize)
+            .and_then(|cells| cells.checked_mul(CELL_STRIDE))
+            .expect("CellGridGeometry::cells_len overflows usize")
     }
 
     /// Atlas buffer length this geometry implies.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the product overflows `usize` — see [`Self::cells_len`].
     #[must_use]
     pub fn atlas_len(&self) -> usize {
-        self.atlas_width as usize * self.atlas_height as usize
+        (self.atlas_width as usize)
+            .checked_mul(self.atlas_height as usize)
+            .expect("CellGridGeometry::atlas_len overflows usize")
+    }
+
+    /// Width of the cell-data buffer as the kernel declares it, in `f32`s.
+    ///
+    /// # Panics
+    ///
+    /// Panics if it overflows `u32`. `channel_kernel` computed this as a
+    /// wrapping `u32` product, so a wrapped value silently declared a buffer
+    /// of a completely different shape than the one bound to it.
+    #[must_use]
+    pub(crate) fn cells_row_width(&self) -> u32 {
+        self.cols
+            .checked_mul(CELL_STRIDE as u32)
+            .expect("CellGridGeometry: cell-buffer row width overflows u32")
     }
 }
 
@@ -133,7 +164,7 @@ fn channel_kernel(
     // Per-cell data: gathers clamp to the buffer edge, so out-of-grid queries
     // read the border cell — harmless, since the final select replaces them
     // with the default background anyway.
-    let cells = DiscreteManifold::kernel_for(bufs.cells, geom.cols * CELL_STRIDE as u32, geom.rows);
+    let cells = DiscreteManifold::kernel_for(bufs.cells, geom.cells_row_width(), geom.rows);
     let cx = col.mul(&k(CELL_STRIDE as f32));
     let field = |offset: usize| {
         let idx = if offset == 0 {
@@ -273,6 +304,16 @@ fn assert_compilable(geom: &CellGridGeometry) {
         pixelflow_codegen::JIT_VECTOR_BYTES,
         "cell-grid compile: Field width does not match the JIT's emitted width"
     );
+    // Both products must be computable before anything downstream trusts
+    // them: cells_len/cells_row_width panic on overflow rather than wrapping,
+    // and a wrapped length paired with an unwrapped row width is how a safe
+    // API ends up gathering past the end of the bound buffer.
+    // (Both accessors panic on overflow; calling them here is the check.)
+    assert!(
+        geom.cells_len() > 0 && geom.cells_row_width() > 0,
+        "cell-grid compile: empty cell buffer for {geom:?}"
+    );
+
     // Gather computes its row-major linear index in f32, which is exact
     // only below 2^24 — beyond that adjacent texels alias. Refuse
     // loudly instead of rendering corrupted gathers.

--- a/pixelflow-core/src/lattice/cell_grid.rs
+++ b/pixelflow-core/src/lattice/cell_grid.rs
@@ -445,8 +445,14 @@ impl CellGridFrame {
         let PlaneRegion { width, y0, rows } = region;
         assert!(width > 0, "bake_channel_rows: zero width");
         let stride = Self::padded_width(width);
+        // Checked for the same reason as `bake_packed_rows`: a wrapped
+        // product would admit an undersized `out` while the unsafe collapse
+        // below still wrote the real row count past its end.
+        let needed = rows
+            .checked_mul(stride)
+            .expect("bake_channel_rows: rows * stride overflows usize");
         assert!(
-            out.len() >= rows * stride,
+            out.len() >= needed,
             "bake_channel_rows: plane of {} f32s cannot hold {rows} rows at stride {stride}",
             out.len()
         );
@@ -650,8 +656,16 @@ impl CellGridPackedFrame {
         let PlaneRegion { width, y0, rows } = region;
         assert!(width > 0, "bake_packed_rows: zero width");
         let stride = CellGridFrame::padded_width(width);
+        // Checked: `rows * stride` wraps in release for a caller-supplied
+        // region large enough, and a wrapped product would let an undersized
+        // `out` pass this guard while the collapse call below still received
+        // the real (enormous) row count and wrote past the slice. The
+        // documented panic must fire before any unsafe call, not after.
+        let needed = rows
+            .checked_mul(stride)
+            .expect("bake_packed_rows: rows * stride overflows usize");
         assert!(
-            out.len() >= rows * stride,
+            out.len() >= needed,
             "bake_packed_rows: plane of {} u32s cannot hold {rows} rows at stride {stride}",
             out.len()
         );

--- a/pixelflow-core/src/lattice/cell_grid.rs
+++ b/pixelflow-core/src/lattice/cell_grid.rs
@@ -11,8 +11,9 @@
 //! arithmetic, per-cell data gathers, a 4-tap atlas read, and the color
 //! blend — over two bound buffers (the per-cell data and the atlas). The
 //! per-frame update rewrites the cell buffer; a geometry change (grid
-//! dimensions, cell size, atlas extents) recompiles the four channel
-//! kernels, which is microseconds through the JIT. This replaces the only
+//! dimensions, cell size, atlas extents) recompiles the program — a few
+//! milliseconds through the JIT, dominated by the e-graph optimizer that
+//! the compile path always runs, and paid only on resize. This replaces the only
 //! alternative the combinator layer offered — a per-frame tree of boxed
 //! `Select`s sized by the runtime grid — with a program whose size is
 //! independent of the grid's.
@@ -45,11 +46,11 @@
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 
-use super::JitVec;
+use super::{BilinearSampler, DiscreteManifold, JitVec};
 use crate::Field;
 use pixelflow_codegen::JitManifold;
-use pixelflow_ir::arena::BufferDecl;
-use pixelflow_ir::{ExprArena, ExprId, OpKind};
+use pixelflow_ir::arena::BufferIdentity;
+use pixelflow_ir::{ExprArena, Kernel};
 
 /// `f32`s per cell in the cell-data buffer.
 pub const CELL_STRIDE: usize = 10;
@@ -108,121 +109,184 @@ impl CellGridGeometry {
     }
 }
 
-/// One channel's program: everything from pixel coordinate to blended
-/// channel value, as a single arena over the two buffers.
-fn channel_arena(geom: &CellGridGeometry, channel: usize, default_bg: f32) -> (ExprArena, ExprId) {
-    let mut a = ExprArena::new();
-    // Buffer 0: per-cell data; buffer 1: the atlas. `CellGridChannel::eval`
-    // binds the context pointers in this order.
-    let cells = a.declare_buffer(BufferDecl {
-        width: geom.cols * CELL_STRIDE as u32,
-        height: geom.rows,
-    });
-    let atlas = a.declare_buffer(BufferDecl {
-        width: geom.atlas_width,
-        height: geom.atlas_height,
-    });
-
-    let x = a.push_var(0);
-    let y = a.push_var(1);
-    let one = a.push_const(1.0);
-    let half = a.push_const(0.5);
+/// One channel's program: everything from pixel coordinate to blended channel
+/// value, composed from the two samplers rather than assembled node by node.
+///
+/// Keyed on extents, not data. A sampler's fragment carries only its buffer
+/// declaration, so the whole program composes from geometry alone and the
+/// per-frame buffers bind later.
+fn channel_kernel(
+    geom: &CellGridGeometry,
+    bufs: GridBuffers,
+    channel: usize,
+    default_bg: f32,
+) -> Kernel {
+    let k = Kernel::constant;
+    let (x, y, z, w) = (Kernel::x(), Kernel::y(), Kernel::z(), Kernel::w());
 
     // Which cell, and where inside it.
-    let inv_cw = a.push_const(1.0 / geom.cell_w);
-    let inv_ch = a.push_const(1.0 / geom.cell_h);
-    let xc = a.push_binary(OpKind::Mul, x, inv_cw);
-    let yc = a.push_binary(OpKind::Mul, y, inv_ch);
-    let col = a.push_unary(OpKind::Floor, xc);
-    let row = a.push_unary(OpKind::Floor, yc);
-    let cw = a.push_const(geom.cell_w);
-    let ch = a.push_const(geom.cell_h);
-    let col_px = a.push_binary(OpKind::Mul, col, cw);
-    let row_px = a.push_binary(OpKind::Mul, row, ch);
-    let lx = a.push_binary(OpKind::Sub, x, col_px);
-    let ly = a.push_binary(OpKind::Sub, y, row_px);
+    let col = x.mul(&k(1.0 / geom.cell_w)).floor();
+    let row = y.mul(&k(1.0 / geom.cell_h)).floor();
+    let lx = x.sub(&col.mul(&k(geom.cell_w)));
+    let ly = y.sub(&row.mul(&k(geom.cell_h)));
 
-    // Per-cell data: gathers clamp to the buffer edge, so out-of-grid
-    // queries read the border cell — harmless, since the final select
-    // replaces them with the default background anyway.
-    let stride = a.push_const(CELL_STRIDE as f32);
-    let cx = a.push_binary(OpKind::Mul, col, stride);
-    let field = |a: &mut ExprArena, base: ExprId, offset: usize| {
-        let off = a.push_const(offset as f32);
-        a.push_binary(OpKind::Add, base, off)
+    // Per-cell data: gathers clamp to the buffer edge, so out-of-grid queries
+    // read the border cell — harmless, since the final select replaces them
+    // with the default background anyway.
+    let cells = DiscreteManifold::kernel_for(bufs.cells, geom.cols * CELL_STRIDE as u32, geom.rows);
+    let cx = col.mul(&k(CELL_STRIDE as f32));
+    let field = |offset: usize| {
+        let idx = if offset == 0 {
+            cx.clone()
+        } else {
+            cx.add(&k(offset as f32))
+        };
+        cells.at(&idx, &row, &z, &w)
     };
-    let u_idx = cx; // offset 0
-    let v_idx = field(&mut a, cx, 1);
-    let fg_idx = field(&mut a, cx, 2 + channel);
-    let bg_idx = field(&mut a, cx, 6 + channel);
-    let u0 = a.push_gather(cells, u_idx, row);
-    let v0 = a.push_gather(cells, v_idx, row);
-    let fg = a.push_gather(cells, fg_idx, row);
-    let bg = a.push_gather(cells, bg_idx, row);
+    let u0 = field(0);
+    let v0 = field(1);
+    let fg = field(2 + channel);
+    let bg = field(6 + channel);
 
-    // Atlas coordinates: point offset into the cell, scaled to texels,
-    // shifted to texel centers.
-    let density = a.push_const(geom.density);
-    let lxd_raw = a.push_binary(OpKind::Mul, lx, density);
-    let lyd_raw = a.push_binary(OpKind::Mul, ly, density);
-    // Clamp to half a texel past the tile content: the taps then land on
-    // this slot's apron and (at most) the neighbor's apron — both zero —
-    // so a cell larger than its tile fades to background rather than
-    // displaying fragments of the adjacent tile.
-    let tile_w_edge = a.push_const(geom.tile_w as f32 + 0.5);
-    let tile_h_edge = a.push_const(geom.tile_h as f32 + 0.5);
-    let lxd = a.push_binary(OpKind::Min, lxd_raw, tile_w_edge);
-    let lyd = a.push_binary(OpKind::Min, lyd_raw, tile_h_edge);
-    let au = a.push_binary(OpKind::Add, u0, lxd);
-    let av = a.push_binary(OpKind::Add, v0, lyd);
-    let ax = a.push_binary(OpKind::Sub, au, half);
-    let ay = a.push_binary(OpKind::Sub, av, half);
+    // Atlas coordinates: point offset into the cell, scaled to texels, shifted
+    // to texel centres. Clamping to half a texel past the tile content keeps
+    // the taps on this slot's apron and (at most) the neighbor's — both zero —
+    // so a cell larger than its tile fades to background rather than showing
+    // fragments of the adjacent tile.
+    let au = u0.add(&lx.mul(&k(geom.density)).min(&k(geom.tile_w as f32 + 0.5)));
+    let av = v0.add(&ly.mul(&k(geom.density)).min(&k(geom.tile_h as f32 + 0.5)));
+    let atlas = BilinearSampler::kernel_for(bufs.atlas, geom.atlas_width, geom.atlas_height);
+    let cov = atlas.at(&au.sub(&k(0.5)), &av.sub(&k(0.5)), &z, &w);
 
-    // 4-tap bilinear read of the atlas (the same blend `bilinear_arena`
-    // builds for a whole-buffer sampler, at computed tile coordinates).
-    let ax0 = a.push_unary(OpKind::Floor, ax);
-    let ay0 = a.push_unary(OpKind::Floor, ay);
-    let ax1 = a.push_binary(OpKind::Add, ax0, one);
-    let ay1 = a.push_binary(OpKind::Add, ay0, one);
-    let fx = a.push_binary(OpKind::Sub, ax, ax0);
-    let fy = a.push_binary(OpKind::Sub, ay, ay0);
-    let gx = a.push_binary(OpKind::Sub, one, fx);
-    let gy = a.push_binary(OpKind::Sub, one, fy);
-    let c00 = a.push_gather(atlas, ax0, ay0);
-    let c10 = a.push_gather(atlas, ax1, ay0);
-    let c01 = a.push_gather(atlas, ax0, ay1);
-    let c11 = a.push_gather(atlas, ax1, ay1);
-    let w00 = a.push_binary(OpKind::Mul, gx, gy);
-    let w10 = a.push_binary(OpKind::Mul, fx, gy);
-    let w01 = a.push_binary(OpKind::Mul, gx, fy);
-    let w11 = a.push_binary(OpKind::Mul, fx, fy);
-    let t00 = a.push_binary(OpKind::Mul, c00, w00);
-    let t10 = a.push_binary(OpKind::Mul, c10, w10);
-    let t01 = a.push_binary(OpKind::Mul, c01, w01);
-    let t11 = a.push_binary(OpKind::Mul, c11, w11);
-    let s0 = a.push_binary(OpKind::Add, t00, t10);
-    let s1 = a.push_binary(OpKind::Add, s0, t01);
-    let cov = a.push_binary(OpKind::Add, s1, t11);
+    // blended = bg + cov·(fg − bg), and the default background off-grid.
+    let blended = bg.add(&cov.mul(&fg.sub(&bg)));
+    let in_grid = x
+        .ge(&k(0.0))
+        .and(&x.lt(&k(geom.cols as f32 * geom.cell_w)))
+        .and(&y.ge(&k(0.0)))
+        .and(&y.lt(&k(geom.rows as f32 * geom.cell_h)));
+    in_grid.select(&blended, &k(default_bg))
+}
 
-    // blended = bg + cov·(fg − bg).
-    let diff = a.push_binary(OpKind::Sub, fg, bg);
-    let scaled = a.push_binary(OpKind::Mul, cov, diff);
-    let blended = a.push_binary(OpKind::Add, bg, scaled);
+/// The whole screen as ONE program: the four channel kernels, each packed to
+/// a byte exactly as `Pixel::from_rgba` does — `(x·255).clamp(0, 255)` then
+/// truncate toward zero — shifted to its byte lane and OR-folded into a
+/// `u32` pixel bit pattern at the root.
+///
+/// `shifts[c]` is the bit position of channel `c` in `(r, g, b, a)` order.
+/// Both pixel orders are little-endian byte arrays wrapping a `u32`, so byte
+/// `i` sits at bit `8·i`: `Rgba8` is `[r, g, b, a]` → `[0, 8, 16, 24]`, and
+/// `Bgra8` is `[b, g, r, a]` → `[16, 8, 0, 24]`.
+///
+/// Truncation (not rounding) is deliberate twice over: it is bit-exact with
+/// the scalar pack's `as u8`, and `cvttps2dq`/`fcvtzs` both truncate toward
+/// zero — no per-target tie divergence to inherit.
+fn packed_kernel(
+    geom: &CellGridGeometry,
+    bufs: GridBuffers,
+    default_bg: [f32; 4],
+    shifts: [u32; 4],
+) -> Kernel {
+    let k = Kernel::constant;
+    let byte = |c: usize| {
+        channel_kernel(geom, bufs, c, default_bg[c])
+            .mul(&k(255.0))
+            .clamp(&k(0.0), &k(255.0))
+            .trunc_to_int()
+            .shl(shifts[c])
+    };
+    byte(0).or(&byte(1)).or(&byte(2)).or(&byte(3))
+}
 
-    // Outside the grid there is no cell data: the default background.
-    let zero = a.push_const(0.0);
-    let grid_w = a.push_const(geom.cols as f32 * geom.cell_w);
-    let grid_h = a.push_const(geom.rows as f32 * geom.cell_h);
-    let x_lo = a.push_binary(OpKind::Ge, x, zero);
-    let x_hi = a.push_binary(OpKind::Lt, x, grid_w);
-    let y_lo = a.push_binary(OpKind::Ge, y, zero);
-    let y_hi = a.push_binary(OpKind::Lt, y, grid_h);
-    let x_in = a.push_binary(OpKind::BitAnd, x_lo, x_hi);
-    let y_in = a.push_binary(OpKind::BitAnd, y_lo, y_hi);
-    let in_grid = a.push_binary(OpKind::BitAnd, x_in, y_in);
-    let bg_default = a.push_const(default_bg);
-    let root = a.push_ternary(OpKind::Select, in_grid, blended, bg_default);
-    (a, root)
+/// The two blocks of memory a cell-grid program reads, identified so that
+/// composing many reads of one buffer still merges to one slot, and so binding
+/// can say which slot is which without inferring it from extents.
+#[derive(Clone, Copy, Debug)]
+struct GridBuffers {
+    cells: BufferIdentity,
+    atlas: BufferIdentity,
+}
+
+impl GridBuffers {
+    fn mint() -> Self {
+        Self {
+            cells: BufferIdentity::mint(),
+            atlas: BufferIdentity::mint(),
+        }
+    }
+}
+
+/// Which buffer a slot of the composed arena reads.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum SlotReads {
+    Cells,
+    Atlas,
+}
+
+/// Attribute each declared slot to one of the program's two buffers.
+///
+/// Matching is on [`BufferIdentity`], so it is a fact rather than an inference
+/// — two buffers of equal extent would be indistinguishable by shape, and
+/// guessing there would bind one pointer for both.
+///
+/// # Panics
+///
+/// Panics on a slot belonging to neither, which would mean a fragment declared
+/// memory this program cannot bind.
+fn slot_roles(arena: &ExprArena, bufs: GridBuffers) -> Vec<SlotReads> {
+    arena
+        .buffers()
+        .iter()
+        .map(|decl| {
+            if decl.id == bufs.cells {
+                SlotReads::Cells
+            } else if decl.id == bufs.atlas {
+                SlotReads::Atlas
+            } else {
+                panic!("cell-grid kernel declared an unbindable buffer {decl:?}")
+            }
+        })
+        .collect()
+}
+
+/// The geometry preconditions every cell-grid compile shares — the
+/// four-channel and packed paths refuse the same shapes for the same reasons.
+///
+/// # Panics
+///
+/// Panics on a degenerate geometry (zero cells, non-positive cell extent or
+/// density, empty atlas), when this build's `Field` width does not match the
+/// JIT's emitted width, or on buffers too large to index exactly in f32.
+fn assert_compilable(geom: &CellGridGeometry) {
+    assert!(
+        geom.cols > 0 && geom.rows > 0 && geom.atlas_width > 0 && geom.atlas_height > 0,
+        "cell-grid compile: degenerate geometry {geom:?}"
+    );
+    assert!(
+        geom.cell_w > 0.0 && geom.cell_h > 0.0 && geom.density > 0.0,
+        "cell-grid compile: non-positive cell extent or density {geom:?}"
+    );
+    assert_eq!(
+        core::mem::size_of::<Field>(),
+        pixelflow_codegen::JIT_VECTOR_BYTES,
+        "cell-grid compile: Field width does not match the JIT's emitted width"
+    );
+    // Gather computes its row-major linear index in f32, which is exact
+    // only below 2^24 — beyond that adjacent texels alias. Refuse
+    // loudly instead of rendering corrupted gathers.
+    const EXACT_F32_INDEX: usize = 1 << 24;
+    assert!(
+        geom.atlas_len() <= EXACT_F32_INDEX,
+        "cell-grid compile: atlas of {} texels exceeds the exactly \
+         f32-indexable range (2^24); gathers would alias adjacent texels",
+        geom.atlas_len()
+    );
+    assert!(
+        geom.cells_len() <= EXACT_F32_INDEX,
+        "cell-grid compile: cell buffer of {} floats exceeds the \
+         exactly f32-indexable range (2^24)",
+        geom.cells_len()
+    );
 }
 
 /// The four compiled channel kernels for one grid/atlas geometry.
@@ -234,7 +298,18 @@ fn channel_arena(geom: &CellGridGeometry, channel: usize, default_bg: f32) -> (E
 pub struct CellGridProgram {
     geom: CellGridGeometry,
     jits: [Arc<JitManifold>; 4],
+    /// What each buffer slot of the compiled arenas reads — see [`SlotReads`].
+    /// Shared so a [`CellGridFrame`] stays cheap to clone.
+    slots: Arc<[SlotReads]>,
 }
+
+/// Upper bound on buffer slots in a composed channel kernel, so binding can
+/// build its context array on the stack: no per-frame allocation.
+///
+/// Splicing merges by [`BufferIdentity`], so this is one slot per *distinct*
+/// buffer however many times each is read — the program reads two. A third
+/// would fail the check in `compile` rather than silently overflow.
+const MAX_SLOTS: usize = 2;
 
 impl CellGridProgram {
     /// JIT-compile the four channel programs for `geom`, with `default_bg`
@@ -247,45 +322,39 @@ impl CellGridProgram {
     /// match the JIT's emitted width, or if compilation fails.
     #[must_use]
     pub fn compile(geom: CellGridGeometry, default_bg: [f32; 4]) -> Self {
+        assert_compilable(&geom);
+        let bufs = GridBuffers::mint();
+        let kernels: [Kernel; 4] =
+            core::array::from_fn(|c| channel_kernel(&geom, bufs, c, default_bg[c]));
+        let slots = slot_roles(kernels[0].parts().0, bufs);
+        for (c, kernel) in kernels.iter().enumerate().skip(1) {
+            assert_eq!(
+                slot_roles(kernel.parts().0, bufs),
+                slots,
+                "cell-grid channel {c} disagrees with channel 0 on slot layout"
+            );
+        }
         assert!(
-            geom.cols > 0 && geom.rows > 0 && geom.atlas_width > 0 && geom.atlas_height > 0,
-            "CellGridProgram::compile: degenerate geometry {geom:?}"
+            slots.len() <= MAX_SLOTS,
+            "cell-grid kernel needs {} buffer slots, over the {MAX_SLOTS} a \
+             frame can bind without allocating",
+            slots.len()
         );
-        assert!(
-            geom.cell_w > 0.0 && geom.cell_h > 0.0 && geom.density > 0.0,
-            "CellGridProgram::compile: non-positive cell extent or density {geom:?}"
-        );
-        assert_eq!(
-            core::mem::size_of::<Field>(),
-            pixelflow_codegen::JIT_VECTOR_BYTES,
-            "CellGridProgram::compile: Field width does not match the JIT's emitted width"
-        );
-        // Gather computes its row-major linear index in f32, which is exact
-        // only below 2^24 — beyond that adjacent texels alias. Refuse
-        // loudly instead of rendering corrupted gathers.
-        const EXACT_F32_INDEX: usize = 1 << 24;
-        assert!(
-            geom.atlas_len() <= EXACT_F32_INDEX,
-            "CellGridProgram::compile: atlas of {} texels exceeds the exactly \
-             f32-indexable range (2^24); gathers would alias adjacent texels",
-            geom.atlas_len()
-        );
-        assert!(
-            geom.cells_len() <= EXACT_F32_INDEX,
-            "CellGridProgram::compile: cell buffer of {} floats exceeds the \
-             exactly f32-indexable range (2^24)",
-            geom.cells_len()
-        );
+
         let jits = core::array::from_fn(|c| {
-            let (arena, root) = channel_arena(&geom, c, default_bg[c]);
+            let (arena, root) = kernels[c].parts();
             // Collapse-mode (internal 2D loop): one call bakes a whole run
             // of rows for a channel. Bound-memory arenas are uncacheable
             // (the code bakes buffer slot metadata); the cache recognizes
             // that and compiles fresh.
-            pixelflow_codegen::jit_cache::compile_collapse_cached(&arena, root)
+            pixelflow_codegen::jit_cache::compile_collapse_cached(arena, root)
                 .expect("cell-grid channel failed to compile")
         });
-        Self { geom, jits }
+        Self {
+            geom,
+            jits,
+            slots: slots.into(),
+        }
     }
 
     /// The geometry this program was compiled for.
@@ -318,6 +387,7 @@ impl CellGridProgram {
         );
         CellGridFrame {
             jits: self.jits.clone(),
+            slots: self.slots.clone(),
             cells,
             atlas,
         }
@@ -329,6 +399,7 @@ impl CellGridProgram {
 #[derive(Clone)]
 pub struct CellGridFrame {
     jits: [Arc<JitManifold>; 4],
+    slots: Arc<[SlotReads]>,
     cells: Arc<Vec<f32>>,
     atlas: Arc<Vec<f32>>,
 }
@@ -383,22 +454,212 @@ impl CellGridFrame {
             return;
         }
         let groups = stride / (pixelflow_codegen::JIT_VECTOR_BYTES / core::mem::size_of::<f32>());
-        let ctx = [self.cells.as_ptr(), self.atlas.as_ptr()];
+        // One base pointer per declared slot, in slot order. Stack-allocated
+        // against the MAX_SLOTS bound `compile` checked, so binding a frame
+        // allocates nothing; trailing entries stay null and are never read
+        // because the kernel only addresses slots it declared.
+        let mut ctx = [core::ptr::null::<f32>(); MAX_SLOTS];
+        for (dst, slot) in ctx.iter_mut().zip(self.slots.iter()) {
+            *dst = match slot {
+                SlotReads::Cells => self.cells.as_ptr(),
+                SlotReads::Atlas => self.atlas.as_ptr(),
+            };
+        }
         // Pixel centers: the rasterizer convention (x + ½, y + ½).
         let x0 = Field::sequential(0.5);
         let y = Field::from(y0 as f32 + 0.5);
         let zero = Field::from(0.0);
         // SAFETY: `compile` checked size_of::<Field>() == JIT_VECTOR_BYTES;
-        // the kernel was compiled from an arena declaring exactly the two
-        // buffers whose lengths `CellGridProgram::frame` asserted against
-        // the same geometry; `ctx` binds their live base pointers (in
-        // declaration order) for the duration of the call; and `out` holds
+        // every slot the kernel declared was attributed to the cell buffer or
+        // the atlas by `slot_roles` (which refuses any other declaration), and
+        // `CellGridProgram::frame` asserted both lengths against this same
+        // geometry; `ctx` binds their live base pointers for the duration of
+        // the call; and `out` holds
         // `rows` full rows of `groups` batches (asserted above) with no
         // scalar tail (row_skip = 0 — the stride IS whole batches).
         unsafe {
             self.jits[channel].call_collapse(
                 ctx.as_ptr(),
                 out.as_mut_ptr(),
+                groups,
+                rows,
+                0,
+                core::mem::transmute::<Field, JitVec>(x0),
+                core::mem::transmute::<Field, JitVec>(y),
+                core::mem::transmute::<Field, JitVec>(zero),
+                core::mem::transmute::<Field, JitVec>(zero),
+            );
+        }
+    }
+}
+
+/// The packed-pixel sibling of [`CellGridProgram`]: ONE compiled program
+/// whose root is a packed `u32` pixel, so the collapse loop stores finished
+/// pixels directly — no per-channel planes, no pack pass. A sibling type
+/// rather than a fifth entry in `jits` because the two paths have different
+/// output types, and the type should refuse baking a packed program into an
+/// `f32` plane (or vice versa) rather than a runtime check catching it.
+pub struct CellGridPackedProgram {
+    geom: CellGridGeometry,
+    jit: Arc<JitManifold>,
+    /// What each buffer slot of the compiled arena reads — see [`SlotReads`].
+    slots: Arc<[SlotReads]>,
+}
+
+impl CellGridPackedProgram {
+    /// JIT-compile the packed program for `geom`, with `default_bg` (linear
+    /// RGBA) painted outside the grid and `shifts[c]` giving the bit position
+    /// of channel `c` in `(r, g, b, a)` order — `[0, 8, 16, 24]` for `Rgba8`,
+    /// `[16, 8, 0, 24]` for `Bgra8` (see [`packed_kernel`]'s derivation).
+    ///
+    /// # Panics
+    ///
+    /// Panics on the same geometry preconditions as
+    /// [`CellGridProgram::compile`], on shifts that are not a permutation of
+    /// the four byte lanes (channels would overlap), if the composed kernel's
+    /// buffer reads do not merge to exactly one cell slot and one atlas slot,
+    /// or if compilation fails.
+    #[must_use]
+    pub fn compile(geom: CellGridGeometry, default_bg: [f32; 4], shifts: [u32; 4]) -> Self {
+        assert_compilable(&geom);
+        {
+            let mut lanes = shifts;
+            lanes.sort_unstable();
+            assert_eq!(
+                lanes,
+                [0, 8, 16, 24],
+                "CellGridPackedProgram::compile: shifts {shifts:?} are not a \
+                 permutation of the byte lanes; channels would overlap"
+            );
+        }
+        let bufs = GridBuffers::mint();
+        let kernel = packed_kernel(&geom, bufs, default_bg, shifts);
+        let slots = slot_roles(kernel.parts().0, bufs);
+        // Identity-merge across the four channels' splices is load-bearing:
+        // all cell reads and atlas taps must land in the same two slots a
+        // frame can bind. A third slot means splice stopped merging — refuse.
+        assert_eq!(
+            slots.iter().filter(|r| **r == SlotReads::Cells).count(),
+            1,
+            "packed cell-grid kernel did not merge its cell reads to one slot"
+        );
+        assert_eq!(
+            slots.iter().filter(|r| **r == SlotReads::Atlas).count(),
+            1,
+            "packed cell-grid kernel did not merge its atlas reads to one slot"
+        );
+        let (arena, root) = kernel.parts();
+        let jit = pixelflow_codegen::jit_cache::compile_collapse_cached(arena, root)
+            .expect("packed cell-grid kernel failed to compile");
+        Self {
+            geom,
+            jit,
+            slots: slots.into(),
+        }
+    }
+
+    /// The geometry this program was compiled for.
+    #[must_use]
+    pub fn geometry(&self) -> &CellGridGeometry {
+        &self.geom
+    }
+
+    /// Bind one frame's data — the same buffers, layout, and length checks as
+    /// [`CellGridProgram::frame`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if either buffer's length does not match the geometry.
+    #[must_use]
+    pub fn frame(&self, cells: Arc<Vec<f32>>, atlas: Arc<Vec<f32>>) -> CellGridPackedFrame {
+        assert_eq!(
+            cells.len(),
+            self.geom.cells_len(),
+            "cell buffer length does not match geometry {:?}",
+            self.geom
+        );
+        assert_eq!(
+            atlas.len(),
+            self.geom.atlas_len(),
+            "atlas buffer length does not match geometry {:?}",
+            self.geom
+        );
+        CellGridPackedFrame {
+            jit: self.jit.clone(),
+            slots: self.slots.clone(),
+            cells,
+            atlas,
+        }
+    }
+}
+
+/// One frame of a packed cell grid: the compiled program plus the data it
+/// reads. Cheap to clone.
+#[derive(Clone)]
+pub struct CellGridPackedFrame {
+    jit: Arc<JitManifold>,
+    slots: Arc<[SlotReads]>,
+    cells: Arc<Vec<f32>>,
+    atlas: Arc<Vec<f32>>,
+}
+
+impl CellGridPackedFrame {
+    /// Bake packed pixels over the pixel rows `y0 .. y0 + rows` at
+    /// pixel-center coordinates, into a plane of
+    /// [`CellGridFrame::padded_width`]`(width)`-stride rows — the same
+    /// region, stride, and whole-batch contract as
+    /// [`CellGridFrame::bake_channel_rows`], with the pack already done.
+    ///
+    /// The kernel's root is int-domain: each lane already holds a packed
+    /// pixel's bit pattern. The collapse store is a raw vector store —
+    /// type-blind bit movement — so writing through the ABI's `*mut f32`
+    /// into a `u32` plane is exact: no float operation touches the value
+    /// between the OR-fold and memory.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the region's width is zero or `out` is shorter than
+    /// `rows * padded_width(width)`.
+    pub fn bake_packed_rows(&self, region: PlaneRegion, out: &mut [u32]) {
+        let PlaneRegion { width, y0, rows } = region;
+        assert!(width > 0, "bake_packed_rows: zero width");
+        let stride = CellGridFrame::padded_width(width);
+        assert!(
+            out.len() >= rows * stride,
+            "bake_packed_rows: plane of {} u32s cannot hold {rows} rows at stride {stride}",
+            out.len()
+        );
+        if rows == 0 {
+            return;
+        }
+        let groups = stride / (pixelflow_codegen::JIT_VECTOR_BYTES / core::mem::size_of::<f32>());
+        // One base pointer per declared slot, in slot order — identical to
+        // `bake_channel_rows`, against the same MAX_SLOTS bound (`compile`
+        // proved exactly two slots).
+        let mut ctx = [core::ptr::null::<f32>(); MAX_SLOTS];
+        for (dst, slot) in ctx.iter_mut().zip(self.slots.iter()) {
+            *dst = match slot {
+                SlotReads::Cells => self.cells.as_ptr(),
+                SlotReads::Atlas => self.atlas.as_ptr(),
+            };
+        }
+        // Pixel centers: the rasterizer convention (x + ½, y + ½).
+        let x0 = Field::sequential(0.5);
+        let y = Field::from(y0 as f32 + 0.5);
+        let zero = Field::from(0.0);
+        // SAFETY: as in `bake_channel_rows` — `assert_compilable` checked
+        // size_of::<Field>() == JIT_VECTOR_BYTES; every declared slot was
+        // attributed to the cell buffer or the atlas by `slot_roles`, and
+        // `frame` asserted both lengths against this same geometry; `ctx` binds
+        // their live base pointers for the duration of the call; `out` holds
+        // `rows` full rows of `groups` batches (asserted above) with no
+        // scalar tail (row_skip = 0). The pointer cast is sound because
+        // `u32` and `f32` share size and alignment and the store is a raw
+        // vector store of the root's bit pattern.
+        unsafe {
+            self.jit.call_collapse(
+                ctx.as_ptr(),
+                out.as_mut_ptr().cast::<f32>(),
                 groups,
                 rows,
                 0,
@@ -450,6 +711,66 @@ mod tests {
             1.0, /* bg */
         ];
         (program, Arc::new(cells), Arc::new(atlas))
+    }
+
+    /// Splicing merges buffer declarations by identity, so the nine reads in
+    /// a channel program (four cell fields — `bg` twice — plus the atlas)
+    /// occupy exactly two slots: one per distinct buffer.
+    ///
+    /// Nodes are a different story, and this pins the gap. 146 against the 77
+    /// the hand-written arena built, because every *use* of a Kernel value
+    /// re-splices its whole fragment: `row` is used by four cell reads, `cx`
+    /// by four, `bg` by two. Identity fixed the slots; it cannot fix this.
+    /// Node sharing is an inlining decision, and it belongs to the e-graph —
+    /// which cannot see this arena at all while `Gather` is unrepresentable
+    /// there. This number falling is the sign that landed.
+    #[test]
+    fn reads_of_one_buffer_share_a_slot_but_not_nodes() {
+        let geom = CellGridGeometry {
+            cols: 2,
+            rows: 1,
+            cell_w: 4.0,
+            cell_h: 4.0,
+            density: 1.0,
+            atlas_width: 12,
+            atlas_height: 6,
+            tile_w: 4,
+            tile_h: 4,
+        };
+        let bufs = GridBuffers::mint();
+        let kernel = channel_kernel(&geom, bufs, 0, 0.0);
+        let (arena, root) = kernel.parts();
+
+        let roles = slot_roles(arena, bufs);
+        assert_eq!(
+            roles.iter().filter(|r| **r == SlotReads::Cells).count(),
+            1,
+            "five cell reads, one buffer, one slot"
+        );
+        assert_eq!(
+            roles.iter().filter(|r| **r == SlotReads::Atlas).count(),
+            1,
+            "one slot for the atlas"
+        );
+        assert_eq!(
+            reachable_nodes(arena, root),
+            146,
+            "composed node count (hand-built was 77)"
+        );
+    }
+
+    fn reachable_nodes(arena: &ExprArena, root: pixelflow_ir::ExprId) -> usize {
+        let mut seen = vec![false; arena.nodes_raw().len()];
+        let mut stack = vec![root];
+        let mut count = 0;
+        while let Some(id) = stack.pop() {
+            if core::mem::replace(&mut seen[id.0 as usize], true) {
+                continue;
+            }
+            count += 1;
+            stack.extend(arena.children(id));
+        }
+        count
     }
 
     /// Row-major index into an 8-wide plane.
@@ -823,5 +1144,250 @@ mod tests {
             "row-offset bake read the wrong absolute row: R = {}",
             padded[1]
         );
+    }
+
+    /// `Rgba8`'s byte lanes: little-endian `[r, g, b, a]`.
+    const RGBA_SHIFTS: [u32; 4] = [0, 8, 16, 24];
+    /// `Bgra8`'s byte lanes: little-endian `[b, g, r, a]`.
+    const BGRA_SHIFTS: [u32; 4] = [16, 8, 0, 24];
+
+    /// The scalar pack the kernel must be bit-exact with:
+    /// `Pixel::from_rgba`'s per-channel `(x·255).clamp(0, 255) as u8`,
+    /// composed with the same shifts.
+    fn pack_expected(rgba: [f32; 4], shifts: [u32; 4]) -> u32 {
+        rgba.iter()
+            .zip(shifts)
+            .map(|(&x, s)| u32::from((x * 255.0).clamp(0.0, 255.0) as u8) << s)
+            .fold(0, |acc, lane| acc | lane)
+    }
+
+    /// Bake packed pixels over pixel centers and unpad to a dense w×h plane.
+    fn packed_plane(frame: &CellGridPackedFrame, w: usize, h: usize) -> alloc::vec::Vec<u32> {
+        let stride = CellGridFrame::padded_width(w);
+        let mut padded = vec![0u32; h * stride];
+        frame.bake_packed_rows(
+            PlaneRegion {
+                width: w,
+                y0: 0,
+                rows: h,
+            },
+            &mut padded,
+        );
+        let mut dense = alloc::vec::Vec::with_capacity(w * h);
+        for row in 0..h {
+            dense.extend_from_slice(&padded[row * stride..row * stride + w]);
+        }
+        dense
+    }
+
+    #[test]
+    fn packed_bake_is_bit_exact_with_channel_bakes_under_both_byte_orders() {
+        // 12×6 over tiny_scene's 8×4 grid: the right and bottom margins are
+        // off-grid, so default_bg flows through the pack too. THE invariant:
+        // for every pixel, the packed bake equals the four channel bakes
+        // composed with the scalar pack — exact u32 equality, no epsilon.
+        let (program, cells, atlas) = tiny_scene();
+        let frame = program.frame(cells.clone(), atlas.clone());
+        let (w, h) = (12, 6);
+        let planes: [alloc::vec::Vec<f32>; 4] = core::array::from_fn(|c| plane(&frame, c, w, h));
+        for shifts in [RGBA_SHIFTS, BGRA_SHIFTS] {
+            let packed =
+                CellGridPackedProgram::compile(*program.geometry(), [0.9, 0.8, 0.7, 0.6], shifts);
+            let got = packed_plane(&packed.frame(cells.clone(), atlas.clone()), w, h);
+            for i in 0..w * h {
+                let expected = pack_expected(
+                    [planes[0][i], planes[1][i], planes[2][i], planes[3][i]],
+                    shifts,
+                );
+                assert_eq!(
+                    got[i], expected,
+                    "pixel {i} under shifts {shifts:?}: {:#010x} != {:#010x}",
+                    got[i], expected
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn packed_bake_parity_holds_on_an_asymmetric_grid() {
+        // The 1×2 grid from the row-offset test (cols ≠ rows, per-row
+        // colors), sampled 6×10 so the right and bottom margins exercise a
+        // non-gray default background through every channel's shift.
+        let (aw, ah, slot) = (12usize, 6usize, 6usize);
+        let mut atlas = vec![0.0f32; aw * ah];
+        for r in 0..4 {
+            for c in 0..4 {
+                atlas[(1 + r) * aw + 1 + c] = 1.0; // tile 0: solid
+                atlas[(1 + r) * aw + slot + 1 + c] = 0.5; // tile 1: half
+            }
+        }
+        let geom = CellGridGeometry {
+            cols: 1,
+            rows: 2,
+            cell_w: 4.0,
+            cell_h: 4.0,
+            density: 1.0,
+            atlas_width: aw as u32,
+            atlas_height: ah as u32,
+            tile_w: 4,
+            tile_h: 4,
+        };
+        let default_bg = [0.25, 0.5, 0.75, 1.0];
+        let cells = Arc::new(vec![
+            1.0, 1.0, /* row0 fg */ 1.0, 0.0, 0.0, 1.0, /* bg */ 0.0, 0.0, 0.0, 1.0, 7.0,
+            1.0, /* row1 fg */ 0.0, 0.0, 1.0, 1.0, /* bg */ 1.0, 1.0, 1.0, 1.0,
+        ]);
+        let atlas = Arc::new(atlas);
+        let (w, h) = (6, 10);
+        let program = CellGridProgram::compile(geom, default_bg);
+        let frame = program.frame(cells.clone(), atlas.clone());
+        let planes: [alloc::vec::Vec<f32>; 4] = core::array::from_fn(|c| plane(&frame, c, w, h));
+        let packed = CellGridPackedProgram::compile(geom, default_bg, RGBA_SHIFTS);
+        let got = packed_plane(&packed.frame(cells, atlas), w, h);
+        for i in 0..w * h {
+            let expected = pack_expected(
+                [planes[0][i], planes[1][i], planes[2][i], planes[3][i]],
+                RGBA_SHIFTS,
+            );
+            assert_eq!(
+                got[i], expected,
+                "pixel {i}: {:#010x} != {:#010x}",
+                got[i], expected
+            );
+        }
+    }
+
+    /// The packed kernel splices four channel fragments (each with its own
+    /// cell reads and atlas taps), and identity-merge must still land them
+    /// all in exactly two slots — one per distinct buffer.
+    #[test]
+    fn packed_kernel_reads_land_in_exactly_two_slots() {
+        let geom = CellGridGeometry {
+            cols: 2,
+            rows: 1,
+            cell_w: 4.0,
+            cell_h: 4.0,
+            density: 1.0,
+            atlas_width: 12,
+            atlas_height: 6,
+            tile_w: 4,
+            tile_h: 4,
+        };
+        let bufs = GridBuffers::mint();
+        let kernel = packed_kernel(&geom, bufs, [0.0; 4], RGBA_SHIFTS);
+        let roles = slot_roles(kernel.parts().0, bufs);
+        assert_eq!(
+            roles.iter().filter(|r| **r == SlotReads::Cells).count(),
+            1,
+            "all four channels' cell reads, one buffer, one slot"
+        );
+        assert_eq!(
+            roles.iter().filter(|r| **r == SlotReads::Atlas).count(),
+            1,
+            "all four channels' atlas taps, one slot"
+        );
+        assert_eq!(roles.len(), 2, "exactly {{Cells, Atlas}}, nothing else");
+    }
+
+    /// Pins the packed program's size, in the spirit of
+    /// `reads_of_one_buffer_share_a_slot_but_not_nodes`: 623 = 4 × 146 (each
+    /// `or` re-splices a whole channel fragment) + 4 × 9 (each channel's pack
+    /// chain: const 255, mul, const 0, max, const 255, min, trunc, const
+    /// shift, shl) + 3 ors. Node sharing is the e-graph's call once it can
+    /// see `Gather`; this number falling is the sign that landed.
+    #[test]
+    fn packed_kernel_node_count_is_the_channel_kernels_plus_the_pack() {
+        let geom = CellGridGeometry {
+            cols: 2,
+            rows: 1,
+            cell_w: 4.0,
+            cell_h: 4.0,
+            density: 1.0,
+            atlas_width: 12,
+            atlas_height: 6,
+            tile_w: 4,
+            tile_h: 4,
+        };
+        let bufs = GridBuffers::mint();
+        let kernel = packed_kernel(&geom, bufs, [0.0; 4], RGBA_SHIFTS);
+        let (arena, root) = kernel.parts();
+        assert_eq!(
+            reachable_nodes(arena, root),
+            623,
+            "composed packed node count (4 channels of 146, plus the pack)"
+        );
+    }
+
+    #[test]
+    fn packed_row_offset_region_matches_the_full_bake() {
+        // Mirrors `baking_a_row_offset_region_samples_the_correct_absolute_row`
+        // for the packed path: a bake starting at y0 = 4 must reproduce rows
+        // 4..8 of the full bake exactly (u32 equality — these are packed
+        // pixels, not floats).
+        let (aw, ah, slot) = (12usize, 6usize, 6usize);
+        let mut atlas = vec![0.0f32; aw * ah];
+        for r in 0..4 {
+            for c in 0..4 {
+                atlas[(1 + r) * aw + 1 + c] = 1.0; // tile 0: solid
+                atlas[(1 + r) * aw + slot + 1 + c] = 0.5; // tile 1: half
+            }
+        }
+        let geom = CellGridGeometry {
+            cols: 1,
+            rows: 2,
+            cell_w: 4.0,
+            cell_h: 4.0,
+            density: 1.0,
+            atlas_width: aw as u32,
+            atlas_height: ah as u32,
+            tile_w: 4,
+            tile_h: 4,
+        };
+        let program = CellGridPackedProgram::compile(geom, [0.0; 4], RGBA_SHIFTS);
+        let cells = Arc::new(vec![
+            1.0, 1.0, /* row0 fg */ 1.0, 0.0, 0.0, 1.0, /* bg */ 0.0, 0.0, 0.0, 1.0, 7.0,
+            1.0, /* row1 fg */ 0.0, 0.0, 1.0, 1.0, /* bg */ 1.0, 1.0, 1.0, 1.0,
+        ]);
+        let frame = program.frame(cells, Arc::new(atlas));
+
+        let full = packed_plane(&frame, 4, 8);
+
+        let stride = CellGridFrame::padded_width(4);
+        let mut padded = vec![0u32; 4 * stride];
+        frame.bake_packed_rows(
+            PlaneRegion {
+                width: 4,
+                y0: 4,
+                rows: 4,
+            },
+            &mut padded,
+        );
+        for row in 0..4 {
+            for col in 0..4 {
+                assert_eq!(
+                    padded[row * stride + col],
+                    full[(row + 4) * 4 + col],
+                    "offset bake row {row} col {col} disagrees with the full bake"
+                );
+            }
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "permutation of the byte lanes")]
+    fn overlapping_pack_shifts_are_refused() {
+        let geom = CellGridGeometry {
+            cols: 1,
+            rows: 1,
+            cell_w: 4.0,
+            cell_h: 4.0,
+            density: 1.0,
+            atlas_width: 12,
+            atlas_height: 6,
+            tile_w: 4,
+            tile_h: 4,
+        };
+        // R and B both at bit 0: the OR would blend two channels' bytes.
+        let _refused = CellGridPackedProgram::compile(geom, [0.0; 4], [0, 8, 0, 24]);
     }
 }

--- a/pixelflow-core/src/lattice/cell_grid.rs
+++ b/pixelflow-core/src/lattice/cell_grid.rs
@@ -501,6 +501,9 @@ impl CellGridFrame {
 /// `f32` plane (or vice versa) rather than a runtime check catching it.
 pub struct CellGridPackedProgram {
     geom: CellGridGeometry,
+    /// The byte lanes this kernel packed for. A frame stores raw words, so
+    /// whoever consumes them must confirm their format agrees.
+    shifts: [u32; 4],
     jit: Arc<JitManifold>,
     /// What each buffer slot of the compiled arena reads — see [`SlotReads`].
     slots: Arc<[SlotReads]>,
@@ -553,9 +556,16 @@ impl CellGridPackedProgram {
             .expect("packed cell-grid kernel failed to compile");
         Self {
             geom,
+            shifts,
             jit,
             slots: slots.into(),
         }
+    }
+
+    /// The byte lanes this program's kernel packs into.
+    #[must_use]
+    pub fn shifts(&self) -> [u32; 4] {
+        self.shifts
     }
 
     /// The packed kernel's emitted bytes (research/profiling harness).
@@ -591,6 +601,7 @@ impl CellGridPackedProgram {
             self.geom
         );
         CellGridPackedFrame {
+            shifts: self.shifts,
             jit: self.jit.clone(),
             slots: self.slots.clone(),
             cells,
@@ -603,6 +614,9 @@ impl CellGridPackedProgram {
 /// reads. Cheap to clone.
 #[derive(Clone)]
 pub struct CellGridPackedFrame {
+    /// The byte lanes the kernel packed for; a consumer storing these words
+    /// must confirm its pixel format agrees.
+    shifts: [u32; 4],
     jit: Arc<JitManifold>,
     slots: Arc<[SlotReads]>,
     cells: Arc<Vec<f32>>,
@@ -610,6 +624,12 @@ pub struct CellGridPackedFrame {
 }
 
 impl CellGridPackedFrame {
+    /// The byte lanes these words are packed into.
+    #[must_use]
+    pub fn shifts(&self) -> [u32; 4] {
+        self.shifts
+    }
+
     /// Bake packed pixels over the pixel rows `y0 .. y0 + rows` at
     /// pixel-center coordinates, into a plane of
     /// [`CellGridFrame::padded_width`]`(width)`-stride rows — the same

--- a/pixelflow-core/src/lattice/cell_grid.rs
+++ b/pixelflow-core/src/lattice/cell_grid.rs
@@ -195,7 +195,9 @@ fn packed_kernel(
             .trunc_to_int()
             .shl(shifts[c])
     };
-    byte(0).or(&byte(1)).or(&byte(2)).or(&byte(3))
+    // Fold in the bit domain, then take the single named exit: the packed
+    // pattern IS the kernel's output.
+    byte(0).or(&byte(1)).or(&byte(2)).or(&byte(3)).into_kernel()
 }
 
 /// The two blocks of memory a cell-grid program reads, identified so that

--- a/pixelflow-core/src/lattice/cell_grid.rs
+++ b/pixelflow-core/src/lattice/cell_grid.rs
@@ -558,6 +558,12 @@ impl CellGridPackedProgram {
         }
     }
 
+    /// The packed kernel's emitted bytes (research/profiling harness).
+    #[cfg(test)]
+    fn jits_code_bytes(&self) -> &[u8] {
+        self.jit.code_bytes()
+    }
+
     /// The geometry this program was compiled for.
     #[must_use]
     pub fn geometry(&self) -> &CellGridGeometry {
@@ -711,6 +717,59 @@ mod tests {
             1.0, /* bg */
         ];
         (program, Arc::new(cells), Arc::new(atlas))
+    }
+
+    /// Research harness: dump the packed kernel's machine code and hot-loop
+    /// it in one process, so a sampling profiler's addresses correlate to
+    /// the dumped bytes exactly. `PIXELFLOW_CODE_DUMP=<path>` receives the
+    /// raw bytes; the base pointer prints to stdout.
+    #[test]
+    #[ignore = "manual profiling harness"]
+    fn profile_dump_packed_kernel() {
+        let geom = CellGridGeometry {
+            cols: 213,
+            rows: 66,
+            cell_w: 12.0,
+            cell_h: 24.0,
+            density: 1.0,
+            atlas_width: 64,
+            atlas_height: 32,
+            tile_w: 12,
+            tile_h: 24,
+        };
+        let program = CellGridPackedProgram::compile(geom, [0.1, 0.1, 0.1, 1.0], [0, 8, 16, 24]);
+        let code = program.jits_code_bytes();
+        std::println!(
+            "CODE_BASE=0x{:x} CODE_LEN={}",
+            code.as_ptr() as usize,
+            code.len()
+        );
+        if let Ok(path) = std::env::var("PIXELFLOW_CODE_DUMP") {
+            std::fs::write(&path, code).expect("dump write failed");
+        }
+        let mut atlas = alloc::vec![0.0f32; geom.atlas_len()];
+        for (i, t) in atlas.iter_mut().enumerate() {
+            *t = ((i * 7) % 11) as f32 / 10.0;
+        }
+        let mut cells = alloc::vec![0.0f32; geom.cells_len()];
+        for (i, c) in cells.iter_mut().enumerate() {
+            *c = ((i * 13) % 17) as f32 / 16.0;
+        }
+        let frame = program.frame(Arc::new(cells), Arc::new(atlas));
+        let (w, h) = (2560usize, 1584usize);
+        let stride = CellGridFrame::padded_width(w);
+        let mut out = alloc::vec![0u32; stride * h];
+        for _ in 0..150 {
+            frame.bake_packed_rows(
+                PlaneRegion {
+                    width: w,
+                    y0: 0,
+                    rows: h,
+                },
+                &mut out,
+            );
+            core::hint::black_box(&out);
+        }
     }
 
     /// Splicing merges buffer declarations by identity, so the nine reads in

--- a/pixelflow-core/src/lattice/mod.rs
+++ b/pixelflow-core/src/lattice/mod.rs
@@ -799,6 +799,15 @@ impl BilinearSampler {
         width: u32,
         height: u32,
     ) -> pixelflow_ir::Kernel {
+        // Same guard as `DiscreteManifold::kernel_for`, for the same reason:
+        // `BindingTable::bind` accepts an empty slice against an empty
+        // declaration, and gather lowering's `saturating_sub(1)` then clamps
+        // every tap to index 0 — so an empty extent reaches the JIT and
+        // dereferences a zero-length buffer instead of failing here.
+        assert!(
+            width > 0 && height > 0,
+            "BilinearSampler::kernel_for: empty buffer ({width}x{height})"
+        );
         let (arena, root) = bilinear_arena(id, width, height);
         pixelflow_ir::Kernel::from_parts(arena, root)
     }

--- a/pixelflow-core/src/lattice/mod.rs
+++ b/pixelflow-core/src/lattice/mod.rs
@@ -98,6 +98,10 @@ pub struct DiscreteManifold {
     pub(crate) width: usize,
     /// Height of the grid (Y dimension).
     pub(crate) height: usize,
+    /// Which memory this is, for merging composed arenas. Clones share it,
+    /// which is sound because the buffer is write-once — there is no mutable
+    /// accessor, so a clone can never diverge from its original.
+    pub(crate) id: pixelflow_ir::arena::BufferIdentity,
 }
 
 impl DiscreteManifold {
@@ -121,6 +125,7 @@ impl DiscreteManifold {
             buffer,
             width,
             height,
+            id: pixelflow_ir::arena::BufferIdentity::mint(),
         }
     }
 
@@ -140,11 +145,6 @@ impl DiscreteManifold {
     #[must_use]
     pub fn buffer(&self) -> &[f32] {
         &self.buffer
-    }
-
-    /// Mutable access to the underlying buffer (row-major).
-    pub fn buffer_mut(&mut self) -> &mut [f32] {
-        &mut self.buffer
     }
 
     /// Consume the DiscreteManifold and return the buffer.
@@ -368,11 +368,7 @@ impl Lattice {
             }
         }
 
-        DiscreteManifold {
-            buffer,
-            width: ex,
-            height: ey * ez * ew,
-        }
+        DiscreteManifold::new(buffer, ex, ey * ez * ew)
     }
 
     /// Bake a [`Kernel`](pixelflow_ir::Kernel) — the front-end value — over the
@@ -409,8 +405,17 @@ impl Lattice {
         let mut buffer = vec![0.0f32; self.len()];
         let full_groups = ex / PARALLELISM;
         let tail = ex % PARALLELISM;
-        // A `Kernel` declares no buffers, so the context register is never
-        // read; the pointer just satisfies the ABI.
+        // Nothing here binds memory, so the context register must never be
+        // read. A kernel composed with a sampler (`BilinearSampler::kernel`)
+        // does declare buffers, and its gathers would load base pointers out
+        // of this null — refuse it here rather than fault in emitted code.
+        assert!(
+            arena.buffers().is_empty(),
+            "Lattice::bake: kernel declares {} buffer(s), but bake binds none. \
+             Bake a buffer-free kernel, or evaluate the sampler through a path \
+             that binds its memory.",
+            arena.buffers().len()
+        );
         let ctx = core::ptr::null();
         let x0 = Field::sequential(self.origin[0]);
         let x_tail = Field::sequential(self.origin[0] + (full_groups * PARALLELISM) as f32);
@@ -468,11 +473,7 @@ impl Lattice {
             }
         }
 
-        DiscreteManifold {
-            buffer,
-            width: ex,
-            height: ey * ez * ew,
-        }
+        DiscreteManifold::new(buffer, ex, ey * ez * ew)
     }
 
     /// Fold all points of the lattice into a per-lane SIMD accumulator.
@@ -731,12 +732,16 @@ pub struct BilinearSampler {
 /// `Σ tap(x?, y?) · weight` with `x0 = floor(X)`, `fx = X − x0`, and the
 /// mirrored pair in y. Gather clamps each tap to the buffer edge.
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-fn bilinear_arena(width: u32, height: u32) -> (pixelflow_ir::ExprArena, pixelflow_ir::ExprId) {
+fn bilinear_arena(
+    id: pixelflow_ir::arena::BufferIdentity,
+    width: u32,
+    height: u32,
+) -> (pixelflow_ir::ExprArena, pixelflow_ir::ExprId) {
     use pixelflow_ir::arena::BufferDecl;
     use pixelflow_ir::{ExprArena, OpKind};
 
     let mut a = ExprArena::new();
-    let buf = a.declare_buffer(BufferDecl { width, height });
+    let buf = a.declare_buffer(BufferDecl { id, width, height });
     let x = a.push_var(0);
     let y = a.push_var(1);
     let one = a.push_const(1.0);
@@ -778,10 +783,87 @@ impl BilinearSampler {
     pub fn texture(&self) -> &DiscreteManifold {
         &self.tex
     }
+
+    /// The 4-tap blend over a buffer of these extents, as a composable
+    /// fragment — read it at *computed* coordinates inside a larger kernel
+    /// with `.at(&u, &v, &z, &w)` instead of only at the caller's own.
+    ///
+    /// Takes extents rather than a sampler because extents are all the IR
+    /// carries; the data binds later. So a program can compose against a
+    /// buffer shape it has not filled yet, which is what lets a grid compile
+    /// from its geometry alone. `bilinear` compiles from this same builder,
+    /// so the composed and called forms cannot drift apart.
+    #[must_use]
+    pub fn kernel_for(
+        id: pixelflow_ir::arena::BufferIdentity,
+        width: u32,
+        height: u32,
+    ) -> pixelflow_ir::Kernel {
+        let (arena, root) = bilinear_arena(id, width, height);
+        pixelflow_ir::Kernel::from_parts(arena, root)
+    }
+
+    /// This sampler's blend as a composable fragment. See [`Self::kernel_for`].
+    ///
+    /// # Panics
+    ///
+    /// Panics when an extent exceeds `u32`.
+    #[must_use]
+    pub fn kernel(&self) -> pixelflow_ir::Kernel {
+        Self::kernel_for(
+            self.tex.id,
+            u32::try_from(self.tex.width).expect("buffer width exceeds u32"),
+            u32::try_from(self.tex.height).expect("buffer height exceeds u32"),
+        )
+    }
 }
 
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 impl DiscreteManifold {
+    /// A nearest-neighbour read of a buffer of these extents, as a composable
+    /// fragment — `.at(&idx, &row, &z, &w)` reads at *computed* indices.
+    ///
+    /// One `Gather`, which already carries [`Self::eval`]'s semantics: floor,
+    /// clamp to the declared extents, index row-major. Takes extents rather
+    /// than `&self` for the same reason as [`BilinearSampler::kernel_for`] —
+    /// extents are what the IR holds, the data binds later.
+    ///
+    /// # Panics
+    ///
+    /// Panics on a zero extent, which would make every gather clamp onto an
+    /// empty buffer.
+    #[must_use]
+    pub fn kernel_for(
+        id: pixelflow_ir::arena::BufferIdentity,
+        width: u32,
+        height: u32,
+    ) -> pixelflow_ir::Kernel {
+        assert!(
+            width > 0 && height > 0,
+            "DiscreteManifold::kernel_for: empty buffer ({width}x{height})"
+        );
+        let mut a = pixelflow_ir::ExprArena::new();
+        let buf = a.declare_buffer(pixelflow_ir::arena::BufferDecl { id, width, height });
+        let (x, y) = (a.push_var(0), a.push_var(1));
+        let root = a.push_gather(buf, x, y);
+        pixelflow_ir::Kernel::from_parts(a, root)
+    }
+
+    /// This buffer's nearest-neighbour read as a composable fragment. See
+    /// [`Self::kernel_for`].
+    ///
+    /// # Panics
+    ///
+    /// Panics on an empty buffer, or when an extent exceeds `u32`.
+    #[must_use]
+    pub fn kernel(&self) -> pixelflow_ir::Kernel {
+        Self::kernel_for(
+            self.id,
+            u32::try_from(self.width).expect("buffer width exceeds u32"),
+            u32::try_from(self.height).expect("buffer height exceeds u32"),
+        )
+    }
+
     /// Wrap this buffer in a [`BilinearSampler`], JIT-compiling the 4-tap
     /// blend kernel bound to it.
     ///
@@ -804,7 +886,7 @@ impl DiscreteManifold {
         );
         let width = u32::try_from(self.width).expect("buffer width exceeds u32");
         let height = u32::try_from(self.height).expect("buffer height exceeds u32");
-        let (arena, root) = bilinear_arena(width, height);
+        let (arena, root) = bilinear_arena(self.id, width, height);
         // Bound-memory arenas are uncacheable (the code bakes buffer slot
         // metadata); compile_cached recognizes that and compiles fresh.
         let jit = pixelflow_codegen::jit_cache::compile_cached(&arena, root)

--- a/pixelflow-core/src/lib.rs
+++ b/pixelflow-core/src/lib.rs
@@ -260,7 +260,8 @@ pub use manifold::Differentiable;
 pub use lattice::BilinearSampler;
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub use lattice::cell_grid::{
-    CELL_STRIDE, CellGridFrame, CellGridGeometry, CellGridProgram, PlaneRegion,
+    CELL_STRIDE, CellGridFrame, CellGridGeometry, CellGridPackedFrame, CellGridPackedProgram,
+    CellGridProgram, PlaneRegion,
 };
 pub use lattice::{DiscreteManifold, Lattice, ReduceOp};
 

--- a/pixelflow-core/src/lib.rs
+++ b/pixelflow-core/src/lib.rs
@@ -130,6 +130,10 @@
 
 extern crate alloc;
 
+// Tests use std (println, env, fs) for harnesses; shipped code stays no_std.
+#[cfg(test)]
+extern crate std;
+
 // ============================================================================
 // Modules
 // ============================================================================

--- a/pixelflow-graphics/src/lib.rs
+++ b/pixelflow-graphics/src/lib.rs
@@ -187,7 +187,7 @@ pub use fonts::{CachedGlyph, CachedText, Font, GlyphCache};
 // Re-export render
 pub use render::color::{
     AttrFlags, Bgra8, BgraColorCube, CocoaPixel, Color, ColorCube, Grayscale, NamedColor, Pixel,
-    PlatformColorCube, Rgba8, RgbaColorCube, WebPixel, X11Pixel,
+    PlatformColorCube, PlatformPixel, Rgba8, RgbaColorCube, WebPixel, X11Pixel,
 };
 pub use render::frame::Frame;
 pub use render::rasterizer::rasterize;

--- a/pixelflow-graphics/src/render/color.rs
+++ b/pixelflow-graphics/src/render/color.rs
@@ -673,6 +673,17 @@ mod tests {
                 pack(BgraColorCube::PACKED_SHIFTS, r, g, b, a),
                 "Bgra8 disagrees with BgraColorCube::PACKED_SHIFTS"
             );
+            assert_eq!(
+                <u32 as Pixel>::from_rgba(r, g, b, a),
+                pack(
+                    <u32 as Pixel>::packed_shifts().expect("u32 is packed RGBA"),
+                    r,
+                    g,
+                    b,
+                    a
+                ),
+                "u32 disagrees with its own packed_shifts"
+            );
         }
     }
     use super::*;

--- a/pixelflow-graphics/src/render/color.rs
+++ b/pixelflow-graphics/src/render/color.rs
@@ -512,6 +512,22 @@ pub type BgraColorCube = ColorCube<
     pixelflow_core::variables::W,
 >;
 
+impl RgbaColorCube {
+    /// Bit position of each `(r, g, b, a)` channel in this cube's packed
+    /// `u32` pixel. Derived from `Rgba8::new`'s `u32::from_le_bytes([r, g,
+    /// b, a])`: r is byte 0. The JIT packed cell-grid kernel takes these, so
+    /// byte order has exactly one home — if the kernel pack and
+    /// `Pixel::from_rgba` ever disagreed, they would have to disagree in
+    /// this file (`packed_shifts_agree_with_pixel_from_rgba` pins it).
+    pub const PACKED_SHIFTS: [u32; 4] = [0, 8, 16, 24];
+}
+
+impl BgraColorCube {
+    /// Bit position of each `(r, g, b, a)` channel — `Bgra8::new` stores
+    /// `[b, g, r, a]`, so r is byte 2. See [`RgbaColorCube::PACKED_SHIFTS`].
+    pub const PACKED_SHIFTS: [u32; 4] = [16, 8, 0, 24];
+}
+
 /// Platform-appropriate ColorCube (handles byte order based on target OS).
 ///
 /// - macOS: RGBA byte order
@@ -602,6 +618,34 @@ pub fn color_manifold<R, G, B, A>(r: R, g: G, b: B, a: A) -> ColorManifold<R, G,
 
 #[cfg(test)]
 mod tests {
+
+    /// The cube's shift table and the scalar `Pixel::from_rgba` are the same
+    /// byte-order fact stated twice; this pins them to each other so the JIT
+    /// pack (which consumes the shifts) can never drift from the scalar pack.
+    #[test]
+    fn packed_shifts_agree_with_pixel_from_rgba() {
+        fn pack(shifts: [u32; 4], r: f32, g: f32, b: f32, a: f32) -> u32 {
+            let q = |x: f32| (x * 255.0).clamp(0.0, 255.0) as u32;
+            (q(r) << shifts[0]) | (q(g) << shifts[1]) | (q(b) << shifts[2]) | (q(a) << shifts[3])
+        }
+        let samples = [
+            (0.0, 0.25, 0.5, 1.0),
+            (1.0, 0.0, 0.999, 0.004),
+            (0.7, 0.7, 0.7, 0.0),
+        ];
+        for (r, g, b, a) in samples {
+            assert_eq!(
+                Rgba8::from_rgba(r, g, b, a).0,
+                pack(RgbaColorCube::PACKED_SHIFTS, r, g, b, a),
+                "Rgba8 disagrees with RgbaColorCube::PACKED_SHIFTS"
+            );
+            assert_eq!(
+                Bgra8::from_rgba(r, g, b, a).0,
+                pack(BgraColorCube::PACKED_SHIFTS, r, g, b, a),
+                "Bgra8 disagrees with BgraColorCube::PACKED_SHIFTS"
+            );
+        }
+    }
     use super::*;
 
     #[test]

--- a/pixelflow-graphics/src/render/color.rs
+++ b/pixelflow-graphics/src/render/color.rs
@@ -380,6 +380,11 @@ impl From<Rgba8> for Bgra8 {
 // =============================================================================
 
 impl Pixel for Rgba8 {
+    /// `Rgba8::new` stores `[r, g, b, a]`, so r is byte 0.
+    fn packed_shifts() -> Option<[u32; 4]> {
+        Some([0, 8, 16, 24])
+    }
+
     #[inline]
     fn from_u32(v: u32) -> Self {
         Self(v)
@@ -399,6 +404,11 @@ impl Pixel for Rgba8 {
 }
 
 impl Pixel for Bgra8 {
+    /// `Bgra8::new` stores `[b, g, r, a]`, so r is byte 2.
+    fn packed_shifts() -> Option<[u32; 4]> {
+        Some([16, 8, 0, 24])
+    }
+
     #[inline]
     fn from_u32(v: u32) -> Self {
         Self(v)
@@ -522,11 +532,30 @@ impl RgbaColorCube {
     pub const PACKED_SHIFTS: [u32; 4] = [0, 8, 16, 24];
 }
 
+// The cube constants and the `Pixel` impls above state one fact; this pins
+// them to each other so a future edit cannot move only one.
+const _: () = assert!(RgbaColorCube::PACKED_SHIFTS[0] == 0);
+const _: () = assert!(BgraColorCube::PACKED_SHIFTS[0] == 16);
+
 impl BgraColorCube {
     /// Bit position of each `(r, g, b, a)` channel — `Bgra8::new` stores
     /// `[b, g, r, a]`, so r is byte 2. See [`RgbaColorCube::PACKED_SHIFTS`].
     pub const PACKED_SHIFTS: [u32; 4] = [16, 8, 0, 24];
 }
+
+/// The platform's framebuffer pixel format — the same choice
+/// [`PlatformColorCube`] makes, for code that needs the `Pixel` type rather
+/// than the cube.
+#[cfg(target_os = "macos")]
+pub type PlatformPixel = Rgba8;
+
+/// See the macOS variant.
+#[cfg(target_os = "linux")]
+pub type PlatformPixel = Bgra8;
+
+/// See the macOS variant.
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+pub type PlatformPixel = Rgba8;
 
 /// Platform-appropriate ColorCube (handles byte order based on target OS).
 ///

--- a/pixelflow-graphics/src/render/pixel.rs
+++ b/pixelflow-graphics/src/render/pixel.rs
@@ -67,4 +67,11 @@ impl Pixel for u32 {
         let a_u8 = (a * 255.0).clamp(0.0, 255.0) as u8;
         u32::from_le_bytes([r_u8, g_u8, b_u8, a_u8])
     }
+
+    // Same layout `from_rgba` above encodes: r is byte 0. Without this
+    // override the default `None` made `Frame<u32>` — a perfectly packed
+    // RGBA target — panic at the format guard.
+    fn packed_shifts() -> Option<[u32; 4]> {
+        Some([0, 8, 16, 24])
+    }
 }

--- a/pixelflow-graphics/src/render/pixel.rs
+++ b/pixelflow-graphics/src/render/pixel.rs
@@ -17,6 +17,20 @@ pub trait Pixel: Copy + Default + Debug + PartialEq + 'static + Send + Sync {
     /// Create from normalized RGBA components [0, 1].
     fn from_rgba(r: f32, g: f32, b: f32, a: f32) -> Self;
 
+    /// Bit position of each `(r, g, b, a)` channel in this format's packed
+    /// `u32`, or `None` for formats that are not a packed RGBA word.
+    ///
+    /// This is [`Pixel::from_rgba`]'s byte order stated as data, so a JIT
+    /// kernel can pack straight to this format instead of computing four
+    /// floats for a scalar pack to place. A renderer that hands a kernel
+    /// these shifts and then stores the result as `Self` cannot disagree
+    /// with `from_rgba` — same source. `None` means "no packed form": such a
+    /// format must go through `from_rgba`.
+    #[must_use]
+    fn packed_shifts() -> Option<[u32; 4]> {
+        None
+    }
+
     // Note: No batch methods here. The Engine knows how to load
     // pixel types into SIMD lanes (assuming valid layout).
 }

--- a/pixelflow-graphics/src/render/scene.rs
+++ b/pixelflow-graphics/src/render/scene.rs
@@ -324,14 +324,6 @@ mod tests {
 
     #[test]
     fn platform_wrapper_needs_no_shifts_from_the_caller() {
-        let Scene::CellGrid(reference) = scene() else {
-            unreachable!()
-        };
-        // Same geometry/data through the platform wrapper: it must compile
-        // and render; pixel values are platform byte order, so only shape
-        // and the alpha-lane content are asserted here (Rgba8 and Bgra8
-        // agree on the alpha byte).
-        let _ = reference;
         let (aw, ah) = (12usize, 6usize);
         let atlas = vec![0.0f32; aw * ah];
         let geom = CellGridGeometry {
@@ -353,7 +345,13 @@ mod tests {
             cell[9] = 1.0; // bg_a
         }
         let frame_data = program.frame(Arc::new(cells), Arc::new(atlas));
-        let mut frame = Frame::<Rgba8>::new(8, 8);
+        // The platform wrapper packs for PlatformPixel, so the frame must BE
+        // PlatformPixel — pairing it with a hardcoded format is the mistake
+        // the render-time format guard exists to catch, and did catch here
+        // (this test asserted Rgba8 and failed on Linux, where the platform
+        // is Bgra8). Alpha is byte 3 in both orders, so the assertion below
+        // is the one claim that holds whichever platform runs it.
+        let mut frame = Frame::<crate::render::color::PlatformPixel>::new(8, 8);
         Scene::CellGrid(frame_data).render(&mut frame, 1);
         assert!(
             frame.data.iter().all(|p| p.0 >> 24 == 255),

--- a/pixelflow-graphics/src/render/scene.rs
+++ b/pixelflow-graphics/src/render/scene.rs
@@ -2,16 +2,23 @@
 //!
 //! The rasterizer's input is either an arbitrary color manifold — rendered
 //! by dense per-batch evaluation through the `Manifold` trait — or a JIT
-//! cell-grid frame ([`pixelflow_core::CellGridFrame`]), whose four channel
-//! planes are baked by ONE internal-loop collapse call per channel per
-//! stripe and then packed to pixels. The cell-grid lane is the production
-//! frame path: no per-batch FFI boundary, no virtual dispatch, and the
-//! collapse kernel's two-level LICM prologues (per-call, per-row) active.
+//! packed cell-grid frame ([`pixelflow_core::CellGridPackedFrame`]): ONE
+//! collapse call per stripe whose kernel computes all four channels and
+//! packs them to `u32` pixels in-register, so what reaches memory is
+//! finished pixels. The cell-grid lane is the production frame path: no
+//! per-batch FFI boundary, no virtual dispatch, no per-pixel scalar pack,
+//! and the collapse kernel's two-level LICM prologues (per-call, per-row)
+//! active. Byte order comes from the platform's ColorCube
+//! ([`compile_platform_cell_grid`]), never from application code.
 
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+use crate::render::color::PlatformColorCube;
 use crate::render::frame::Frame;
 use crate::render::Pixel;
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-use pixelflow_core::{CellGridFrame, PlaneRegion};
+use pixelflow_core::{
+    CellGridFrame, CellGridGeometry, CellGridPackedFrame, CellGridPackedProgram, PlaneRegion,
+};
 use pixelflow_core::{Discrete, Manifold};
 use std::sync::Arc;
 
@@ -20,10 +27,10 @@ use std::sync::Arc;
 pub enum Scene {
     /// Dense per-batch evaluation of an arbitrary color manifold.
     Surface(Arc<dyn Manifold<Output = Discrete> + Send + Sync>),
-    /// A JIT cell-grid frame: channel planes baked by the 2D collapse
-    /// kernel, packed to pixels per stripe.
+    /// A JIT packed cell-grid frame: the 2D collapse kernel writes
+    /// finished `u32` pixels; stripes copy rows into the frame.
     #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-    CellGrid(CellGridFrame),
+    CellGrid(CellGridPackedFrame),
 }
 
 impl From<Arc<dyn Manifold<Output = Discrete> + Send + Sync>> for Scene {
@@ -33,10 +40,22 @@ impl From<Arc<dyn Manifold<Output = Discrete> + Send + Sync>> for Scene {
 }
 
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-impl From<CellGridFrame> for Scene {
-    fn from(frame: CellGridFrame) -> Self {
+impl From<CellGridPackedFrame> for Scene {
+    fn from(frame: CellGridPackedFrame) -> Self {
         Self::CellGrid(frame)
     }
+}
+
+/// Compile the packed cell-grid program with THIS platform's pixel byte
+/// order, taken from [`PlatformColorCube`] — the one home byte order has.
+/// Applications pass geometry and colors; they never see a shift.
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[must_use]
+pub fn compile_platform_cell_grid(
+    geom: CellGridGeometry,
+    default_bg: [f32; 4],
+) -> CellGridPackedProgram {
+    CellGridPackedProgram::compile(geom, default_bg, PlatformColorCube::PACKED_SHIFTS)
 }
 
 impl core::fmt::Debug for Scene {
@@ -53,8 +72,8 @@ impl Scene {
     /// Render this scene into `frame` with up to `num_threads` workers.
     ///
     /// Surfaces go through the work-stealing per-batch rasterizer; cell
-    /// grids bake channel planes stripe-parallel through the collapse
-    /// kernels and pack via [`Pixel::from_rgba`].
+    /// grids bake finished packed pixels stripe-parallel through the one
+    /// collapse kernel and copy rows into the frame.
     pub fn render<P: Pixel + Send>(&self, frame: &mut Frame<P>, num_threads: usize) {
         match self {
             Self::Surface(manifold) => {
@@ -66,14 +85,14 @@ impl Scene {
     }
 }
 
-/// Bake and pack a cell-grid frame, stripe-parallel.
+/// Bake a packed cell-grid frame, stripe-parallel.
 ///
-/// Each worker owns a contiguous run of rows: it bakes the four channel
-/// planes for its stripe (one collapse call per channel — the pixel loop
-/// lives inside the JIT) and packs them row by row.
+/// Each worker owns a contiguous run of rows: one collapse call bakes its
+/// stripe's finished pixels (the pixel loop and the pack both live inside
+/// the JIT), and each row is copied `width`-wide into the frame.
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 fn render_cell_grid<P: Pixel + Send>(
-    grid: &CellGridFrame,
+    grid: &CellGridPackedFrame,
     frame: &mut Frame<P>,
     num_threads: usize,
 ) {
@@ -98,34 +117,39 @@ fn render_cell_grid<P: Pixel + Send>(
 
     std::thread::scope(|scope| {
         for (y0, band) in bands {
-            scope.spawn(move || bake_and_pack_stripe(grid, width, y0, band));
+            scope.spawn(move || bake_packed_stripe(grid, width, y0, band));
         }
     });
 }
 
-/// Scratch budget per worker for the four channel planes. Bounds the
-/// bake-and-pack working set to cache-friendly chunks instead of sizing
-/// temporaries to the whole stripe (a 4K frame would otherwise stage
-/// ~127 MiB of planes per render).
+/// Staging budget per worker: the kernel writes whole batches on a padded
+/// stride, and frame rows are width-packed, so rows stage here and are
+/// copied `width`-wide. A quarter of the old four-plane scratch would
+/// already hold the same rows; keeping the budget quadruples the rows per
+/// collapse call instead.
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-const PLANE_SCRATCH_BYTES: usize = 1 << 20;
+const STAGING_SCRATCH_BYTES: usize = 1 << 20;
 
-/// Bake the four channel planes for rows `y0..y0 + band.len()/width` and
-/// pack them into `band`, in bounded-height chunks reusing one scratch
-/// allocation.
+/// Bake rows `y0..y0 + band.len()/width` and copy them into `band`, in
+/// bounded-height chunks reusing one staging allocation.
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-fn bake_and_pack_stripe<P: Pixel>(grid: &CellGridFrame, width: usize, y0: usize, band: &mut [P]) {
+fn bake_packed_stripe<P: Pixel>(
+    grid: &CellGridPackedFrame,
+    width: usize,
+    y0: usize,
+    band: &mut [P],
+) {
     let stride = CellGridFrame::padded_width(width);
-    let chunk_rows = PLANE_SCRATCH_BYTES / (4 * stride * core::mem::size_of::<f32>());
-    bake_and_pack_chunked(grid, width, y0, band, chunk_rows);
+    let chunk_rows = STAGING_SCRATCH_BYTES / (stride * core::mem::size_of::<u32>());
+    bake_packed_chunked(grid, width, y0, band, chunk_rows);
 }
 
-/// [`bake_and_pack_stripe`] with an explicit chunk height (rows of plane
-/// scratch per pass) — split out so tests can force chunk boundaries that
-/// the production budget would only hit on very large frames.
+/// [`bake_packed_stripe`] with an explicit chunk height — split out so tests
+/// can force chunk boundaries the production budget would only hit on very
+/// large frames.
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-fn bake_and_pack_chunked<P: Pixel>(
-    grid: &CellGridFrame,
+fn bake_packed_chunked<P: Pixel>(
+    grid: &CellGridPackedFrame,
     width: usize,
     y0: usize,
     band: &mut [P],
@@ -134,33 +158,24 @@ fn bake_and_pack_chunked<P: Pixel>(
     let rows = band.len() / width;
     let stride = CellGridFrame::padded_width(width);
     let chunk_rows = chunk_rows.clamp(1, rows.max(1));
-    let mut planes = vec![0.0f32; 4 * chunk_rows * stride];
+    let mut staging = vec![0u32; chunk_rows * stride];
 
     let mut done = 0usize;
     while done < rows {
         let n = chunk_rows.min(rows - done);
-        {
-            let (r, rest) = planes.split_at_mut(chunk_rows * stride);
-            let (g, rest) = rest.split_at_mut(chunk_rows * stride);
-            let (b, a) = rest.split_at_mut(chunk_rows * stride);
-            let region = PlaneRegion {
+        grid.bake_packed_rows(
+            PlaneRegion {
                 width,
                 y0: y0 + done,
                 rows: n,
-            };
-            grid.bake_channel_rows(0, region, r);
-            grid.bake_channel_rows(1, region, g);
-            grid.bake_channel_rows(2, region, b);
-            grid.bake_channel_rows(3, region, a);
-        }
-        let plane =
-            |c: usize| &planes[c * chunk_rows * stride..c * chunk_rows * stride + n * stride];
-        let (r, g, b, a) = (plane(0), plane(1), plane(2), plane(3));
+            },
+            &mut staging,
+        );
         for row in 0..n {
-            let p = row * stride;
-            let o = (done + row) * width;
-            for i in 0..width {
-                band[o + i] = P::from_rgba(r[p + i], g[p + i], b[p + i], a[p + i]);
+            let src = &staging[row * stride..row * stride + width];
+            let dst = &mut band[(done + row) * width..(done + row + 1) * width];
+            for (d, s) in dst.iter_mut().zip(src) {
+                *d = P::from_u32(*s);
             }
         }
         done += n;
@@ -172,7 +187,8 @@ fn bake_and_pack_chunked<P: Pixel>(
 mod tests {
     use super::*;
     use crate::render::color::Rgba8;
-    use pixelflow_core::{CellGridGeometry, CellGridProgram};
+    use crate::render::color::RgbaColorCube;
+    use pixelflow_core::CellGridPackedProgram;
 
     /// A 2×2 grid of solid/half tiles; oracle is the scalar blend math.
     fn scene() -> Scene {
@@ -195,7 +211,11 @@ mod tests {
             tile_w: 4,
             tile_h: 4,
         };
-        let program = CellGridProgram::compile(geom, [0.25, 0.25, 0.25, 1.0]);
+        let program = CellGridPackedProgram::compile(
+            geom,
+            [0.25, 0.25, 0.25, 1.0],
+            RgbaColorCube::PACKED_SHIFTS,
+        );
         #[rustfmt::skip]
         let cells = vec![
             // (0,0): solid tile, red on black
@@ -236,10 +256,10 @@ mod tests {
         // Force chunk boundaries (3-row chunks over an 8-row band) and
         // require pixel identity with the unchunked bake.
         //
-        // `bake_and_pack_chunked` is production logic (`bake_and_pack_stripe`
+        // `bake_packed_chunked` is production logic (`bake_packed_stripe`
         // calls it on the real render path too), not a test-only seam — but
         // its `chunk_rows` argument is derived internally from
-        // `PLANE_SCRATCH_BYTES`, which only forces a chunk boundary on
+        // `STAGING_SCRATCH_BYTES`, which only forces a chunk boundary on
         // frames far larger than a unit test should render. Calling it
         // directly with a small `chunk_rows` is the only way to exercise
         // that boundary deterministically; going through `Scene::render`
@@ -253,9 +273,48 @@ mod tests {
         let (w, h) = (9usize, 8usize);
         let mut whole = vec![Rgba8::from_u32(0); w * h];
         let mut chunked = vec![Rgba8::from_u32(0); w * h];
-        super::bake_and_pack_chunked(&grid, w, 0, &mut whole, h);
-        super::bake_and_pack_chunked(&grid, w, 0, &mut chunked, 3);
+        super::bake_packed_chunked(&grid, w, 0, &mut whole, h);
+        super::bake_packed_chunked(&grid, w, 0, &mut chunked, 3);
         assert_eq!(whole, chunked, "chunk boundaries must not change pixels");
+    }
+
+    #[test]
+    fn platform_wrapper_needs_no_shifts_from_the_caller() {
+        let Scene::CellGrid(reference) = scene() else {
+            unreachable!()
+        };
+        // Same geometry/data through the platform wrapper: it must compile
+        // and render; pixel values are platform byte order, so only shape
+        // and the alpha-lane content are asserted here (Rgba8 and Bgra8
+        // agree on the alpha byte).
+        let _ = reference;
+        let (aw, ah) = (12usize, 6usize);
+        let atlas = vec![0.0f32; aw * ah];
+        let geom = CellGridGeometry {
+            cols: 2,
+            rows: 2,
+            cell_w: 4.0,
+            cell_h: 4.0,
+            density: 1.0,
+            atlas_width: aw as u32,
+            atlas_height: ah as u32,
+            tile_w: 4,
+            tile_h: 4,
+        };
+        let program = super::compile_platform_cell_grid(geom, [0.0, 0.0, 0.0, 1.0]);
+        // Zero coverage everywhere, so every in-grid pixel shows its cell's
+        // BACKGROUND — which must be opaque for the alpha assertion to hold.
+        let mut cells = vec![0.0f32; geom.cells_len()];
+        for cell in cells.chunks_mut(pixelflow_core::CELL_STRIDE) {
+            cell[9] = 1.0; // bg_a
+        }
+        let frame_data = program.frame(Arc::new(cells), Arc::new(atlas));
+        let mut frame = Frame::<Rgba8>::new(8, 8);
+        Scene::CellGrid(frame_data).render(&mut frame, 1);
+        assert!(
+            frame.data.iter().all(|p| p.0 >> 24 == 255),
+            "alpha lane must be opaque regardless of platform byte order"
+        );
     }
 
     #[test]
@@ -266,5 +325,137 @@ mod tests {
         scene.render(&mut one, 1);
         scene.render(&mut many, 4);
         assert_eq!(one.data, many.data, "thread count must not change pixels");
+    }
+}
+
+#[cfg(test)]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+mod frame_bench {
+    //! Steady-state frame-bake comparison: the retired four-plane-then-pack
+    //! shape against the packed kernel. Ignored by default — run manually:
+    //! `cargo test --release -p pixelflow-graphics --lib -- --ignored
+    //! bench_packed --nocapture`. The four-channel program still exists in
+    //! pixelflow-core as the parity oracle, which is what lets the retired
+    //! shape be reconstructed here without keeping dead render code.
+    use super::*;
+    use crate::render::color::{Rgba8, RgbaColorCube};
+    use pixelflow_core::{CellGridGeometry, CellGridPackedProgram, CellGridProgram};
+
+    fn realistic() -> (CellGridGeometry, Vec<f32>, Vec<f32>) {
+        // A 2560x1584 frame of 12x24 cells: 213x66 — a full-screen terminal.
+        let geom = CellGridGeometry {
+            cols: 213,
+            rows: 66,
+            cell_w: 12.0,
+            cell_h: 24.0,
+            density: 1.0,
+            atlas_width: 64,
+            atlas_height: 32,
+            tile_w: 12,
+            tile_h: 24,
+        };
+        let mut atlas = vec![0.0f32; geom.atlas_len()];
+        for (i, t) in atlas.iter_mut().enumerate() {
+            *t = ((i * 7) % 11) as f32 / 10.0;
+        }
+        let mut cells = vec![0.0f32; geom.cells_len()];
+        for (i, c) in cells.iter_mut().enumerate() {
+            *c = ((i * 13) % 17) as f32 / 16.0;
+        }
+        (geom, cells, atlas)
+    }
+
+    fn median_ns(mut samples: Vec<u128>) -> u128 {
+        samples.sort_unstable();
+        samples[samples.len() / 2]
+    }
+
+    #[test]
+    #[ignore = "manual benchmark; run in --release with --nocapture"]
+    fn bench_packed_vs_four_plane() {
+        let (geom, cells, atlas) = realistic();
+        let (w, h) = (2560usize, 1584usize);
+        let stride = CellGridFrame::padded_width(w);
+        let cells = Arc::new(cells);
+        let atlas = Arc::new(atlas);
+
+        let four = CellGridProgram::compile(geom, [0.1, 0.1, 0.1, 1.0])
+            .frame(cells.clone(), atlas.clone());
+        let packed = CellGridPackedProgram::compile(
+            geom,
+            [0.1, 0.1, 0.1, 1.0],
+            RgbaColorCube::PACKED_SHIFTS,
+        )
+        .frame(cells, atlas);
+
+        let mut band = vec![Rgba8::from_u32(0); w * h];
+        let chunk_rows = STAGING_SCRATCH_BYTES / (stride * core::mem::size_of::<u32>());
+
+        // The retired shape: four plane bakes plus a per-pixel from_rgba.
+        let old_pass = |band: &mut [Rgba8]| {
+            let mut planes = vec![0.0f32; 4 * chunk_rows * stride];
+            let mut done = 0usize;
+            while done < h {
+                let n = chunk_rows.min(h - done);
+                {
+                    let (r, rest) = planes.split_at_mut(chunk_rows * stride);
+                    let (g, rest) = rest.split_at_mut(chunk_rows * stride);
+                    let (b, a) = rest.split_at_mut(chunk_rows * stride);
+                    let region = PlaneRegion {
+                        width: w,
+                        y0: done,
+                        rows: n,
+                    };
+                    four.bake_channel_rows(0, region, r);
+                    four.bake_channel_rows(1, region, g);
+                    four.bake_channel_rows(2, region, b);
+                    four.bake_channel_rows(3, region, a);
+                }
+                let plane = |c: usize| &planes[c * chunk_rows * stride..];
+                for row in 0..n {
+                    let p = row * stride;
+                    let o = (done + row) * w;
+                    for i in 0..w {
+                        band[o + i] = Rgba8::from_rgba(
+                            plane(0)[p + i],
+                            plane(1)[p + i],
+                            plane(2)[p + i],
+                            plane(3)[p + i],
+                        );
+                    }
+                }
+                done += n;
+            }
+        };
+        let new_pass = |band: &mut [Rgba8]| bake_packed_chunked(&packed, w, 0, band, chunk_rows);
+
+        const WARM: usize = 3;
+        const RUNS: usize = 15;
+        for _ in 0..WARM {
+            old_pass(&mut band);
+            new_pass(&mut band);
+        }
+        let mut old_ns = Vec::with_capacity(RUNS);
+        let mut new_ns = Vec::with_capacity(RUNS);
+        for _ in 0..RUNS {
+            let t = std::time::Instant::now();
+            old_pass(&mut band);
+            old_ns.push(t.elapsed().as_nanos());
+            let t = std::time::Instant::now();
+            new_pass(&mut band);
+            new_ns.push(t.elapsed().as_nanos());
+        }
+        let (o, n) = (median_ns(old_ns), median_ns(new_ns));
+        let px = (w * h) as u128;
+        println!("frame {w}x{h} ({px} px), single-threaded, median of {RUNS}:");
+        println!(
+            "  four-plane + per-pixel pack: {o} ns/frame ({:.3} ns/px)",
+            o as f64 / px as f64
+        );
+        println!(
+            "  packed kernel + row copy:    {n} ns/frame ({:.3} ns/px)",
+            n as f64 / px as f64
+        );
+        println!("  speedup: {:.2}x", o as f64 / n as f64);
     }
 }

--- a/pixelflow-graphics/src/render/scene.rs
+++ b/pixelflow-graphics/src/render/scene.rs
@@ -370,6 +370,29 @@ mod frame_bench {
         samples[samples.len() / 2]
     }
 
+    /// Hot-loop-only target for profilers: nothing but the packed path,
+    /// long enough to sample. `cargo test --release ... --ignored
+    /// profile_packed` under samply/xctrace.
+    #[test]
+    #[ignore = "manual profiling target"]
+    fn profile_packed_hot_loop() {
+        let (geom, cells, atlas) = realistic();
+        let (w, h) = (2560usize, 1584usize);
+        let stride = CellGridFrame::padded_width(w);
+        let packed = CellGridPackedProgram::compile(
+            geom,
+            [0.1, 0.1, 0.1, 1.0],
+            RgbaColorCube::PACKED_SHIFTS,
+        )
+        .frame(Arc::new(cells), Arc::new(atlas));
+        let chunk_rows = STAGING_SCRATCH_BYTES / (stride * core::mem::size_of::<u32>());
+        let mut band = vec![Rgba8::from_u32(0); w * h];
+        for _ in 0..150 {
+            bake_packed_chunked(&packed, w, 0, &mut band, chunk_rows);
+            std::hint::black_box(&band);
+        }
+    }
+
     #[test]
     #[ignore = "manual benchmark; run in --release with --nocapture"]
     fn bench_packed_vs_four_plane() {

--- a/pixelflow-graphics/src/render/scene.rs
+++ b/pixelflow-graphics/src/render/scene.rs
@@ -12,7 +12,7 @@
 //! ([`compile_platform_cell_grid`]), never from application code.
 
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-use crate::render::color::PlatformColorCube;
+use crate::render::color::{PlatformColorCube, PlatformPixel};
 use crate::render::frame::Frame;
 use crate::render::Pixel;
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
@@ -46,16 +46,50 @@ impl From<CellGridPackedFrame> for Scene {
     }
 }
 
+/// Compile the packed cell-grid program for the pixel format `P`, taking
+/// byte order from `P` itself — so the format the kernel packs for is the
+/// format the frame stores, by construction. Applications pass geometry and
+/// colors; they never see a shift.
+///
+/// Use [`compile_platform_cell_grid`] when the frame is the platform's own
+/// format, which is the production path.
+///
+/// # Panics
+///
+/// Panics for a `P` with no packed RGBA form ([`Pixel::packed_shifts`]
+/// returns `None`) — a grayscale or exotic format must render through the
+/// surface lane, and silently packing RGBA into it would be garbage.
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[must_use]
+pub fn compile_cell_grid_for<P: Pixel>(
+    geom: CellGridGeometry,
+    default_bg: [f32; 4],
+) -> CellGridPackedProgram {
+    let shifts = P::packed_shifts().unwrap_or_else(|| {
+        panic!(
+            "compile_cell_grid_for: {} has no packed RGBA form; render it \
+             through the surface lane instead",
+            core::any::type_name::<P>()
+        )
+    });
+    CellGridPackedProgram::compile(geom, default_bg, shifts)
+}
+
 /// Compile the packed cell-grid program with THIS platform's pixel byte
-/// order, taken from [`PlatformColorCube`] — the one home byte order has.
-/// Applications pass geometry and colors; they never see a shift.
+/// order — [`PlatformColorCube`] and [`PlatformPixel`] are the same choice,
+/// pinned to each other below.
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 #[must_use]
 pub fn compile_platform_cell_grid(
     geom: CellGridGeometry,
     default_bg: [f32; 4],
 ) -> CellGridPackedProgram {
-    CellGridPackedProgram::compile(geom, default_bg, PlatformColorCube::PACKED_SHIFTS)
+    debug_assert_eq!(
+        PlatformPixel::packed_shifts(),
+        Some(PlatformColorCube::PACKED_SHIFTS),
+        "the platform pixel and platform color cube must agree on byte order"
+    );
+    compile_cell_grid_for::<PlatformPixel>(geom, default_bg)
 }
 
 impl core::fmt::Debug for Scene {
@@ -100,6 +134,16 @@ fn render_cell_grid<P: Pixel + Send>(
     if width == 0 || height == 0 {
         return;
     }
+    // The kernel baked a packed word for the shifts it was compiled with;
+    // storing that word as a format with different byte order would swap R
+    // and B in every pixel. The old per-pixel `from_rgba` path converted, so
+    // any `P` worked; this path moves bits, so the formats must match.
+    assert_eq!(
+        P::packed_shifts(),
+        Some(grid.shifts()),
+        "cell-grid frame format does not match the shifts its kernel packed \
+         for — compile with `compile_cell_grid_for::<P>`"
+    );
     let workers = num_threads.max(1).min(height);
     let rows_per = height.div_ceil(workers);
     let mut bands: Vec<(usize, &mut [P])> = Vec::with_capacity(workers);
@@ -480,5 +524,82 @@ mod frame_bench {
             n as f64 / px as f64
         );
         println!("  speedup: {:.2}x", o as f64 / n as f64);
+    }
+}
+
+#[cfg(test)]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+mod pixel_format_tests {
+    use super::*;
+    use crate::render::color::{Bgra8, Rgba8};
+
+    /// The kernel packs for one byte order and the frame stores raw words,
+    /// so a mismatched frame format would swap R and B in every pixel. The
+    /// old per-pixel `from_rgba` path converted; this one must refuse.
+    #[test]
+    #[should_panic(expected = "does not match the shifts its kernel packed for")]
+    fn mismatched_frame_format_is_refused() {
+        let (aw, ah) = (12usize, 6usize);
+        let geom = CellGridGeometry {
+            cols: 2,
+            rows: 2,
+            cell_w: 4.0,
+            cell_h: 4.0,
+            density: 1.0,
+            atlas_width: aw as u32,
+            atlas_height: ah as u32,
+            tile_w: 4,
+            tile_h: 4,
+        };
+        // Compiled for Rgba8's lanes...
+        let program = compile_cell_grid_for::<Rgba8>(geom, [0.0, 0.0, 0.0, 1.0]);
+        let frame_data = program.frame(
+            Arc::new(vec![0.0f32; geom.cells_len()]),
+            Arc::new(vec![0.0f32; aw * ah]),
+        );
+        // ...rendered into a Bgra8 frame.
+        let mut frame = Frame::<Bgra8>::new(8, 8);
+        Scene::CellGrid(frame_data).render(&mut frame, 1);
+    }
+
+    /// Both packed formats work when the kernel is compiled for them.
+    #[test]
+    fn each_packed_format_renders_through_its_own_shifts() {
+        let (aw, ah) = (12usize, 6usize);
+        let geom = CellGridGeometry {
+            cols: 2,
+            rows: 2,
+            cell_w: 4.0,
+            cell_h: 4.0,
+            density: 1.0,
+            atlas_width: aw as u32,
+            atlas_height: ah as u32,
+            tile_w: 4,
+            tile_h: 4,
+        };
+        // Opaque red background everywhere: coverage is zero (empty atlas),
+        // so every in-grid pixel is its cell's background.
+        let mut cells = vec![0.0f32; geom.cells_len()];
+        for cell in cells.chunks_mut(pixelflow_core::CELL_STRIDE) {
+            cell[6] = 1.0; // bg_r
+            cell[9] = 1.0; // bg_a
+        }
+        let atlas = Arc::new(vec![0.0f32; aw * ah]);
+        let cells = Arc::new(cells);
+
+        let rgba = compile_cell_grid_for::<Rgba8>(geom, [1.0, 0.0, 0.0, 1.0])
+            .frame(cells.clone(), atlas.clone());
+        let mut rf = Frame::<Rgba8>::new(8, 8);
+        Scene::CellGrid(rgba).render(&mut rf, 1);
+
+        let bgra = compile_cell_grid_for::<Bgra8>(geom, [1.0, 0.0, 0.0, 1.0]).frame(cells, atlas);
+        let mut bf = Frame::<Bgra8>::new(8, 8);
+        Scene::CellGrid(bgra).render(&mut bf, 1);
+
+        // Same color through both formats: the raw words differ (byte order),
+        // the decoded channels agree.
+        assert_ne!(rf.data[0].0, bf.data[0].0, "byte orders must differ");
+        assert_eq!((rf.data[0].r(), rf.data[0].b()), (255, 0));
+        assert_eq!((bf.data[0].r(), bf.data[0].b()), (255, 0));
     }
 }

--- a/pixelflow-ir/src/arena.rs
+++ b/pixelflow-ir/src/arena.rs
@@ -25,6 +25,35 @@ pub struct ExprId(pub u32);
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, PartialOrd, Ord)]
 pub struct BufferId(pub u16);
 
+/// Which block of memory a declaration refers to, independent of any arena.
+///
+/// [`BufferId`] is a slot index into *one* arena's table, so it cannot answer
+/// "the same buffer?" across a merge — two fragments each call their own
+/// buffer slot 0. Extents cannot answer it either: two atlases of equal size
+/// are a coincidence, not a fact, and treating them as one would bind a single
+/// pointer for both and silently read the wrong pixels.
+///
+/// So identity is provenance. You get one by minting it, and copy it into
+/// every declaration that names that memory; nothing else can collide with it.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, PartialOrd, Ord)]
+pub struct BufferIdentity(u32);
+
+impl BufferIdentity {
+    /// Mint an identity distinct from every other in this process.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the counter is exhausted, rather than wrapping onto a live
+    /// identity and aliasing two unrelated buffers.
+    #[must_use]
+    pub fn mint() -> Self {
+        static NEXT: core::sync::atomic::AtomicU32 = core::sync::atomic::AtomicU32::new(0);
+        let id = NEXT.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+        assert!(id != u32::MAX, "BufferIdentity: counter exhausted");
+        Self(id)
+    }
+}
+
 /// Declaration of a bound memory buffer: the static shape of a collapsed
 /// lattice. The extents are part of the IR (like a `Const`) even though the
 /// contents are bound later, at JIT-compile time. Static extents are what
@@ -34,6 +63,10 @@ pub struct BufferId(pub u16);
 /// Layout is row-major with `stride == width`.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub struct BufferDecl {
+    /// Which memory this names. Two declarations of the same buffer must carry
+    /// the same identity — that is what lets a merge collapse them into one
+    /// slot instead of binding the pointer twice.
+    pub id: BufferIdentity,
     /// X extent (samples per row).
     pub width: u32,
     /// Y extent (number of rows).
@@ -734,13 +767,14 @@ impl ExprArena {
     /// variables directly (an identity contramap); warp it afterwards with
     /// [`ExprArena::substitute_vars_with`].
     ///
-    /// # Panics
-    ///
-    /// Panics if the fragment references bound memory (`Buffer` leaves) —
-    /// merging buffer tables is not supported yet, and no kernel surface can
-    /// produce buffers today.
+    /// Buffers the fragment reads are merged into this arena's table by
+    /// [`BufferIdentity`] and its `Buffer` leaves remapped, so a sampler
+    /// composes like anything else and reading the same memory from twenty
+    /// places still binds one pointer.
     pub fn splice(&mut self, other: &ExprArena, root: ExprId) -> ExprId {
         let mut id_map: Vec<Option<ExprId>> = vec![None; other.nodes.len()];
+        // Fragment-local BufferId -> this arena's slot, filled lazily.
+        let mut buf_map: Vec<Option<BufferId>> = vec![None; other.buffers.len()];
 
         enum Task {
             Descend(ExprId),
@@ -771,11 +805,29 @@ impl ExprArena {
                         ExprNode::Var(i) => self.push_var(i),
                         ExprNode::Const(v) => self.push_const(v),
                         ExprNode::Param(i) => self.push_param(i),
-                        ExprNode::Buffer(b) => panic!(
-                            "splice: fragment references Buffer({}) — buffer-table merging \
-                             is not supported",
-                            b.0
-                        ),
+                        ExprNode::Buffer(b) => {
+                            let slot = match buf_map[b.0 as usize] {
+                                Some(slot) => slot,
+                                None => {
+                                    let decl = other.buffers[b.0 as usize];
+                                    let slot =
+                                        match self.buffers.iter().position(|d| d.id == decl.id) {
+                                            Some(i) => {
+                                                assert_eq!(
+                                                    self.buffers[i], decl,
+                                                    "splice: two declarations share a \
+                                                 BufferIdentity but disagree on extents"
+                                                );
+                                                BufferId(i as u16)
+                                            }
+                                            None => self.declare_buffer(decl),
+                                        };
+                                    buf_map[b.0 as usize] = Some(slot);
+                                    slot
+                                }
+                            };
+                            self.push_buffer(slot)
+                        }
                         ExprNode::Unary(op, a) => {
                             let a = m(a);
                             self.push_unary(op, a)
@@ -1209,6 +1261,7 @@ mod tests {
     fn push_gather_should_create_node_when_valid() {
         let mut arena = ExprArena::new();
         let buf = arena.declare_buffer(BufferDecl {
+            id: crate::arena::BufferIdentity::mint(),
             width: 16,
             height: 8,
         });
@@ -1340,6 +1393,96 @@ mod composition_tests {
         // x, y, s, add = 4 nodes — not 6 (s duplicated).
         assert_eq!(host.nodes_raw().len() - before, 4);
         assert_eq!(eval(&host, spliced, &[3.0, 2.0, 0.0, 0.0]), 12.0);
+    }
+
+    #[test]
+    fn splice_merges_buffer_tables_keeping_reads_distinct() {
+        // Two donors that each call their own buffer slot 0. Merging must give
+        // two slots, and each gather must still read the buffer it was written
+        // against — remapping the id, not just renumbering it.
+        let mut donor_a = ExprArena::new();
+        let pa = donor_a.declare_buffer(BufferDecl {
+            id: crate::arena::BufferIdentity::mint(),
+            width: 2,
+            height: 1,
+        });
+        let (ax, ay) = (donor_a.push_var(0), donor_a.push_var(1));
+        let a_root = donor_a.push_gather(pa, ax, ay);
+
+        let mut donor_b = ExprArena::new();
+        let qb = donor_b.declare_buffer(BufferDecl {
+            id: crate::arena::BufferIdentity::mint(),
+            width: 2,
+            height: 1,
+        });
+        let (bx, by) = (donor_b.push_var(0), donor_b.push_var(1));
+        let b_root = donor_b.push_gather(qb, bx, by);
+
+        let mut host = ExprArena::new();
+        let sa = host.splice(&donor_a, a_root);
+        let sb = host.splice(&donor_b, b_root);
+        let root = host.push_binary(OpKind::Add, sa, sb);
+        assert_eq!(host.buffers().len(), 2, "two donors, two slots");
+
+        let (p, q) = ([10.0f32, 20.0], [3.0f32, 4.0]);
+        let binding = BindingTable::bind(&host, &[&p[..], &q[..]]).expect("bind");
+        assert_eq!(eval_scalar(&host, root, &[0.0; 4], &binding), 13.0);
+        assert_eq!(
+            eval_scalar(&host, root, &[1.0, 0.0, 0.0, 0.0], &binding),
+            24.0
+        );
+    }
+
+    #[test]
+    fn splice_gives_one_slot_to_a_buffer_read_twice() {
+        // Within a single splice, one buffer stays one slot however many times
+        // the fragment gathers from it. (Across separate splices it does not —
+        // that needs an identity outliving the arena-local BufferId.)
+        let mut donor = ExprArena::new();
+        let buf = donor.declare_buffer(BufferDecl {
+            id: crate::arena::BufferIdentity::mint(),
+            width: 2,
+            height: 1,
+        });
+        let (x, y) = (donor.push_var(0), donor.push_var(1));
+        let one = donor.push_const(1.0);
+        let x1 = donor.push_binary(OpKind::Add, x, one);
+        let g0 = donor.push_gather(buf, x, y);
+        let g1 = donor.push_gather(buf, x1, y);
+        let frag = donor.push_binary(OpKind::Add, g0, g1);
+
+        let mut host = ExprArena::new();
+        let root = host.splice(&donor, frag);
+        assert_eq!(host.buffers().len(), 1, "one buffer read twice, one slot");
+
+        let p = [5.0f32, 7.0];
+        let binding = BindingTable::bind(&host, &[&p[..]]).expect("bind");
+        assert_eq!(eval_scalar(&host, root, &[0.0; 4], &binding), 12.0);
+    }
+
+    #[test]
+    fn splicing_one_buffer_from_two_places_binds_it_once() {
+        // Separate splices, same memory: identity merges them. This is what
+        // lets a sampler be read from all over a kernel and still cost one
+        // binding — without it each use would want its own pointer.
+        let mut donor = ExprArena::new();
+        let buf = donor.declare_buffer(BufferDecl {
+            id: BufferIdentity::mint(),
+            width: 2,
+            height: 1,
+        });
+        let (x, y) = (donor.push_var(0), donor.push_var(1));
+        let frag = donor.push_gather(buf, x, y);
+
+        let mut host = ExprArena::new();
+        let first = host.splice(&donor, frag);
+        let second = host.splice(&donor, frag);
+        let root = host.push_binary(OpKind::Add, first, second);
+        assert_eq!(host.buffers().len(), 1, "one buffer, one slot");
+
+        let p = [5.0f32, 7.0];
+        let binding = BindingTable::bind(&host, &[&p[..]]).expect("bind");
+        assert_eq!(eval_scalar(&host, root, &[0.0; 4], &binding), 10.0);
     }
 
     #[test]

--- a/pixelflow-ir/src/arena.rs
+++ b/pixelflow-ir/src/arena.rs
@@ -48,8 +48,20 @@ impl BufferIdentity {
     #[must_use]
     pub fn mint() -> Self {
         static NEXT: core::sync::atomic::AtomicU32 = core::sync::atomic::AtomicU32::new(0);
-        let id = NEXT.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
-        assert!(id != u32::MAX, "BufferIdentity: counter exhausted");
+        // `fetch_add` + assert was wrong: the add WRAPS before the assert
+        // fires, so if that panic is ever caught — or merely unwinds a
+        // non-fatal worker thread — the counter has already returned to 0 and
+        // the next mint hands out an identity that is still live. Two
+        // unrelated buffers would then compare identical and merge into one
+        // splice/JIT slot. `fetch_update` declining to store leaves the
+        // counter permanently exhausted instead.
+        let id = NEXT
+            .fetch_update(
+                core::sync::atomic::Ordering::Relaxed,
+                core::sync::atomic::Ordering::Relaxed,
+                |n| n.checked_add(1),
+            )
+            .expect("BufferIdentity: counter exhausted");
         Self(id)
     }
 }

--- a/pixelflow-ir/src/dyadic.rs
+++ b/pixelflow-ir/src/dyadic.rs
@@ -128,37 +128,45 @@ impl Dyadic {
         let magnitude = self.mantissa.unsigned_abs();
         // floor(log2(value)): a k-bit magnitude scaled by 2^exp lies in
         // [2^(k-1+exp), 2^(k+exp)).
-        let unbiased = self.magnitude_bits() as i32 - 1 + self.exp;
+        //
+        // All exponent arithmetic here is i64. `normalize` legitimately
+        // accepts exp == i32::MAX (it only rejects an overflowing ADD), so
+        // every one of these steps — the binade, the target, the shift, and
+        // the bias below — can leave i32 for a value the type itself allows.
+        // Widening is cheaper than checking each one, and the results are
+        // clamped into f32's range regardless.
+        let exp_wide = i64::from(self.exp);
+        let unbiased = i64::from(self.magnitude_bits()) - 1 + exp_wide;
 
         // A normal result keeps 24 significand bits; below 2^-126 the
         // significand loses bits instead of the exponent falling further, so
         // the rounding position pins at 2^-149. Taking the max is what moves
         // the rounding point into the subnormal range — the case hand-rolled
         // conversions usually miss.
-        let target_exp =
-            core::cmp::max(unbiased - (F32_SIGNIFICAND_BITS - 1), F32_MIN_SUBNORMAL_EXP);
-        let shift = target_exp - self.exp;
+        let target_exp = core::cmp::max(
+            unbiased - i64::from(F32_SIGNIFICAND_BITS - 1),
+            i64::from(F32_MIN_SUBNORMAL_EXP),
+        );
+        let shift = target_exp - exp_wide;
 
         let mut significand: u128 = if shift <= 0 {
             // Widening: exact. In the normal branch `shift == bits - 24`, so a
             // negative shift means fewer than 24 bits and cannot overflow.
             magnitude << (-shift) as u32
+        } else if shift >= 128 {
+            // Everything is below the round bit. The magnitude is < 2^128
+            // ≤ 2·half, so it can only reach a tie at shift == 128 with a
+            // magnitude above 2^127.
+            u128::from(shift == 128 && magnitude > (1u128 << 127))
         } else {
             let drop = shift as u32;
-            if drop >= 128 {
-                // Everything is below the round bit. The magnitude is < 2^128
-                // = 2^(drop) ≤ 2·half, so it can only reach a tie when
-                // drop == 128 and magnitude > 2^127.
-                u128::from(drop == 128 && magnitude > (1u128 << 127))
-            } else {
-                let quotient = magnitude >> drop;
-                let dropped = magnitude & ((1u128 << drop) - 1);
-                let half = 1u128 << (drop - 1);
-                // Round-nearest, ties-to-even: up when past halfway, or
-                // exactly halfway with an odd quotient.
-                let round_up = dropped > half || (dropped == half && quotient & 1 == 1);
-                quotient + u128::from(round_up)
-            }
+            let quotient = magnitude >> drop;
+            let dropped = magnitude & ((1u128 << drop) - 1);
+            let half = 1u128 << (drop - 1);
+            // Round-nearest, ties-to-even: up when past halfway, or exactly
+            // halfway with an odd quotient.
+            let round_up = dropped > half || (dropped == half && quotient & 1 == 1);
+            quotient + u128::from(round_up)
         };
 
         // Rounding can carry the significand out of its binade (0xFF_FFFF + 1).
@@ -168,7 +176,7 @@ impl Dyadic {
             exp += 1;
         }
 
-        let biased = exp + F32_EXP_BIAS_TO_BIASED;
+        let biased = exp + i64::from(F32_EXP_BIAS_TO_BIASED);
         let magnitude_bits: u32 = if biased >= 0xFF {
             0x7F80_0000 // ±∞
         } else if significand >= 1 << (F32_SIGNIFICAND_BITS - 1) {

--- a/pixelflow-ir/src/dyadic.rs
+++ b/pixelflow-ir/src/dyadic.rs
@@ -83,24 +83,31 @@ impl Dyadic {
 
     /// Exact sum, or `None` if it would exceed the mantissa's width.
     ///
+    /// Named `checked_*` rather than implementing `core::ops::Add`: the
+    /// fallibility is load-bearing (declining past the cap is what keeps this
+    /// type from ever rounding), and an operator would have to return `Self`,
+    /// forcing an unwrap that reintroduces exactly the silent wrongness the
+    /// type exists to prevent. The prefix also states the fallibility at every
+    /// call site instead of in the docs.
+    ///
     /// Aligning exponents shifts one mantissa left, which can overflow. The
     /// check must happen BEFORE the shift: `checked_shl` only reports a
     /// shift amount ≥ bit width, never bits shifted off the top, so it does
     /// not detect this. Compare the shift against `leading_zeros()` instead.
     #[must_use]
-    pub fn add(self, _rhs: Self) -> Option<Self> {
+    pub fn checked_add(self, _rhs: Self) -> Option<Self> {
         todo!("A: align exponents (checked), integer add, normalize")
     }
 
-    /// Exact difference, or `None` past the mantissa's width. See [`Self::add`].
+    /// Exact difference, or `None` past the mantissa's width. See [`Self::checked_add`].
     #[must_use]
-    pub fn sub(self, _rhs: Self) -> Option<Self> {
+    pub fn checked_sub(self, _rhs: Self) -> Option<Self> {
         todo!("A")
     }
 
     /// Exact product, or `None` past the mantissa's width.
     #[must_use]
-    pub fn mul(self, _rhs: Self) -> Option<Self> {
+    pub fn checked_mul(self, _rhs: Self) -> Option<Self> {
         todo!("A: checked mantissa product, exponents add, normalize")
     }
 
@@ -126,7 +133,7 @@ impl Dyadic {
 
     /// Negation — always exact, never widens.
     #[must_use]
-    pub fn neg(self) -> Self {
+    pub fn negate(self) -> Self {
         todo!("A")
     }
 

--- a/pixelflow-ir/src/dyadic.rs
+++ b/pixelflow-ir/src/dyadic.rs
@@ -70,15 +70,20 @@ impl Dyadic {
     /// which `Eq`/`Hash` are defined. Without this, `2 × 2^0` and `1 × 2^1`
     /// would be distinct keys for one number and hash-consing would split
     /// e-classes that denote the same value.
-    fn normalize(mantissa: i128, exp: i32) -> Self {
+    /// `None` if the exponent would overflow `i32`. Reachable in O(log)
+    /// public operations — repeatedly squaring `2.0` walks the exponent up
+    /// exponentially — and an unchecked `exp + shift` would panic in debug or
+    /// wrap to a radically different value in release. Declining is the same
+    /// answer the mantissa cap gives.
+    fn normalize(mantissa: i128, exp: i32) -> Option<Self> {
         if mantissa == 0 {
-            return Self::ZERO;
+            return Some(Self::ZERO);
         }
         let shift = mantissa.trailing_zeros();
-        Self {
+        Some(Self {
             mantissa: mantissa >> shift,
-            exp: exp + shift as i32,
-        }
+            exp: exp.checked_add(shift as i32)?,
+        })
     }
 
     /// Number of significant bits in the magnitude (1 for `±1`).
@@ -110,7 +115,7 @@ impl Dyadic {
             (fraction | (1 << 23), biased - F32_EXP_BIAS_TO_BIASED)
         };
         let signed = if negative { -magnitude } else { magnitude };
-        Some(Self::normalize(signed, exp))
+        Self::normalize(signed, exp)
     }
 
     /// Round to the nearest `f32`, ties to even — exactly ONE rounding.
@@ -215,7 +220,7 @@ impl Dyadic {
         }
         let aligned = high.mantissa << shift as u32;
         let sum = low.mantissa.checked_add(aligned)?;
-        Some(Self::normalize(sum, low.exp))
+        Self::normalize(sum, low.exp)
     }
 
     /// Exact difference, or `None` past the mantissa's width. See [`Self::checked_add`].
@@ -232,7 +237,7 @@ impl Dyadic {
         }
         let mantissa = self.mantissa.checked_mul(rhs.mantissa)?;
         let exp = self.exp.checked_add(rhs.exp)?;
-        Some(Self::normalize(mantissa, exp))
+        Self::normalize(mantissa, exp)
     }
 
     /// Quotient, but ONLY when it is exactly representable as a dyadic.
@@ -254,7 +259,7 @@ impl Dyadic {
             return None;
         }
         let exp = self.exp.checked_sub(rhs.exp)?;
-        Some(Self::normalize(self.mantissa / rhs.mantissa, exp))
+        Self::normalize(self.mantissa / rhs.mantissa, exp)
     }
 
     /// Square root, but ONLY when exact.
@@ -277,7 +282,7 @@ impl Dyadic {
             return None;
         }
         let root = exact_isqrt(self.mantissa.unsigned_abs())?;
-        Some(Self::normalize(root as i128, self.exp / 2))
+        Self::normalize(root as i128, self.exp / 2)
     }
 
     /// Negation — always exact, never widens.

--- a/pixelflow-ir/src/dyadic.rs
+++ b/pixelflow-ir/src/dyadic.rs
@@ -1,0 +1,162 @@
+//! Exact dyadic rationals: `mantissa × 2^exp` with an integer mantissa.
+//!
+//! Every finite `f32` IS a dyadic rational, so this type represents them all
+//! exactly — and, unlike any fixed-width float, `+ − ×` over dyadics never
+//! round: the mantissa grows instead.
+//!
+//! # Why exactness, rather than more precision
+//!
+//! The e-graph's equality relation must hold only ℝ-true facts. Constant
+//! folding in `f32` computes f32-truths (`x + 2²⁴ = 2²⁴`) while the algebraic
+//! rewrites compute ℝ-truths (`(x+y) − y = x`); each is sound alone, but at an
+//! ill-conditioned input their conjunction puts two UNEQUAL constants in one
+//! e-class, and congruence closure amplifies that into everything-equals-
+//! everything. A wider float (f64, f128) moves the trigger further out but
+//! keeps it reachable, so the refusal valve stays load-bearing forever. Exact
+//! arithmetic makes the contradiction *unconstructible*.
+//!
+//! # The cap, and why declining is the point
+//!
+//! The mantissa is an `i128`, so precision is finite in practice. When an
+//! operation would exceed it, the operation returns `None` — it does NOT
+//! round. That distinction is the whole design: a float silently rounds at
+//! its boundary (and can therefore contradict the algebra), while this
+//! declines and leaves the value symbolic, which is sound. Loud abstention
+//! instead of a quiet wrong answer.
+//!
+//! # Signed zero
+//!
+//! Dyadics have one zero; `from_f32(-0.0)` and `from_f32(0.0)` both give
+//! [`Dyadic::ZERO`], and `to_f32` returns `+0.0`. Callers must therefore not
+//! fold through this domain when a result *depends* on zero's sign. In
+//! practice that is already handled: `Recip`/`Rsqrt` are refused by
+//! `OpKind::fold_is_platform_specific`, and `try_div` refuses a zero divisor
+//! (`±inf` is not a dyadic rational, so there is nothing to return).
+
+/// A dyadic rational `mantissa × 2^exp`, normalized.
+///
+/// The normal form is: `mantissa` odd, or the value is exactly
+/// [`Dyadic::ZERO`] (`mantissa == 0 && exp == 0`). Normalization is what makes
+/// `Eq`/`Ord`/`Hash` agree with mathematical equality, so every constructor
+/// and operation must return a normalized value — two dyadics denoting the
+/// same number must have identical fields.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub struct Dyadic {
+    /// Signed significand. Odd in normal form (or zero).
+    mantissa: i128,
+    /// Power-of-two scale.
+    exp: i32,
+}
+
+impl Dyadic {
+    /// The additive identity, and the sole representation of zero.
+    pub const ZERO: Self = Self {
+        mantissa: 0,
+        exp: 0,
+    };
+
+    /// Exact conversion from `f32`.
+    ///
+    /// `None` for NaN and ±∞, which are not dyadic rationals — callers route
+    /// those through the bit domain instead. `±0.0` both map to
+    /// [`Dyadic::ZERO`] (see the module docs on signed zero).
+    ///
+    /// Must handle subnormals: they carry no implicit leading 1, so decoding
+    /// them as if they did is wrong by a factor of two and misplaces the
+    /// exponent.
+    #[must_use]
+    pub fn from_f32(_value: f32) -> Option<Self> {
+        todo!("A: exact IEEE-754 binary32 decode, including subnormals")
+    }
+
+    /// Round to the nearest `f32`, ties to even — exactly ONE rounding.
+    ///
+    /// This is the delicate one. Correct behavior requires a round bit AND a
+    /// sticky bit (is anything nonzero below the round bit?), carry
+    /// propagation when rounding overflows the significand into the next
+    /// binade, the subnormal boundary (fewer than 24 bits of significand
+    /// available, so the rounding position moves), and overflow to ±∞.
+    #[must_use]
+    pub fn to_f32(self) -> f32 {
+        todo!("A: correctly-rounded binary32 encode (RNE, subnormals, overflow)")
+    }
+
+    /// Exact sum, or `None` if it would exceed the mantissa's width.
+    ///
+    /// Aligning exponents shifts one mantissa left, which can overflow. The
+    /// check must happen BEFORE the shift: `checked_shl` only reports a
+    /// shift amount ≥ bit width, never bits shifted off the top, so it does
+    /// not detect this. Compare the shift against `leading_zeros()` instead.
+    #[must_use]
+    pub fn add(self, _rhs: Self) -> Option<Self> {
+        todo!("A: align exponents (checked), integer add, normalize")
+    }
+
+    /// Exact difference, or `None` past the mantissa's width. See [`Self::add`].
+    #[must_use]
+    pub fn sub(self, _rhs: Self) -> Option<Self> {
+        todo!("A")
+    }
+
+    /// Exact product, or `None` past the mantissa's width.
+    #[must_use]
+    pub fn mul(self, _rhs: Self) -> Option<Self> {
+        todo!("A: checked mantissa product, exponents add, normalize")
+    }
+
+    /// Quotient, but ONLY when it is exactly representable as a dyadic.
+    ///
+    /// Division does not close over dyadic rationals (`1/3`), so this returns
+    /// `Some` only when the result multiplies back exactly. `None` for a zero
+    /// divisor.
+    #[must_use]
+    pub fn try_div(self, _rhs: Self) -> Option<Self> {
+        todo!("A: exact-only division")
+    }
+
+    /// Square root, but ONLY when exact.
+    ///
+    /// Like division, `sqrt` does not close (`√2`). Exact requires both an
+    /// even exponent (after normalization adjustment) and a perfect-square
+    /// mantissa. `None` for a negative value.
+    #[must_use]
+    pub fn try_sqrt(self) -> Option<Self> {
+        todo!("A: exact-only integer sqrt")
+    }
+
+    /// Negation — always exact, never widens.
+    #[must_use]
+    pub fn neg(self) -> Self {
+        todo!("A")
+    }
+
+    /// Absolute value — always exact, never widens.
+    #[must_use]
+    pub fn abs(self) -> Self {
+        todo!("A")
+    }
+
+    /// Whether this is [`Dyadic::ZERO`].
+    #[must_use]
+    pub fn is_zero(self) -> bool {
+        todo!("A")
+    }
+}
+
+impl PartialOrd for Dyadic {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Dyadic {
+    /// Total order by mathematical value.
+    ///
+    /// NOT lexicographic on the fields: `1 × 2^1` and `1 × 2^0` compare by
+    /// value, not by mantissa first. Comparing requires aligning exponents,
+    /// which can exceed the width — fall back to comparing signs and
+    /// magnitude-by-exponent rather than returning a wrong answer.
+    fn cmp(&self, _other: &Self) -> core::cmp::Ordering {
+        todo!("A: value ordering, overflow-safe")
+    }
+}

--- a/pixelflow-ir/src/dyadic.rs
+++ b/pixelflow-ir/src/dyadic.rs
@@ -33,6 +33,17 @@
 //! `OpKind::fold_is_platform_specific`, and `try_div` refuses a zero divisor
 //! (`±inf` is not a dyadic rational, so there is nothing to return).
 
+use core::cmp::Ordering;
+
+/// binary32 significand width, including the implicit leading bit.
+const F32_SIGNIFICAND_BITS: i32 = 24;
+/// Exponent of the least significant bit of the smallest subnormal, `2^-149`.
+const F32_MIN_SUBNORMAL_EXP: i32 = -149;
+/// `exp + F32_EXP_BIAS_TO_BIASED` converts a significand exponent into the
+/// stored biased exponent: `+127` for the IEEE bias, `+23` because the stored
+/// significand is scaled by `2^23`.
+const F32_EXP_BIAS_TO_BIASED: i32 = 150;
+
 /// A dyadic rational `mantissa × 2^exp`, normalized.
 ///
 /// The normal form is: `mantissa` odd, or the value is exactly
@@ -55,30 +66,120 @@ impl Dyadic {
         exp: 0,
     };
 
+    /// Strip trailing zero bits so the mantissa is odd — the normal form on
+    /// which `Eq`/`Hash` are defined. Without this, `2 × 2^0` and `1 × 2^1`
+    /// would be distinct keys for one number and hash-consing would split
+    /// e-classes that denote the same value.
+    fn normalize(mantissa: i128, exp: i32) -> Self {
+        if mantissa == 0 {
+            return Self::ZERO;
+        }
+        let shift = mantissa.trailing_zeros();
+        Self {
+            mantissa: mantissa >> shift,
+            exp: exp + shift as i32,
+        }
+    }
+
+    /// Number of significant bits in the magnitude (1 for `±1`).
+    fn magnitude_bits(self) -> u32 {
+        128 - self.mantissa.unsigned_abs().leading_zeros()
+    }
+
     /// Exact conversion from `f32`.
     ///
     /// `None` for NaN and ±∞, which are not dyadic rationals — callers route
     /// those through the bit domain instead. `±0.0` both map to
     /// [`Dyadic::ZERO`] (see the module docs on signed zero).
-    ///
-    /// Must handle subnormals: they carry no implicit leading 1, so decoding
-    /// them as if they did is wrong by a factor of two and misplaces the
-    /// exponent.
     #[must_use]
-    pub fn from_f32(_value: f32) -> Option<Self> {
-        todo!("A: exact IEEE-754 binary32 decode, including subnormals")
+    pub fn from_f32(value: f32) -> Option<Self> {
+        if !value.is_finite() {
+            return None;
+        }
+        let bits = value.to_bits();
+        let negative = bits >> 31 == 1;
+        let biased = ((bits >> 23) & 0xFF) as i32;
+        let fraction = i128::from(bits & 0x007F_FFFF);
+
+        // Subnormals carry NO implicit leading 1 and are all scaled by the
+        // same 2^-149; decoding them as if they had the implicit bit is wrong
+        // by a factor of two AND misplaces the exponent.
+        let (magnitude, exp) = if biased == 0 {
+            (fraction, F32_MIN_SUBNORMAL_EXP)
+        } else {
+            (fraction | (1 << 23), biased - F32_EXP_BIAS_TO_BIASED)
+        };
+        let signed = if negative { -magnitude } else { magnitude };
+        Some(Self::normalize(signed, exp))
     }
 
     /// Round to the nearest `f32`, ties to even — exactly ONE rounding.
-    ///
-    /// This is the delicate one. Correct behavior requires a round bit AND a
-    /// sticky bit (is anything nonzero below the round bit?), carry
-    /// propagation when rounding overflows the significand into the next
-    /// binade, the subnormal boundary (fewer than 24 bits of significand
-    /// available, so the rounding position moves), and overflow to ±∞.
     #[must_use]
     pub fn to_f32(self) -> f32 {
-        todo!("A: correctly-rounded binary32 encode (RNE, subnormals, overflow)")
+        if self.mantissa == 0 {
+            return 0.0;
+        }
+        let negative = self.mantissa < 0;
+        let magnitude = self.mantissa.unsigned_abs();
+        // floor(log2(value)): a k-bit magnitude scaled by 2^exp lies in
+        // [2^(k-1+exp), 2^(k+exp)).
+        let unbiased = self.magnitude_bits() as i32 - 1 + self.exp;
+
+        // A normal result keeps 24 significand bits; below 2^-126 the
+        // significand loses bits instead of the exponent falling further, so
+        // the rounding position pins at 2^-149. Taking the max is what moves
+        // the rounding point into the subnormal range — the case hand-rolled
+        // conversions usually miss.
+        let target_exp =
+            core::cmp::max(unbiased - (F32_SIGNIFICAND_BITS - 1), F32_MIN_SUBNORMAL_EXP);
+        let shift = target_exp - self.exp;
+
+        let mut significand: u128 = if shift <= 0 {
+            // Widening: exact. In the normal branch `shift == bits - 24`, so a
+            // negative shift means fewer than 24 bits and cannot overflow.
+            magnitude << (-shift) as u32
+        } else {
+            let drop = shift as u32;
+            if drop >= 128 {
+                // Everything is below the round bit. The magnitude is < 2^128
+                // = 2^(drop) ≤ 2·half, so it can only reach a tie when
+                // drop == 128 and magnitude > 2^127.
+                u128::from(drop == 128 && magnitude > (1u128 << 127))
+            } else {
+                let quotient = magnitude >> drop;
+                let dropped = magnitude & ((1u128 << drop) - 1);
+                let half = 1u128 << (drop - 1);
+                // Round-nearest, ties-to-even: up when past halfway, or
+                // exactly halfway with an odd quotient.
+                let round_up = dropped > half || (dropped == half && quotient & 1 == 1);
+                quotient + u128::from(round_up)
+            }
+        };
+
+        // Rounding can carry the significand out of its binade (0xFF_FFFF + 1).
+        let mut exp = target_exp;
+        if significand >= 1 << F32_SIGNIFICAND_BITS {
+            significand >>= 1;
+            exp += 1;
+        }
+
+        let biased = exp + F32_EXP_BIAS_TO_BIASED;
+        let magnitude_bits: u32 = if biased >= 0xFF {
+            0x7F80_0000 // ±∞
+        } else if significand >= 1 << (F32_SIGNIFICAND_BITS - 1) {
+            // Normal: the leading bit is implicit. A subnormal that rounded up
+            // to 2^23 lands here with biased == 1 — exactly the smallest
+            // normal, which is the correct answer.
+            ((biased as u32) << 23) | (significand as u32 - (1 << 23))
+        } else {
+            // Subnormal: the significand IS the stored fraction.
+            significand as u32
+        };
+        f32::from_bits(if negative {
+            magnitude_bits | 0x8000_0000
+        } else {
+            magnitude_bits
+        })
     }
 
     /// Exact sum, or `None` if it would exceed the mantissa's width.
@@ -89,69 +190,146 @@ impl Dyadic {
     /// forcing an unwrap that reintroduces exactly the silent wrongness the
     /// type exists to prevent. The prefix also states the fallibility at every
     /// call site instead of in the docs.
-    ///
-    /// Aligning exponents shifts one mantissa left, which can overflow. The
-    /// check must happen BEFORE the shift: `checked_shl` only reports a
-    /// shift amount ≥ bit width, never bits shifted off the top, so it does
-    /// not detect this. Compare the shift against `leading_zeros()` instead.
     #[must_use]
-    pub fn checked_add(self, _rhs: Self) -> Option<Self> {
-        todo!("A: align exponents (checked), integer add, normalize")
+    pub fn checked_add(self, rhs: Self) -> Option<Self> {
+        if self.mantissa == 0 {
+            return Some(rhs);
+        }
+        if rhs.mantissa == 0 {
+            return Some(self);
+        }
+        let (low, high) = if self.exp <= rhs.exp {
+            (self, rhs)
+        } else {
+            (rhs, self)
+        };
+        let shift = high.exp.checked_sub(low.exp)?;
+
+        // The check must precede the shift. `checked_shl` reports only a
+        // shift amount ≥ bit width, NEVER bits shifted off the top, so it
+        // cannot detect this — and a silently truncated mantissa is precisely
+        // the rounding this type exists to refuse. `i128` has 127 magnitude
+        // bits available beside the sign.
+        if shift < 0 || high.magnitude_bits() as i32 + shift > 127 {
+            return None;
+        }
+        let aligned = high.mantissa << shift as u32;
+        let sum = low.mantissa.checked_add(aligned)?;
+        Some(Self::normalize(sum, low.exp))
     }
 
     /// Exact difference, or `None` past the mantissa's width. See [`Self::checked_add`].
     #[must_use]
-    pub fn checked_sub(self, _rhs: Self) -> Option<Self> {
-        todo!("A")
+    pub fn checked_sub(self, rhs: Self) -> Option<Self> {
+        self.checked_add(rhs.negate())
     }
 
     /// Exact product, or `None` past the mantissa's width.
     #[must_use]
-    pub fn checked_mul(self, _rhs: Self) -> Option<Self> {
-        todo!("A: checked mantissa product, exponents add, normalize")
+    pub fn checked_mul(self, rhs: Self) -> Option<Self> {
+        if self.mantissa == 0 || rhs.mantissa == 0 {
+            return Some(Self::ZERO);
+        }
+        let mantissa = self.mantissa.checked_mul(rhs.mantissa)?;
+        let exp = self.exp.checked_add(rhs.exp)?;
+        Some(Self::normalize(mantissa, exp))
     }
 
     /// Quotient, but ONLY when it is exactly representable as a dyadic.
     ///
     /// Division does not close over dyadic rationals (`1/3`), so this returns
-    /// `Some` only when the result multiplies back exactly. `None` for a zero
-    /// divisor.
+    /// `Some` only when the result is exact. Both mantissas are odd in normal
+    /// form, and an odd divisor shares no factor with the `2^exp` scale, so
+    /// exactness reduces to the divisor's mantissa dividing evenly. `None`
+    /// for a zero divisor — `±∞` is not a dyadic rational.
     #[must_use]
-    pub fn try_div(self, _rhs: Self) -> Option<Self> {
-        todo!("A: exact-only division")
+    pub fn try_div(self, rhs: Self) -> Option<Self> {
+        if rhs.mantissa == 0 {
+            return None;
+        }
+        if self.mantissa == 0 {
+            return Some(Self::ZERO);
+        }
+        if self.mantissa % rhs.mantissa != 0 {
+            return None;
+        }
+        let exp = self.exp.checked_sub(rhs.exp)?;
+        Some(Self::normalize(self.mantissa / rhs.mantissa, exp))
     }
 
     /// Square root, but ONLY when exact.
     ///
-    /// Like division, `sqrt` does not close (`√2`). Exact requires both an
-    /// even exponent (after normalization adjustment) and a perfect-square
-    /// mantissa. `None` for a negative value.
+    /// Like division, `sqrt` does not close (`√2`). Requires an even exponent
+    /// and a perfect-square mantissa. An ODD exponent can never be exact: the
+    /// only way to make it even is to borrow a factor of two into the
+    /// mantissa, and a normalized mantissa is odd, so the result would carry
+    /// exactly one factor of two — never a perfect square. `None` for a
+    /// negative value.
     #[must_use]
     pub fn try_sqrt(self) -> Option<Self> {
-        todo!("A: exact-only integer sqrt")
+        if self.mantissa < 0 {
+            return None;
+        }
+        if self.mantissa == 0 {
+            return Some(Self::ZERO);
+        }
+        if self.exp % 2 != 0 {
+            return None;
+        }
+        let root = exact_isqrt(self.mantissa.unsigned_abs())?;
+        Some(Self::normalize(root as i128, self.exp / 2))
     }
 
     /// Negation — always exact, never widens.
+    ///
+    /// A normalized mantissa is odd or zero, and `i128::MIN` is even, so the
+    /// negation can never overflow.
     #[must_use]
     pub fn negate(self) -> Self {
-        todo!("A")
+        Self {
+            mantissa: -self.mantissa,
+            exp: self.exp,
+        }
     }
 
     /// Absolute value — always exact, never widens.
     #[must_use]
     pub fn abs(self) -> Self {
-        todo!("A")
+        Self {
+            mantissa: self.mantissa.abs(),
+            exp: self.exp,
+        }
     }
 
     /// Whether this is [`Dyadic::ZERO`].
     #[must_use]
     pub fn is_zero(self) -> bool {
-        todo!("A")
+        self.mantissa == 0
     }
 }
 
+/// Integer square root, `Some` only when `n` is a perfect square.
+///
+/// Newton descending from a power-of-two overestimate: the iterate decreases
+/// monotonically to `floor(sqrt(n))`, so the first non-decrease terminates it.
+/// The final multiply is checked because `x·x` can reach `2^128` exactly.
+fn exact_isqrt(n: u128) -> Option<u128> {
+    if n < 2 {
+        return Some(n);
+    }
+    let mut x = 1u128 << (128 - n.leading_zeros()).div_ceil(2);
+    loop {
+        let next = (x + n / x) / 2;
+        if next >= x {
+            break;
+        }
+        x = next;
+    }
+    (x.checked_mul(x)? == n).then_some(x)
+}
+
 impl PartialOrd for Dyadic {
-    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
@@ -160,10 +338,38 @@ impl Ord for Dyadic {
     /// Total order by mathematical value.
     ///
     /// NOT lexicographic on the fields: `1 × 2^1` and `1 × 2^0` compare by
-    /// value, not by mantissa first. Comparing requires aligning exponents,
-    /// which can exceed the width — fall back to comparing signs and
-    /// magnitude-by-exponent rather than returning a wrong answer.
-    fn cmp(&self, _other: &Self) -> core::cmp::Ordering {
-        todo!("A: value ordering, overflow-safe")
+    /// value. Magnitudes are separated first by binade (`bits + exp` brackets
+    /// `floor(log2)`), which is overflow-free; only a binade tie needs an
+    /// alignment, and a tie forces the shift to equal the bit-length
+    /// difference, so that alignment always fits.
+    fn cmp(&self, other: &Self) -> Ordering {
+        let (sign_a, sign_b) = (self.mantissa.signum(), other.mantissa.signum());
+        if sign_a != sign_b {
+            return sign_a.cmp(&sign_b);
+        }
+        if sign_a == 0 {
+            return Ordering::Equal;
+        }
+
+        let binade_a = i64::from(self.magnitude_bits()) + i64::from(self.exp);
+        let binade_b = i64::from(other.magnitude_bits()) + i64::from(other.exp);
+        let magnitude_order = if binade_a != binade_b {
+            binade_a.cmp(&binade_b)
+        } else if self.exp <= other.exp {
+            let shift = (other.exp - self.exp) as u32;
+            self.mantissa
+                .unsigned_abs()
+                .cmp(&(other.mantissa.unsigned_abs() << shift))
+        } else {
+            let shift = (self.exp - other.exp) as u32;
+            (self.mantissa.unsigned_abs() << shift).cmp(&other.mantissa.unsigned_abs())
+        };
+
+        // More negative is smaller.
+        if sign_a < 0 {
+            magnitude_order.reverse()
+        } else {
+            magnitude_order
+        }
     }
 }

--- a/pixelflow-ir/src/eval.rs
+++ b/pixelflow-ir/src/eval.rs
@@ -246,6 +246,7 @@ mod tests {
 
         let mut arena = ExprArena::new();
         let b = arena.declare_buffer(BufferDecl {
+            id: crate::arena::BufferIdentity::mint(),
             width: width as u32,
             height: height as u32,
         });
@@ -284,6 +285,7 @@ mod tests {
 
         let mut arena = ExprArena::new();
         let b = arena.declare_buffer(BufferDecl {
+            id: crate::arena::BufferIdentity::mint(),
             width: width as u32,
             height: height as u32,
         });
@@ -342,6 +344,7 @@ mod tests {
         let buf = vec![5.0f32, 6.0, 7.0, 8.0];
         let mut arena = ExprArena::new();
         let b = arena.declare_buffer(BufferDecl {
+            id: crate::arena::BufferIdentity::mint(),
             width: 4,
             height: 1,
         });
@@ -431,10 +434,12 @@ mod tests {
         let inp = alloc::vec![10.0f32, 20.0, 30.0];
         let mut arena = ExprArena::new();
         let wb = arena.declare_buffer(BufferDecl {
+            id: crate::arena::BufferIdentity::mint(),
             width: 3,
             height: 1,
         });
         let ib = arena.declare_buffer(BufferDecl {
+            id: crate::arena::BufferIdentity::mint(),
             width: 3,
             height: 1,
         });
@@ -454,6 +459,7 @@ mod tests {
     fn bind_rejects_wrong_length() {
         let mut arena = ExprArena::new();
         let _ = arena.declare_buffer(BufferDecl {
+            id: crate::arena::BufferIdentity::mint(),
             width: 4,
             height: 2,
         });
@@ -473,6 +479,7 @@ mod tests {
     fn bind_rejects_wrong_count() {
         let mut arena = ExprArena::new();
         let _ = arena.declare_buffer(BufferDecl {
+            id: crate::arena::BufferIdentity::mint(),
             width: 2,
             height: 2,
         });

--- a/pixelflow-ir/src/kernel.rs
+++ b/pixelflow-ir/src/kernel.rs
@@ -424,34 +424,18 @@ impl Kernel {
 
     // ─────────────────────────── int domain ───────────────────────
 
-    /// Truncate toward zero to a lane-wide `i32` (`cvttps2dq` / `fcvtzs`).
+    /// Truncate toward zero to a lane-wide `i32`, entering the BIT domain
+    /// (`cvttps2dq` / `fcvtzs`).
     ///
-    /// The result is a BIT PATTERN, not a number — the same discipline as a
-    /// comparison mask. It may only flow into the bitwise domain
-    /// ([`Kernel::shl`], [`Kernel::or`], [`Kernel::and`]) or a raw store;
-    /// float arithmetic on it is meaningless.
+    /// Returns [`Bits`], not `Kernel`, because the result is a bit pattern
+    /// rather than a number: multiplying it by `2.0` is meaningless, and with
+    /// one shared type that mistake compiles and yields plausible pixels. The
+    /// type is the enforcement — see "Denote before you build" in CLAUDE.md.
     #[must_use]
-    pub fn trunc_to_int(&self) -> Self {
-        self.map(OpKind::TruncToInt)
-    }
-
-    /// `self << bits` — a logical shift of the lane's bit pattern
-    /// (int domain: operand and result are bit patterns, see
-    /// [`Kernel::trunc_to_int`]).
-    ///
-    /// The count is pushed as a `Const` operand, which the emitter folds into
-    /// the hardware shift immediate; a dynamic count is not representable.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `bits >= 32` — a 32-bit lane has no bits there.
-    #[must_use]
-    pub fn shl(&self, bits: u32) -> Self {
-        assert!(bits < 32, "Kernel::shl: shift of {bits} on a 32-bit lane");
-        let mut arena = self.inner.arena.clone();
-        let count = arena.push_const(bits as f32);
-        let root = arena.push_binary(OpKind::Shl, self.inner.root, count);
-        Self::wrap(arena, root)
+    pub fn trunc_to_int(&self) -> Bits {
+        Bits {
+            inner: self.map(OpKind::TruncToInt),
+        }
     }
 
     // ─────────────────────────── control ──────────────────────────
@@ -638,6 +622,72 @@ impl Kernel {
     }
 }
 
+/// A kernel whose lanes are BIT PATTERNS rather than numbers — the discrete
+/// half of the language, entered by [`Kernel::trunc_to_int`].
+///
+/// [`Kernel`] carries continuous values; `Bits` carries the integer/bitwise
+/// domain. Keeping them apart is load-bearing rather than tidy: with a single
+/// type, `Kernel::x().shl(8)` shifts an IEEE-754 *representation* and
+/// `trunc_to_int().mul(2.0)` does float arithmetic on an `i32` bit pattern.
+/// Both compile, neither is meaningful, and both produce plausible-looking
+/// output — the worst failure mode there is. Only the operations that are
+/// meaningful on bit patterns exist here.
+///
+/// This types the *conversion* boundary. Comparison masks are also bit
+/// patterns and still travel as `Kernel` — typing those too is the general
+/// case, tracked separately.
+#[derive(Clone)]
+pub struct Bits {
+    inner: Kernel,
+}
+
+impl Bits {
+    /// `self << bits` — a logical shift of the lane's bit pattern.
+    ///
+    /// The count is pushed as a `Const` operand, which the emitter folds into
+    /// the hardware shift immediate.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `bits >= 32` — a 32-bit lane has no bits there.
+    #[must_use]
+    pub fn shl(&self, bits: u32) -> Self {
+        assert!(bits < 32, "Bits::shl: shift of {bits} on a 32-bit lane");
+        let mut arena = self.inner.inner.arena.clone();
+        let count = arena.push_const(bits as f32);
+        let root = arena.push_binary(OpKind::Shl, self.inner.inner.root, count);
+        Self {
+            inner: Kernel::wrap(arena, root),
+        }
+    }
+
+    /// Bitwise OR of two lane patterns.
+    #[must_use]
+    pub fn or(&self, rhs: &Self) -> Self {
+        Self {
+            inner: self.inner.or(&rhs.inner),
+        }
+    }
+
+    /// Bitwise AND of two lane patterns.
+    #[must_use]
+    pub fn and(&self, rhs: &Self) -> Self {
+        Self {
+            inner: self.inner.and(&rhs.inner),
+        }
+    }
+
+    /// Reinterpret as a [`Kernel`] for storage or as a kernel root.
+    ///
+    /// The lanes still hold a bit pattern; this is the deliberate, named exit
+    /// from the bit domain, taken when the pattern IS the output (a packed
+    /// pixel written to a frame buffer).
+    #[must_use]
+    pub fn into_kernel(self) -> Kernel {
+        self.inner
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -704,14 +754,17 @@ mod tests {
         // OR-folded. 3.7 truncates toward zero to 3; 3 << 8 | 2 = 0x0302.
         let lo = Kernel::x().trunc_to_int();
         let hi = Kernel::y().trunc_to_int().shl(8);
-        let packed = hi.or(&lo);
+        let packed = hi.or(&lo).into_kernel();
         assert_eq!(eval(&packed, 2.9, 3.7).to_bits(), 0x0302);
     }
 
+    /// The count is still checked at runtime; the OPERAND no longer needs
+    /// checking, because `Kernel::x().shl(32)` does not compile at all now —
+    /// `shl` exists only on [`Bits`], which only `trunc_to_int` produces.
     #[test]
     #[should_panic(expected = "32-bit lane")]
     fn shl_past_the_lane_is_refused() {
-        let _refused = Kernel::x().shl(32);
+        let _refused = Kernel::x().trunc_to_int().shl(32);
     }
 
     #[test]

--- a/pixelflow-ir/src/kernel.rs
+++ b/pixelflow-ir/src/kernel.rs
@@ -422,6 +422,38 @@ impl Kernel {
         self.combine(rhs, OpKind::BitOr)
     }
 
+    // ─────────────────────────── int domain ───────────────────────
+
+    /// Truncate toward zero to a lane-wide `i32` (`cvttps2dq` / `fcvtzs`).
+    ///
+    /// The result is a BIT PATTERN, not a number — the same discipline as a
+    /// comparison mask. It may only flow into the bitwise domain
+    /// ([`Kernel::shl`], [`Kernel::or`], [`Kernel::and`]) or a raw store;
+    /// float arithmetic on it is meaningless.
+    #[must_use]
+    pub fn trunc_to_int(&self) -> Self {
+        self.map(OpKind::TruncToInt)
+    }
+
+    /// `self << bits` — a logical shift of the lane's bit pattern
+    /// (int domain: operand and result are bit patterns, see
+    /// [`Kernel::trunc_to_int`]).
+    ///
+    /// The count is pushed as a `Const` operand, which the emitter folds into
+    /// the hardware shift immediate; a dynamic count is not representable.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `bits >= 32` — a 32-bit lane has no bits there.
+    #[must_use]
+    pub fn shl(&self, bits: u32) -> Self {
+        assert!(bits < 32, "Kernel::shl: shift of {bits} on a 32-bit lane");
+        let mut arena = self.inner.arena.clone();
+        let count = arena.push_const(bits as f32);
+        let root = arena.push_binary(OpKind::Shl, self.inner.root, count);
+        Self::wrap(arena, root)
+    }
+
     // ─────────────────────────── control ──────────────────────────
 
     /// `self ? if_true : if_false` — `self` is the mask.
@@ -664,6 +696,22 @@ mod tests {
             &Kernel::w(),
         );
         assert_eq!(eval(&warped, 3.0, 4.0), 4.0 * 8.0);
+    }
+
+    #[test]
+    fn trunc_shl_or_pack_a_byte_lane() {
+        // The packing idiom: clamp-truncated bytes shifted to their lanes and
+        // OR-folded. 3.7 truncates toward zero to 3; 3 << 8 | 2 = 0x0302.
+        let lo = Kernel::x().trunc_to_int();
+        let hi = Kernel::y().trunc_to_int().shl(8);
+        let packed = hi.or(&lo);
+        assert_eq!(eval(&packed, 2.9, 3.7).to_bits(), 0x0302);
+    }
+
+    #[test]
+    #[should_panic(expected = "32-bit lane")]
+    fn shl_past_the_lane_is_refused() {
+        let _refused = Kernel::x().shl(32);
     }
 
     #[test]

--- a/pixelflow-ir/src/kind.rs
+++ b/pixelflow-ir/src/kind.rs
@@ -218,6 +218,26 @@ impl OpKind {
             // no host whose answer is worth baking. Unconditional: an estimate
             // is only guaranteed close, never equal, so no argument is safe.
             Self::Recip | Self::Rsqrt => true,
+            // An INVALID float->int conversion — non-finite, or outside i32 —
+            // has three different answers. x86 `cvttps2dq` yields the
+            // "integer indefinite" 0x8000_0000 for every invalid input
+            // (including NaN and +inf); aarch64 `FCVTZS` SATURATES to the
+            // destination's min/max with NaN going to 0; and Rust's `as i32`,
+            // which `eval_unary` uses, saturates like aarch64. So the two
+            // architectures disagree with each other, not merely with the
+            // folder: `+inf` folds to i32::MAX's pattern but executes as
+            // i32::MIN on x86. Value-aware, like the rows above — a
+            // conversion that IS in range agrees everywhere and still folds.
+            //
+            // The limit is 2^31 rather than `i32::MAX as f32`, because that
+            // cast rounds UP to 2^31 and would admit values above the range.
+            Self::TruncToInt => match args {
+                [x] => {
+                    const I32_LIMIT: f32 = 2_147_483_648.0; // 2^31
+                    !x.is_finite() || *x >= I32_LIMIT || *x < -I32_LIMIT
+                }
+                _ => false,
+            },
             // One rounding or two. `mul_add` is the single-rounding FMA every
             // first-class target has (`vfmadd`, `FMLA`); `x * y + z` is what
             // SSE2 emits without one. Value-aware, because they agree for most

--- a/pixelflow-ir/src/lib.rs
+++ b/pixelflow-ir/src/lib.rs
@@ -18,6 +18,9 @@
 
 extern crate alloc;
 
+/// Exact dyadic rationals — the constant domain the e-graph folds in, so
+/// that folding cannot contradict the algebraic rewrites. See the module docs.
+pub mod dyadic;
 pub mod kind;
 pub mod traits;
 pub mod variance;

--- a/pixelflow-ir/tests/dyadic_spec.rs
+++ b/pixelflow-ir/tests/dyadic_spec.rs
@@ -1309,3 +1309,32 @@ fn odd_scaled_helper_agrees_with_direct_construction() {
     assert_eq!(via_helper, direct);
     assert_eq!(oracle, 15.0 * 2f64.powi(10));
 }
+
+/// The exponent is finite too, and repeatedly squaring walks it up
+/// exponentially — `2^(2^k)` reaches `i32::MAX` in ~31 squarings. Normalizing
+/// past that must DECLINE, exactly as the mantissa cap does, rather than
+/// panicking in debug or wrapping to a wildly different value in release.
+#[test]
+fn exponent_overflow_declines_instead_of_wrapping() {
+    let mut value = Dyadic::from_f32(2.0).expect("2.0 is dyadic");
+    // Square until the exponent can no longer grow; every step must either
+    // succeed or decline, and none may panic.
+    let mut declined = false;
+    for _ in 0..64 {
+        match value.checked_mul(value) {
+            Some(next) => value = next,
+            None => {
+                declined = true;
+                break;
+            }
+        }
+    }
+    assert!(
+        declined,
+        "repeated squaring must eventually decline rather than wrap the exponent"
+    );
+    // And the surviving value is still a well-formed dyadic that compares and
+    // converts without panicking.
+    assert!(value.to_f32().is_finite() || value.to_f32().is_infinite());
+    assert_eq!(value.cmp(&value), core::cmp::Ordering::Equal);
+}

--- a/pixelflow-ir/tests/dyadic_spec.rs
+++ b/pixelflow-ir/tests/dyadic_spec.rs
@@ -1338,3 +1338,36 @@ fn exponent_overflow_declines_instead_of_wrapping() {
     assert!(value.to_f32().is_finite() || value.to_f32().is_infinite());
     assert_eq!(value.cmp(&value), core::cmp::Ordering::Equal);
 }
+
+/// `normalize` legitimately accepts `exp == i32::MAX` — it only rejects an
+/// ADD that would overflow — so `to_f32` must survive the extremes the type
+/// itself permits. Every exponent step there (binade, target, shift, bias)
+/// would leave `i32` for such a value; they are computed in `i64` and the
+/// result saturates to ±∞ or zero.
+#[test]
+fn to_f32_survives_the_exponent_extremes_the_type_allows() {
+    // Walk to the largest exponent reachable, then convert.
+    let mut big = Dyadic::from_f32(2.0).expect("2.0");
+    while let Some(next) = big.checked_mul(big) {
+        big = next;
+    }
+    assert!(
+        big.to_f32().is_infinite() && big.to_f32() > 0.0,
+        "an enormous positive dyadic must convert to +inf, not panic or wrap"
+    );
+    assert!(
+        big.negate().to_f32().is_infinite() && big.negate().to_f32() < 0.0,
+        "and its negation to -inf"
+    );
+
+    // The same walk downward: repeated squaring of a tiny value underflows.
+    let mut tiny = Dyadic::from_f32(0.5).expect("0.5");
+    while let Some(next) = tiny.checked_mul(tiny) {
+        tiny = next;
+    }
+    assert_eq!(
+        tiny.to_f32(),
+        0.0,
+        "an enormously small positive dyadic must convert to +0.0"
+    );
+}

--- a/pixelflow-ir/tests/dyadic_spec.rs
+++ b/pixelflow-ir/tests/dyadic_spec.rs
@@ -1,0 +1,1311 @@
+//! Adversarial, specification-only test suite for [`Dyadic`].
+//!
+//! **Independence note:** these tests were written from `pixelflow-ir/src/dyadic.rs`'s
+//! module docs and per-method doc comments ONLY, while the method bodies were
+//! still `todo!()`. No implementation body was read or relied on. All
+//! constructions below go through the public API (`Dyadic`'s fields are
+//! private), so nothing here can accidentally depend on internal layout.
+//!
+//! # Oracle strategy
+//!
+//! `Dyadic`'s own fields are inaccessible from outside the crate, so a value
+//! can only be inspected via `to_f32()` -- which is itself under test. To get
+//! an oracle independent of `Dyadic`, most rounding/overflow/subnormal tests
+//! build a value from small, individually-exact pieces (odd `f32`-exact
+//! integers times an exact power of two, see [`pow2`] and [`odd_scaled`]),
+//! track the SAME value as an exact `f64`, and compare `dyadic.to_f32()`
+//! against Rust's own guaranteed round-to-nearest-ties-to-even `f64 as f32`
+//! cast of that `f64` (see [`assert_dyadic_matches_f64`]). This was spot
+//! checked against real `rustc` output for every nontrivial case below
+//! (ties, carries, overflow, underflow) before being encoded here, so the
+//! expected bit patterns are independently verified, not merely asserted to
+//! agree with themselves.
+//!
+//! Where a value fits in an ordinary named f32 constant (`f32::MAX`,
+//! `f32::MIN_POSITIVE`, ...), that constant is used directly instead.
+//!
+//! # Running
+//!
+//! `cargo test -p pixelflow-ir --test dyadic_spec` runs everything except the
+//! exhaustive round-trip, which is `#[ignore]`d -- see that test's doc
+//! comment for how to run it.
+//!
+//! # Expected state right now
+//!
+//! `src/dyadic.rs` bodies are `todo!()` as of this writing. Every test here
+//! is expected to panic on first contact with a `todo!()`. That is not a
+//! failure of this suite.
+
+use pixelflow_ir::dyadic::Dyadic;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+// ============================================================================
+// Helpers (public-API only; no field access)
+// ============================================================================
+
+/// Shorthand for an expected-successful `from_f32`. Panics loudly (with the
+/// input value) if decoding fails, rather than propagating a confusing
+/// `unwrap()` panic with no context.
+fn d(x: f32) -> Dyadic {
+    Dyadic::from_f32(x).unwrap_or_else(|| panic!("from_f32({x:e}) must decode (finite input)"))
+}
+
+/// Exact `2^k` as a Dyadic, for ANY `i32` k -- including exponents far
+/// outside f32's own representable range (roughly -149..=127). Built by
+/// binary exponentiation from `from_f32(2.0)` / `from_f32(0.5)`, so the
+/// mantissa is always the literal integer `1` throughout construction: every
+/// `mul` call below is therefore trivially in-range, which is what makes
+/// this helper safe to use as scaffolding for tests that specifically probe
+/// the overflow boundary of OTHER operations.
+fn pow2(k: i32) -> Dyadic {
+    let one = d(1.0);
+    if k == 0 {
+        return one;
+    }
+    let (mut base, mut n) = if k > 0 {
+        (d(2.0), k as u32)
+    } else {
+        (d(0.5), k.unsigned_abs())
+    };
+    let mut acc = one;
+    while n > 0 {
+        if n & 1 == 1 {
+            acc = acc.checked_mul(base).unwrap_or_else(|| {
+                panic!(
+                    "pow2({k}) helper: `mul` returned None accumulating 2^{k}; \
+                     the mantissa is always 1 in this helper so this cannot \
+                     legitimately overflow -- `mul` itself is broken"
+                )
+            });
+        }
+        base = base.checked_mul(base).unwrap_or_else(|| {
+            panic!(
+                "pow2({k}) helper: `mul` returned None squaring the base for \
+                 2^{k}; the mantissa is always 1 in this helper so this cannot \
+                 legitimately overflow -- `mul` itself is broken"
+            )
+        });
+        n >>= 1;
+    }
+    acc
+}
+
+/// `3^64` as a Dyadic: a ~102-bit ODD mantissa at exponent 0, built by six
+/// successive self-squarings from a single f32-exact seed (`3.0`). Chosen
+/// because it sits comfortably inside i128's 127-bit magnitude cap, while
+/// squaring it once more (`3^128`, ~203 bits) is exactly where `mul` must
+/// decline -- see the "declining at the cap" tests below. Also doubles as a
+/// "big mantissa, small exponent" counterexample for the Ord tests.
+fn three_pow_64() -> Dyadic {
+    let mut v = d(3.0);
+    let mut label = 1u32;
+    for _ in 0..6 {
+        label *= 2;
+        v = v.checked_mul(v).unwrap_or_else(|| {
+            panic!(
+                "3^{label}: mul declined despite fitting comfortably in i128 \
+                 (~102 bits at the end); either `mul` is broken or the \
+                 mantissa cap is far lower than documented"
+            )
+        });
+    }
+    v
+}
+
+/// Build `(product of odd factors) x 2^exp` as both an exact `Dyadic` and an
+/// exact `f64` oracle. Every factor must be odd, positive, and small enough
+/// to be f32-exact (<= 2^24 - 1), so each decodes via `from_f32` without any
+/// normalizing shift, and the running product must stay under 2^53 so the
+/// f64 oracle also holds it exactly. Panics loudly if a caller violates
+/// those preconditions -- a silently-wrong oracle would be worse than none.
+fn odd_scaled(factors: &[i64], exp: i32) -> (Dyadic, f64) {
+    let mut val = d(1.0);
+    let mut product: i128 = 1;
+    for &f in factors {
+        assert_eq!(f.rem_euclid(2), 1, "odd_scaled: factor {f} must be odd");
+        assert!(
+            f > 0 && f <= 0x00FF_FFFF,
+            "odd_scaled: factor {f} must be a positive f32-exact odd integer (<= 2^24 - 1)"
+        );
+        val = val.checked_mul(d(f as f32)).unwrap_or_else(|| {
+            panic!("odd_scaled{factors:?}: mantissa product overflowed i128 -- reduce the test's factors")
+        });
+        product = product
+            .checked_mul(f as i128)
+            .expect("odd_scaled helper: test-chosen factors overflowed i128 in the oracle itself");
+    }
+    assert!(
+        product < (1i128 << 53),
+        "odd_scaled{factors:?}: product {product} exceeds 2^53, the f64 oracle would itself be inexact"
+    );
+    let oracle = (product as f64) * 2f64.powi(exp);
+    val = val.checked_mul(pow2(exp)).unwrap_or_else(|| {
+        panic!("odd_scaled{factors:?} * 2^{exp}: scale overflowed -- reduce the test's exponent")
+    });
+    (val, oracle)
+}
+
+/// The exact IEEE-754 binary32 bit pattern for `(-1)^neg * 2^e`, for `e` in
+/// `-149..=127` (smallest subnormal through largest normal exponent). Built
+/// directly from the bit layout so it is exact BY CONSTRUCTION -- unlike
+/// `2f32.powi(e)`, which computes via repeated floating-point
+/// multiplication and is not guaranteed exact for every e in this range.
+fn pow2_f32_bits(e: i32, neg: bool) -> u32 {
+    assert!(
+        (-149..=127).contains(&e),
+        "pow2_f32_bits: e={e} out of f32's representable exponent range"
+    );
+    let magnitude = if e >= -126 {
+        let biased_exp = (e + 127) as u32; // 1..=254
+        biased_exp << 23
+    } else {
+        1u32 << (e + 149) // subnormal: mantissa field alone encodes the power of two
+    };
+    if neg {
+        magnitude | 0x8000_0000
+    } else {
+        magnitude
+    }
+}
+
+/// Core round-trip assertion used by every sampled/exhaustive round-trip
+/// test: `from_f32(x).map(to_f32) == Some(x)` for finite x, `None` for
+/// NaN/inf, with the documented exception that `-0.0` round-trips to `+0.0`
+/// (both collapse to the one [`Dyadic::ZERO`]).
+fn assert_roundtrip_bits(bits: u32) {
+    let x = f32::from_bits(bits);
+    if x.is_nan() {
+        assert!(
+            Dyadic::from_f32(x).is_none(),
+            "NaN (bits {bits:#010x}) must decode to None"
+        );
+        return;
+    }
+    if x.is_infinite() {
+        assert!(
+            Dyadic::from_f32(x).is_none(),
+            "infinity (bits {bits:#010x}) must decode to None"
+        );
+        return;
+    }
+    let Some(dy) = Dyadic::from_f32(x) else {
+        panic!("finite value {x:e} (bits {bits:#010x}) must decode to Some, got None");
+    };
+    let back = dy.to_f32();
+    let expected_bits = if bits == 0x8000_0000 { 0u32 } else { bits };
+    assert_eq!(
+        back.to_bits(),
+        expected_bits,
+        "round-trip mismatch: x={x:e} bits={bits:#010x} -> to_f32 bits={:#010x}, expected {expected_bits:#010x}",
+        back.to_bits()
+    );
+}
+
+/// Assert that converting `dy` to f32 matches Rust's own guaranteed
+/// correctly-rounded (round-to-nearest, ties-to-even) `f64 as f32` cast of
+/// the independently-known exact value `oracle`. This oracle is wholly
+/// external to `Dyadic`'s implementation.
+fn assert_dyadic_matches_f64(label: &str, dy: Dyadic, oracle: f64) {
+    let got = dy.to_f32();
+    let want = oracle as f32;
+    assert_eq!(
+        got.to_bits(),
+        want.to_bits(),
+        "{label}: to_f32() = {got:e} (bits {:#010x}), oracle (({oracle:e}) as f32) = {want:e} (bits {:#010x})",
+        got.to_bits(),
+        want.to_bits()
+    );
+}
+
+fn hash_of(x: Dyadic) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    x.hash(&mut hasher);
+    hasher.finish()
+}
+
+// ============================================================================
+// 1. from_f32: NaN / infinity / signed-zero contract
+// ============================================================================
+
+#[test]
+fn from_f32_rejects_all_nan_shapes() {
+    let nans: [(&str, u32); 6] = [
+        ("quiet NaN", f32::NAN.to_bits()),
+        (
+            "quiet NaN, negative sign bit",
+            f32::NAN.to_bits() | 0x8000_0000,
+        ),
+        ("signaling-shaped NaN pattern", 0x7FA0_0000),
+        ("signaling-shaped NaN, negative", 0xFFA0_0000),
+        ("NaN with minimal payload", 0x7F80_0001),
+        ("NaN with max payload, negative", 0xFFFF_FFFF),
+    ];
+    for (label, bits) in nans {
+        let x = f32::from_bits(bits);
+        assert!(
+            x.is_nan(),
+            "test bug: bits {bits:#010x} ({label}) is not actually NaN"
+        );
+        assert!(
+            Dyadic::from_f32(x).is_none(),
+            "{label} (bits {bits:#010x}) must decode to None, not Some"
+        );
+    }
+}
+
+#[test]
+fn from_f32_rejects_both_infinities() {
+    assert!(
+        Dyadic::from_f32(f32::INFINITY).is_none(),
+        "+inf must decode to None"
+    );
+    assert!(
+        Dyadic::from_f32(f32::NEG_INFINITY).is_none(),
+        "-inf must decode to None"
+    );
+}
+
+#[test]
+fn from_f32_collapses_signed_zero_to_the_one_zero() {
+    let pos = Dyadic::from_f32(0.0).expect("+0.0 must decode");
+    let neg = Dyadic::from_f32(-0.0).expect("-0.0 must decode");
+    assert_eq!(pos, Dyadic::ZERO, "+0.0 must decode to Dyadic::ZERO");
+    assert_eq!(
+        neg,
+        Dyadic::ZERO,
+        "-0.0 must decode to Dyadic::ZERO (module docs: there is one zero)"
+    );
+    assert_eq!(pos, neg);
+}
+
+#[test]
+fn to_f32_of_zero_is_always_positive_zero() {
+    assert_eq!(
+        Dyadic::ZERO.to_f32().to_bits(),
+        0.0f32.to_bits(),
+        "ZERO.to_f32() must be +0.0"
+    );
+    let via_neg_zero = Dyadic::from_f32(-0.0).unwrap();
+    assert_eq!(
+        via_neg_zero.to_f32().to_bits(),
+        0.0f32.to_bits(),
+        "zero built from -0.0 must still round-trip to +0.0, per module docs"
+    );
+}
+
+#[test]
+fn from_f32_accepts_ordinary_finite_values() {
+    for x in [
+        1.0f32,
+        -1.0,
+        0.5,
+        128.0 / 255.0,
+        f32::MIN_POSITIVE,
+        f32::MAX,
+        f32::MIN,
+        core::f32::consts::PI,
+    ] {
+        assert!(
+            Dyadic::from_f32(x).is_some(),
+            "finite value {x:e} must decode to Some"
+        );
+    }
+}
+
+// ============================================================================
+// 2. Round-trip: from_f32 -> to_f32 (sampled by default, exhaustive ignored)
+// ============================================================================
+
+#[test]
+fn round_trip_all_positive_subnormals() {
+    for bits in 0x0000_0001u32..=0x007f_ffff {
+        assert_roundtrip_bits(bits);
+    }
+}
+
+#[test]
+fn round_trip_all_negative_subnormals() {
+    for bits in 0x8000_0001u32..=0x807f_ffff {
+        assert_roundtrip_bits(bits);
+    }
+}
+
+#[test]
+fn round_trip_all_powers_of_two() {
+    for e in -149i32..=127 {
+        assert_roundtrip_bits(pow2_f32_bits(e, false));
+        assert_roundtrip_bits(pow2_f32_bits(e, true));
+    }
+}
+
+#[test]
+fn round_trip_dense_near_binade_boundaries() {
+    // A spread of exponents from deep subnormal, across the subnormal/normal
+    // seam, through the middle of the normal range, to just below overflow.
+    const BOUNDARY_EXPONENTS: [i32; 9] = [-149, -126, -100, -23, -1, 23, 100, 126, 127];
+    const SPAN: u32 = 4096;
+    for &e in &BOUNDARY_EXPONENTS {
+        for &neg in &[false, true] {
+            let center = pow2_f32_bits(e, neg);
+            let lo = center.saturating_sub(SPAN);
+            let hi = center.saturating_add(SPAN);
+            for bits in lo..=hi {
+                assert_roundtrip_bits(bits);
+            }
+        }
+    }
+}
+
+#[test]
+fn round_trip_pseudo_random_spread() {
+    // Deterministic LCG (Numerical Recipes constants), full 32-bit state --
+    // no `rand` dependency, fully reproducible across runs/machines.
+    let mut state: u32 = 0x2545_F491;
+    const SAMPLES: usize = 1_000_000;
+    for _ in 0..SAMPLES {
+        state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+        assert_roundtrip_bits(state);
+    }
+}
+
+#[test]
+#[ignore = "exhaustive: iterates all 2^32 f32 bit patterns (~a few minutes in \
+            release, impractically slow in debug). Run explicitly with: \
+            cargo test -p pixelflow-ir --test dyadic_spec --release -- \
+            --ignored exhaustive_round_trip_over_all_f32_bit_patterns"]
+fn exhaustive_round_trip_over_all_f32_bit_patterns() {
+    for bits in 0u32..=u32::MAX {
+        assert_roundtrip_bits(bits);
+    }
+}
+
+// ============================================================================
+// 3. Subnormals: decode correctness and the subnormal/normal seam
+// ============================================================================
+
+#[test]
+fn smallest_subnormal_decodes_and_doubles_correctly() {
+    let smallest = Dyadic::from_f32(f32::from_bits(1)).expect("smallest subnormal must decode");
+    let doubled = smallest
+        .checked_add(smallest)
+        .expect("doubling the smallest subnormal must not overflow");
+    let expected = Dyadic::from_f32(f32::from_bits(2)).expect("2nd-smallest subnormal must decode");
+    assert_eq!(
+        doubled, expected,
+        "2 * (bit-pattern 1) must equal (bit-pattern 2): if from_f32 wrongly \
+         assumed an implicit leading 1 for subnormals, this identity would break"
+    );
+}
+
+#[test]
+fn subnormal_doubling_identity_across_the_subnormal_range() {
+    for k in [1u32, 2, 3, 0xFF, 0x3FFF, 0x003F_FFFF] {
+        let x = Dyadic::from_f32(f32::from_bits(k))
+            .unwrap_or_else(|| panic!("bits {k:#010x} must decode (subnormal)"));
+        let doubled = x
+            .checked_add(x)
+            .unwrap_or_else(|| panic!("doubling subnormal bits {k:#010x} must not overflow"));
+        let expected_bits = 2 * k;
+        let expected = Dyadic::from_f32(f32::from_bits(expected_bits))
+            .unwrap_or_else(|| panic!("bits {expected_bits:#010x} must decode"));
+        assert_eq!(
+            doubled, expected,
+            "2x(bits {k:#010x}) must equal bits {expected_bits:#010x}"
+        );
+    }
+}
+
+#[test]
+fn largest_subnormal_and_smallest_normal_are_exactly_one_ulp_apart() {
+    let largest_subnormal =
+        Dyadic::from_f32(f32::from_bits(0x007f_ffff)).expect("largest subnormal must decode");
+    let smallest_normal = Dyadic::from_f32(f32::MIN_POSITIVE).expect("smallest normal must decode");
+    let smallest_subnormal =
+        Dyadic::from_f32(f32::from_bits(1)).expect("smallest subnormal must decode");
+
+    assert_ne!(
+        largest_subnormal, smallest_normal,
+        "these are adjacent but distinct f32 values"
+    );
+
+    let gap = smallest_normal
+        .checked_sub(largest_subnormal)
+        .expect("adjacent-value subtraction must not overflow");
+    assert_eq!(
+        gap, smallest_subnormal,
+        "smallest_normal - largest_subnormal must equal exactly the smallest \
+         subnormal (2^-126 - (2^-126 - 2^-149) = 2^-149) -- this cross-checks \
+         subnormal AND normal decoding against each other without inspecting fields"
+    );
+}
+
+#[test]
+fn subnormal_normal_seam_tie_rounds_up_to_smallest_normal_ties_to_even() {
+    // Exactly halfway between the largest subnormal (2^-126 - 2^-149) and
+    // the smallest normal (2^-126): 2^-126 - 2^-150. The smallest normal has
+    // an even trailing mantissa bit (field 0); the largest subnormal an odd
+    // one (field 2^23-1). Ties-to-even must cross the seam.
+    let tie = pow2(-126)
+        .checked_sub(pow2(-150))
+        .expect("seam tie construction must not overflow");
+    let oracle = 2f64.powi(-126) - 2f64.powi(-150);
+    assert_dyadic_matches_f64("subnormal/normal seam tie", tie, oracle);
+    assert_eq!(
+        tie.to_f32().to_bits(),
+        f32::MIN_POSITIVE.to_bits(),
+        "must round exactly to the smallest normal f32"
+    );
+}
+
+#[test]
+fn value_just_inside_subnormal_side_of_seam_still_rounds_up_to_smallest_normal() {
+    // 2^-126 - 2^-151 is only 0.25 subnormal-ULPs below the smallest normal
+    // -- not a tie, unambiguously closer to the normal side.
+    let v = pow2(-126)
+        .checked_sub(pow2(-151))
+        .expect("must not overflow");
+    let oracle = 2f64.powi(-126) - 2f64.powi(-151);
+    assert_dyadic_matches_f64("0.25-ulp below the seam", v, oracle);
+    assert_eq!(v.to_f32().to_bits(), f32::MIN_POSITIVE.to_bits());
+}
+
+#[test]
+fn tie_between_zero_and_smallest_subnormal_rounds_to_even_zero() {
+    let tie = pow2(-150); // exactly half of the smallest subnormal (2^-149)
+    let oracle = 2f64.powi(-150);
+    assert_dyadic_matches_f64("zero/smallest-subnormal tie", tie, oracle);
+    assert_eq!(
+        tie.to_f32().to_bits(),
+        0.0f32.to_bits(),
+        "tie must resolve to zero (the even neighbor)"
+    );
+}
+
+#[test]
+fn just_above_the_zero_tie_rounds_up_to_smallest_subnormal() {
+    let v = pow2(-150)
+        .checked_add(pow2(-200))
+        .expect("must not overflow");
+    let oracle = 2f64.powi(-150) + 2f64.powi(-200);
+    assert_dyadic_matches_f64("just above zero/smallest-subnormal tie", v, oracle);
+    assert_eq!(
+        v.to_f32().to_bits(),
+        1u32,
+        "must round up to bit pattern 1 (smallest subnormal)"
+    );
+}
+
+#[test]
+fn just_below_the_zero_tie_rounds_down_to_zero() {
+    let v = pow2(-150)
+        .checked_sub(pow2(-200))
+        .expect("must not overflow");
+    let oracle = 2f64.powi(-150) - 2f64.powi(-200);
+    assert_dyadic_matches_f64("just below zero/smallest-subnormal tie", v, oracle);
+    assert_eq!(v.to_f32().to_bits(), 0u32);
+}
+
+#[test]
+fn deep_underflow_rounds_to_correctly_signed_zero() {
+    assert_eq!(
+        pow2(-500).to_f32().to_bits(),
+        0u32,
+        "deep positive underflow -> +0.0"
+    );
+    assert_eq!(
+        pow2(-500).negate().to_f32().to_bits(),
+        0x8000_0000u32,
+        "deep negative underflow -> -0.0 (sign survives rounding, per IEEE \
+         correctly-rounded conversion semantics)"
+    );
+}
+
+// ============================================================================
+// 4. Rounding: ties-to-even, and carry into the next binade
+// ============================================================================
+
+#[test]
+fn in_binade_tie_with_even_lsb_below_rounds_down() {
+    // Within [1,2): representable value m=2^23-2 has an EVEN mantissa field.
+    // The tie exactly between it and m+1 (odd) must resolve DOWN to m.
+    let v = d(1.0)
+        .checked_add(d(16_777_213.0).checked_mul(pow2(-24)).unwrap())
+        .unwrap();
+    let oracle = 1.0 + 16_777_213.0 * 2f64.powi(-24);
+    assert_dyadic_matches_f64("in-binade tie, even lsb below", v, oracle);
+    assert_eq!(
+        v.to_f32().to_bits(),
+        0x3FFF_FFFE,
+        "must round down to the even-mantissa neighbor"
+    );
+}
+
+#[test]
+fn in_binade_tie_with_odd_lsb_below_rounds_up_without_carry() {
+    // m=5 (odd) -> tie must resolve UP to m+1=6 (even), staying inside [1,2).
+    let v = d(1.0)
+        .checked_add(d(11.0).checked_mul(pow2(-24)).unwrap())
+        .unwrap();
+    let oracle = 1.0 + 11.0 * 2f64.powi(-24);
+    assert_dyadic_matches_f64("in-binade tie, odd lsb below, no carry", v, oracle);
+    assert_eq!(v.to_f32().to_bits(), 0x3F80_0006);
+}
+
+#[test]
+fn value_just_below_an_in_binade_tie_rounds_to_the_lower_neighbor() {
+    let tie = d(1.0)
+        .checked_add(d(11.0).checked_mul(pow2(-24)).unwrap())
+        .unwrap();
+    let v = tie.checked_sub(pow2(-30)).unwrap();
+    let oracle = (1.0 + 11.0 * 2f64.powi(-24)) - 2f64.powi(-30);
+    assert_dyadic_matches_f64("just below an in-binade tie", v, oracle);
+    assert_eq!(v.to_f32().to_bits(), 0x3F80_0005);
+}
+
+#[test]
+fn value_just_above_an_in_binade_tie_rounds_to_the_upper_neighbor() {
+    let tie = d(1.0)
+        .checked_add(d(11.0).checked_mul(pow2(-24)).unwrap())
+        .unwrap();
+    let v = tie.checked_add(pow2(-30)).unwrap();
+    let oracle = (1.0 + 11.0 * 2f64.powi(-24)) + 2f64.powi(-30);
+    assert_dyadic_matches_f64("just above an in-binade tie", v, oracle);
+    assert_eq!(v.to_f32().to_bits(), 0x3F80_0006);
+}
+
+#[test]
+fn tie_at_top_of_binade_carries_into_the_next_exponent() {
+    // 2.0 - 2^-24 is exactly halfway between (2.0 - 2^-23) [odd mantissa
+    // field 0x7FFFFF] and 2.0 itself [mantissa field 0, even, next binade].
+    // Ties-to-even must carry into the next exponent.
+    let v = pow2(1).checked_sub(pow2(-24)).unwrap();
+    let oracle = 2f64.powi(1) - 2f64.powi(-24);
+    assert_dyadic_matches_f64("carry-tie at top of [1,2)", v, oracle);
+    assert_eq!(v.to_f32().to_bits(), 2.0f32.to_bits());
+}
+
+#[test]
+fn value_just_below_a_power_of_two_that_is_not_a_tie_still_carries() {
+    // 2.0 - 2^-30 is unambiguously (NOT a tie) closer to 2.0 than to
+    // 2.0 - 2^-23, so it must round up and carry into the next binade even
+    // though nothing about this specific case is a tie.
+    let v = pow2(1).checked_sub(pow2(-30)).unwrap();
+    let oracle = 2f64.powi(1) - 2f64.powi(-30);
+    assert_dyadic_matches_f64("non-tie carry just below 2.0", v, oracle);
+    assert_eq!(v.to_f32().to_bits(), 2.0f32.to_bits());
+}
+
+// ============================================================================
+// 5. Overflow to infinity, and rounding to the largest finite f32 instead
+// ============================================================================
+
+#[test]
+fn tie_just_above_f32_max_rounds_to_infinity_ties_to_even() {
+    // f32::MAX's mantissa field is all-ones (odd); infinity's is 0 (even).
+    // The tie exactly halfway to 2^128 must resolve to infinity.
+    let max = d(f32::MAX);
+    let tie = max.checked_add(pow2(103)).unwrap(); // ulp at this binade is 2^104, half is 2^103
+    let oracle = f32::MAX as f64 + 2f64.powi(103);
+    assert_dyadic_matches_f64("tie just above f32::MAX", tie, oracle);
+    assert_eq!(tie.to_f32(), f32::INFINITY);
+}
+
+#[test]
+fn value_a_quarter_ulp_above_f32_max_rounds_down_to_f32_max_not_infinity() {
+    let max = d(f32::MAX);
+    let v = max.checked_add(pow2(102)).unwrap(); // 0.25 ulp over
+    let oracle = f32::MAX as f64 + 2f64.powi(102);
+    assert_dyadic_matches_f64("0.25 ulp above f32::MAX", v, oracle);
+    assert_eq!(
+        v.to_f32(),
+        f32::MAX,
+        "must round DOWN to the largest finite f32, not overflow to infinity"
+    );
+}
+
+#[test]
+fn value_three_quarter_ulp_above_f32_max_overflows_to_infinity() {
+    let max = d(f32::MAX);
+    let v = max
+        .checked_add(d(3.0).checked_mul(pow2(102)).unwrap())
+        .unwrap(); // 0.75 ulp over
+    let oracle = f32::MAX as f64 + 3.0 * 2f64.powi(102);
+    assert_dyadic_matches_f64("0.75 ulp above f32::MAX", v, oracle);
+    assert_eq!(v.to_f32(), f32::INFINITY);
+}
+
+#[test]
+fn overflow_and_near_max_rounding_are_sign_symmetric() {
+    let neg_max = d(f32::MAX).negate();
+
+    let tie = neg_max.checked_sub(pow2(103)).unwrap();
+    assert_eq!(
+        tie.to_f32(),
+        f32::NEG_INFINITY,
+        "negative tie must round to -infinity"
+    );
+
+    let below = neg_max.checked_sub(pow2(102)).unwrap();
+    assert_eq!(
+        below.to_f32(),
+        f32::MIN,
+        "0.25 ulp past -MAX must round to the most-negative finite f32"
+    );
+
+    let above = neg_max
+        .checked_sub(d(3.0).checked_mul(pow2(102)).unwrap())
+        .unwrap();
+    assert_eq!(
+        above.to_f32(),
+        f32::NEG_INFINITY,
+        "0.75 ulp past -MAX must overflow to -infinity"
+    );
+}
+
+#[test]
+fn far_beyond_f32_range_overflows_to_infinity_of_the_right_sign() {
+    assert_eq!(pow2(200).to_f32(), f32::INFINITY);
+    assert_eq!(pow2(200).negate().to_f32(), f32::NEG_INFINITY);
+    assert_eq!(
+        pow2(1000).to_f32(),
+        f32::INFINITY,
+        "must saturate, not panic or wrap, arbitrarily far past the range"
+    );
+}
+
+// ============================================================================
+// 6. Exactness: the motivating (x + 2^k) - 2^k case
+// ============================================================================
+
+fn exactness_survives_round_trip_at_magnitude(k: i32) {
+    let big = pow2(k);
+    for x in [
+        128.0f32 / 255.0,
+        1.0 / 3.0,
+        std::f32::consts::PI,
+        -7.0 / 9.0,
+        12345.679,
+    ] {
+        let small = d(x);
+        let result = small
+            .checked_add(big)
+            .unwrap_or_else(|| {
+                panic!("{x} + 2^{k} must not overflow (tiny mantissa, exponent gap fits i128)")
+            })
+            .checked_sub(big)
+            .unwrap_or_else(|| panic!("(...) - 2^{k} must not overflow"));
+        assert_eq!(
+            result, small,
+            "({x} + 2^{k}) - 2^{k} must be EXACTLY {x} again -- this is the \
+             motivating case from the module docs (f32 arithmetic absorbs it to 0)"
+        );
+        assert_eq!(
+            result.to_f32().to_bits(),
+            x.to_bits(),
+            "and must round-trip back to the identical f32 bit pattern"
+        );
+    }
+}
+
+#[test]
+fn exactness_survives_add_then_sub_at_2_24() {
+    exactness_survives_round_trip_at_magnitude(24);
+}
+
+#[test]
+fn exactness_survives_add_then_sub_at_2_30() {
+    exactness_survives_round_trip_at_magnitude(30);
+}
+
+#[test]
+fn exactness_survives_add_then_sub_at_2_60() {
+    exactness_survives_round_trip_at_magnitude(60);
+}
+
+#[test]
+fn exactness_survives_add_then_sub_at_2_80() {
+    exactness_survives_round_trip_at_magnitude(80);
+}
+
+#[test]
+fn f32_arithmetic_absorbs_the_small_addend_for_contrast() {
+    // NOT a Dyadic test: documents WHY Dyadic exists (module docs, "Why
+    // exactness, rather than more precision"). Plain f32 rounds (x + 2^24)
+    // back down before subtracting 2^24 back off, losing x entirely.
+    let x: f32 = 128.0 / 255.0;
+    let absorbed = (x + 2f32.powi(24)) - 2f32.powi(24);
+    assert_ne!(
+        absorbed, x,
+        "expected f32 to LOSE x={x} at this magnitude (the motivating failure); \
+         if this now holds, this contrast comment/test is stale"
+    );
+}
+
+// ============================================================================
+// 7. Declining at the cap: None instead of a wrong value
+// ============================================================================
+
+#[test]
+fn mul_succeeds_all_the_way_up_to_the_127_bit_cap() {
+    let v = three_pow_64();
+    assert!(!v.is_zero());
+    // Cross-check via a second, independently-specified operation: dividing
+    // 3^64 by itself must be exactly ONE, confirming the value survived
+    // construction intact (not silently truncated to something else that
+    // happens to also be nonzero).
+    assert_eq!(v.try_div(v), Some(d(1.0)));
+}
+
+#[test]
+fn mul_declines_past_the_127_bit_mantissa_width() {
+    // 3^64 (~102 bits) is comfortably within i128; 3^128 (~203 bits) is not.
+    let v = three_pow_64();
+    let overflowed = v.checked_mul(v);
+    assert!(
+        overflowed.is_none(),
+        "3^64 * 3^64 = 3^128 needs ~203 mantissa bits; i128 holds ~127. \
+         mul() must return None, not a truncated/wrapped value. Got: {overflowed:?}"
+    );
+}
+
+#[test]
+fn mul_decline_is_sign_independent() {
+    let v = three_pow_64();
+    assert!(
+        v.negate().checked_mul(v).is_none(),
+        "negative lhs must not bypass the overflow check"
+    );
+    assert!(
+        v.checked_mul(v.negate()).is_none(),
+        "negative rhs must not bypass the overflow check"
+    );
+    assert!(
+        v.negate().checked_mul(v.negate()).is_none(),
+        "negative*negative must not bypass the overflow check"
+    );
+}
+
+#[test]
+fn add_declines_when_the_exponent_gap_exceeds_capacity() {
+    let big = three_pow_64(); // ~102-bit odd mantissa, exponent 0
+    let far = pow2(-400); // mantissa 1, exponent -400
+    assert!(
+        big.checked_add(far).is_none(),
+        "add must decline (None) rather than silently truncate when aligning \
+         a ~102-bit mantissa across a 400-exponent gap exceeds i128's width"
+    );
+    assert!(
+        far.checked_add(big).is_none(),
+        "add must decline symmetrically regardless of operand order"
+    );
+}
+
+#[test]
+fn sub_declines_when_the_exponent_gap_exceeds_capacity() {
+    let big = three_pow_64();
+    let far = pow2(-400);
+    assert!(
+        big.checked_sub(far).is_none(),
+        "sub must decline past capacity, same as add (see Self::add docs)"
+    );
+    assert!(
+        far.checked_sub(big).is_none(),
+        "sub must decline symmetrically regardless of operand order"
+    );
+}
+
+// ============================================================================
+// 8. try_div
+// ============================================================================
+
+#[test]
+fn try_div_exact_simple_fractions() {
+    assert_eq!(d(1.0).try_div(d(2.0)), Some(d(0.5)));
+    assert_eq!(d(3.0).try_div(d(4.0)), Some(d(0.75)));
+    assert_eq!(d(6.0).try_div(d(3.0)), Some(d(2.0)));
+    assert_eq!(d(1.0).try_div(d(1024.0)), Some(d(1.0 / 1024.0)));
+}
+
+#[test]
+fn try_div_by_self_gives_exactly_one() {
+    let one = d(1.0);
+    for x in [
+        d(128.0 / 255.0),
+        d(-7.5),
+        d(f32::MIN_POSITIVE),
+        d(f32::MAX),
+        pow2(-100),
+        pow2(77),
+        three_pow_64(),
+    ] {
+        assert_eq!(
+            x.try_div(x),
+            Some(one),
+            "x/x must be exactly ONE for x={x:?}"
+        );
+    }
+}
+
+#[test]
+fn try_div_identity_with_one() {
+    for x in [1.0f32, -1.0, 0.5, 128.0 / 255.0, core::f32::consts::PI] {
+        let dx = d(x);
+        assert_eq!(
+            dx.try_div(d(1.0)),
+            Some(dx),
+            "x/1 must equal x exactly for x={x}"
+        );
+    }
+}
+
+#[test]
+fn try_div_powers_of_two_are_always_exact() {
+    for a in [100, 30, 0, -30] {
+        for b in [70, 10, 0, -10] {
+            let got = pow2(a).try_div(pow2(b));
+            assert_eq!(
+                got,
+                Some(pow2(a - b)),
+                "2^{a} / 2^{b} must be exactly 2^{}",
+                a - b
+            );
+        }
+    }
+}
+
+#[test]
+fn try_div_zero_numerator_by_nonzero_is_exactly_zero() {
+    assert_eq!(Dyadic::ZERO.try_div(d(7.0)), Some(Dyadic::ZERO));
+    assert_eq!(Dyadic::ZERO.try_div(pow2(-50)), Some(Dyadic::ZERO));
+}
+
+#[test]
+fn try_div_by_zero_is_always_none() {
+    assert!(
+        d(5.0).try_div(Dyadic::ZERO).is_none(),
+        "nonzero / 0 must be None (no dyadic represents infinity)"
+    );
+    assert!(
+        Dyadic::ZERO.try_div(Dyadic::ZERO).is_none(),
+        "0 / 0 must be None per the documented zero-divisor rule"
+    );
+    assert!(d(-3.0).try_div(Dyadic::ZERO).is_none());
+}
+
+#[test]
+fn try_div_declines_on_genuinely_inexact_quotients() {
+    for (num, den) in [(1.0, 3.0), (1.0, 5.0), (1.0, 10.0), (2.0, 7.0), (10.0, 3.0)] {
+        assert!(
+            d(num).try_div(d(den)).is_none(),
+            "{num}/{den} is not exactly representable as a dyadic rational \
+             (denominator has a prime factor other than 2) -- must be None"
+        );
+    }
+}
+
+// ============================================================================
+// 9. try_sqrt
+// ============================================================================
+
+#[test]
+fn try_sqrt_perfect_squares() {
+    assert_eq!(d(4.0).try_sqrt(), Some(d(2.0)));
+    assert_eq!(d(9.0).try_sqrt(), Some(d(3.0)));
+    assert_eq!(d(25.0).try_sqrt(), Some(d(5.0)));
+    assert_eq!(d(49.0).try_sqrt(), Some(d(7.0)));
+    assert_eq!(d(0.25).try_sqrt(), Some(d(0.5)));
+    assert_eq!(pow2(-10).try_sqrt(), Some(pow2(-5)));
+    assert_eq!(pow2(20).try_sqrt(), Some(pow2(10)));
+}
+
+#[test]
+fn try_sqrt_zero_gives_some_zero() {
+    assert_eq!(Dyadic::ZERO.try_sqrt(), Some(Dyadic::ZERO));
+    assert_eq!(d(0.0).try_sqrt(), Some(Dyadic::ZERO));
+    assert_eq!(d(-0.0).try_sqrt(), Some(Dyadic::ZERO));
+}
+
+#[test]
+fn try_sqrt_negative_is_always_none() {
+    assert!(d(-4.0).try_sqrt().is_none());
+    assert!(pow2(2).negate().try_sqrt().is_none());
+    assert!(d(-0.0001).try_sqrt().is_none());
+}
+
+#[test]
+fn try_sqrt_non_square_mantissa_is_none_even_with_even_exponent() {
+    // exp=0 (even) in every case here, isolating "mantissa isn't a perfect
+    // square" as the sole reason for None.
+    for x in [2.0f32, 3.0, 5.0, 6.0, 7.0, 8.0, 15.0, 21.0] {
+        assert!(
+            d(x).try_sqrt().is_none(),
+            "{x} is not a perfect square, try_sqrt must be None"
+        );
+    }
+}
+
+#[test]
+fn try_sqrt_odd_exponent_is_none_even_with_perfect_square_mantissa() {
+    // pow2(k) always has mantissa 1 (trivially a perfect square, 1 = 1^2),
+    // isolating "exponent parity" as the sole pass/fail factor.
+    for e in -21..=21 {
+        let v = pow2(e);
+        if e % 2 == 0 {
+            assert_eq!(
+                v.try_sqrt(),
+                Some(pow2(e / 2)),
+                "2^{e} (even exponent) must have an exact sqrt"
+            );
+        } else {
+            assert!(
+                v.try_sqrt().is_none(),
+                "2^{e} (odd exponent) must NOT have an exact sqrt (irrational)"
+            );
+        }
+    }
+}
+
+#[test]
+fn try_sqrt_declines_when_both_mantissa_and_exponent_are_wrong() {
+    // mantissa=9 (a perfect square) at an ODD combined exponent: a
+    // perfect-square mantissa alone must not be sufficient.
+    let v = d(9.0).checked_mul(pow2(1)).unwrap(); // 9 * 2 = 18
+    assert!(
+        v.try_sqrt().is_none(),
+        "18 = 9*2 has a perfect-square mantissa but odd exponent; sqrt(18) is irrational"
+    );
+}
+
+// ============================================================================
+// 10. neg / abs / is_zero
+// ============================================================================
+
+#[test]
+fn neg_matches_f32_negation_for_ordinary_values() {
+    for x in [
+        1.0f32,
+        -1.0,
+        0.5,
+        128.0 / 255.0,
+        f32::MIN_POSITIVE,
+        f32::MAX,
+        core::f32::consts::PI,
+    ] {
+        assert_eq!(
+            d(x).negate(),
+            d(-x),
+            "neg(x) must equal from_f32(-x) for x={x}"
+        );
+    }
+}
+
+#[test]
+fn neg_is_its_own_inverse() {
+    for x in [d(7.0), pow2(100), pow2(-100), Dyadic::ZERO, three_pow_64()] {
+        assert_eq!(x.negate().negate(), x);
+    }
+}
+
+#[test]
+fn neg_zero_is_still_the_one_zero() {
+    assert_eq!(Dyadic::ZERO.negate(), Dyadic::ZERO);
+}
+
+#[test]
+fn adding_a_value_to_its_negation_gives_exactly_zero() {
+    for x in [
+        d(7.0),
+        d(128.0 / 255.0),
+        pow2(100),
+        pow2(-100),
+        three_pow_64(),
+        Dyadic::ZERO,
+    ] {
+        assert_eq!(
+            x.checked_add(x.negate()),
+            Some(Dyadic::ZERO),
+            "x + (-x) must be exactly zero and must not overflow (same magnitude, opposite sign)"
+        );
+    }
+}
+
+#[test]
+fn abs_matches_f32_abs_for_ordinary_values() {
+    for x in [
+        1.0f32,
+        -1.0,
+        0.5,
+        -0.5,
+        128.0 / 255.0,
+        -128.0 / 255.0,
+        f32::MAX,
+        f32::MIN,
+    ] {
+        assert_eq!(
+            d(x).abs(),
+            d(x.abs()),
+            "abs(x) must equal from_f32(x.abs()) for x={x}"
+        );
+    }
+}
+
+#[test]
+fn abs_is_idempotent_and_matches_its_negations_abs() {
+    for x in [d(-7.0), d(7.0), pow2(50).negate(), pow2(50), Dyadic::ZERO] {
+        let a = x.abs();
+        assert_eq!(a.abs(), a, "abs must be idempotent");
+        assert_eq!(a, x.negate().abs(), "abs(x) must equal abs(-x)");
+    }
+}
+
+#[test]
+fn is_zero_true_only_for_zero() {
+    assert!(Dyadic::ZERO.is_zero());
+    assert!(d(0.0).is_zero());
+    assert!(d(-0.0).is_zero());
+    for x in [d(1.0), d(-1.0), pow2(100), pow2(-100), pow2(-500)] {
+        // pow2(-500) underflows to 0.0 in f32 but is a genuinely nonzero
+        // Dyadic value -- is_zero must not go through any f32 round-trip.
+        assert!(!x.is_zero(), "{x:?} is not zero, is_zero must be false");
+    }
+}
+
+#[test]
+fn is_zero_true_for_results_that_cancel_out() {
+    assert!(d(5.0).checked_sub(d(5.0)).unwrap().is_zero());
+    assert!(d(0.0).checked_mul(d(12345.6)).unwrap().is_zero());
+    assert!(Dyadic::ZERO.try_div(d(7.0)).unwrap().is_zero());
+    assert!(
+        three_pow_64()
+            .checked_sub(three_pow_64())
+            .unwrap()
+            .is_zero()
+    );
+}
+
+// ============================================================================
+// 11. Normalization: Eq / Hash agree with mathematical value
+// ============================================================================
+//
+// `Dyadic` derives `PartialEq`/`Eq`/`Hash` FIELD-WISE. That is only sound
+// because the type's invariant guarantees every publicly-obtainable value is
+// normalized (mantissa odd, or exactly ZERO) -- see the struct's doc comment.
+// These tests exercise that invariant directly: values built via different
+// arithmetic routes must land on IDENTICAL fields, not just "equal enough".
+
+#[test]
+fn different_construction_routes_to_the_same_value_are_equal_and_hash_equal() {
+    let via_add = d(2.0).checked_add(d(2.0)).unwrap();
+    let via_mul = d(1.0).checked_mul(d(4.0)).unwrap();
+    let via_from_f32 = d(4.0);
+    let via_sub = d(6.0).checked_sub(d(2.0)).unwrap();
+    let via_div = d(8.0).try_div(d(2.0)).unwrap();
+    let via_sqrt = d(16.0).try_sqrt().unwrap();
+
+    let routes = [via_add, via_mul, via_from_f32, via_sub, via_div, via_sqrt];
+    for (i, &a) in routes.iter().enumerate() {
+        for (j, &b) in routes.iter().enumerate() {
+            assert_eq!(
+                a, b,
+                "route {i} and route {j} must both denote 4.0 and be =="
+            );
+            assert_eq!(
+                hash_of(a),
+                hash_of(b),
+                "route {i} and route {j} are == and MUST hash equal"
+            );
+        }
+    }
+}
+
+#[test]
+fn zero_built_every_which_way_is_the_identical_value() {
+    let routes = [
+        Dyadic::ZERO,
+        d(0.0),
+        d(-0.0),
+        d(5.0).checked_sub(d(5.0)).unwrap(),
+        d(1.0).checked_sub(d(1.0)).unwrap(),
+        d(0.0).checked_mul(d(12345.0)).unwrap(),
+        Dyadic::ZERO.try_div(d(9.0)).unwrap(),
+        Dyadic::ZERO.try_sqrt().unwrap(),
+        Dyadic::ZERO.negate(),
+        pow2(70).checked_sub(pow2(70)).unwrap(),
+    ];
+    for (i, &a) in routes.iter().enumerate() {
+        assert_eq!(a, Dyadic::ZERO, "route {i} must equal Dyadic::ZERO");
+        assert_eq!(
+            hash_of(a),
+            hash_of(Dyadic::ZERO),
+            "route {i} must hash equal to Dyadic::ZERO"
+        );
+    }
+}
+
+#[test]
+fn addition_of_two_odd_mantissas_renormalizes_away_trailing_zero_bits() {
+    // odd + odd is always even -- every one of these MUST renormalize back
+    // to an odd mantissa (or ZERO), or Eq/Hash silently stop agreeing with
+    // mathematical value.
+    assert_eq!(
+        d(3.0).checked_add(d(5.0)).unwrap(),
+        pow2(3),
+        "3+5=8=2^3 must fully normalize (3 trailing zero bits stripped)"
+    );
+    assert_eq!(d(3.0).checked_add(d(13.0)).unwrap(), pow2(4), "3+13=16=2^4");
+    assert_eq!(d(1.0).checked_add(d(7.0)).unwrap(), pow2(3), "1+7=8=2^3");
+    // Strip a much longer run of trailing zeros in a single call.
+    assert_eq!(
+        d(524_287.0).checked_add(d(1.0)).unwrap(),
+        pow2(19),
+        "524287+1=2^19 (524287=2^19-1 is odd) must strip all 19 trailing zero bits"
+    );
+}
+
+#[test]
+fn subtraction_can_also_produce_a_value_needing_renormalization() {
+    assert_eq!(d(7.0).checked_sub(d(3.0)).unwrap(), pow2(2), "7-3=4=2^2");
+    assert_eq!(
+        d(1.0).checked_sub(d(-7.0)).unwrap(),
+        pow2(3),
+        "1-(-7)=8=2^3"
+    );
+}
+
+// ============================================================================
+// 12. Ord: total order by VALUE, not lexicographic on fields
+// ============================================================================
+
+#[test]
+fn ord_is_not_lexicographic_on_mantissa_first() {
+    // Small mantissa + large exponent (2^30) vs a large-ish, exponent-0
+    // mantissa (8388607, an odd f32-exact int). A mantissa-first
+    // lexicographic comparison would see 1 < 8388607 and conclude A < B;
+    // the real values disagree: 2^30 (~1.07e9) > 8388607 (~8.39e6).
+    let a = pow2(30);
+    let b = d(8_388_607.0);
+    assert!(
+        a > b,
+        "2^30 must compare greater than 8388607 by VALUE, not by a smaller stored mantissa"
+    );
+    assert!(b < a);
+}
+
+#[test]
+fn ord_is_not_lexicographic_on_exponent_first() {
+    // Small exponent + large mantissa (8388607) vs large exponent + mantissa
+    // 1 (2^5=32). An exponent-first lexicographic comparison would see A's
+    // exponent as larger and conclude A > B; by real value, 32 < 8388607.
+    let a = pow2(5);
+    let b = d(8_388_607.0);
+    assert!(
+        a < b,
+        "32 must compare less than 8388607 by VALUE, regardless of which has the larger stored exponent"
+    );
+    assert!(b > a);
+}
+
+#[test]
+fn ord_handles_astronomically_different_magnitudes() {
+    let huge = pow2(1000);
+    let big = three_pow_64(); // ~2^101, mantissa ~102 bits, exponent 0
+    assert!(
+        huge > big,
+        "2^1000 must compare greater than a ~2^101 value with a much larger stored mantissa"
+    );
+}
+
+#[test]
+fn ord_across_signs_and_around_zero() {
+    let neg_huge = pow2(50).negate();
+    let neg_tiny = pow2(-50).negate();
+    let pos_tiny = pow2(-50);
+    let pos_huge = pow2(50);
+
+    assert!(
+        neg_huge < neg_tiny,
+        "more-negative huge value must sort before less-negative tiny value"
+    );
+    assert!(neg_tiny < Dyadic::ZERO);
+    assert!(Dyadic::ZERO < pos_tiny);
+    assert!(pos_tiny < pos_huge);
+    assert!(neg_huge < pos_tiny);
+    assert!(neg_tiny < pos_huge);
+}
+
+#[test]
+fn ord_treats_zero_built_any_way_as_equal_in_comparisons() {
+    let z1 = Dyadic::ZERO;
+    let z2 = d(-0.0);
+    assert_eq!(z1.cmp(&z2), std::cmp::Ordering::Equal);
+    assert_eq!(z1.cmp(&z2), core::cmp::Ordering::Equal);
+}
+
+#[test]
+fn partial_cmp_always_agrees_with_cmp() {
+    let values = [
+        pow2(5),
+        pow2(-5),
+        Dyadic::ZERO,
+        pow2(5).negate(),
+        d(8_388_607.0),
+        three_pow_64(),
+    ];
+    for &a in &values {
+        for &b in &values {
+            assert_eq!(a.partial_cmp(&b), Some(a.cmp(&b)));
+        }
+    }
+}
+
+#[test]
+fn sorting_a_scrambled_set_recovers_the_known_value_order() {
+    let neg_huge = pow2(50).negate();
+    let neg_big = pow2(10).negate();
+    let neg_small = pow2(-10).negate();
+    let neg_tiny = pow2(-100).negate();
+    let zero = Dyadic::ZERO;
+    let pos_tiny = pow2(-100);
+    let pos_small = pow2(-10);
+    let pos_mid = d(8_388_607.0);
+    let pos_big = pow2(30);
+    let pos_v = three_pow_64();
+    let pos_huge = pow2(1000);
+
+    // Independently-known ascending order by real value.
+    let expected: Vec<Dyadic> = vec![
+        neg_huge, neg_big, neg_small, neg_tiny, zero, pos_tiny, pos_small, pos_mid, pos_big, pos_v,
+        pos_huge,
+    ];
+
+    // Feed sort() a deliberately scrambled input built from the same values.
+    let mut scrambled: Vec<Dyadic> = vec![
+        pos_huge, neg_small, zero, pos_v, neg_huge, pos_tiny, pos_mid, neg_tiny, pos_big, neg_big,
+        pos_small,
+    ];
+    scrambled.sort();
+
+    assert_eq!(
+        scrambled, expected,
+        "Ord must recover the true value order from a scrambled input; a \
+         lexicographic-on-fields bug would reorder some of these"
+    );
+}
+
+// ============================================================================
+// 13. Odd-scaled helper self-test
+// ============================================================================
+//
+// A quick sanity check that the `odd_scaled` helper (used above for the
+// subnormal-rounding tests) actually agrees with the equivalent `pow2`-based
+// construction, so a bug in the helper itself can't quietly invalidate the
+// tests that use it.
+
+#[test]
+fn odd_scaled_helper_agrees_with_direct_construction() {
+    let (via_helper, oracle) = odd_scaled(&[3, 5], 10); // 15 * 2^10
+    let direct = d(15.0).checked_mul(pow2(10)).unwrap();
+    assert_eq!(via_helper, direct);
+    assert_eq!(oracle, 15.0 * 2f64.powi(10));
+}

--- a/pixelflow-runtime/src/platform/macos/sys.rs
+++ b/pixelflow-runtime/src/platform/macos/sys.rs
@@ -97,6 +97,25 @@ extern "C" {
     pub fn class_addMethod(cls: Class, name: Sel, imp: *const c_void, types: *const u8) -> BOOL;
 }
 
+pub type DispatchQueue = *mut c_void;
+pub type DispatchFunction = extern "C" fn(Id);
+
+// libdispatch is part of libSystem, which every macOS binary links
+// implicitly; no explicit #[link] is needed the way it is for libobjc above.
+//
+// `dispatch_get_main_queue()` is a header-only `dispatch/queue.h` inline that
+// just takes the address of this global — it is not itself an exported
+// function symbol, so we bind the global directly instead.
+extern "C" {
+    static _dispatch_main_q: c_void;
+    pub fn dispatch_async_f(queue: DispatchQueue, context: Id, work: DispatchFunction);
+}
+
+#[inline(always)]
+pub unsafe fn dispatch_get_main_queue() -> DispatchQueue {
+    std::ptr::addr_of!(_dispatch_main_q) as DispatchQueue
+}
+
 // --- Inline Helpers ---
 
 /// Get a class by name.

--- a/pixelflow-runtime/src/platform/waker.rs
+++ b/pixelflow-runtime/src/platform/waker.rs
@@ -186,6 +186,17 @@ mod cocoa_waker {
     /// event queue, which wakes the runloop from [NSApp nextEventMatchingMask...].
     /// Posts are coalesced: while one wake event is already queued, `wake()`
     /// is a single atomic op and no Objective-C call.
+    ///
+    /// The event construction and posting itself is dispatched onto the main
+    /// queue rather than done inline on the calling (background) thread.
+    /// AppKit is not thread-safe, and constructing/posting an NSEvent from a
+    /// background thread was observed to intermittently crash the process
+    /// 14-22s after launch with `_NSAssertMainEventQueueIsCurrentEventQueue`
+    /// deep inside `_DPSNextEvent` — an internal AppKit consistency check
+    /// that a concurrent background-thread call had corrupted. `dispatch_async`
+    /// onto the main queue both moves the AppKit call to the main thread and
+    /// wakes `nextEventMatchingMask`, which services the main queue's
+    /// run-loop source while blocked waiting for an event.
     #[derive(Clone)]
     pub struct CocoaWaker;
 
@@ -211,56 +222,68 @@ mod cocoa_waker {
     impl EventLoopWaker for CocoaWaker {
         fn wake(&self) -> Result<(), RuntimeError> {
             // Coalesce: a wake event is already queued, the pump will see it.
+            // This check and the dispatch_async call below are the only parts
+            // of wake() that run on the calling (background) thread; both are
+            // thread-safe (an atomic op and a libdispatch primitive).
             if WAKE_EVENT_QUEUED.swap(true, Ordering::SeqCst) {
                 return Ok(());
             }
             unsafe {
-                log::trace!("CocoaWaker: Waking up NSApp");
-                let app = NSApplication::shared();
-
-                let event_cls = sys::class(b"NSEvent\0");
-                let sel_other = sys::sel(b"otherEventWithType:location:modifierFlags:timestamp:windowNumber:context:subtype:data1:data2:\0");
-
-                // Signature: (Class, SEL, NSUInteger, NSPoint, NSUInteger, double, NSInteger, id, short, long, long) -> id
-                let sig: unsafe extern "C" fn(
-                    Id,
-                    sys::Sel,
-                    u64,
-                    cocoa::NSPoint,
-                    u64,
-                    f64,
-                    i64,
-                    Id,
-                    i16,
-                    i64,
-                    i64,
-                ) -> Id = std::mem::transmute(sys::objc_msgSend as *const std::ffi::c_void);
-
-                let event = sig(
-                    event_cls,
-                    sel_other,
-                    sys::NS_APP_DEFINED,
-                    cocoa::NSPoint::new(0.0, 0.0),
-                    0,
-                    0.0,
-                    0,
-                    ptr::null_mut(),
-                    0,
-                    0,
-                    0,
-                );
-
-                if !event.is_null() {
-                    let sel_post = sys::sel(b"postEvent:atStart:\0");
-                    sys::send_2::<(), Id, BOOL>(app.0, sel_post, event, NO);
-                } else {
-                    // Post failed: release the token or every future wake()
-                    // would be suppressed and the pump could sleep forever.
-                    WAKE_EVENT_QUEUED.store(false, Ordering::SeqCst);
-                    log::warn!("CocoaWaker: failed to construct wake NSEvent");
-                }
+                let queue = sys::dispatch_get_main_queue();
+                sys::dispatch_async_f(queue, ptr::null_mut(), post_wake_event);
             }
             Ok(())
+        }
+    }
+
+    /// Runs on the main thread via `dispatch_async_f`. Constructs and posts
+    /// the wake NSEvent — the only part of the wake path that touches AppKit.
+    extern "C" fn post_wake_event(_context: Id) {
+        unsafe {
+            log::trace!("CocoaWaker: Waking up NSApp");
+            let app = NSApplication::shared();
+
+            let event_cls = sys::class(b"NSEvent\0");
+            let sel_other = sys::sel(b"otherEventWithType:location:modifierFlags:timestamp:windowNumber:context:subtype:data1:data2:\0");
+
+            // Signature: (Class, SEL, NSUInteger, NSPoint, NSUInteger, double, NSInteger, id, short, long, long) -> id
+            let sig: unsafe extern "C" fn(
+                Id,
+                sys::Sel,
+                u64,
+                cocoa::NSPoint,
+                u64,
+                f64,
+                i64,
+                Id,
+                i16,
+                i64,
+                i64,
+            ) -> Id = std::mem::transmute(sys::objc_msgSend as *const std::ffi::c_void);
+
+            let event = sig(
+                event_cls,
+                sel_other,
+                sys::NS_APP_DEFINED,
+                cocoa::NSPoint::new(0.0, 0.0),
+                0,
+                0.0,
+                0,
+                ptr::null_mut(),
+                0,
+                0,
+                0,
+            );
+
+            if !event.is_null() {
+                let sel_post = sys::sel(b"postEvent:atStart:\0");
+                sys::send_2::<(), Id, BOOL>(app.0, sel_post, event, NO);
+            } else {
+                // Post failed: release the token or every future wake()
+                // would be suppressed and the pump could sleep forever.
+                WAKE_EVENT_QUEUED.store(false, Ordering::SeqCst);
+                log::warn!("CocoaWaker: failed to construct wake NSEvent");
+            }
         }
     }
 }

--- a/pixelflow-search/src/egraph/codegen.rs
+++ b/pixelflow-search/src/egraph/codegen.rs
@@ -168,6 +168,12 @@ fn eclass_to_code(
         ENode::Var(3) => "W".to_string(),
         ENode::Var(i) => format!("V{}", i),
         ENode::Const(bits) => format_const(f32::from_bits(*bits)),
+        // String codegen serves the AOT macro tier, which compiles before any
+        // runtime buffer exists — a Buffer here is a pipeline-order bug.
+        ENode::Buffer(decl) => panic!(
+            "eclass_to_code: ENode::Buffer({decl:?}) has no source-code form — \
+             buffer-bearing kernels are runtime-JIT only"
+        ),
         ENode::Op { op, children } => {
             let child_codes: Vec<String> = children
                 .iter()

--- a/pixelflow-search/src/egraph/cost.rs
+++ b/pixelflow-search/src/egraph/cost.rs
@@ -257,7 +257,9 @@ impl CostModel {
     /// Uses `op.kind()` to convert at the boundary from `&dyn Op` to `OpKind`.
     pub fn node_op_cost(&self, node: &ENode) -> usize {
         match node {
-            ENode::Var(_) | ENode::Const(_) => 0,
+            // Buffer is a leaf like Var/Const: the cost of the read lives on
+            // the Gather that consumes it.
+            ENode::Var(_) | ENode::Const(_) | ENode::Buffer(_) => 0,
             // `Dwrt` is the internal autodiff marker. It is rewritten away by
             // the chain rule; a surviving one is the (not-yet-wired) jet
             // fallback. Either way extraction must never choose it, so it is

--- a/pixelflow-search/src/egraph/deps.rs
+++ b/pixelflow-search/src/egraph/deps.rs
@@ -184,6 +184,9 @@ impl DepsAnalysis {
     ) -> Variance {
         match node {
             ENode::Const(_) => Variance::CONST,
+            // A buffer reference is coordinate-invariant — the *read* varies
+            // through Gather's x/y children, which the Op arm unions in.
+            ENode::Buffer(_) => Variance::CONST,
             ENode::Var(v) => var_variance(*v),
             ENode::Op { children, .. } => {
                 let mut v = Variance::CONST; // Identity for union
@@ -206,6 +209,7 @@ impl DepsAnalysis {
     fn leaf_deps_and_children(node: &ENode) -> (Option<Variance>, Vec<EClassId>) {
         match node {
             ENode::Const(_) => (Some(Variance::CONST), vec![]),
+            ENode::Buffer(_) => (Some(Variance::CONST), vec![]),
             ENode::Var(v) => (Some(var_variance(*v)), vec![]),
             ENode::Op { children, .. } => (None, children.clone()),
         }

--- a/pixelflow-search/src/egraph/extract.rs
+++ b/pixelflow-search/src/egraph/extract.rs
@@ -434,7 +434,7 @@ fn break_single_cycle(egraph: &EGraph, cycle: &[usize], best_node: &mut Vec<Opti
         let canonical = egraph.find(EClassId(cid as u32));
         let nodes = egraph.nodes(canonical);
         for (idx, node) in nodes.iter().enumerate() {
-            if matches!(node, ENode::Var(_) | ENode::Const(_)) {
+            if matches!(node, ENode::Var(_) | ENode::Const(_) | ENode::Buffer(_)) {
                 best_node[cid] = Some(idx);
                 return;
             }
@@ -469,7 +469,7 @@ fn break_single_cycle(egraph: &EGraph, cycle: &[usize], best_node: &mut Vec<Opti
     let mut best_in_cycle_count = usize::MAX;
     for (idx, node) in nodes.iter().enumerate() {
         let count = match node {
-            ENode::Var(_) | ENode::Const(_) => 0,
+            ENode::Var(_) | ENode::Const(_) | ENode::Buffer(_) => 0,
             ENode::Op { children, .. } => children
                 .iter()
                 .filter(|&&c| {
@@ -553,7 +553,9 @@ pub fn extract<C: CostFunction>(
 
             for (idx, node) in nodes.iter().enumerate() {
                 let this_node_cost = match node {
-                    ENode::Var(_) | ENode::Const(_) => costs.node_cost(node, None),
+                    ENode::Var(_) | ENode::Const(_) | ENode::Buffer(_) => {
+                        costs.node_cost(node, None)
+                    }
                     ENode::Op { children, .. } => {
                         // Check for self-referential children
                         if children.iter().any(|&c| egraph.find(c) == canonical) {
@@ -753,6 +755,16 @@ pub fn choices_to_arena(
     let mut arena = ExprArena::with_capacity(num_classes);
     // Cache: canonical e-class id → ExprId (None = not yet visited).
     let mut id_map: Vec<Option<ExprId>> = alloc::vec![None; num_classes];
+    // Buffer identity → declared slot in the output arena. Distinct e-classes
+    // can carry the same identity only if their decls differ, which is a
+    // corrupt graph (one memory, two extents) — assert, never alias silently.
+    let mut buffer_slots: alloc::collections::BTreeMap<
+        pixelflow_ir::arena::BufferIdentity,
+        (
+            pixelflow_ir::arena::BufferId,
+            pixelflow_ir::arena::BufferDecl,
+        ),
+    > = alloc::collections::BTreeMap::new();
     let mut result_stack: Vec<ExprId> = Vec::new();
     let mut task_stack: Vec<Task> = alloc::vec![Task::Visit(root)];
 
@@ -805,6 +817,31 @@ pub fn choices_to_arena(
                     }
                     ENode::Const(bits) => {
                         let expr_id = arena.push_const(f32::from_bits(*bits));
+                        if idx < id_map.len() {
+                            id_map[idx] = Some(expr_id);
+                        }
+                        result_stack.push(expr_id);
+                    }
+                    ENode::Buffer(decl) => {
+                        // One slot per distinct identity: e-classes already
+                        // dedupe equal decls, so a repeat identity here means
+                        // two decls disagreeing on extents.
+                        let buf_id = match buffer_slots.get(&decl.id) {
+                            Some(&(buf_id, prior)) => {
+                                assert!(
+                                    prior == *decl,
+                                    "choices_to_arena: BufferIdentity declared twice with \
+                                     different extents ({prior:?} vs {decl:?})"
+                                );
+                                buf_id
+                            }
+                            None => {
+                                let buf_id = arena.declare_buffer(*decl);
+                                buffer_slots.insert(decl.id, (buf_id, *decl));
+                                buf_id
+                            }
+                        };
+                        let expr_id = arena.push_buffer(buf_id);
                         if idx < id_map.len() {
                             id_map[idx] = Some(expr_id);
                         }
@@ -1005,7 +1042,9 @@ pub fn extract_dag<C: CostFunction>(egraph: &EGraph, root: EClassId, costs: &C) 
 
             for (idx, node) in nodes.iter().enumerate() {
                 let this_node_cost = match node {
-                    ENode::Var(_) | ENode::Const(_) => costs.node_cost(node, None),
+                    ENode::Var(_) | ENode::Const(_) | ENode::Buffer(_) => {
+                        costs.node_cost(node, None)
+                    }
                     ENode::Op { children, .. } => {
                         if children.iter().any(|&c| egraph.find(c) == canonical) {
                             CYCLE_COST

--- a/pixelflow-search/src/egraph/extract.rs
+++ b/pixelflow-search/src/egraph/extract.rs
@@ -735,12 +735,75 @@ pub fn build_extracted_dag_from_choices(
 ///
 /// Post-order guarantees nodes are appended in topological order (children before
 /// parents), which is a requirement of [`pixelflow_ir::ExprArena`].
+/// Re-pin every `Shl`/`Shr` count child to a `Const` representative.
+///
+/// The emitter lowers shifts to hardware immediates, so the count child MUST
+/// extract as a `Const`. But a count's e-class can legitimately hold
+/// arithmetic as well — a reachable `4 + 4` folds into the same class as `8`
+/// — and extraction picks by COST, so a cost model that prices the `Add`
+/// lower (a learned one, or any future retuning) hands codegen a non-constant
+/// child and it panics. Substituting a `Const` from the same class is sound
+/// by definition: same class means equal value.
+///
+/// # Panics
+///
+/// Panics if a shift-count class holds no `Const` at all. That cannot arise
+/// from a well-formed arena (the count entered as a literal) and would panic
+/// in the emitter regardless — failing here names the real cause.
+fn pin_shift_counts(egraph: &EGraph, choices: &[Option<usize>]) -> alloc::vec::Vec<Option<usize>> {
+    let mut pinned = choices.to_vec();
+    for idx in 0..egraph.num_classes() {
+        let canonical = egraph.find(EClassId(idx as u32));
+        if canonical.0 as usize != idx {
+            continue;
+        }
+        let Some(node_idx) = pinned.get(idx).and_then(|o| *o) else {
+            continue;
+        };
+        let Some(ENode::Op { op, children }) = egraph.nodes(canonical).get(node_idx) else {
+            continue;
+        };
+        if !matches!(
+            op.kind(),
+            pixelflow_ir::OpKind::Shl | pixelflow_ir::OpKind::Shr
+        ) {
+            continue;
+        }
+        let Some(&count) = children.get(1) else {
+            continue;
+        };
+        let count_class = egraph.find(count);
+        let ci = count_class.0 as usize;
+        let count_nodes = egraph.nodes(count_class);
+        if let Some(chosen) = pinned.get(ci).and_then(|o| *o)
+            && matches!(count_nodes.get(chosen), Some(ENode::Const(_)))
+        {
+            continue;
+        }
+        let const_idx = count_nodes
+            .iter()
+            .position(|n| matches!(n, ENode::Const(_)))
+            .unwrap_or_else(|| {
+                panic!(
+                    "pin_shift_counts: shift-count e-class {ci} holds no Const; \
+                     the emitter's immediate-only shift lowering cannot be met"
+                )
+            });
+        pinned[ci] = Some(const_idx);
+    }
+    pinned
+}
+
 pub fn choices_to_arena(
     egraph: &EGraph,
     root: EClassId,
     choices: &[Option<usize>],
 ) -> (pixelflow_ir::ExprArena, pixelflow_ir::ExprId) {
     use pixelflow_ir::{ExprArena, ExprId};
+
+    // Shifts must reach codegen with a constant count — see `pin_shift_counts`.
+    let pinned = pin_shift_counts(egraph, choices);
+    let choices: &[Option<usize>] = &pinned;
 
     enum Task {
         /// Visit an e-class: push it to the result stack if cached, otherwise

--- a/pixelflow-search/src/egraph/graph.rs
+++ b/pixelflow-search/src/egraph/graph.rs
@@ -58,6 +58,14 @@ pub struct EGraph {
     /// Which rewrite application (if any) is currently executing — read by
     /// `add()`/`union()` to attribute newly created nodes/unions.
     active_application: Option<ActiveApplication>,
+    /// The constant each class is known to equal, as f32 bits, indexed by
+    /// class id — maintained independently of `EClass::nodes` on purpose.
+    /// `rebuild` drains a class's nodes with `mem::take` and only THEN
+    /// performs congruence unions, so a guard that scanned the node vector
+    /// saw an empty class and waved contradictory merges through at exactly
+    /// the moment congruence closure does its work. The fact must outlive the
+    /// nodes.
+    const_fact: Vec<Option<u32>>,
     /// Unions REFUSED because they would assert two numerically unequal
     /// constants equal — a proved falsehood the graph declines to absorb.
     /// Distinct (bits, bits) pairs, kept for reporting and tests; see
@@ -84,6 +92,7 @@ impl Clone for EGraph {
             step: self.step,
             provenance: self.provenance.clone(),
             active_application: self.active_application,
+            const_fact: self.const_fact.clone(),
             refused_const_unions: self.refused_const_unions.clone(),
         }
     }
@@ -116,6 +125,7 @@ impl EGraph {
             step: 0,
             provenance: Provenance::new(),
             active_application: None,
+            const_fact: Vec::new(),
             refused_const_unions: Vec::new(),
         }
     }
@@ -135,6 +145,7 @@ impl EGraph {
             step: 0,
             provenance: Provenance::new(),
             active_application: None,
+            const_fact: Vec::new(),
             refused_const_unions: Vec::new(),
         }
     }
@@ -203,6 +214,7 @@ impl EGraph {
             None => Origin::Seed,
         };
         self.provenance.record_origin(enode_id, origin);
+        self.const_fact.push(node.as_f32().map(f32::to_bits));
         self.classes.push(EClass {
             nodes: vec![node.clone()],
             tags: vec![enode_id],
@@ -249,12 +261,14 @@ impl EGraph {
         // Min/Max over NaN. Bit equality additionally admits identical NaN
         // patterns, which `==` would wrongly reject: an all-ones comparison
         // mask reads as NaN and must be unionable with itself.
-        let const_of = |class: EClassId, classes: &[EClass]| {
-            classes[class.index()].nodes.iter().find_map(|n| n.as_f32())
-        };
-        if let (Some(ca), Some(cb)) = (const_of(a, &self.classes), const_of(b, &self.classes)) {
-            if ca != cb && ca.to_bits() != cb.to_bits() {
-                let pair = (ca.to_bits(), cb.to_bits());
+        // Read the class-level fact, NOT the node vector: `rebuild` drains
+        // nodes with `mem::take` before performing congruence unions, so a
+        // node-scanning guard is blind exactly when congruence closure runs.
+        let (fa, fb) = (self.const_fact[a.index()], self.const_fact[b.index()]);
+        if let (Some(ba), Some(bb)) = (fa, fb) {
+            let (ca, cb) = (f32::from_bits(ba), f32::from_bits(bb));
+            if ca != cb && ba != bb {
+                let pair = (ba, bb);
                 if !self.refused_const_unions.contains(&pair) {
                     std::eprintln!(
                         "pixelflow e-graph: refusing a union that would assert \
@@ -276,6 +290,11 @@ impl EGraph {
         let child_tags = std::mem::take(&mut self.classes[child.index()].tags);
         self.classes[parent.index()].nodes.extend(child_nodes);
         self.classes[parent.index()].tags.extend(child_tags);
+        // The guard above proved the two facts agree (or that at most one
+        // exists), so `or` is a merge, not a choice.
+        if self.const_fact[parent.index()].is_none() {
+            self.const_fact[parent.index()] = self.const_fact[child.index()];
+        }
         self.worklist.push(parent);
         self.provenance.record_union(UnionEvent {
             rule_idx: self.active_application.map(|a| a.rule_idx),

--- a/pixelflow-search/src/egraph/graph.rs
+++ b/pixelflow-search/src/egraph/graph.rs
@@ -963,24 +963,27 @@ impl EGraph {
     /// `apply_action_from_rule` so provenance attribution stays correct;
     /// this function itself has no notion of "which rule" — it only knows
     /// how to execute the `RewriteAction` variants.
+    /// Union `a` and `b`, reporting whether the graph actually changed.
+    ///
+    /// [`EGraph::union`] REFUSES merges that would assert two numerically
+    /// unequal constants equal, so "the classes differed beforehand" is not
+    /// evidence that anything merged. Counting a refusal as a change made
+    /// saturation believe it had made progress, so it rebuilt and re-applied
+    /// the same refused rewrite every iteration until its limit.
+    fn union_counted(&mut self, a: EClassId, b: EClassId) -> usize {
+        if self.find(a) == self.find(b) {
+            return 0;
+        }
+        self.union(a, b);
+        usize::from(self.find(a) == self.find(b))
+    }
+
     fn apply_action(&mut self, class_id: EClassId, action: RewriteAction) -> usize {
         match action {
-            RewriteAction::Union(target_id) => {
-                if self.find(class_id) != self.find(target_id) {
-                    self.union(class_id, target_id);
-                    1
-                } else {
-                    0
-                }
-            }
+            RewriteAction::Union(target_id) => self.union_counted(class_id, target_id),
             RewriteAction::Create(new_node) => {
                 let new_id = self.add(new_node);
-                if self.find(class_id) != self.find(new_id) {
-                    self.union(class_id, new_id);
-                    1
-                } else {
-                    0
-                }
+                self.union_counted(class_id, new_id)
             }
             RewriteAction::Distribute {
                 outer,
@@ -1004,12 +1007,7 @@ impl EGraph {
                     children: vec![ab_id, ac_id],
                 };
                 let result_id = self.add(result_node);
-                if self.find(class_id) != self.find(result_id) {
-                    self.union(class_id, result_id);
-                    1
-                } else {
-                    0
-                }
+                self.union_counted(class_id, result_id)
             }
             RewriteAction::Factor {
                 outer,
@@ -1028,12 +1026,7 @@ impl EGraph {
                     children: vec![common, sum_id],
                 };
                 let result_id = self.add(result_node);
-                if self.find(class_id) != self.find(result_id) {
-                    self.union(class_id, result_id);
-                    1
-                } else {
-                    0
-                }
+                self.union_counted(class_id, result_id)
             }
             RewriteAction::Canonicalize {
                 target,
@@ -1051,12 +1044,7 @@ impl EGraph {
                     children: vec![a, inv_id],
                 };
                 let target_id = self.add(target_node);
-                if self.find(class_id) != self.find(target_id) {
-                    self.union(class_id, target_id);
-                    1
-                } else {
-                    0
-                }
+                self.union_counted(class_id, target_id)
             }
             RewriteAction::Associate { op, a, b, c } => {
                 let bc_node = ENode::Op {
@@ -1069,12 +1057,7 @@ impl EGraph {
                     children: vec![a, bc_id],
                 };
                 let result_id = self.add(result_node);
-                if self.find(class_id) != self.find(result_id) {
-                    self.union(class_id, result_id);
-                    1
-                } else {
-                    0
-                }
+                self.union_counted(class_id, result_id)
             }
             RewriteAction::ReverseAssociate { op, a, b, c } => {
                 // a op (b op c) → (a op b) op c
@@ -1088,12 +1071,7 @@ impl EGraph {
                     children: vec![ab_id, c],
                 };
                 let result_id = self.add(result_node);
-                if self.find(class_id) != self.find(result_id) {
-                    self.union(class_id, result_id);
-                    1
-                } else {
-                    0
-                }
+                self.union_counted(class_id, result_id)
             }
             RewriteAction::OddParity { func, inner } => {
                 // For odd functions: Op(neg(x)) → neg(Op(x))
@@ -1108,12 +1086,7 @@ impl EGraph {
                     children: vec![func_id],
                 };
                 let neg_id = self.add(neg_node);
-                if self.find(class_id) != self.find(neg_id) {
-                    self.union(class_id, neg_id);
-                    1
-                } else {
-                    0
-                }
+                self.union_counted(class_id, neg_id)
             }
             RewriteAction::AngleAddition {
                 term1_op1,
@@ -1190,12 +1163,7 @@ impl EGraph {
                     }
                 };
 
-                if self.find(class_id) != self.find(result_id) {
-                    self.union(class_id, result_id);
-                    1
-                } else {
-                    0
-                }
+                self.union_counted(class_id, result_id)
             }
             RewriteAction::Homomorphism {
                 func,
@@ -1227,12 +1195,7 @@ impl EGraph {
                 };
                 let result_id = self.add(result);
 
-                if self.find(class_id) != self.find(result_id) {
-                    self.union(class_id, result_id);
-                    1
-                } else {
-                    0
-                }
+                self.union_counted(class_id, result_id)
             }
             RewriteAction::PowerCombine { base, exp_a, exp_b } => {
                 // x^a * x^b → x^(a+b)
@@ -1251,12 +1214,7 @@ impl EGraph {
                 };
                 let result_id = self.add(result);
 
-                if self.find(class_id) != self.find(result_id) {
-                    self.union(class_id, result_id);
-                    1
-                } else {
-                    0
-                }
+                self.union_counted(class_id, result_id)
             }
             RewriteAction::ReverseAngleAddition { trig_op, a, b } => {
                 // sin(a)cos(b) + cos(a)sin(b) → sin(a + b)
@@ -1276,12 +1234,7 @@ impl EGraph {
                 };
                 let result_id = self.add(result);
 
-                if self.find(class_id) != self.find(result_id) {
-                    self.union(class_id, result_id);
-                    1
-                } else {
-                    0
-                }
+                self.union_counted(class_id, result_id)
             }
             RewriteAction::HalfAngleProduct { x } => {
                 // sin(x) * cos(x) → sin(x + x) / 2
@@ -1312,12 +1265,7 @@ impl EGraph {
                 };
                 let result_id = self.add(result);
 
-                if self.find(class_id) != self.find(result_id) {
-                    self.union(class_id, result_id);
-                    1
-                } else {
-                    0
-                }
+                self.union_counted(class_id, result_id)
             }
             RewriteAction::Doubling { a } => {
                 // a + a → 2 * a
@@ -1329,12 +1277,7 @@ impl EGraph {
                 };
                 let result_id = self.add(result);
 
-                if self.find(class_id) != self.find(result_id) {
-                    self.union(class_id, result_id);
-                    1
-                } else {
-                    0
-                }
+                self.union_counted(class_id, result_id)
             }
             RewriteAction::Halving { a } => {
                 // 2 * a → a + a
@@ -1344,12 +1287,7 @@ impl EGraph {
                 };
                 let result_id = self.add(result);
 
-                if self.find(class_id) != self.find(result_id) {
-                    self.union(class_id, result_id);
-                    1
-                } else {
-                    0
-                }
+                self.union_counted(class_id, result_id)
             }
             RewriteAction::PowerRecurrence { base, exponent } => {
                 let n_minus_1 = ENode::constant((exponent - 1) as f32);
@@ -1364,12 +1302,7 @@ impl EGraph {
                     children: vec![base, pow_id],
                 };
                 let result_id = self.add(result);
-                if self.find(class_id) != self.find(result_id) {
-                    self.union(class_id, result_id);
-                    1
-                } else {
-                    0
-                }
+                self.union_counted(class_id, result_id)
             }
             RewriteAction::LogPower {
                 log_op,
@@ -1386,12 +1319,7 @@ impl EGraph {
                     children: vec![exponent, log_x_id],
                 };
                 let result_id = self.add(result);
-                if self.find(class_id) != self.find(result_id) {
-                    self.union(class_id, result_id);
-                    1
-                } else {
-                    0
-                }
+                self.union_counted(class_id, result_id)
             }
             RewriteAction::ExpandSquare { a, b } => {
                 let a2 = ENode::Op {
@@ -1426,12 +1354,7 @@ impl EGraph {
                     children: vec![sum1_id, b2_id],
                 };
                 let result_id = self.add(result);
-                if self.find(class_id) != self.find(result_id) {
-                    self.union(class_id, result_id);
-                    1
-                } else {
-                    0
-                }
+                self.union_counted(class_id, result_id)
             }
             RewriteAction::DiffOfSquares { a, b } => {
                 let sum = ENode::Op {
@@ -1449,21 +1372,11 @@ impl EGraph {
                     children: vec![sum_id, diff_id],
                 };
                 let result_id = self.add(result);
-                if self.find(class_id) != self.find(result_id) {
-                    self.union(class_id, result_id);
-                    1
-                } else {
-                    0
-                }
+                self.union_counted(class_id, result_id)
             }
             RewriteAction::Differentiate { inner, var } => {
                 let deriv_id = self.build_derivative(&inner, var);
-                if self.find(class_id) != self.find(deriv_id) {
-                    self.union(class_id, deriv_id);
-                    1
-                } else {
-                    0
-                }
+                self.union_counted(class_id, deriv_id)
             }
         }
     }

--- a/pixelflow-search/src/egraph/graph.rs
+++ b/pixelflow-search/src/egraph/graph.rs
@@ -58,6 +58,11 @@ pub struct EGraph {
     /// Which rewrite application (if any) is currently executing — read by
     /// `add()`/`union()` to attribute newly created nodes/unions.
     active_application: Option<ActiveApplication>,
+    /// Unions REFUSED because they would assert two numerically unequal
+    /// constants equal — a proved falsehood the graph declines to absorb.
+    /// Distinct (bits, bits) pairs, kept for reporting and tests; see
+    /// [`EGraph::union`].
+    refused_const_unions: Vec<(u32, u32)>,
 }
 
 impl Default for EGraph {
@@ -79,6 +84,7 @@ impl Clone for EGraph {
             step: self.step,
             provenance: self.provenance.clone(),
             active_application: self.active_application,
+            refused_const_unions: self.refused_const_unions.clone(),
         }
     }
 }
@@ -110,6 +116,7 @@ impl EGraph {
             step: 0,
             provenance: Provenance::new(),
             active_application: None,
+            refused_const_unions: Vec::new(),
         }
     }
 
@@ -128,6 +135,7 @@ impl EGraph {
             step: 0,
             provenance: Provenance::new(),
             active_application: None,
+            refused_const_unions: Vec::new(),
         }
     }
 
@@ -204,11 +212,63 @@ impl EGraph {
         id
     }
 
+    /// Refused constant unions: `(bits, bits)` pairs the graph declined to
+    /// assert equal. Non-empty means some kernel hit the folding-vs-algebra
+    /// collision — see the refusal block in [`EGraph::union`].
+    #[must_use]
+    pub fn refused_const_unions(&self) -> &[(u32, u32)] {
+        &self.refused_const_unions
+    }
+
     pub fn union(&mut self, a: EClassId, b: EClassId) -> EClassId {
         let a = self.find_mut(a);
         let b = self.find_mut(b);
         if a == b {
             return a;
+        }
+        // An e-class asserts "these are all equal", so a union placing two
+        // numerically UNEQUAL constants in one class would be a proved
+        // falsehood — and congruence closure amplifies any proved falsehood
+        // into everything-equals-everything, with extraction tie-breaking
+        // arbitrarily between unequal constants. The falsehoods are real:
+        // constant folding computes f32-truths (`x + 2²⁴ = 2²⁴`) while the
+        // algebraic rules compute ℝ-truths (`(x+y)−y = x`), each sound
+        // alone. At the collision, REFUSE the union: an under-merged e-graph
+        // is still sound — every class still holds only provably-equal
+        // terms, and the cost is missed CSE at exactly the collision points
+        // — while a false merge is unbounded. First prover keeps the class;
+        // the refusal is journaled and reported so ill-conditioned kernels
+        // are loud instead of subtly nondeterministic. (Folding constants in
+        // f64 is the planned complement: it makes the folder agree with the
+        // algebra at f32-observable scales, so collisions become
+        // vanishingly rare and this valve becomes a pure detector.)
+        //
+        // `ca == cb` (not bit equality) deliberately admits ±0.0 — signed
+        // zero selection is already platform-unspecified, so an optimizer
+        // choosing a sign is within contract, same license as commuting
+        // Min/Max over NaN. Bit equality additionally admits identical NaN
+        // patterns, which `==` would wrongly reject: an all-ones comparison
+        // mask reads as NaN and must be unionable with itself.
+        let const_of = |class: EClassId, classes: &[EClass]| {
+            classes[class.index()].nodes.iter().find_map(|n| n.as_f32())
+        };
+        if let (Some(ca), Some(cb)) = (const_of(a, &self.classes), const_of(b, &self.classes)) {
+            if ca != cb && ca.to_bits() != cb.to_bits() {
+                let pair = (ca.to_bits(), cb.to_bits());
+                if !self.refused_const_unions.contains(&pair) {
+                    std::eprintln!(
+                        "pixelflow e-graph: refusing a union that would assert \
+                         {ca} = {cb} (bits {:#010x} vs {:#010x}) — the rule set \
+                         derived contradictory constants (f32 folding vs \
+                         algebra at an ill-conditioned input); keeping the \
+                         classes separate costs only missed CSE",
+                        pair.0,
+                        pair.1
+                    );
+                    self.refused_const_unions.push(pair);
+                }
+                return if a.0 < b.0 { a } else { b };
+            }
         }
         let (parent, child) = if a.0 < b.0 { (a, b) } else { (b, a) };
         self.parent[child.index()] = parent;

--- a/pixelflow-search/src/egraph/graph.rs
+++ b/pixelflow-search/src/egraph/graph.rs
@@ -401,6 +401,22 @@ impl EGraph {
                         // (`active_application` is whatever the caller left
                         // it as — normally `None` outside rule application).
                         self.union(id, existing);
+
+                        // `union` REFUSES a merge that would assert two
+                        // unequal constants equal, and a refusal here needs
+                        // handling that a rule-driven refusal does not: the
+                        // node below would be pushed back into `id` while
+                        // `memo` names `existing`, leaving ONE ENode in two
+                        // contradictory classes with only one of them
+                        // reachable by lookup — later matching or extraction
+                        // could then give the same expression different
+                        // values. Leave the node with the class memo already
+                        // names. `id` loses a node congruent to one it can no
+                        // longer be merged with, which is under-merging: it
+                        // costs CSE, not correctness.
+                        if self.find(id) != self.find(existing) {
+                            continue;
+                        }
                     }
                 } else {
                     self.memo.insert(node.clone(), id);

--- a/pixelflow-search/src/egraph/graph.rs
+++ b/pixelflow-search/src/egraph/graph.rs
@@ -165,7 +165,7 @@ impl EGraph {
 
     fn canonicalize_node(&self, node: &mut ENode) {
         match node {
-            ENode::Var(_) | ENode::Const(_) => {}
+            ENode::Var(_) | ENode::Const(_) | ENode::Buffer(_) => {}
             ENode::Op { children, .. } => {
                 for child in children {
                     *child = self.find(*child);
@@ -454,6 +454,7 @@ impl EGraph {
         match &class.nodes[0] {
             ENode::Var(_) => pixelflow_ir::OpKind::Var,
             ENode::Const(_) => pixelflow_ir::OpKind::Const,
+            ENode::Buffer(_) => pixelflow_ir::OpKind::Buffer,
             ENode::Op { op, .. } => op.kind(),
         }
     }
@@ -514,13 +515,10 @@ impl EGraph {
                 ExprNode::Param(i) => {
                     panic!("add_arena: ExprNode::Param({i}) not valid after kernel compilation")
                 }
-                ExprNode::Buffer(b) => {
-                    panic!(
-                        "add_arena: ExprNode::Buffer({}) — memory ops are not yet representable \
-                         in the e-graph (KERNELS_AND_LATTICES.md M3)",
-                        b.0
-                    )
-                }
+                // The leaf carries the full decl (identity + extents), so
+                // hash-consing merges buffer references across arenas iff they
+                // name the same memory — see `ENode::Buffer`.
+                ExprNode::Buffer(b) => self.add(ENode::Buffer(*arena.buffer_decl(*b))),
                 ExprNode::Unary(op, child) => {
                     let child_id = id_map[child.0 as usize].unwrap_or_else(|| {
                         panic!(
@@ -574,8 +572,15 @@ impl EGraph {
                             c
                         )
                     });
-                    let static_op = ops::op_from_kind(*op)
-                        .unwrap_or_else(|| panic!("add_arena: no static Op for OpKind {:?}", op));
+                    // Gather is deliberately absent from `op_from_kind` (no
+                    // rewrite rule may name it) but representable as opaque
+                    // structure — resolve it directly.
+                    let static_op: &'static dyn crate::egraph::ops::Op = match *op {
+                        pixelflow_ir::OpKind::Gather => &ops::Gather,
+                        other => ops::op_from_kind(other).unwrap_or_else(|| {
+                            panic!("add_arena: no static Op for OpKind {other:?}")
+                        }),
+                    };
                     self.add(ENode::Op {
                         op: static_op,
                         children: vec![a_id, b_id, c_id],
@@ -1414,6 +1419,14 @@ impl EGraph {
             ENode::Const(_) => return self.add(ENode::constant(0.0)),
             ENode::Var(i) => {
                 return self.add(ENode::constant(if *i == var { 1.0 } else { 0.0 }));
+            }
+            // A Buffer leaf is not a value — it only ever appears as Gather's
+            // first child, and no rewrite builds `Dwrt(buffer)`. Reaching one
+            // here means the graph is malformed; fail loudly. (`Dwrt(gather)`
+            // is the Op arm below: Gather has no derivative table entry, so it
+            // reconstructs the Dwrt as the jet fallback.)
+            ENode::Buffer(decl) => {
+                panic!("build_derivative: Dwrt applied to a Buffer leaf ({decl:?})")
             }
             ENode::Op { op, children } => (*op, children.clone()),
         };

--- a/pixelflow-search/src/egraph/graph.rs
+++ b/pixelflow-search/src/egraph/graph.rs
@@ -270,15 +270,22 @@ impl EGraph {
             if ca != cb && ba != bb {
                 let pair = (ba, bb);
                 if !self.refused_const_unions.contains(&pair) {
-                    std::eprintln!(
-                        "pixelflow e-graph: refusing a union that would assert \
-                         {ca} = {cb} (bits {:#010x} vs {:#010x}) — the rule set \
-                         derived contradictory constants (f32 folding vs \
-                         algebra at an ill-conditioned input); keeping the \
-                         classes separate costs only missed CSE",
-                        pair.0,
-                        pair.1
-                    );
+                    // Journal ALWAYS; print only on request. This fires
+                    // during ordinary kernel compilation — two computation
+                    // orders of one real quantity disagreeing by an ulp is
+                    // enough — so unconditional stderr would spam every
+                    // build. `refused_const_unions()` is the durable record.
+                    if std::env::var_os("PIXELFLOW_REPORT_CONST_REFUSALS").is_some() {
+                        std::eprintln!(
+                            "pixelflow e-graph: refusing a union that would assert \
+                             {ca} = {cb} (bits {:#010x} vs {:#010x}) — the rule set \
+                             derived contradictory constants (f32 folding vs \
+                             algebra at an ill-conditioned input); keeping the \
+                             classes separate costs only missed CSE",
+                            pair.0,
+                            pair.1
+                        );
+                    }
                     self.refused_const_unions.push(pair);
                 }
                 return if a.0 < b.0 { a } else { b };

--- a/pixelflow-search/src/egraph/node.rs
+++ b/pixelflow-search/src/egraph/node.rs
@@ -2,6 +2,7 @@
 
 use super::ops::Op;
 use alloc::vec::Vec;
+use pixelflow_ir::arena::BufferDecl;
 
 /// Identifier for an equivalence class in the e-graph.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -26,6 +27,15 @@ pub enum ENode {
     Var(u8),
     /// Constant value (stored as f32 bits)
     Const(u32),
+    /// Bound-memory leaf: a buffer declaration, read through a `Gather` node.
+    ///
+    /// Carries the full [`BufferDecl`] rather than an arena-local `BufferId`
+    /// because e-classes outlive any one arena: `BufferIdentity` is
+    /// process-unique, so two `Buffer` leaves are the same e-class iff they
+    /// name the same memory with the same extents — which is exactly the
+    /// hash-consing CSE this leaf exists for. Extraction redeclares the decl
+    /// into the output arena.
+    Buffer(BufferDecl),
     /// Operation with children
     Op {
         op: &'static dyn Op,
@@ -63,7 +73,7 @@ impl ENode {
     /// Get children of this node.
     pub fn children(&self) -> Vec<EClassId> {
         match self {
-            ENode::Var(_) | ENode::Const(_) => vec![],
+            ENode::Var(_) | ENode::Const(_) | ENode::Buffer(_) => vec![],
             ENode::Op { children, .. } => children.clone(),
         }
     }
@@ -84,6 +94,12 @@ impl PartialEq for ENode {
         match (self, other) {
             (ENode::Var(a), ENode::Var(b)) => a == b,
             (ENode::Const(a), ENode::Const(b)) => a == b,
+            // Full-decl equality: same identity AND same extents. Identity
+            // alone would hash-cons two decls that disagree on extents, and
+            // extraction would then redeclare only one of them — a silent
+            // extent corruption. Splice already asserts decls agree, so in a
+            // well-formed graph this is equivalent to identity equality.
+            (ENode::Buffer(a), ENode::Buffer(b)) => a == b,
             (
                 ENode::Op {
                     op: op1,
@@ -115,6 +131,10 @@ impl core::hash::Hash for ENode {
             ENode::Const(bits) => {
                 1u8.hash(state);
                 bits.hash(state);
+            }
+            ENode::Buffer(decl) => {
+                3u8.hash(state);
+                decl.hash(state);
             }
             ENode::Op { op, children } => {
                 2u8.hash(state);

--- a/pixelflow-search/src/egraph/ops.rs
+++ b/pixelflow-search/src/egraph/ops.rs
@@ -136,6 +136,25 @@ define_op!(Select);
 // === Aggregates ===
 define_op!(Tuple);
 
+// === Memory ===
+// `Gather(buffer, x, y)` — bound-memory read (floor indices, clamp to the
+// declared extents, row-major). Present as an `Op` so the e-graph can carry it
+// as opaque structure — two gathers hash-cons into one e-class iff buffer
+// identity and all three children match — but deliberately ABSENT from
+// [`op_from_kind`]: rewrite templates resolve ops through that lookup, and
+// returning `None` there is what keeps the rule set unable to name Gather.
+// Its semantics depend on bound memory, so no algebraic rule (and no constant
+// fold) may ever look through it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(crate) struct Gather;
+
+impl Op for Gather {
+    #[inline]
+    fn kind(&self) -> OpKind {
+        OpKind::Gather
+    }
+}
+
 // === Differentiation ===
 // `Dwrt(expr, var)` is the single autodiff operator. It exists only inside the
 // e-graph: chain-rule rewrites push it toward the leaves until it dissolves
@@ -199,8 +218,14 @@ pub fn op_from_kind(kind: OpKind) -> Option<&'static dyn Op> {
         | OpKind::Shr
         | OpKind::BitAnd
         | OpKind::BitOr => None,
-        // Memory ops are not yet representable in the e-graph: a Buffer leaf
-        // references an arena-local table that e-classes cannot carry.
+        // Memory ops are representable (`ENode::Buffer` carries the full
+        // `BufferDecl` — `BufferIdentity` is process-unique, so no arena-local
+        // table is needed) but stay opaque to the rule set: `None` here is
+        // what denies every rewrite template the ability to name them, so
+        // their participation is hash-consing CSE only. `add_arena` and the
+        // runtime tier resolve `Gather` directly via the crate-private
+        // `Gather` op above. `RawGather` and `Reduce` are lowered
+        // before/after the e-graph and never appear in one.
         OpKind::Buffer | OpKind::Gather | OpKind::RawGather | OpKind::Reduce => None,
     }
 }

--- a/pixelflow-search/src/math/algebra.rs
+++ b/pixelflow-search/src/math/algebra.rs
@@ -927,11 +927,12 @@ impl Rewrite for ConstantFold {
         // arithmetic into code that may run somewhere that computes
         // differently. `fold_is_platform_specific` owns the classification (NaN
         // and signed-zero Min/Max, NaN Gt/Ge, Round at a tie, the reciprocal
-        // estimates, MulAdd's one-vs-two roundings) so it lives in one place
-        // next to the semantics rather than as conditions here.
+        // estimates, MulAdd's one-vs-two roundings, invalid TruncToInt) so it
+        // lives in one place next to the semantics rather than as conditions
+        // here.
         //
-        // Complete for `Round`/`Recip`/`Rsqrt` (unary — no rewrite can
-        // reintroduce the fold) and for `MulAdd` (its only commutable pair is
+        // Complete for `Round`/`Recip`/`Rsqrt`/`TruncToInt` (unary — no rewrite
+        // can reintroduce the fold) and for `MulAdd` (its only commutable pair is
         // the two multiplicands, which round identically either way). Partial
         // for `Min`/`Max`: the e-graph installs commutativity for them, so a
         // commuted form can still be folded. That is permitted, since the

--- a/pixelflow-search/src/math/mod.rs
+++ b/pixelflow-search/src/math/mod.rs
@@ -197,6 +197,7 @@ mod tests {
         match node {
             ENode::Var(idx) => arena.push_var(idx),
             ENode::Const(bits) => arena.push_const(f32::from_bits(bits)),
+            ENode::Buffer(decl) => panic!("Buffer({decl:?}) reached math tests"),
             ENode::Op { op, children } => {
                 let kind = op.kind();
                 let child_ids: Vec<ExprId> = children

--- a/pixelflow-search/src/nnue/factored.rs
+++ b/pixelflow-search/src/nnue/factored.rs
@@ -1030,9 +1030,9 @@ impl EdgeAccumulator {
             }
 
             match node {
-                ENode::Var(_) | ENode::Const(_) => {
+                ENode::Var(_) | ENode::Const(_) | ENode::Buffer(_) => {
                     // Leaf: no edges to add. If shared, ref loads are zero-cost
-                    // (it's just a variable or constant).
+                    // (a variable, constant, or bound-buffer handle).
                 }
                 ENode::Op { op, children } => {
                     let parent_op = op.kind();
@@ -1067,6 +1067,7 @@ impl EdgeAccumulator {
                                 child_nodes.get(child_node_idx).map(|n| match n {
                                     ENode::Var(_) => OpKind::Var,
                                     ENode::Const(_) => OpKind::Const,
+                                    ENode::Buffer(_) => OpKind::Buffer,
                                     ENode::Op { op: cop, .. } => cop.kind(),
                                 })
                             }

--- a/pixelflow-search/src/runtime.rs
+++ b/pixelflow-search/src/runtime.rs
@@ -35,12 +35,18 @@ use std::sync::{Arc, Mutex, OnceLock};
 /// same rule set and extraction policy (static latency-prior by default,
 /// `PIXELFLOW_NNUE_WEIGHTS` opt-in) as the `kernel!`/`kernel_jit!` macros.
 ///
+/// `Buffer`/`Gather` (bound-memory reads) are representable: they enter the
+/// e-graph as opaque structure — no rewrite rule can name them, so their
+/// gain is hash-consing CSE (splice-duplicated sampler subtrees collapse to
+/// one node) plus ordinary rewriting of the coordinate arithmetic that feeds
+/// them. Extraction redeclares each distinct `BufferIdentity` once in the
+/// output arena.
+///
 /// Returns `None`, unchanged, when the subgraph reachable from `root`
 /// contains a construct the e-graph doesn't model:
 ///
-/// - `Buffer`/`Gather`/`RawGather` (bound-memory reads) — no rewrite rule
-///   reasons about memory, and the e-graph would just be dead weight around
-///   an opaque leaf.
+/// - `RawGather` — produced by lowering, after the e-graph's place in the
+///   pipeline; reaching one here means the arena is already lowered.
 /// - `Nary` (the `Reduce` binder, from `Kernel::over`) — rewriting under a
 ///   binder is unsound without binder-aware rules (none exist yet); this is
 ///   a documented follow-up, not silently wrong output.
@@ -171,8 +177,16 @@ fn canonical_key(arena: &ExprArena, root: ExprId) -> Vec<u8> {
             }
             &ExprNode::Buffer(b) => {
                 key.push(3);
-                key.extend_from_slice(&b.0.to_le_bytes());
-                let BufferDecl { width, height, .. } = *arena.buffer_decl(b);
+                // Key by process-unique BufferIdentity, NOT the arena-local
+                // slot index: two arenas can both call their own buffer "slot
+                // 0" with equal extents while naming different memory, and a
+                // slot-keyed cache would hand one of them the other's
+                // optimized arena — whose redeclared identity binds the wrong
+                // pixels. Identity is process-local, which is exactly the
+                // lifetime of this in-process cache. It has no byte accessor,
+                // so serialize its (injective) Debug form.
+                let BufferDecl { id, width, height } = *arena.buffer_decl(b);
+                key.extend_from_slice(alloc::format!("{id:?}").as_bytes());
                 key.extend_from_slice(&width.to_le_bytes());
                 key.extend_from_slice(&height.to_le_bytes());
             }
@@ -241,6 +255,50 @@ impl Op for MaskOr {
     }
 }
 
+// ─────────────────────── Runtime-only integer-domain ops ─────────────────────
+//
+// The packed cell-grid kernel's spine: clamp → `TruncToInt` → `Shl` →
+// or-fold builds a `u32` pixel per lane, so the production frame kernel is
+// unrepresentable — and therefore compiles with NO CSE across its four
+// channels — unless these enter the e-graph. Runtime-tier only, for the
+// same reason as the mask ops above. Opaque structure: no rewrite rule can
+// name them (nothing here or in `op_from_kind` hands them to a template),
+// their results are bit patterns the float rule set has no semantics for,
+// and `ConstantFold` cannot reach them because folding is rule-driven.
+// `Shl`/`Shr` keep `Const` shift operands by the same argument — no rule
+// can rewrite an operand of an unnameable op's node, and extraction emits
+// `Const` leaves verbatim — so the emitter's immediate-only contract holds.
+struct IntTrunc;
+impl Op for IntTrunc {
+    fn kind(&self) -> OpKind {
+        OpKind::TruncToInt
+    }
+}
+struct IntFromInt;
+impl Op for IntFromInt {
+    fn kind(&self) -> OpKind {
+        OpKind::IntToFloat
+    }
+}
+struct IntAdd;
+impl Op for IntAdd {
+    fn kind(&self) -> OpKind {
+        OpKind::IAdd
+    }
+}
+struct IntShl;
+impl Op for IntShl {
+    fn kind(&self) -> OpKind {
+        OpKind::Shl
+    }
+}
+struct IntShr;
+impl Op for IntShr {
+    fn kind(&self) -> OpKind {
+        OpKind::Shr
+    }
+}
+
 /// Whether the runtime tier can represent `kind` in its e-graph — i.e.,
 /// whether an arena containing it still optimizes rather than bailing.
 /// Test hook for the representability guards; the semantics live in
@@ -251,11 +309,19 @@ pub fn is_egraph_representable(kind: OpKind) -> bool {
 }
 
 /// [`crate::egraph::ops::op_from_kind`] extended with the runtime-only mask
-/// ops above. Every conversion in this module resolves ops through this.
+/// ops above and the opaque `Gather` op (absent from the global lookup so no
+/// rewrite template can name it — its participation is hash-consing CSE
+/// only). Every conversion in this module resolves ops through this.
 fn runtime_op_from_kind(kind: OpKind) -> Option<&'static dyn Op> {
     match kind {
         OpKind::BitAnd => Some(&MaskAnd),
         OpKind::BitOr => Some(&MaskOr),
+        OpKind::TruncToInt => Some(&IntTrunc),
+        OpKind::IntToFloat => Some(&IntFromInt),
+        OpKind::IAdd => Some(&IntAdd),
+        OpKind::Shl => Some(&IntShl),
+        OpKind::Shr => Some(&IntShr),
+        OpKind::Gather => Some(&crate::egraph::ops::Gather),
         other => crate::egraph::ops::op_from_kind(other),
     }
 }
@@ -301,7 +367,12 @@ fn arena_to_egraph(
                         memo.insert(id, class);
                         result_stack.push(class);
                     }
-                    ExprNode::Param(_) | ExprNode::Buffer(_) => return None,
+                    ExprNode::Param(_) => return None,
+                    &ExprNode::Buffer(b) => {
+                        let class = egraph.add(ENode::Buffer(*arena.buffer_decl(b)));
+                        memo.insert(id, class);
+                        result_stack.push(class);
+                    }
                     &ExprNode::Unary(kind, a) => {
                         runtime_op_from_kind(kind)?;
                         task_stack.push(Task::Complete(id));
@@ -533,13 +604,97 @@ mod tests {
         assert_semantics_preserved(&want_arena, want_root, &(got_arena, got_root));
     }
 
+    /// Ids of every node reachable from `root`, discovery order.
+    fn reachable_ids(arena: &ExprArena, root: ExprId) -> Vec<ExprId> {
+        let mut seen = vec![false; arena.nodes_raw().len()];
+        let mut stack = vec![root];
+        let mut out = Vec::new();
+        while let Some(id) = stack.pop() {
+            if core::mem::replace(&mut seen[id.0 as usize], true) {
+                continue;
+            }
+            out.push(id);
+            stack.extend(arena.children(id));
+        }
+        out
+    }
+
+    fn count_gathers(arena: &ExprArena, root: ExprId) -> usize {
+        reachable_ids(arena, root)
+            .iter()
+            .filter(|&&id| matches!(arena.node(id), ExprNode::Ternary(OpKind::Gather, ..)))
+            .count()
+    }
+
+    /// Identities of buffers referenced by reachable `Buffer` leaves.
+    fn reachable_buffer_identities(
+        arena: &ExprArena,
+        root: ExprId,
+    ) -> std::collections::BTreeSet<pixelflow_ir::arena::BufferIdentity> {
+        reachable_ids(arena, root)
+            .iter()
+            .filter_map(|&id| match arena.node(id) {
+                &ExprNode::Buffer(b) => Some(arena.buffer_decl(b).id),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Bind slices to an arena by buffer *identity*, not slot order: the
+    /// optimizer redeclares buffers in extraction-traversal order, so the
+    /// optimized arena's slot numbering can differ from the input's.
+    fn bind_by_identity<'a>(
+        arena: &ExprArena,
+        by_id: &[(pixelflow_ir::arena::BufferIdentity, &'a [f32])],
+    ) -> BindingTable<'a> {
+        let slices: Vec<&[f32]> = arena
+            .buffers()
+            .iter()
+            .map(|d| {
+                by_id
+                    .iter()
+                    .find(|(id, _)| *id == d.id)
+                    .unwrap_or_else(|| panic!("no slice for buffer identity {:?}", d.id))
+                    .1
+            })
+            .collect();
+        BindingTable::bind(arena, &slices).expect("bind_by_identity")
+    }
+
+    /// Eval parity for buffer-bearing arenas, both sides bound by identity.
+    fn assert_gather_semantics_preserved(
+        arena: &ExprArena,
+        root: ExprId,
+        optimized: &(ExprArena, ExprId),
+        by_id: &[(pixelflow_ir::arena::BufferIdentity, &[f32])],
+    ) {
+        let (opt_arena, opt_root) = optimized;
+        let want_bind = bind_by_identity(arena, by_id);
+        let got_bind = bind_by_identity(opt_arena, by_id);
+        // Coordinates chosen off integer boundaries so Gather's floor cannot
+        // flip cells on rounding differences introduced by rewrites.
+        let coords: &[(f32, f32)] = &[(0.3, 0.4), (1.5, 0.6), (2.2, 1.7), (3.6, 2.4), (-1.2, 9.5)];
+        for &(cx, cy) in coords {
+            let want = eval_scalar(arena, root, &[cx, cy, 0.0, 0.0], &want_bind);
+            let got = eval_scalar(opt_arena, *opt_root, &[cx, cy, 0.0, 0.0], &got_bind);
+            assert!(
+                (want - got).abs() < 1e-3,
+                "gather optimization changed semantics at ({cx},{cy}): {want} != {got}"
+            );
+        }
+    }
+
     #[test]
-    fn buffer_gather_bails_out() {
-        // BilinearSampler-shaped: a Gather anywhere reachable from root means
-        // "don't touch this" — return None rather than mis-optimize memory
-        // ops the e-graph doesn't model.
+    fn gather_arena_round_trips_through_the_egraph() {
+        // BilinearSampler-shaped: the e-graph must now carry the Gather as
+        // opaque structure and hand back an arena that declares the same
+        // buffer (by identity) and evaluates identically.
+        let identity = pixelflow_ir::arena::BufferIdentity::mint();
+        let data: Vec<f32> = (0..16).map(|i| i as f32 * 3.0 + 1.0).collect();
+
         let mut a = ExprArena::new();
         let buf = a.declare_buffer(BufferDecl {
+            id: identity,
             width: 4,
             height: 4,
         });
@@ -549,10 +704,219 @@ mod tests {
         let one = a.push_const(1.0);
         let root = a.push_binary(OpKind::Add, g, one);
 
-        assert!(
-            optimize_runtime_arena(&a, root).is_none(),
-            "an arena reaching a Buffer/Gather must not be optimized"
+        let arc = optimize_runtime_arena(&a, root)
+            .expect("a Gather-bearing arena must optimize, not bail");
+        let (opt_arena, opt_root) = (arc.0.clone(), arc.1);
+
+        assert_eq!(
+            reachable_buffer_identities(&opt_arena, opt_root),
+            reachable_buffer_identities(&a, root),
+            "extraction must redeclare the same buffers, by identity"
         );
+        assert_gather_semantics_preserved(
+            &a,
+            root,
+            &(opt_arena, opt_root),
+            &[(identity, data.as_slice())],
+        );
+    }
+
+    #[test]
+    fn duplicated_gathers_cse_into_one_node() {
+        // The composition problem this change exists to solve: every use of a
+        // sampler Kernel re-splices its fragment, so the SAME gather (same
+        // buffer identity, same coordinate subtree) appears twice as two
+        // disjoint copies. Hash-consing must collapse them to one node.
+        let identity = pixelflow_ir::arena::BufferIdentity::mint();
+        let data: Vec<f32> = (0..16).map(|i| (i * i) as f32).collect();
+
+        let mut a = ExprArena::new();
+        let buf = a.declare_buffer(BufferDecl {
+            id: identity,
+            width: 4,
+            height: 4,
+        });
+        // Two structurally identical copies, pushed separately — exactly what
+        // splice produces.
+        let mut push_dup = |a: &mut ExprArena| {
+            let x = a.push_var(0);
+            let y = a.push_var(1);
+            let one = a.push_const(1.0);
+            let xx = a.push_binary(OpKind::Add, x, one);
+            a.push_gather(buf, xx, y)
+        };
+        let g1 = push_dup(&mut a);
+        let g2 = push_dup(&mut a);
+        // Mul (not Add) so the doubling rule can't restructure the root and
+        // muddy the count assertions.
+        let root = a.push_binary(OpKind::Mul, g1, g2);
+
+        let before = reachable_count(&a, root);
+        assert_eq!(
+            count_gathers(&a, root),
+            2,
+            "input must contain the duplicate"
+        );
+
+        let arc = optimize_runtime_arena(&a, root).expect("must optimize");
+        let (opt_arena, opt_root) = (arc.0.clone(), arc.1);
+        let after = reachable_count(&opt_arena, opt_root);
+
+        assert!(
+            after < before,
+            "CSE must strictly shrink the arena (before={before}, after={after})"
+        );
+        assert_eq!(
+            count_gathers(&opt_arena, opt_root),
+            1,
+            "the two identical gathers must share one node"
+        );
+        assert_gather_semantics_preserved(
+            &a,
+            root,
+            &(opt_arena, opt_root),
+            &[(identity, data.as_slice())],
+        );
+    }
+
+    #[test]
+    fn distinct_buffer_identities_never_merge() {
+        // Equal extents and identical coordinates are a coincidence, not the
+        // same memory: gathers of different identities must stay distinct.
+        let id_a = pixelflow_ir::arena::BufferIdentity::mint();
+        let id_b = pixelflow_ir::arena::BufferIdentity::mint();
+        let data_a: Vec<f32> = (0..16).map(|i| i as f32).collect();
+        let data_b: Vec<f32> = (0..16).map(|i| 1000.0 - i as f32).collect();
+
+        let mut a = ExprArena::new();
+        let buf_a = a.declare_buffer(BufferDecl {
+            id: id_a,
+            width: 4,
+            height: 4,
+        });
+        let buf_b = a.declare_buffer(BufferDecl {
+            id: id_b,
+            width: 4,
+            height: 4,
+        });
+        let x = a.push_var(0);
+        let y = a.push_var(1);
+        let ga = a.push_gather(buf_a, x, y);
+        let gb = a.push_gather(buf_b, x, y);
+        let root = a.push_binary(OpKind::Sub, ga, gb);
+
+        let arc = optimize_runtime_arena(&a, root).expect("must optimize");
+        let (opt_arena, opt_root) = (arc.0.clone(), arc.1);
+
+        assert_eq!(
+            count_gathers(&opt_arena, opt_root),
+            2,
+            "different identities with identical extents/coords must not merge"
+        );
+        assert_eq!(
+            reachable_buffer_identities(&opt_arena, opt_root).len(),
+            2,
+            "both identities must survive extraction"
+        );
+        assert_gather_semantics_preserved(
+            &a,
+            root,
+            &(opt_arena, opt_root),
+            &[(id_a, data_a.as_slice()), (id_b, data_b.as_slice())],
+        );
+    }
+
+    #[test]
+    fn composed_cell_grid_kernel_shape_deduplicates() {
+        // Faithful synthetic of the packed terminal kernel: cell-grid
+        // coordinate arithmetic (cell index + intra-cell offset) feeding 5
+        // gathers of one buffer (glyph atlas channels) and 4 of another
+        // (color planes), with the coordinate subtree re-spliced VERBATIM for
+        // every gather — exactly the duplication Kernel composition produces.
+        let atlas_id = pixelflow_ir::arena::BufferIdentity::mint();
+        let color_id = pixelflow_ir::arena::BufferIdentity::mint();
+        let atlas: Vec<f32> = (0..(64 * 32)).map(|i| (i % 97) as f32).collect();
+        let colors: Vec<f32> = (0..(64 * 32)).map(|i| (i % 251) as f32 * 0.5).collect();
+
+        let mut a = ExprArena::new();
+        let atlas_buf = a.declare_buffer(BufferDecl {
+            id: atlas_id,
+            width: 64,
+            height: 32,
+        });
+        let color_buf = a.declare_buffer(BufferDecl {
+            id: color_id,
+            width: 64,
+            height: 32,
+        });
+
+        // The shared coordinate arithmetic, duplicated per gather: cell
+        // coords (floor(X/8), floor(Y/16)), intra-cell offsets, and an
+        // atlas-space remap. The atlas cell stride (10, 18) differs from the
+        // screen cell size (8, 16) so no algebraic rule can cancel the
+        // arithmetic away — deduplication must come from hash-consing, as in
+        // the real kernel.
+        let mut push_coords = |a: &mut ExprArena| {
+            let x = a.push_var(0);
+            let y = a.push_var(1);
+            let cw = a.push_const(8.0);
+            let ch = a.push_const(16.0);
+            let aw = a.push_const(10.0);
+            let ah = a.push_const(18.0);
+            let xc = a.push_binary(OpKind::Div, x, cw);
+            let cx = a.push_unary(OpKind::Floor, xc);
+            let yc = a.push_binary(OpKind::Div, y, ch);
+            let cy = a.push_unary(OpKind::Floor, yc);
+            let cxw = a.push_binary(OpKind::Mul, cx, cw);
+            let fx = a.push_binary(OpKind::Sub, x, cxw);
+            let cyh = a.push_binary(OpKind::Mul, cy, ch);
+            let fy = a.push_binary(OpKind::Sub, y, cyh);
+            let cxa = a.push_binary(OpKind::Mul, cx, aw);
+            let cya = a.push_binary(OpKind::Mul, cy, ah);
+            let sx = a.push_binary(OpKind::Add, cxa, fx);
+            let sy = a.push_binary(OpKind::Add, cya, fy);
+            (sx, sy)
+        };
+
+        let mut acc = a.push_const(0.0);
+        for i in 0..9 {
+            let (sx, sy) = push_coords(&mut a);
+            let buf = if i < 5 { atlas_buf } else { color_buf };
+            let g = a.push_gather(buf, sx, sy);
+            let w = a.push_const(0.1 + i as f32 * 0.07);
+            let wg = a.push_binary(OpKind::Mul, g, w);
+            acc = a.push_binary(OpKind::Add, acc, wg);
+        }
+        let root = acc;
+
+        let before = reachable_count(&a, root);
+        assert_eq!(count_gathers(&a, root), 9);
+
+        let arc = optimize_runtime_arena(&a, root).expect("must optimize");
+        let (opt_arena, opt_root) = (arc.0.clone(), arc.1);
+        let after = reachable_count(&opt_arena, opt_root);
+
+        // Report shape for the record: 9 duplicated ~13-node coordinate
+        // subtrees must collapse to (at most) one shared copy, and the 5+4
+        // gathers to one per (buffer, coords) pair — here 2 total.
+        assert!(
+            after < before,
+            "composed kernel must come back deduplicated (before={before}, after={after})"
+        );
+        assert_eq!(
+            count_gathers(&opt_arena, opt_root),
+            2,
+            "5 atlas + 4 color gathers of identical coords must CSE to one each"
+        );
+        assert_gather_semantics_preserved(
+            &a,
+            root,
+            &(opt_arena, opt_root),
+            &[(atlas_id, atlas.as_slice()), (color_id, colors.as_slice())],
+        );
+
+        // Keep the measured counts visible in test output (`--nocapture`).
+        println!("composed cell-grid shape: before={before} nodes, after={after} nodes");
     }
 
     #[test]

--- a/pixelflow-search/src/runtime.rs
+++ b/pixelflow-search/src/runtime.rs
@@ -75,6 +75,15 @@ pub fn optimize_runtime_arena(arena: &ExprArena, root: ExprId) -> Option<Arc<(Ex
     static CACHE: OnceLock<Mutex<HashMap<Vec<u8>, Option<Arc<(ExprArena, ExprId)>>>>> =
         OnceLock::new();
 
+    // Buffer-bearing arenas bypass the cache entirely: `BufferIdentity` is
+    // process-unique and minted per construction, so two compiles never
+    // share a key — every lookup would miss while every insert stayed
+    // forever (the cache is static and unbounded). A terminal resizing all
+    // day would leak one full optimized arena per recompile for zero hits.
+    if !arena.buffers().is_empty() {
+        return optimize_runtime_arena_uncached(arena, root).map(Arc::new);
+    }
+
     let key = canonical_key(arena, root);
     let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
     if let Some(hit) = cache
@@ -125,7 +134,33 @@ fn optimize_runtime_arena_uncached(arena: &ExprArena, root: ExprId) -> Option<(E
 
     let policy = env_extraction_policy();
     let choices = policy.choices(&egraph, root_class);
-    Some(choices_to_arena(&egraph, root_class, &choices))
+    let (extracted, extracted_root) = choices_to_arena(&egraph, root_class, &choices);
+
+    // The extracted arena declares buffers in extraction-traversal order,
+    // which need not match the input's — and slot order is ABI: the JIT
+    // loads slot i's base pointer from the caller's context array at i*8,
+    // and callers bind in the order the arena THEY BUILT declared. A
+    // different extraction (a commuted equivalent under another cost model)
+    // must not silently permute their pointers. Re-splicing onto a table
+    // pre-declared in input order makes the invariant structural: splice
+    // dedups buffers by identity onto the existing slots.
+    if arena.buffers().is_empty() {
+        return Some((extracted, extracted_root));
+    }
+    let mut ordered = ExprArena::new();
+    for decl in arena.buffers() {
+        let _slot = ordered.declare_buffer(*decl);
+    }
+    let root = ordered.splice(&extracted, extracted_root);
+    debug_assert!(
+        ordered
+            .buffers()
+            .iter()
+            .zip(arena.buffers())
+            .all(|(a, b)| a.id == b.id),
+        "buffer slot order must survive optimization"
+    );
+    Some((ordered, root))
 }
 
 /// Canonical serialization of the subgraph reachable from `root`: nodes in
@@ -777,6 +812,37 @@ mod tests {
             &(opt_arena, opt_root),
             &[(identity, data.as_slice())],
         );
+    }
+
+    /// Slot order is the binding ABI: the JIT loads slot i's base pointer
+    /// from the context array at i*8, and callers bind in the order the arena
+    /// THEY built declared. Extraction traverses in its own order — here the
+    /// root's first child reads the SECOND-declared buffer — so a rebuild
+    /// that declared buffers in traversal order would silently swap the
+    /// caller's two pointers and read the wrong memory.
+    #[test]
+    fn optimization_preserves_buffer_slot_order() {
+        let mut a = ExprArena::new();
+        let buf_a = a.declare_buffer(BufferDecl {
+            id: pixelflow_ir::arena::BufferIdentity::mint(),
+            width: 4,
+            height: 1,
+        });
+        let buf_b = a.declare_buffer(BufferDecl {
+            id: pixelflow_ir::arena::BufferIdentity::mint(),
+            width: 8,
+            height: 1,
+        });
+        let x = a.push_var(0);
+        let y = a.push_var(1);
+        let gb = a.push_gather(buf_b, x, y);
+        let ga = a.push_gather(buf_a, x, y);
+        let root = a.push_binary(OpKind::Add, gb, ga);
+
+        let out = optimize_runtime_arena(&a, root).expect("buffer kernel must optimize");
+        let input: Vec<_> = a.buffers().iter().map(|d| d.id).collect();
+        let output: Vec<_> = out.0.buffers().iter().map(|d| d.id).collect();
+        assert_eq!(input, output, "slot order must survive optimization");
     }
 
     #[test]

--- a/pixelflow-search/src/runtime.rs
+++ b/pixelflow-search/src/runtime.rs
@@ -172,7 +172,7 @@ fn canonical_key(arena: &ExprArena, root: ExprId) -> Vec<u8> {
             &ExprNode::Buffer(b) => {
                 key.push(3);
                 key.extend_from_slice(&b.0.to_le_bytes());
-                let BufferDecl { width, height } = *arena.buffer_decl(b);
+                let BufferDecl { width, height, .. } = *arena.buffer_decl(b);
                 key.extend_from_slice(&width.to_le_bytes());
                 key.extend_from_slice(&height.to_le_bytes());
             }

--- a/pixelflow-search/tests/fold_exactness.rs
+++ b/pixelflow-search/tests/fold_exactness.rs
@@ -94,3 +94,52 @@ fn exact_and_ordinary_folds_still_fold() {
     let m = a.push_binary(OpKind::Mul, x, c);
     assert_eq!(opt_root(&a, m), ExprNode::Const(128.0));
 }
+
+/// The refusal guard must hold during REBUILD, not just during rule
+/// application. `rebuild` drains a class's nodes with `mem::take` and only
+/// then performs congruence unions, so a guard that scanned the node vector
+/// was blind at exactly the moment congruence closure does its merging: the
+/// class looked constant-free and a contradictory merge went through.
+///
+/// Construction (the reviewer's reproduction): give `Add(X, A)` the constant
+/// 1 and `Add(X, B)` the constant 2, then union `A` with `B`. Congruence now
+/// says the two `Add` nodes are the same node, so rebuild tries to merge
+/// their classes — which would assert 1 = 2.
+#[test]
+fn refusal_survives_rebuild_congruence() {
+    use pixelflow_search::egraph::{EGraph, ENode, all_rules};
+
+    let mut eg = EGraph::with_rules(all_rules());
+    let x = eg.add(ENode::Var(0));
+    let a = eg.add(ENode::Var(1));
+    let b = eg.add(ENode::Var(2));
+
+    let add = |eg: &mut EGraph, l, r| {
+        eg.add(ENode::Op {
+            op: pixelflow_search::egraph::ops::op_from_kind(OpKind::Add).expect("Add op"),
+            children: vec![l, r],
+        })
+    };
+    let add_a = add(&mut eg, x, a);
+    let add_b = add(&mut eg, x, b);
+
+    let one = eg.add(ENode::constant(1.0));
+    let two = eg.add(ENode::constant(2.0));
+    eg.union(add_a, one);
+    eg.union(add_b, two);
+
+    // Makes the two Add nodes congruent, forcing rebuild to consider merging
+    // their classes.
+    eg.union(a, b);
+    eg.rebuild();
+
+    assert!(
+        !eg.refused_const_unions().is_empty(),
+        "rebuild-time congruence must hit the refusal guard, not slip past it"
+    );
+    assert_ne!(
+        eg.find(one),
+        eg.find(two),
+        "1 and 2 must not share a class — that is the corruption the guard exists to stop"
+    );
+}

--- a/pixelflow-search/tests/fold_exactness.rs
+++ b/pixelflow-search/tests/fold_exactness.rs
@@ -1,0 +1,96 @@
+//! The e-graph refuses to assert a proved falsehood.
+//!
+//! Constant folding computes f32-truths (`x + 2²⁴ = 2²⁴`); the algebraic
+//! rules compute ℝ-truths (`(x+y)−y = x`). Each is sound alone, but at a
+//! catastrophic-cancellation input their conjunction derives two UNEQUAL
+//! constants for one expression. Before the refusal valve, that union went
+//! through: one e-class held both constants, extraction tie-broke between
+//! them, and `((x+2²⁴)−2²⁴)·255` came back as `x` — neither the f32 answer
+//! (0) nor the ℝ answer (128), just whichever node the tie-break hit.
+//!
+//! The valve refuses the union (an under-merged e-graph is still sound; the
+//! cost is missed CSE at the collision), journals it, and leaves the first
+//! prover owning the class — so the extracted result is the f32-execution
+//! answer, exactly what the unoptimized kernel computes. Symbolic priority
+//! (the ℝ answer winning outright) is the planned f64 constant-domain
+//! follow-up; this valve is the soundness floor it builds on.
+
+use pixelflow_ir::OpKind;
+use pixelflow_ir::arena::{ExprArena, ExprId, ExprNode};
+
+const X: f32 = 128.0 / 255.0;
+const Y: f32 = 16_777_216.0; // 2^24: f32 spacing here is 2.0, so X + Y rounds to Y.
+
+fn cancel(a: &mut ExprArena) -> ExprId {
+    let x = a.push_const(X);
+    let y = a.push_const(Y);
+    let s = a.push_binary(OpKind::Add, x, y);
+    a.push_binary(OpKind::Sub, s, y)
+}
+
+fn opt_root(a: &ExprArena, root: ExprId) -> ExprNode {
+    let out = pixelflow_search::runtime::optimize_runtime_arena(a, root)
+        .expect("pure arithmetic must optimize");
+    out.0.node(out.1).clone()
+}
+
+/// The collision leaves ONE constant owning the class — whichever prover
+/// got there first under the (deterministic) rule schedule — and everything
+/// downstream agrees with it. Under the current schedule the symbolic
+/// cancellation wins and the ℝ answer comes out; the pinned VALUES below are
+/// schedule-dependent, the pinned INVARIANT — one constant, consistent
+/// downstream, never a tie-break between two — is not.
+#[test]
+fn cancellation_extracts_one_consistent_constant() {
+    let mut a = ExprArena::new();
+    let d = cancel(&mut a);
+    assert_eq!(
+        opt_root(&a, d),
+        ExprNode::Const(X),
+        "the class must hold exactly one constant (currently the symbolic \
+         ℝ answer); two constants tie-breaking arbitrarily is the bug"
+    );
+
+    let mut a = ExprArena::new();
+    let d = cancel(&mut a);
+    let c = a.push_const(255.0);
+    let m = a.push_binary(OpKind::Mul, d, c);
+    assert_eq!(
+        opt_root(&a, m),
+        ExprNode::Const(128.0),
+        "downstream arithmetic must fold from the class's single constant"
+    );
+}
+
+/// The refusal is journaled: the collision is loud, not silent.
+#[test]
+fn refused_union_is_journaled() {
+    use pixelflow_search::egraph::{EGraph, all_rules};
+
+    let mut a = ExprArena::new();
+    let d = cancel(&mut a);
+    let mut eg = EGraph::with_rules(all_rules());
+    let root = eg.add_arena(&a, d);
+    eg.saturate_with_limit(60);
+    let _ = root;
+    assert!(
+        !eg.refused_const_unions().is_empty(),
+        "the folding-vs-algebra collision must be recorded, not absorbed"
+    );
+}
+
+/// Ordinary folding is untouched by the valve.
+#[test]
+fn exact_and_ordinary_folds_still_fold() {
+    let mut a = ExprArena::new();
+    let p = a.push_const(3.0);
+    let q = a.push_const(2.0);
+    let m = a.push_binary(OpKind::Mul, p, q);
+    assert_eq!(opt_root(&a, m), ExprNode::Const(6.0));
+
+    let mut a = ExprArena::new();
+    let x = a.push_const(X);
+    let c = a.push_const(255.0);
+    let m = a.push_binary(OpKind::Mul, x, c);
+    assert_eq!(opt_root(&a, m), ExprNode::Const(128.0));
+}

--- a/scripts/check-cl-metadata.sh
+++ b/scripts/check-cl-metadata.sh
@@ -39,7 +39,11 @@ git cat-file -e "${head_commit}^{commit}" || {
 
 commit_list=$(mktemp)
 trap 'rm -f "$commit_list"' EXIT
-git log --format='%H%x09%s' "${base_commit}..${head_commit}" >"$commit_list" || {
+# `--no-merges`: a merge commit records no change of its own, so it has no
+# description to give — the subject is git's own generated text. Requiring a
+# conventional subject there would reject every "Update branch", and main's
+# own history already contains such merges.
+git log --no-merges --format='%H%x09%s' "${base_commit}..${head_commit}" >"$commit_list" || {
   echo "failed to enumerate CL commits: ${base_commit}..${head_commit}" >&2
   exit 2
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -285,10 +285,27 @@ fn launch_stability_check(runs: u32, watch_seconds: u64) {
             continue;
         }
 
-        std::thread::sleep(std::time::Duration::from_secs(1));
-        let pid = find_pid(binary_match);
+        // LaunchServices returns before the process spawns, and a cold CI
+        // runner (first registration of the bundle, cold dyld cache) can
+        // take several seconds — one fixed sleep misread that as a crash.
+        // Poll with a deadline instead; a genuinely failed launch still
+        // fails, just honestly.
+        const APPEAR_DEADLINE_MS: u64 = 15_000;
+        const APPEAR_POLL_MS: u64 = 250;
+        let mut pid = None;
+        let mut waited = 0u64;
+        while waited < APPEAR_DEADLINE_MS {
+            std::thread::sleep(std::time::Duration::from_millis(APPEAR_POLL_MS));
+            waited += APPEAR_POLL_MS;
+            pid = find_pid(binary_match);
+            if pid.is_some() {
+                break;
+            }
+        }
         let Some(pid) = pid else {
-            eprintln!("::error::run {run}: process never appeared after launch");
+            eprintln!(
+                "::error::run {run}: process never appeared within {APPEAR_DEADLINE_MS}ms of launch"
+            );
             failures += 1;
             continue;
         };

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -307,6 +307,13 @@ fn launch_stability_check(runs: u32, watch_seconds: u64) {
                 "::error::run {run}: process never appeared within {APPEAR_DEADLINE_MS}ms of launch"
             );
             failures += 1;
+            // First disappearance: gather enough evidence to distinguish the
+            // three ways this happens — LaunchServices silently declining the
+            // (unsigned) bundle, the binary dying faster than the poll, or
+            // the pgrep pattern not matching on this host.
+            if failures == 1 {
+                launch_failure_diagnostics(&app_bundle, binary_match);
+            }
             continue;
         };
 
@@ -364,6 +371,71 @@ fn launch_stability_check(runs: u32, watch_seconds: u64) {
 
 /// Finds the PID of a running process by matching `pattern` against its full
 /// command line, mirroring `pgrep -f`.
+/// Evidence dump for "process never appeared": what IS running, whether the
+/// binary can run at all outside LaunchServices, any crash reports, and what
+/// the unified log says about the launch. Diagnostic-only — failures here are
+/// reported, never fatal, because this runs after the check already failed.
+fn launch_failure_diagnostics(app_bundle: &std::path::Path, binary_match: &str) {
+    eprintln!("---- diagnostics: pgrep view ----");
+    let pg = Command::new("pgrep").args(["-fl", "CoreTerm"]).output();
+    match pg {
+        Ok(o) => eprintln!(
+            "pgrep -fl CoreTerm (status {}):\n{}{}",
+            o.status,
+            String::from_utf8_lossy(&o.stdout),
+            String::from_utf8_lossy(&o.stderr)
+        ),
+        Err(e) => eprintln!("pgrep failed to run: {e}"),
+    }
+
+    eprintln!("---- diagnostics: direct exec (bypasses LaunchServices) ----");
+    let binary = app_bundle.join("Contents/MacOS/CoreTerm");
+    match Command::new(&binary).spawn() {
+        Err(e) => eprintln!("direct exec failed to spawn: {e}"),
+        Ok(mut child) => {
+            std::thread::sleep(std::time::Duration::from_secs(3));
+            match child.try_wait() {
+                Ok(None) => {
+                    eprintln!(
+                        "direct exec: alive after 3s — the binary runs; the \
+                         failure is in the LaunchServices path (match: {binary_match})"
+                    );
+                    let _ = child.kill();
+                    let _ = child.wait();
+                }
+                Ok(Some(status)) => {
+                    eprintln!("direct exec: exited within 3s: {status}");
+                    let _ = child.wait();
+                }
+                Err(e) => eprintln!("direct exec: try_wait failed: {e}"),
+            }
+        }
+    }
+
+    eprintln!("---- diagnostics: unified log (last 2m, launch-related) ----");
+    let log = Command::new("log")
+        .args([
+            "show",
+            "--last",
+            "2m",
+            "--style",
+            "compact",
+            "--predicate",
+            "eventMessage CONTAINS[c] \"coreterm\" OR subsystem == \"com.apple.launchservices\"",
+        ])
+        .output();
+    match log {
+        Ok(o) => {
+            let text = String::from_utf8_lossy(&o.stdout);
+            let tail: Vec<&str> = text.lines().rev().take(60).collect();
+            for line in tail.iter().rev() {
+                eprintln!("{line}");
+            }
+        }
+        Err(e) => eprintln!("log show failed to run: {e}"),
+    }
+}
+
 fn find_pid(pattern: &str) -> Option<u32> {
     let output = Command::new("pgrep").args(["-f", pattern]).output().ok()?;
     let stdout = String::from_utf8_lossy(&output.stdout);

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -26,6 +26,12 @@ fn main() {
         eprintln!("                [--clippy to also run clippy per level]");
         eprintln!("                [--build-only to skip test execution entirely --");
         eprintln!("                 presubmit's fast path; postsubmit runs the tests]");
+        eprintln!("  launch-stability-check");
+        eprintln!("                Build, bundle, and launch CoreTerm.app repeatedly,");
+        eprintln!("                failing if any launch crashes");
+        eprintln!("                [--runs N] [--watch-seconds S]");
+        eprintln!("  bundle        Build and assemble CoreTerm.app WITHOUT launching it");
+        eprintln!("                (for CI signing/notarization; see bundle-run to also launch)");
         std::process::exit(1);
     }
 
@@ -34,6 +40,11 @@ fn main() {
             // Pass through any additional arguments after "bundle-run"
             let extra_args = if args.len() > 2 { &args[2..] } else { &[] };
             bundle_run(extra_args);
+        }
+        "bundle" => {
+            let extra_args = if args.len() > 2 { &args[2..] } else { &[] };
+            let (_workspace_root, app_bundle) = build_and_bundle(extra_args);
+            println!("Bundled (not launched): {}", app_bundle.display());
         }
         "bake-eigen" => {
             bake_eigen();
@@ -47,11 +58,25 @@ fn main() {
             };
             isa_matrix(with_clippy, mode);
         }
+        "launch-stability-check" => {
+            let runs =
+                parse_u32_flag(&args[2..], "--runs").unwrap_or(LAUNCH_STABILITY_DEFAULT_RUNS);
+            let watch_seconds = parse_u32_flag(&args[2..], "--watch-seconds")
+                .map(u64::from)
+                .unwrap_or(LAUNCH_STABILITY_DEFAULT_WATCH_SECONDS);
+            launch_stability_check(runs, watch_seconds);
+        }
         _ => {
             eprintln!("Unknown command: {}", args[1]);
             std::process::exit(1);
         }
     }
+}
+
+/// Parses `--flag VALUE` out of an argument slice, if present.
+fn parse_u32_flag(args: &[String], flag: &str) -> Option<u32> {
+    let idx = args.iter().position(|a| a == flag)?;
+    args.get(idx + 1)?.parse().ok()
 }
 
 /// Find the workspace root by looking for Cargo.toml with [workspace]
@@ -78,12 +103,16 @@ fn find_workspace_root() -> PathBuf {
     }
 }
 
-/// Builds the project in release mode and bundles it into a macOS .app structure.
-/// Then launches the application.
+/// Builds the project in release mode and assembles the macOS .app bundle,
+/// without launching it. Shared by `bundle-run` (build + bundle + launch
+/// once, for interactive dev use) and `launch-stability-check` (build +
+/// bundle + launch repeatedly, for CI).
 ///
 /// # Parameters
 /// * `extra_args` - Additional arguments to pass to `cargo build`.
-fn bundle_run(extra_args: &[String]) {
+///
+/// Returns `(workspace_root, app_bundle_path)`.
+fn build_and_bundle(extra_args: &[String]) -> (PathBuf, PathBuf) {
     // Find workspace root so this works from any subdirectory
     let workspace_root = find_workspace_root();
     println!("Workspace root: {}", workspace_root.display());
@@ -179,6 +208,17 @@ fn bundle_run(extra_args: &[String]) {
         .status()
         .expect("Failed to touch app bundle");
 
+    (workspace_root, app_bundle)
+}
+
+/// Builds the project in release mode and bundles it into a macOS .app structure.
+/// Then launches the application.
+///
+/// # Parameters
+/// * `extra_args` - Additional arguments to pass to `cargo build`.
+fn bundle_run(extra_args: &[String]) {
+    let (_workspace_root, app_bundle) = build_and_bundle(extra_args);
+
     println!("Launching CoreTerm.app...");
     println!("Logs will be written to /tmp/core-term.log");
 
@@ -196,6 +236,173 @@ fn bundle_run(extra_args: &[String]) {
 
     println!("CoreTerm.app launched successfully!");
     println!("Monitor logs with: tail -f /tmp/core-term.log");
+}
+
+// ============================================================================
+// macOS launch stability check
+// ============================================================================
+//
+// MetalOps hand-pumps NSApplication's event queue (nextEventMatchingMask)
+// instead of calling -[NSApplication run], because the actor scheduler needs
+// to interleave event pumping with message handling on the main thread (see
+// pixelflow-runtime/src/platform/macos/platform.rs). A background thread
+// that called into AppKit unsynchronized with that pump (the original
+// CocoaWaker::wake, see pixelflow-runtime/src/platform/waker.rs) corrupted
+// AppKit's internal main-event-queue bookkeeping, which AppKit only actually
+// noticed and asserted on later: observed 14-22s after launch, roughly 2 out
+// of every 3 raw launches -- well after the window a human tester normally
+// watches, and invisible to every other CI job. It needs a real window
+// server session (a Linux runner has none at all) and a real LaunchServices
+// bundle launch (`cargo run`/`cargo test` spawn the binary directly,
+// bypassing that launch path). This is what would have caught it, and what
+// stops it from silently coming back.
+const LAUNCH_STABILITY_DEFAULT_RUNS: u32 = 15;
+// Real crashes were observed 14-22s after launch; watch a few seconds past
+// that so a slow CI runner doesn't get a false pass by checking too early.
+const LAUNCH_STABILITY_DEFAULT_WATCH_SECONDS: u64 = 25;
+
+fn launch_stability_check(runs: u32, watch_seconds: u64) {
+    let (_workspace_root, app_bundle) = build_and_bundle(&[]);
+    let binary_match = "CoreTerm.app/Contents/MacOS/CoreTerm";
+
+    let crash_dir = PathBuf::from(env::var("HOME").expect("HOME not set"))
+        .join("Library/Logs/DiagnosticReports");
+
+    // Anything at or after this instant is a crash from THIS check, not a
+    // stale report from an earlier, unrelated run.
+    let check_start = std::time::SystemTime::now();
+
+    let mut failures: u32 = 0;
+
+    for run in 1..=runs {
+        let status = Command::new("open")
+            .arg(&app_bundle)
+            .status()
+            .expect("Failed to launch app");
+        if !status.success() {
+            eprintln!("::error::run {run}: 'open' itself failed");
+            failures += 1;
+            continue;
+        }
+
+        std::thread::sleep(std::time::Duration::from_secs(1));
+        let pid = find_pid(binary_match);
+        let Some(pid) = pid else {
+            eprintln!("::error::run {run}: process never appeared after launch");
+            failures += 1;
+            continue;
+        };
+
+        let mut died_at = None;
+        for elapsed in 1..=watch_seconds {
+            std::thread::sleep(std::time::Duration::from_secs(1));
+            if !pid_alive(pid) {
+                died_at = Some(elapsed);
+                break;
+            }
+        }
+
+        match died_at {
+            Some(t) => {
+                eprintln!(
+                    "::error::run {run} (pid={pid}): process died after {t}s (expected to survive {watch_seconds}s)"
+                );
+                failures += 1;
+            }
+            None => {
+                println!("run {run} (pid={pid}): survived {watch_seconds}s");
+            }
+        }
+
+        kill_pid(pid);
+        std::thread::sleep(std::time::Duration::from_secs(1));
+    }
+
+    println!();
+    println!(
+        "Checking for new crash reports under {}...",
+        crash_dir.display()
+    );
+    let new_crashes = find_crash_reports_since(&crash_dir, check_start);
+    if !new_crashes.is_empty() {
+        eprintln!(
+            "::error::{} new crash report(s) appeared during {runs} launches:",
+            new_crashes.len()
+        );
+        for f in &new_crashes {
+            eprintln!("::error::  {}", f.display());
+        }
+        failures += 1;
+    }
+
+    if failures > 0 {
+        eprintln!("::error::macOS launch stability check FAILED ({failures} issue(s) across {runs} launches)");
+        std::process::exit(1);
+    }
+
+    println!(
+        "macOS launch stability check passed: {runs}/{runs} launches survived {watch_seconds}s with no crash reports."
+    );
+}
+
+/// Finds the PID of a running process by matching `pattern` against its full
+/// command line, mirroring `pgrep -f`.
+fn find_pid(pattern: &str) -> Option<u32> {
+    let output = Command::new("pgrep").args(["-f", pattern]).output().ok()?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    stdout.lines().next()?.trim().parse().ok()
+}
+
+/// Checks whether `pid` is alive via `kill -0` (sends no signal, just probes).
+fn pid_alive(pid: u32) -> bool {
+    Command::new("kill")
+        .args(["-0", &pid.to_string()])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn kill_pid(pid: u32) {
+    match Command::new("kill").arg(pid.to_string()).status() {
+        Ok(status) if status.success() => {}
+        // Most likely: the process already exited (e.g. it crashed) between
+        // the last liveness check and here -- not a failure of the check
+        // itself, so this is intentionally non-fatal.
+        Ok(status) => {
+            println!("note: 'kill {pid}' exited with {status}, process likely already gone")
+        }
+        Err(e) => println!("note: failed to run 'kill {pid}': {e}"),
+    }
+}
+
+/// Lists `CoreTerm-*.ips` crash reports modified at or after `since`.
+fn find_crash_reports_since(
+    crash_dir: &std::path::Path,
+    since: std::time::SystemTime,
+) -> Vec<PathBuf> {
+    let Ok(entries) = fs::read_dir(crash_dir) else {
+        return Vec::new();
+    };
+
+    let mut found = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+        if !name.starts_with("CoreTerm-") || !name.ends_with(".ips") {
+            continue;
+        }
+        let Ok(metadata) = entry.metadata() else {
+            continue;
+        };
+        let Ok(modified) = metadata.modified() else {
+            continue;
+        };
+        if modified >= since {
+            found.push(path);
+        }
+    }
+    found.sort();
+    found
 }
 
 // ============================================================================

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -400,12 +400,18 @@ fn launch_failure_diagnostics(app_bundle: &std::path::Path, binary_match: &str) 
                         "direct exec: alive after 3s — the binary runs; the \
                          failure is in the LaunchServices path (match: {binary_match})"
                     );
-                    let _ = child.kill();
-                    let _ = child.wait();
+                    if let Err(e) = child.kill() {
+                        eprintln!("direct exec: kill failed: {e}");
+                    }
+                    if let Err(e) = child.wait() {
+                        eprintln!("direct exec: wait failed: {e}");
+                    }
                 }
                 Ok(Some(status)) => {
                     eprintln!("direct exec: exited within 3s: {status}");
-                    let _ = child.wait();
+                    if let Err(e) = child.wait() {
+                        eprintln!("direct exec: wait failed: {e}");
+                    }
                 }
                 Err(e) => eprintln!("direct exec: try_wait failed: {e}"),
             }


### PR DESCRIPTION
Rebased onto main (post #972/#974/#976/#979). Eight commits, reviewed bottom-up.

## What this is
The cell grid — the terminal's production frame path — rewritten in the kernel language and compiled as **one packed program**: samplers composed at computed coordinates, four channels sharing geometry/cell-reads/atlas-taps through e-graph CSE, packing to `u32` pixels in-register through the type-blind collapse store. Byte order lives on the ColorCube family (`PlatformColorCube` picks the shifts exactly as it picks the cube; a test pins them to `Pixel::from_rgba`); applications pass geometry and colors only.

## Steady-state numbers (2560×1584, single thread, median of 15, re-measured after rebase)
| path | ns/px | frame |
|---|---|---|
| four-plane + per-pixel pack (optimized, main's compile entry) | 28.0 | 114 ms |
| **packed kernel + row copy** | **10.9** | **44 ms** |

**2.58×** over the four-plane path (3.05× over what shipped before main's optimizer-in-compile-entry landed). Also deletes 1 MiB/worker of plane scratch and the per-pixel pack loop. The packed kernel extracts 623 → 121 nodes — cross-channel geometry, cell reads, and atlas taps merged.

## Load-bearing substrate (bottom of the stack)
- **`BufferIdentity`**: process-unique identity on `BufferDecl`; `splice` merges buffer tables by it, so buffer-bearing kernels compose (previously: panic) and N reads of one buffer bind one slot. The optimizer cache keys buffers by identity, not slot index — two arenas' "slot 0" can name different memory.
- **E-graph totality over the runtime IR**: `Buffer` as an `ENode` leaf carrying its decl; `Gather` + the integer/bitwise domain as opaque runtime-tier ops — CSE-only, unnameable by rewrite templates, unreachable by the folder. Without this the packed kernel bailed at the door and benchmarked 1.01× against four planes (both unoptimized — the tie is what exposed it). Pinned by `packed_pixel_shape_optimizes`.
- **Cell grid in the language**: `channel_arena` (60 hand-pushed IR nodes × 4) deleted; `DiscreteManifold`/`BilinearSampler` expose composable Kernel fragments keyed on extents (data binds later).
- **CocoaWaker main-thread dispatch** (the intermittent AppKit launch crash) + a CI job that launches the real bundle repeatedly, which `cargo test` can never exercise.
- Profiling substrate for the squeeze work: `JitManifold::code_bytes` + in-process dump/hot-loop harnesses. First profile: **100.0% of frame self-time is inside the JIT kernel** — the row copy does not register.

Dropped during rebase as superseded by main: the `from_index` UB fix (dense renumbering dissolved the gaps) and the cost-table match conversion (#976's `OpMap::from_fn` is the same shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)