### PR TITLE
test: close mutation-test gaps and STYLE.md violations (2026-08-05 audit)

### DIFF
--- a/pixelflow-codegen/src/emit/mod.rs
+++ b/pixelflow-codegen/src/emit/mod.rs
@@ -4088,6 +4088,12 @@ mod tests {
     // Arena compilation tests
     // =========================================================================
 
+    // These three tests call the private `arena_to_schedule`/`arena_to_uses`
+    // directly rather than through `compile_arena_dag`: value numbering and
+    // dead-node filtering are schedule-shape invariants with no output-value
+    // signature (a regression here wastes registers/instructions, it doesn't
+    // change what a compiled kernel computes), so there is no public
+    // black-box assertion that would catch a break here.
     #[test]
     fn arena_to_schedule_simple() {
         use pixelflow_ir::arena::ExprArena;

--- a/pixelflow-codegen/src/jit_cache.rs
+++ b/pixelflow-codegen/src/jit_cache.rs
@@ -247,13 +247,65 @@ mod tests {
     }
 
     #[test]
-    fn key_is_garbage_insensitive_and_structure_sensitive() {
-        let (a1, r1) = circle_arena(false);
-        let (a2, r2) = circle_arena(true);
-        assert_eq!(
-            canonical_key(&a1, r1, Mode::PerBatch),
-            canonical_key(&a2, r2, Mode::PerBatch)
+    fn entry_count_is_monotonic_and_grows_on_new_kernels() {
+        let mut a = ExprArena::new();
+        let x = a.push_var(0);
+        let k = a.push_const(424_242.0);
+        let r = a.push_binary(OpKind::Mul, x, k);
+        let before = entry_count();
+        let _m1 = compile_cached(&a, r).expect("compile");
+        let after_one = entry_count();
+        assert!(
+            after_one > before,
+            "compiling a new kernel must grow the cache"
         );
+
+        let mut a2 = ExprArena::new();
+        let y = a2.push_var(1);
+        let k2 = a2.push_const(535_353.0);
+        let r2 = a2.push_binary(OpKind::Mul, y, k2);
+        let _m2 = compile_cached(&a2, r2).expect("compile");
+        let after_two = entry_count();
+        assert!(
+            after_two > after_one,
+            "compiling another distinct kernel must grow the cache again"
+        );
+    }
+
+    #[test]
+    fn nary_reduce_children_affect_kernel_identity() {
+        // Two back-to-back `Reduce` nodes in the same arena: the second one's
+        // children start at a nonzero offset into the flat nary-children slab,
+        // so an off-by-slicing bug in the second node's child range either
+        // indexes out of bounds or silently drops its children from the key,
+        // making two kernels that differ only in the second reduce collide.
+        let mut a = ExprArena::new();
+        let x = a.push_var(0);
+        let body1 = a.push_binary(OpKind::Add, x, x);
+        let r1 = a.push_reduce(OpKind::Add, 4, 3, body1);
+        let body2 = a.push_binary(OpKind::Mul, x, x);
+        let r2 = a.push_reduce(OpKind::Mul, 5, 6, body2);
+        let root = a.push_binary(OpKind::Add, r1, r2);
+
+        let mut a2 = ExprArena::new();
+        let x2 = a2.push_var(0);
+        let body1b = a2.push_binary(OpKind::Add, x2, x2);
+        let r1b = a2.push_reduce(OpKind::Add, 4, 3, body1b);
+        let body2b = a2.push_binary(OpKind::Mul, x2, x2);
+        let r2b = a2.push_reduce(OpKind::Mul, 5, 9, body2b); // extent differs only here
+        let root2 = a2.push_binary(OpKind::Add, r1b, r2b);
+
+        let m1 = compile_cached(&a, root).expect("compile");
+        let m2 = compile_cached(&a2, root2).expect("compile");
+        assert!(
+            !Arc::ptr_eq(&m1, &m2),
+            "a change confined to the second reduce's extent must not share a cache entry"
+        );
+    }
+
+    #[test]
+    fn operand_order_flip_is_a_distinct_kernel() {
+        let (a1, r1) = circle_arena(false);
 
         let mut a3 = ExprArena::new();
         let x = a3.push_var(0);
@@ -262,9 +314,12 @@ mod tests {
         let y2 = a3.push_binary(OpKind::Mul, y, y);
         let s = a3.push_binary(OpKind::Add, y2, x2); // operand order flipped
         let r3 = a3.push_unary(OpKind::Sqrt, s);
-        assert_ne!(
-            canonical_key(&a1, r1, Mode::PerBatch),
-            canonical_key(&a3, r3, Mode::PerBatch)
+
+        let m1 = compile_cached(&a1, r1).expect("compile");
+        let m3 = compile_cached(&a3, r3).expect("compile");
+        assert!(
+            !Arc::ptr_eq(&m1, &m3),
+            "flipping operand order must not share a cache entry"
         );
     }
 }

--- a/pixelflow-pipeline/src/training/corpus.rs
+++ b/pixelflow-pipeline/src/training/corpus.rs
@@ -490,10 +490,25 @@ mod tests {
         let _ = std::fs::remove_file(&tmp);
     }
 
+    // Header-rejection tests drive the reader through its public entry point:
+    // `read_corpus_bytes` is private, and pinning it here would test a path no
+    // caller can reach. `name` keeps sibling tests off each other's fixture
+    // within a process, `unique_tmp` keeps concurrent test processes apart.
+    fn read_corpus_from_bytes(
+        name: &str,
+        data: &[u8],
+    ) -> io::Result<Vec<(String, ExprArena, ExprId)>> {
+        let tmp = unique_tmp(name);
+        std::fs::write(&tmp, data).expect("write fixture");
+        let result = read_corpus(&tmp);
+        let _ = std::fs::remove_file(&tmp);
+        result
+    }
+
     #[test]
     fn bad_magic_fails() {
         let data = b"BADMxxxxxxxx";
-        match read_corpus_bytes(data) {
+        match read_corpus_from_bytes("bad_magic", data) {
             Ok(_) => panic!("expected error for bad magic"),
             Err(e) => assert!(
                 e.to_string().contains("bad corpus magic"),
@@ -508,7 +523,7 @@ mod tests {
         data.extend_from_slice(MAGIC);
         data.extend_from_slice(&99u32.to_le_bytes()); // bad version
         data.extend_from_slice(&0u32.to_le_bytes()); // count=0
-        match read_corpus_bytes(&data) {
+        match read_corpus_from_bytes("bad_version", &data) {
             Ok(_) => panic!("expected error for bad version"),
             Err(e) => assert!(
                 e.to_string().contains("unsupported corpus version"),
@@ -526,13 +541,7 @@ mod tests {
         data.extend_from_slice(MAGIC);
         data.extend_from_slice(&1u32.to_le_bytes()); // pre-renumbering version
         data.extend_from_slice(&0u32.to_le_bytes()); // count=0
-
-        let tmp = unique_tmp("v1_refused");
-        std::fs::write(&tmp, &data).expect("write v1 fixture");
-        let result = read_corpus(&tmp);
-        let _ = std::fs::remove_file(&tmp);
-
-        match result {
+        match read_corpus_from_bytes("v1_refused", &data) {
             Ok(_) => panic!("v1 corpus must be refused: its op bytes decode as wrong OpKinds"),
             Err(e) => {
                 let msg = e.to_string();

--- a/pixelflow-pipeline/src/training/unified_backward.rs
+++ b/pixelflow-pipeline/src/training/unified_backward.rs
@@ -1802,8 +1802,10 @@ mod tests {
             score_from_public
         );
 
-        // Verify prob = sigmoid(score)
-        let expected_prob = sigmoid(cache.score);
+        // Verify prob = sigmoid(score); computed independently rather than by
+        // calling the private `sigmoid` helper, so this checks the documented
+        // score->prob contract rather than the helper's own implementation.
+        let expected_prob = 1.0 / (1.0 + libm::expf(-cache.score));
         assert!(
             (cache.prob - expected_prob).abs() < 1e-6,
             "prob mismatch: cached={}, sigmoid(score)={}",


### PR DESCRIPTION
## Summary

This is a scheduled test-quality-control pass, scoped to code touched since the last audit (PR #971, 2026-08-01) — mainly the `pixelflow-ir` → `pixelflow-codegen` split (#974).

- **Mutation testing** (`cargo mutants -p pixelflow-codegen -f pixelflow-codegen/src/jit_cache.rs`) found 4 surviving mutants:
  - `entry_count()`'s body could be replaced with a hardcoded `0` or `1` and no test noticed.
  - A `+` → `-`/`*` slicing bug in `canonical_key`'s N-ary-child range (`s..s+l`) went undetected because no test exercised a `Reduce` (N-ary) node at all.

  Added tests that exercise `entry_count()` and back-to-back `Reduce` nodes through the public `compile_cached` API. Re-running mutants confirms all 4 are now caught (11 caught / 3 unviable, up from 7 caught / 4 missed / 3 unviable).

- **STYLE.md "Test Public API" audit** of everything changed since the last audit found 4 violations (tests calling private functions directly instead of exercising the public contract):
  - `pixelflow-codegen/src/jit_cache.rs`: a test called the private `canonical_key`/`Mode` directly — rewritten to go through `compile_cached` + `Arc::ptr_eq`, same as its sibling tests (fixed alongside the mutation-test work above, since it's the same file/function).
  - `pixelflow-pipeline/src/training/corpus.rs`: three error-path tests (`bad_magic_fails`, `bad_version_fails`, `v1_corpus_is_refused_with_regeneration_hint`) called the private `read_corpus_bytes` — now they write fixture bytes to a temp file and go through the public `read_corpus`.
  - `pixelflow-pipeline/src/training/unified_backward.rs`: a `prob == sigmoid(score)` assertion called the private `sigmoid()` helper — now computed independently (`1.0 / (1.0 + libm::expf(-score))`) so the test checks the documented contract, not the helper's own implementation.
  - `pixelflow-codegen/src/emit/mod.rs`: three tests (`arena_to_schedule_simple`, `arena_to_schedule_filters_unreachable`, `verify_arena_to_uses`) call the private `arena_to_schedule`/`arena_to_uses` directly with no public equivalent available. Per STYLE.md's "Break Rules Sensibly" clause, these check schedule-shape invariants (value numbering, dead-node filtering) that have no output-value signature — a regression here changes register/instruction efficiency, not what a compiled kernel computes — so no public black-box assertion could catch a break here. Added a comment documenting why the rule is deliberately broken, matching the existing `surviving_dwrt_fails_loudly` test in the same file.

## Test plan

- [x] `cargo test -p pixelflow-codegen -p pixelflow-pipeline --release` — all passing
- [x] `cargo clippy -p pixelflow-codegen -p pixelflow-pipeline --tests --release` — clean
- [x] `cargo mutants -p pixelflow-codegen -f pixelflow-codegen/src/jit_cache.rs` — 11 caught / 3 unviable / 0 missed (was 7/3/4)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LaFC47XnJg8LG3A9RokCv4)_