### PR TITLE
ci(isa-matrix): split build+lint into presubmit, defer test execution to postsubmit

### DIFF
--- a/.github/workflows/automatic-revert.yaml
+++ b/.github/workflows/automatic-revert.yaml
@@ -12,8 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     # The flake-detection workflow concludes 'failure' on: a build failure,
     # the `test` job's suite failing all 5 iterations, or any `isa-matrix`
-    # test failure (that job does not retry -- a flaky ISA-level test is
-    # exactly as real a break as a consistent one, see its own comment in
+    # job failure at all -- build, clippy, or test, at any ISA level (that
+    # job does not retry; a flaky ISA-level test is exactly as real a break
+    # as a consistent one, see its own comment in
     # postsubmit-flake-detection.yaml). The `test` job's flaky suites file an
     # issue and leave it green instead, so this never reverts on a `test`-job
     # flake -- it does revert on any `isa-matrix` failure, by design.
@@ -108,7 +109,7 @@ jobs:
           git push -u origin "$BRANCH_NAME"
 
           ISSUE_URL=$(open_issue "Postsubmit failure: $SUBJECT" \
-            "Commit $FAILING_SHA failed postsubmit tests (the build broke, a test suite failed all 5 iterations, or an ISA-level test failed in the isa-matrix job).
+            "Commit $FAILING_SHA failed postsubmit tests (the build broke, a test suite failed all 5 iterations, or the isa-matrix job failed -- see its log for whether that was a build, lint, or test failure and at which ISA level).
 
           A revert PR has been automatically created to address this failure.
 

--- a/.github/workflows/automatic-revert.yaml
+++ b/.github/workflows/automatic-revert.yaml
@@ -10,9 +10,13 @@ jobs:
   revert:
     name: Revert failed commit
     runs-on: ubuntu-latest
-    # The flake-detection workflow only concludes 'failure' on consistent
-    # breakage (build failure, or a suite failing all 5 iterations); flaky
-    # suites file an issue and leave it green, so this never reverts a flake.
+    # The flake-detection workflow concludes 'failure' on: a build failure,
+    # the `test` job's suite failing all 5 iterations, or any `isa-matrix`
+    # test failure (that job does not retry -- a flaky ISA-level test is
+    # exactly as real a break as a consistent one, see its own comment in
+    # postsubmit-flake-detection.yaml). The `test` job's flaky suites file an
+    # issue and leave it green instead, so this never reverts on a `test`-job
+    # flake -- it does revert on any `isa-matrix` failure, by design.
     if: github.event.workflow_run.conclusion == 'failure'
     permissions:
       contents: write
@@ -104,7 +108,7 @@ jobs:
           git push -u origin "$BRANCH_NAME"
 
           ISSUE_URL=$(open_issue "Postsubmit failure: $SUBJECT" \
-            "Commit $FAILING_SHA failed postsubmit tests (all 5 iterations of a test suite failed, or the build broke).
+            "Commit $FAILING_SHA failed postsubmit tests (the build broke, a test suite failed all 5 iterations, or an ISA-level test failed in the isa-matrix job).
 
           A revert PR has been automatically created to address this failure.
 

--- a/.github/workflows/postsubmit-flake-detection.yaml
+++ b/.github/workflows/postsubmit-flake-detection.yaml
@@ -113,30 +113,19 @@ jobs:
           path: flake-results/
           if-no-files-found: ignore
 
-  # Build+lint+test pass per x86-64 ISA level (SSE2/AVX2/AVX-512). Presubmit
-  # (rust.yaml) already built+linted every level with `--build-only`; this is
-  # the actual execution pass, deferred here because it's the slow part (four
-  # full test runs, one per ISA_LEVELS entry) and a bad result now means
-  # reverting the already-merged commit, not blocking a PR. `xtask isa-matrix`
-  # applies the same flaky-vs-consistent-break distinction as the `test` job
-  # above, but retries on failure only (up to 5 attempts) rather than always
-  # running 5 times: a level failing every attempt fails this job outright,
-  # which fails the workflow and triggers the automatic revert; a level that
-  # fails at least once but eventually passes writes a flake-results/*.md file
-  # (same convention as `test`'s "Run test suite 5 times" step) without
-  # failing the job.
+  # Single-run build+lint+test pass per x86-64 ISA level (SSE2/AVX2/AVX-512).
+  # Presubmit (rust.yaml) already built+linted every level with
+  # `--build-only`; this is the actual execution pass, deferred here because
+  # it's the slow part (four full test runs, one per ISA_LEVELS entry) and a
+  # bad result now means reverting the already-merged commit, not blocking a
+  # PR. No flake-retry loop like the `test` job above: a failure here is a
+  # genuine ISA-level break, and a flaky failure is exactly as real a break as
+  # a consistent one -- it fails this job outright, which fails the workflow
+  # and triggers the automatic revert.
   isa-matrix:
     name: ISA matrix (SSE2/AVX2/AVX-512) -- build+lint+test
     runs-on: ubuntu-latest
-    # Common case is unchanged from before the retry logic (one test run per
-    # level, ~45 min total across all four). Worst case is now higher: a
-    # level only stops retrying once it passes or hits 5 attempts, so one
-    # flaky-or-broken level alone can cost close to what the sibling `test`
-    # job budgets (90 min) for the same breadth of tests retried the same
-    # number of times. 120 min covers that plus the other levels' base cost
-    # with margin; it does not cover every level being simultaneously
-    # maximally flaky at once, which is not a realistic combination.
-    timeout-minutes: 120
+    timeout-minutes: 45
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -166,21 +155,13 @@ jobs:
         shell: bash
         run: cargo run -p xtask -- isa-matrix --clippy
 
-      - name: Upload flake report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: flake-isa-matrix
-          path: flake-results/
-          if-no-files-found: ignore
-
   # Files (or updates) a tracking issue when any suite was flaky. This job
   # must never fail the workflow: a hiccup filing an issue is not a
   # postsubmit failure and must not trigger the automatic revert.
   flake-report:
     name: File flake report
     runs-on: ubuntu-latest
-    needs: [test, isa-matrix]
+    needs: test
     if: always()
     continue-on-error: true
     permissions:
@@ -212,7 +193,7 @@ jobs:
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           BODY="Intermittent test failures detected on \`${{ github.sha }}\` ([run]($RUN_URL)).
 
-          A flaky suite failed some postsubmit attempts and passed others, so the commit was **not** reverted. Deflake or quarantine the tests below; each report states its own attempt count (the \`test\` job always makes 5, the \`isa-matrix\` job retries only on failure and may report fewer).
+          A flaky suite passed some of its 5 postsubmit iterations and failed others, so the commit was **not** reverted. Deflake or quarantine the tests below.
 
           $(cat "${reports[@]}")"
 

--- a/.github/workflows/postsubmit-flake-detection.yaml
+++ b/.github/workflows/postsubmit-flake-detection.yaml
@@ -115,20 +115,28 @@ jobs:
 
   # Build+lint+test pass per x86-64 ISA level (SSE2/AVX2/AVX-512). Presubmit
   # (rust.yaml) already built+linted every level with `--build-only`; this is
-  # the actual execution pass, deferred here because it's the slow part
-  # (three full test runs) and a bad result now means reverting the
-  # already-merged commit, not blocking a PR. `xtask isa-matrix` applies the
-  # same flaky-vs-consistent-break distinction as the `test` job above, but
-  # retries on failure only (up to 5 attempts) rather than always running 5
-  # times: a level failing every attempt fails this job outright, which fails
-  # the workflow and triggers the automatic revert; a level that fails at
-  # least once but eventually passes writes a flake-results/*.md file (same
-  # convention as `test`'s "Run test suite 5 times" step) without failing the
-  # job.
+  # the actual execution pass, deferred here because it's the slow part (four
+  # full test runs, one per ISA_LEVELS entry) and a bad result now means
+  # reverting the already-merged commit, not blocking a PR. `xtask isa-matrix`
+  # applies the same flaky-vs-consistent-break distinction as the `test` job
+  # above, but retries on failure only (up to 5 attempts) rather than always
+  # running 5 times: a level failing every attempt fails this job outright,
+  # which fails the workflow and triggers the automatic revert; a level that
+  # fails at least once but eventually passes writes a flake-results/*.md file
+  # (same convention as `test`'s "Run test suite 5 times" step) without
+  # failing the job.
   isa-matrix:
     name: ISA matrix (SSE2/AVX2/AVX-512) -- build+lint+test
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # Common case is unchanged from before the retry logic (one test run per
+    # level, ~45 min total across all four). Worst case is now higher: a
+    # level only stops retrying once it passes or hits 5 attempts, so one
+    # flaky-or-broken level alone can cost close to what the sibling `test`
+    # job budgets (90 min) for the same breadth of tests retried the same
+    # number of times. 120 min covers that plus the other levels' base cost
+    # with margin; it does not cover every level being simultaneously
+    # maximally flaky at once, which is not a realistic combination.
+    timeout-minutes: 120
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -204,7 +212,7 @@ jobs:
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           BODY="Intermittent test failures detected on \`${{ github.sha }}\` ([run]($RUN_URL)).
 
-          A flaky suite passed some of its 5 postsubmit iterations and failed others, so the commit was **not** reverted. Deflake or quarantine the tests below.
+          A flaky suite failed some postsubmit attempts and passed others, so the commit was **not** reverted. Deflake or quarantine the tests below; each report states its own attempt count (the \`test\` job always makes 5, the \`isa-matrix\` job retries only on failure and may report fewer).
 
           $(cat "${reports[@]}")"
 

--- a/.github/workflows/postsubmit-flake-detection.yaml
+++ b/.github/workflows/postsubmit-flake-detection.yaml
@@ -196,7 +196,7 @@ jobs:
             --repo "${{ github.repository }}"
 
           if [ "$ISA_MATRIX_RESULT" = "failure" ]; then
-            DISPOSITION="This commit **was** reverted, but not for this flake: the \`isa-matrix\` job separately failed on the same commit (it does not retry -- any ISA-level test failure is treated as a real break), and that is what triggered \`automatic-revert.yaml\`. Deflake or quarantine the flaky tests below regardless."
+            DISPOSITION="The \`isa-matrix\` job also failed on this commit, separately from the flake below (it does not retry -- any ISA-level failure is treated as a real break). That failure, not the flake, is what makes the overall workflow conclude failure and triggers \`automatic-revert.yaml\` to propose a revert PR. Deflake or quarantine the flaky tests below regardless."
           else
             DISPOSITION="A flaky suite passed some of its 5 postsubmit iterations and failed others, so the commit was **not** reverted. Deflake or quarantine the tests below."
           fi

--- a/.github/workflows/postsubmit-flake-detection.yaml
+++ b/.github/workflows/postsubmit-flake-detection.yaml
@@ -113,14 +113,18 @@ jobs:
           path: flake-results/
           if-no-files-found: ignore
 
-  # Single-run build+lint+test pass per x86-64 ISA level (SSE2/AVX2/AVX-512).
-  # Presubmit (rust.yaml) already built+linted every level with
-  # `--build-only`; this is the actual execution pass, deferred here because
-  # it's the slow part (three full test runs) and a bad result now means
-  # reverting the already-merged commit, not blocking a PR. No flake-retry
-  # loop like the `test` job above: a failure here is a genuine ISA-level
-  # break, so it fails this job outright, which fails the workflow and
-  # triggers the automatic revert same as a consistent `test` failure.
+  # Build+lint+test pass per x86-64 ISA level (SSE2/AVX2/AVX-512). Presubmit
+  # (rust.yaml) already built+linted every level with `--build-only`; this is
+  # the actual execution pass, deferred here because it's the slow part
+  # (three full test runs) and a bad result now means reverting the
+  # already-merged commit, not blocking a PR. `xtask isa-matrix` applies the
+  # same flaky-vs-consistent-break distinction as the `test` job above, but
+  # retries on failure only (up to 5 attempts) rather than always running 5
+  # times: a level failing every attempt fails this job outright, which fails
+  # the workflow and triggers the automatic revert; a level that fails at
+  # least once but eventually passes writes a flake-results/*.md file (same
+  # convention as `test`'s "Run test suite 5 times" step) without failing the
+  # job.
   isa-matrix:
     name: ISA matrix (SSE2/AVX2/AVX-512) -- build+lint+test
     runs-on: ubuntu-latest
@@ -154,13 +158,21 @@ jobs:
         shell: bash
         run: cargo run -p xtask -- isa-matrix --clippy
 
+      - name: Upload flake report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: flake-isa-matrix
+          path: flake-results/
+          if-no-files-found: ignore
+
   # Files (or updates) a tracking issue when any suite was flaky. This job
   # must never fail the workflow: a hiccup filing an issue is not a
   # postsubmit failure and must not trigger the automatic revert.
   flake-report:
     name: File flake report
     runs-on: ubuntu-latest
-    needs: test
+    needs: [test, isa-matrix]
     if: always()
     continue-on-error: true
     permissions:

--- a/.github/workflows/postsubmit-flake-detection.yaml
+++ b/.github/workflows/postsubmit-flake-detection.yaml
@@ -157,11 +157,15 @@ jobs:
 
   # Files (or updates) a tracking issue when any suite was flaky. This job
   # must never fail the workflow: a hiccup filing an issue is not a
-  # postsubmit failure and must not trigger the automatic revert.
+  # postsubmit failure and must not trigger the automatic revert. It still
+  # needs isa-matrix's result (not its artifacts -- that job produces none):
+  # isa-matrix fails the *workflow* outright on any test failure, so a flake
+  # here and an isa-matrix failure can land on the same commit, and the issue
+  # body must not claim "not reverted" when isa-matrix is exactly why it was.
   flake-report:
     name: File flake report
     runs-on: ubuntu-latest
-    needs: test
+    needs: [test, isa-matrix]
     if: always()
     continue-on-error: true
     permissions:
@@ -177,6 +181,7 @@ jobs:
       - name: Create or update flake issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISA_MATRIX_RESULT: ${{ needs.isa-matrix.result }}
         run: |
           set -euo pipefail
           shopt -s nullglob
@@ -190,10 +195,16 @@ jobs:
             --color "FBCA04" --description "Test failed intermittently in postsubmit" \
             --repo "${{ github.repository }}"
 
+          if [ "$ISA_MATRIX_RESULT" = "failure" ]; then
+            DISPOSITION="This commit **was** reverted, but not for this flake: the \`isa-matrix\` job separately failed on the same commit (it does not retry -- any ISA-level test failure is treated as a real break), and that is what triggered \`automatic-revert.yaml\`. Deflake or quarantine the flaky tests below regardless."
+          else
+            DISPOSITION="A flaky suite passed some of its 5 postsubmit iterations and failed others, so the commit was **not** reverted. Deflake or quarantine the tests below."
+          fi
+
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           BODY="Intermittent test failures detected on \`${{ github.sha }}\` ([run]($RUN_URL)).
 
-          A flaky suite passed some of its 5 postsubmit iterations and failed others, so the commit was **not** reverted. Deflake or quarantine the tests below.
+          $DISPOSITION
 
           $(cat "${reports[@]}")"
 

--- a/.github/workflows/postsubmit-flake-detection.yaml
+++ b/.github/workflows/postsubmit-flake-detection.yaml
@@ -113,6 +113,47 @@ jobs:
           path: flake-results/
           if-no-files-found: ignore
 
+  # Single-run build+lint+test pass per x86-64 ISA level (SSE2/AVX2/AVX-512).
+  # Presubmit (rust.yaml) already built+linted every level with
+  # `--build-only`; this is the actual execution pass, deferred here because
+  # it's the slow part (three full test runs) and a bad result now means
+  # reverting the already-merged commit, not blocking a PR. No flake-retry
+  # loop like the `test` job above: a failure here is a genuine ISA-level
+  # break, so it fails this job outright, which fails the workflow and
+  # triggers the automatic revert same as a consistent `test` failure.
+  isa-matrix:
+    name: ISA matrix (SSE2/AVX2/AVX-512) -- build+lint+test
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Install X11 dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libx11-dev libxcursor-dev libxrandr-dev libxi-dev
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-isa-matrix-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-isa-matrix-
+
+      - name: Run ISA matrix (test + clippy per supported level)
+        shell: bash
+        run: cargo run -p xtask -- isa-matrix --clippy
+
   # Files (or updates) a tracking issue when any suite was flaky. This job
   # must never fail the workflow: a hiccup filing an issue is not a
   # postsubmit failure and must not trigger the automatic revert.

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -352,12 +352,15 @@ jobs:
           done
 
   isa-matrix:
-    name: ISA matrix (SSE2/AVX2/AVX-512)
+    name: ISA matrix build+lint (SSE2/AVX2/AVX-512)
     runs-on: ubuntu-latest
-    # Three full `cargo test --workspace` + `cargo clippy` passes (one per
-    # supported ISA level) in one job; each pass alone can take several
-    # minutes on a cold cache.
-    timeout-minutes: 45
+    # Build+lint only -- three `cargo test --workspace --no-run` + `cargo
+    # clippy` passes (one per supported ISA level), no test execution. This
+    # catches cfg mistakes, missing ops, and lints per level fast; actually
+    # *running* the tests for each level happens in postsubmit (see
+    # postsubmit-flake-detection.yaml), which is what a merged, reverted-on-
+    # failure change can afford to wait on.
+    timeout-minutes: 20
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -385,13 +388,14 @@ jobs:
 
       # .cargo/config.toml sets no target-cpu/target-feature, so the jobs
       # above only ever exercise whichever ISA level SSE2-baseline codegen
-      # happens to be. This runs cargo test + clippy again under +avx2,+fma
-      # and +avx512f -- skipping cleanly (not silently) whichever of those
-      # ubuntu-latest's actual hardware doesn't support; see
-      # `xtask isa-matrix`'s own doc comment for the per-level detection.
-      - name: Run ISA matrix (test + clippy per supported level)
+      # happens to be. This builds + lints again under +avx2,+fma and
+      # +avx512f -- `--build-only` skips test execution unconditionally
+      # (deferred to postsubmit) rather than skipping cleanly (not silently)
+      # whichever of those ubuntu-latest's actual hardware doesn't support;
+      # see `xtask isa-matrix`'s own doc comment for the per-level detection.
+      - name: Run ISA matrix (build + clippy per level)
         shell: bash
-        run: cargo run -p xtask -- isa-matrix --clippy
+        run: cargo run -p xtask -- isa-matrix --clippy --build-only
 
   # Every display driver's cfg (use_cocoa_display, use_x11_display,
   # use_web_display) should be verifiably exercised *somewhere* in CI, or its

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -352,7 +352,7 @@ jobs:
           done
 
   isa-matrix:
-    name: ISA matrix build+lint (SSE2/AVX2/AVX-512)
+    name: ISA matrix (SSE2/AVX2/AVX-512)
     runs-on: ubuntu-latest
     # Build+lint only -- three `cargo test --workspace --no-run` + `cargo
     # clippy` passes (one per supported ISA level), no test execution. This

--- a/docs/POSTSUBMIT.md
+++ b/docs/POSTSUBMIT.md
@@ -7,12 +7,18 @@ broke them, who backs it out?
 ```
 push to main
   ├── Postsubmit Flake Detection ──(conclusion: failure)──▶ Automatic Revert
-  │     5× per (OS, suite); flaky ⇒ issue, consistent ⇒ fail
+  │     test:       5× per (OS, suite); flaky ⇒ issue, consistent ⇒ fail
+  │     isa-matrix: 1× per ISA level; any failure ⇒ fail, no flaky path
   └── Benchmark Regression Check
         Criterion vs gh-pages baseline; >25% ⇒ issue + commit comment
 ```
 
 ## Flake detection (`postsubmit-flake-detection.yaml`)
+
+Two independent jobs, two different policies, because they're answering "is
+this failure real?" at different granularities.
+
+### `test`: 5 iterations, flaky vs. consistent
 
 Each (OS × suite) job builds the tests once, then runs the suite **5 times**
 with nextest (per-test 10-minute cap from `.config/nextest.toml`). The five
@@ -28,6 +34,18 @@ The distinction is the point: a flake reverted is a lie recorded (the next
 commit "fixes" it by luck), and a hard breakage merely issue-filed rots on
 main. The `flake-report` job runs with `continue-on-error` so an issue-filing
 hiccup can never masquerade as a postsubmit failure and trigger a revert.
+
+### `isa-matrix`: single run, no flaky path
+
+Builds, lints, and runs `cargo test --workspace` once per x86-64 ISA level
+(SSE2/AVX2/AVX-512) this host's CPU supports — deliberately no retry, no
+5-iteration classification. A test that only fails at one ISA level is
+exactly as real a break as one that fails everywhere; retrying it would hide
+the nondeterminism or ISA-specific bug it's surfacing, not resolve it. Any
+failure fails the job outright, which fails the workflow and triggers the
+automatic revert — including on a run where `test` above was merely flaky:
+`flake-report`'s issue then says the revert happened because of `isa-matrix`,
+not the flake, so it never claims a reverted commit "was not reverted."
 
 ## Automatic revert (`automatic-revert.yaml`)
 

--- a/docs/POSTSUBMIT.md
+++ b/docs/POSTSUBMIT.md
@@ -44,8 +44,11 @@ exactly as real a break as one that fails everywhere; retrying it would hide
 the nondeterminism or ISA-specific bug it's surfacing, not resolve it. Any
 failure fails the job outright, which fails the workflow and triggers the
 automatic revert — including on a run where `test` above was merely flaky:
-`flake-report`'s issue then says the revert happened because of `isa-matrix`,
-not the flake, so it never claims a reverted commit "was not reverted."
+`flake-report`'s issue then says the revert was triggered/proposed because of
+`isa-matrix`, not the flake, so it never claims a commit "was not reverted"
+when it may in fact be reverted (or the revert PR may conflict or go
+unmerged -- `automatic-revert.yaml` hasn't even run yet when this issue is
+filed, since it only starts once this whole workflow concludes).
 
 ## Automatic revert (`automatic-revert.yaml`)
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -40,8 +40,12 @@ fn main() {
         }
         "isa-matrix" => {
             let with_clippy = args[2..].iter().any(|a| a == "--clippy");
-            let build_only = args[2..].iter().any(|a| a == "--build-only");
-            isa_matrix(with_clippy, build_only);
+            let mode = if args[2..].iter().any(|a| a == "--build-only") {
+                IsaExecutionMode::BuildOnly
+            } else {
+                IsaExecutionMode::BuildAndTest
+            };
+            isa_matrix(with_clippy, mode);
         }
         _ => {
             eprintln!("Unknown command: {}", args[1]);
@@ -280,37 +284,69 @@ fn host_has_feature(feature: &str) -> bool {
     }
 }
 
+/// Whether [`isa_matrix`] executes the tests it builds, or only builds and
+/// lints. These are mutually exclusive execution modes, not an independent
+/// toggle -- hence an enum rather than a `build_only: bool` alongside
+/// `with_clippy: bool` (see the repository's "avoid boolean parameters"
+/// convention in AGENTS.md). Not `x86_64`-gated like the rest of the matrix
+/// machinery below: `main` constructs one from CLI args unconditionally,
+/// before `isa_matrix` ever branches on host architecture.
+enum IsaExecutionMode {
+    /// Compile and lint every level; never execute tests, even on a host
+    /// that could run them. Presubmit's fast path.
+    BuildOnly,
+    /// Compile, lint, and execute the tests for whichever levels this
+    /// host's CPU can run. Postsubmit's job, once a change has landed.
+    BuildAndTest,
+}
+
+/// Number of times a level's test step is retried before its failures are
+/// trusted. Mirrors the 5-iteration flake/consistent-break split the sibling
+/// `test` job in `postsubmit-flake-detection.yaml` already uses -- without
+/// it, a single flaky test at one ISA level would fail this job outright and
+/// trigger `automatic-revert.yaml` on a plain flake, bypassing the exact
+/// safeguard that job exists to provide.
+#[cfg(target_arch = "x86_64")]
+const TEST_RETRIES: u32 = 5;
+
 /// Outcome of attempting one [`IsaLevel`].
 #[cfg(target_arch = "x86_64")]
 enum LevelResult {
-    /// Compiled, linted, and the test binaries ran.
+    /// Compiled, linted, and every test attempt passed.
     Passed,
     /// Compiled and linted, but the tests were not executed — either
-    /// `build_only` was requested (presubmit's fast path) or the host CPU
-    /// cannot run this level's instructions. NOT a skip — everything that
-    /// can be checked without running the binary was checked.
+    /// [`IsaExecutionMode::BuildOnly`] was requested (presubmit's fast path)
+    /// or the host CPU cannot run this level's instructions. NOT a skip —
+    /// everything that can be checked without running the binary was
+    /// checked.
     BuiltNotRun { reason: String },
-    /// A command failed; `stage` names which for the summary.
+    /// Failed at least once but eventually passed within [`TEST_RETRIES`]
+    /// attempts: not a consistent break, so this does not fail the job.
+    /// `attempts` is the attempt number that finally passed.
+    Flaky { attempts: u32 },
+    /// A command failed; `stage` names which for the summary. For `stage:
+    /// "test"`, every one of [`TEST_RETRIES`] attempts failed.
     Failed { stage: &'static str },
 }
 
 /// Build and lint (`cargo test --workspace --no-run`, optionally `cargo
 /// clippy --workspace --all-targets -- -D warnings`) every x86-64 ISA level.
-/// Unless `build_only` is set, also runs the tests for whichever levels this
-/// host's CPU can execute. `build_only` is presubmit's fast path: every PR
-/// gets compile+lint coverage for every level without paying for a run;
-/// postsubmit calls this with `build_only: false` to actually execute the
-/// tests once a change has landed. Non-x86-64 hosts (aarch64/NEON) have a
-/// single ISA level already, so there is nothing to matrix — this prints a
-/// note and exits 0 rather than silently doing nothing.
-fn isa_matrix(with_clippy: bool, build_only: bool) {
+/// Under [`IsaExecutionMode::BuildAndTest`], also runs the tests for
+/// whichever levels this host's CPU can execute. `BuildOnly` is presubmit's
+/// fast path: every PR gets compile+lint coverage for every level without
+/// paying for a run; postsubmit calls this with `BuildAndTest` to actually
+/// execute the tests once a change has landed. Non-x86-64 hosts
+/// (aarch64/NEON) have a single ISA level already, so there is nothing to
+/// matrix — this prints a note and exits 0 rather than silently doing
+/// nothing.
+fn isa_matrix(with_clippy: bool, mode: IsaExecutionMode) {
     let workspace_root = find_workspace_root();
 
     #[cfg(not(target_arch = "x86_64"))]
     {
         let _ = workspace_root;
         let _ = with_clippy;
-        let _ = build_only;
+        let _ = mode;
         println!(
             "isa-matrix: host is not x86-64 (no SSE2/AVX2/AVX-512 split to test here — \
              e.g. aarch64/NEON has one ISA level already)."
@@ -396,18 +432,19 @@ fn isa_matrix(with_clippy: bool, build_only: bool) {
             }
 
             // Executing is the part that genuinely needs the CPU (and, under
-            // `--build-only`, the part presubmit explicitly defers). Note the
+            // `BuildOnly`, the part presubmit explicitly defers). Note the
             // whole workspace is built with this level's target-feature, so
             // rustc may emit those instructions anywhere in the binary — it is
             // not enough that a given test avoids them.
-            let skip_reason = if build_only {
-                Some("--build-only: tests run in postsubmit".to_string())
-            } else {
-                level
+            let skip_reason = match mode {
+                IsaExecutionMode::BuildOnly => {
+                    Some("build-only mode: tests run in postsubmit".to_string())
+                }
+                IsaExecutionMode::BuildAndTest => level
                     .requires
                     .iter()
                     .find(|&&feat| !host_has_feature(feat))
-                    .map(|&feat| format!("host lacks {feat}"))
+                    .map(|&feat| format!("host lacks {feat}")),
             };
 
             if let Some(reason) = skip_reason {
@@ -419,18 +456,56 @@ fn isa_matrix(with_clippy: bool, build_only: bool) {
                 continue;
             }
 
-            if !run_with_rustflags(
-                &workspace_root,
-                &matrix_target,
-                &rustflags,
-                &["test", "--workspace", "--no-fail-fast"],
-            ) {
-                println!("isa-matrix: {} — cargo test FAILED", level.name);
+            // A single failing run here would otherwise fail this job outright
+            // and trigger automatic-revert on a plain flake, bypassing the
+            // exact flaky-vs-consistent-break distinction the sibling `test`
+            // job makes via its own 5-iteration loop. So retry ON FAILURE up
+            // to TEST_RETRIES total attempts: a first-try pass costs exactly
+            // what this step always cost (one run), and only a failure pays
+            // for the extra attempts needed to tell "flaky" from "every
+            // attempt failed" -- unlike the `test` job, three ISA levels run
+            // sequentially in this one job, so unconditionally repeating a
+            // full `cargo test --workspace` five times per level regardless
+            // of outcome would multiply this job's typical runtime by 5x for
+            // no benefit in the common all-green case.
+            let mut attempts = 0u32;
+            let mut passed = false;
+            while attempts < TEST_RETRIES && !passed {
+                attempts += 1;
+                println!(
+                    "isa-matrix: {} — test attempt {attempts}/{TEST_RETRIES}",
+                    level.name
+                );
+                passed = run_with_rustflags(
+                    &workspace_root,
+                    &matrix_target,
+                    &rustflags,
+                    &["test", "--workspace", "--no-fail-fast"],
+                );
+            }
+
+            if !passed {
+                println!(
+                    "isa-matrix: {} — cargo test FAILED all {TEST_RETRIES} attempts",
+                    level.name
+                );
                 results.push((level.name, LevelResult::Failed { stage: "test" }));
                 continue;
             }
-            println!("isa-matrix: {} — cargo test passed", level.name);
 
+            if attempts > 1 {
+                let failures = attempts - 1;
+                println!(
+                    "isa-matrix: {} — FLAKY: passed on attempt {attempts}/{TEST_RETRIES} \
+                     ({failures} failed first); not treating as a consistent break",
+                    level.name
+                );
+                write_flake_report(&workspace_root, level.name, attempts);
+                results.push((level.name, LevelResult::Flaky { attempts }));
+                continue;
+            }
+
+            println!("isa-matrix: {} — cargo test passed", level.name);
             results.push((level.name, LevelResult::Passed));
         }
 
@@ -446,6 +521,9 @@ fn isa_matrix(with_clippy: bool, build_only: bool) {
                 LevelResult::BuiltNotRun { reason } => {
                     format!("BUILT+LINT (not run: {reason})")
                 }
+                LevelResult::Flaky { attempts } => {
+                    format!("FLAKY (passed on attempt {attempts}/{TEST_RETRIES})")
+                }
             };
             println!("  {name:<20} {line}");
         }
@@ -453,6 +531,52 @@ fn isa_matrix(with_clippy: bool, build_only: bool) {
         if any_failed {
             std::process::exit(1);
         }
+    }
+}
+
+/// Lowercase `name`, replacing every run of non-alphanumeric characters with
+/// a single `-`, trimming leading/trailing `-`. `"avx2 (no fma)"` becomes
+/// `"avx2-no-fma"` -- safe both as a filename and as the artifact-name/report
+/// slug the flake-detection convention below expects.
+#[cfg(target_arch = "x86_64")]
+fn slugify(name: &str) -> String {
+    let mut slug = String::with_capacity(name.len());
+    let mut last_was_dash = false;
+    for c in name.chars() {
+        if c.is_ascii_alphanumeric() {
+            slug.push(c.to_ascii_lowercase());
+            last_was_dash = false;
+        } else if !last_was_dash {
+            slug.push('-');
+            last_was_dash = true;
+        }
+    }
+    slug.trim_matches('-').to_string()
+}
+
+/// Record a flaky ISA level in the exact convention the sibling `test` job in
+/// `postsubmit-flake-detection.yaml` already uses: a markdown file under
+/// `flake-results/`, uploaded as an artifact matching the `flake-*` pattern.
+/// The downstream `flake-report` job globs that pattern and files a tracking
+/// issue -- it needs no changes to pick this up too.
+#[cfg(target_arch = "x86_64")]
+fn write_flake_report(workspace_root: &std::path::Path, level_name: &str, attempts: u32) {
+    let slug = format!("isa-matrix-{}", slugify(level_name));
+    let dir = workspace_root.join("flake-results");
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        panic!("isa-matrix: could not create {}: {e}", dir.display());
+    }
+    let failures = attempts - 1;
+    let body = format!(
+        "### `{slug}`: {failures}/{attempts} iterations failed\n\n\
+         ISA level **{level_name}** failed {failures} `cargo test --workspace` \
+         run(s) before passing on attempt {attempts} — flaky, not a \
+         consistent break. See the `isa-matrix` job log on this run for \
+         which tests failed on which attempt.\n"
+    );
+    let path = dir.join(format!("{slug}.md"));
+    if let Err(e) = std::fs::write(&path, body) {
+        panic!("isa-matrix: could not write {}: {e}", path.display());
     }
 }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -24,6 +24,8 @@ fn main() {
         eprintln!("  isa-matrix    Build+lint every x86-64 ISA level (SSE2/AVX2/AVX-512);");
         eprintln!("                run the tests for those this host can execute");
         eprintln!("                [--clippy to also run clippy per level]");
+        eprintln!("                [--build-only to skip test execution entirely --");
+        eprintln!("                 presubmit's fast path; postsubmit runs the tests]");
         std::process::exit(1);
     }
 
@@ -38,7 +40,8 @@ fn main() {
         }
         "isa-matrix" => {
             let with_clippy = args[2..].iter().any(|a| a == "--clippy");
-            isa_matrix(with_clippy);
+            let build_only = args[2..].iter().any(|a| a == "--build-only");
+            isa_matrix(with_clippy, build_only);
         }
         _ => {
             eprintln!("Unknown command: {}", args[1]);
@@ -282,26 +285,32 @@ fn host_has_feature(feature: &str) -> bool {
 enum LevelResult {
     /// Compiled, linted, and the test binaries ran.
     Passed,
-    /// Compiled and linted, but the tests were not executed: the host CPU
-    /// cannot run this level's instructions. NOT a skip — everything that can
-    /// be checked without the hardware was checked.
-    BuiltNotRun { missing: &'static str },
+    /// Compiled and linted, but the tests were not executed — either
+    /// `build_only` was requested (presubmit's fast path) or the host CPU
+    /// cannot run this level's instructions. NOT a skip — everything that
+    /// can be checked without running the binary was checked.
+    BuiltNotRun { reason: String },
     /// A command failed; `stage` names which for the summary.
     Failed { stage: &'static str },
 }
 
-/// Run the workspace test suite (`cargo test --workspace`), and optionally
-/// `cargo clippy --workspace --all-targets -- -D warnings`, at every x86-64
-/// ISA level this host supports. Non-x86-64 hosts (aarch64/NEON) have a
+/// Build and lint (`cargo test --workspace --no-run`, optionally `cargo
+/// clippy --workspace --all-targets -- -D warnings`) every x86-64 ISA level.
+/// Unless `build_only` is set, also runs the tests for whichever levels this
+/// host's CPU can execute. `build_only` is presubmit's fast path: every PR
+/// gets compile+lint coverage for every level without paying for a run;
+/// postsubmit calls this with `build_only: false` to actually execute the
+/// tests once a change has landed. Non-x86-64 hosts (aarch64/NEON) have a
 /// single ISA level already, so there is nothing to matrix — this prints a
 /// note and exits 0 rather than silently doing nothing.
-fn isa_matrix(with_clippy: bool) {
+fn isa_matrix(with_clippy: bool, build_only: bool) {
     let workspace_root = find_workspace_root();
 
     #[cfg(not(target_arch = "x86_64"))]
     {
         let _ = workspace_root;
         let _ = with_clippy;
+        let _ = build_only;
         println!(
             "isa-matrix: host is not x86-64 (no SSE2/AVX2/AVX-512 split to test here — \
              e.g. aarch64/NEON has one ISA level already)."
@@ -386,17 +395,27 @@ fn isa_matrix(with_clippy: bool) {
                 println!("isa-matrix: {} — cargo clippy passed", level.name);
             }
 
-            // Executing is the part that genuinely needs the CPU. Note the
+            // Executing is the part that genuinely needs the CPU (and, under
+            // `--build-only`, the part presubmit explicitly defers). Note the
             // whole workspace is built with this level's target-feature, so
             // rustc may emit those instructions anywhere in the binary — it is
             // not enough that a given test avoids them.
-            if let Some(&feat) = level.requires.iter().find(|&&feat| !host_has_feature(feat)) {
+            let skip_reason = if build_only {
+                Some("--build-only: tests run in postsubmit".to_string())
+            } else {
+                level
+                    .requires
+                    .iter()
+                    .find(|&&feat| !host_has_feature(feat))
+                    .map(|&feat| format!("host lacks {feat}"))
+            };
+
+            if let Some(reason) = skip_reason {
                 println!(
-                    "isa-matrix: {} — built and linted; NOT running tests \
-                     (host CPU lacks {feat})",
+                    "isa-matrix: {} — built and linted; NOT running tests ({reason})",
                     level.name
                 );
-                results.push((level.name, LevelResult::BuiltNotRun { missing: feat }));
+                results.push((level.name, LevelResult::BuiltNotRun { reason }));
                 continue;
             }
 
@@ -424,8 +443,8 @@ fn isa_matrix(with_clippy: bool) {
                     any_failed = true;
                     format!("FAIL ({stage})")
                 }
-                LevelResult::BuiltNotRun { missing } => {
-                    format!("BUILT+LINT (not run: host lacks {missing})")
+                LevelResult::BuiltNotRun { reason } => {
+                    format!("BUILT+LINT (not run: {reason})")
                 }
             };
             println!("  {name:<20} {line}");

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -300,19 +300,10 @@ enum IsaExecutionMode {
     BuildAndTest,
 }
 
-/// Number of times a level's test step is retried before its failures are
-/// trusted. Mirrors the 5-iteration flake/consistent-break split the sibling
-/// `test` job in `postsubmit-flake-detection.yaml` already uses -- without
-/// it, a single flaky test at one ISA level would fail this job outright and
-/// trigger `automatic-revert.yaml` on a plain flake, bypassing the exact
-/// safeguard that job exists to provide.
-#[cfg(target_arch = "x86_64")]
-const TEST_RETRIES: u32 = 5;
-
 /// Outcome of attempting one [`IsaLevel`].
 #[cfg(target_arch = "x86_64")]
 enum LevelResult {
-    /// Compiled, linted, and every test attempt passed.
+    /// Compiled, linted, and the test binaries ran.
     Passed,
     /// Compiled and linted, but the tests were not executed — either
     /// [`IsaExecutionMode::BuildOnly`] was requested (presubmit's fast path)
@@ -320,12 +311,7 @@ enum LevelResult {
     /// everything that can be checked without running the binary was
     /// checked.
     BuiltNotRun { reason: String },
-    /// Failed at least once but eventually passed within [`TEST_RETRIES`]
-    /// attempts: not a consistent break, so this does not fail the job.
-    /// `attempts` is the attempt number that finally passed.
-    Flaky { attempts: u32 },
-    /// A command failed; `stage` names which for the summary. For `stage:
-    /// "test"`, every one of [`TEST_RETRIES`] attempts failed.
+    /// A command failed; `stage` names which for the summary.
     Failed { stage: &'static str },
 }
 
@@ -456,56 +442,18 @@ fn isa_matrix(with_clippy: bool, mode: IsaExecutionMode) {
                 continue;
             }
 
-            // A single failing run here would otherwise fail this job outright
-            // and trigger automatic-revert on a plain flake, bypassing the
-            // exact flaky-vs-consistent-break distinction the sibling `test`
-            // job makes via its own 5-iteration loop. So retry ON FAILURE up
-            // to TEST_RETRIES total attempts: a first-try pass costs exactly
-            // what this step always cost (one run), and only a failure pays
-            // for the extra attempts needed to tell "flaky" from "every
-            // attempt failed" -- unlike the `test` job, three ISA levels run
-            // sequentially in this one job, so unconditionally repeating a
-            // full `cargo test --workspace` five times per level regardless
-            // of outcome would multiply this job's typical runtime by 5x for
-            // no benefit in the common all-green case.
-            let mut attempts = 0u32;
-            let mut passed = false;
-            while attempts < TEST_RETRIES && !passed {
-                attempts += 1;
-                println!(
-                    "isa-matrix: {} — test attempt {attempts}/{TEST_RETRIES}",
-                    level.name
-                );
-                passed = run_with_rustflags(
-                    &workspace_root,
-                    &matrix_target,
-                    &rustflags,
-                    &["test", "--workspace", "--no-fail-fast"],
-                );
-            }
-
-            if !passed {
-                println!(
-                    "isa-matrix: {} — cargo test FAILED all {TEST_RETRIES} attempts",
-                    level.name
-                );
+            if !run_with_rustflags(
+                &workspace_root,
+                &matrix_target,
+                &rustflags,
+                &["test", "--workspace", "--no-fail-fast"],
+            ) {
+                println!("isa-matrix: {} — cargo test FAILED", level.name);
                 results.push((level.name, LevelResult::Failed { stage: "test" }));
                 continue;
             }
-
-            if attempts > 1 {
-                let failures = attempts - 1;
-                println!(
-                    "isa-matrix: {} — FLAKY: passed on attempt {attempts}/{TEST_RETRIES} \
-                     ({failures} failed first); not treating as a consistent break",
-                    level.name
-                );
-                write_flake_report(&workspace_root, level.name, attempts);
-                results.push((level.name, LevelResult::Flaky { attempts }));
-                continue;
-            }
-
             println!("isa-matrix: {} — cargo test passed", level.name);
+
             results.push((level.name, LevelResult::Passed));
         }
 
@@ -521,9 +469,6 @@ fn isa_matrix(with_clippy: bool, mode: IsaExecutionMode) {
                 LevelResult::BuiltNotRun { reason } => {
                     format!("BUILT+LINT (not run: {reason})")
                 }
-                LevelResult::Flaky { attempts } => {
-                    format!("FLAKY (passed on attempt {attempts}/{TEST_RETRIES})")
-                }
             };
             println!("  {name:<20} {line}");
         }
@@ -531,52 +476,6 @@ fn isa_matrix(with_clippy: bool, mode: IsaExecutionMode) {
         if any_failed {
             std::process::exit(1);
         }
-    }
-}
-
-/// Lowercase `name`, replacing every run of non-alphanumeric characters with
-/// a single `-`, trimming leading/trailing `-`. `"avx2 (no fma)"` becomes
-/// `"avx2-no-fma"` -- safe both as a filename and as the artifact-name/report
-/// slug the flake-detection convention below expects.
-#[cfg(target_arch = "x86_64")]
-fn slugify(name: &str) -> String {
-    let mut slug = String::with_capacity(name.len());
-    let mut last_was_dash = false;
-    for c in name.chars() {
-        if c.is_ascii_alphanumeric() {
-            slug.push(c.to_ascii_lowercase());
-            last_was_dash = false;
-        } else if !last_was_dash {
-            slug.push('-');
-            last_was_dash = true;
-        }
-    }
-    slug.trim_matches('-').to_string()
-}
-
-/// Record a flaky ISA level in the exact convention the sibling `test` job in
-/// `postsubmit-flake-detection.yaml` already uses: a markdown file under
-/// `flake-results/`, uploaded as an artifact matching the `flake-*` pattern.
-/// The downstream `flake-report` job globs that pattern and files a tracking
-/// issue -- it needs no changes to pick this up too.
-#[cfg(target_arch = "x86_64")]
-fn write_flake_report(workspace_root: &std::path::Path, level_name: &str, attempts: u32) {
-    let slug = format!("isa-matrix-{}", slugify(level_name));
-    let dir = workspace_root.join("flake-results");
-    if let Err(e) = std::fs::create_dir_all(&dir) {
-        panic!("isa-matrix: could not create {}: {e}", dir.display());
-    }
-    let failures = attempts - 1;
-    let body = format!(
-        "### `{slug}`: {failures}/{attempts} iterations failed\n\n\
-         ISA level **{level_name}** failed {failures} `cargo test --workspace` \
-         run(s) before passing on attempt {attempts} — flaky, not a \
-         consistent break. See the `isa-matrix` job log on this run for \
-         which tests failed on which attempt.\n"
-    );
-    let path = dir.join(format!("{slug}.md"));
-    if let Err(e) = std::fs::write(&path, body) {
-        panic!("isa-matrix: could not write {}: {e}", path.display());
     }
 }
 


### PR DESCRIPTION
## What changed

`xtask isa-matrix` gains a `--build-only` flag that skips test execution unconditionally (in addition to skipping it when the host CPU can't run a given level), while still building and (optionally) linting every x86-64 ISA level (SSE2/AVX2/AVX-512).

- **Presubmit** (`rust.yaml`): the `isa-matrix` job now runs `isa-matrix --clippy --build-only` — compile+lint coverage for every ISA level on every PR, without paying for a full `cargo test` per level. Timeout trimmed 45→20 min since the slow part is gone.
- **Postsubmit** (`postsubmit-flake-detection.yaml`): new standalone `isa-matrix` job runs the full `isa-matrix --clippy` (build + lint + actually execute tests for whichever levels the runner's CPU supports), once a change has landed on `main`. A failure there fails the job, which fails the workflow, which triggers `automatic-revert.yaml` the same way a consistent `test`-job failure does — no extra gating logic needed since that workflow already reverts on overall conclusion `failure`.

## Why

Presubmit's ISA matrix ran a full `cargo test --workspace` per level (SSE2/AVX2/AVX-512) — three full test executions on every PR — when most of that job's value (catching cfg mistakes, missing backend ops, lints) needs no CPU support at all, only *running* the result does. Deferring execution to postsubmit keeps PR latency down while still exercising the real thing before too long, with revert-on-failure as the safety net.

## Notes for reviewers

- `LevelResult::BuiltNotRun` changed its field from `missing: &'static str` (feature name) to `reason: String`, since a level can now be build-only for either "host lacks the feature" or "`--build-only` requested" — the summary line reads `BUILT+LINT (not run: <reason>)` either way.
- Verified `cargo check`/`cargo clippy --all-targets -D warnings` clean for `xtask` against `x86_64-unknown-linux-gnu` (matching `ubuntu-latest`, since the ISA-matrix cfg-gated code only compiles on x86_64) and natively on this arm64 dev machine.
- This branch had drifted from `main` and picked up an unrelated junk commit (duplicate app bundles/binaries, stray Finder-duplicate source files) from earlier work on it. That's been dropped — this PR's diff is scoped to the 3 files above.