### PR TITLE
test(core-term): descriptive test names + mutation-testing gap fixes

### DIFF
--- a/core-term/src/ansi/pict.rs
+++ b/core-term/src/ansi/pict.rs
@@ -143,18 +143,18 @@ mod generator_tests {
     }
 
     #[test]
-    fn covers_uniform_factors() {
+    fn it_should_cover_every_pair_of_values_when_all_factors_have_the_same_arity() {
         assert_covers_all_pairs(&[3, 3, 3, 3]);
         assert_covers_all_pairs(&[4, 4, 4, 4, 4]);
     }
 
     #[test]
-    fn covers_mixed_arity_factors() {
+    fn it_should_cover_every_pair_of_values_when_factors_have_mixed_arity() {
         assert_covers_all_pairs(&[2, 3, 4, 5, 2, 1]);
     }
 
     #[test]
-    fn is_far_smaller_than_exhaustive() {
+    fn it_should_generate_far_fewer_rows_than_the_exhaustive_cross_product() {
         let counts = [4, 4, 4, 4, 4, 4];
         let rows = pairwise(&counts);
         let exhaustive: usize = counts.iter().product();
@@ -167,7 +167,7 @@ mod generator_tests {
     }
 
     #[test]
-    fn is_deterministic() {
+    fn it_should_produce_the_same_rows_for_the_same_input_on_repeated_calls() {
         assert_eq!(pairwise(&[3, 4, 2, 5]), pairwise(&[3, 4, 2, 5]));
     }
 }

--- a/core-term/src/io/event_monitor_actor/mod.rs
+++ b/core-term/src/io/event_monitor_actor/mod.rs
@@ -421,7 +421,7 @@ mod tests {
     }
 
     #[test]
-    fn write_before_bind_is_flushed_at_bind() {
+    fn it_should_flush_writes_queued_before_bind_once_bound() {
         // Data sent on the writer handle before spawn() (before Bind lands)
         // must queue and flush once bound, not be dropped.
         let pty = NixPty::spawn_with_config(&PtyConfig {

--- a/core-term/src/term/cursor.rs
+++ b/core-term/src/term/cursor.rs
@@ -476,18 +476,12 @@ mod tests {
 
     #[test]
     fn it_should_map_decscusr_code_zero_to_the_default_shape() {
-        assert_eq!(
-            CursorShape::from_decscusr_code(0),
-            CursorShape::default()
-        );
+        assert_eq!(CursorShape::from_decscusr_code(0), CursorShape::default());
     }
 
     #[test]
     fn it_should_map_an_unrecognized_decscusr_code_to_the_default_shape() {
-        assert_eq!(
-            CursorShape::from_decscusr_code(99),
-            CursorShape::default()
-        );
+        assert_eq!(CursorShape::from_decscusr_code(99), CursorShape::default());
     }
 
     #[test]
@@ -503,7 +497,10 @@ mod tests {
         for shape in shapes {
             let json = serde_json::to_string(&shape).expect("serialize");
             let round_tripped: CursorShape = serde_json::from_str(&json).expect("deserialize");
-            assert_eq!(round_tripped, shape, "round trip through {json} changed the shape");
+            assert_eq!(
+                round_tripped, shape,
+                "round trip through {json} changed the shape"
+            );
         }
     }
 
@@ -559,10 +556,9 @@ mod tests {
 
     #[test]
     fn it_should_restore_default_attributes_position_and_visibility_on_reset() {
-        let custom_attributes = {
-            let mut attrs = Attributes::default();
-            attrs.fg = crate::color::Color::Indexed(9);
-            attrs
+        let custom_attributes = Attributes {
+            fg: crate::color::Color::Indexed(9),
+            ..Attributes::default()
         };
         let context = super::ScreenContext {
             width: 80,

--- a/core-term/src/term/cursor.rs
+++ b/core-term/src/term/cursor.rs
@@ -454,7 +454,8 @@ impl<'de> Deserialize<'de> for CursorShape {
 
 #[cfg(test)]
 mod tests {
-    use super::CursorShape;
+    use super::{Cursor, CursorController, CursorShape};
+    use crate::{glyph::Attributes, term::cursor_visibility::CursorVisibility};
 
     #[test]
     fn it_should_map_each_documented_decscusr_code_to_its_own_distinct_shape() {
@@ -534,5 +535,51 @@ mod tests {
     fn it_should_reject_an_unknown_shape_name_when_deserializing() {
         let result: Result<CursorShape, _> = serde_json::from_str("\"NotAShape\"");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn it_should_default_the_unfocused_shape_independently_from_the_focused_shape() {
+        let cursor = Cursor::default();
+        // The default config gives focused and unfocused cursors distinct shapes
+        // (SteadyBlock vs SteadyBar) -- unfocused_shape must not just mirror shape.
+        assert_ne!(cursor.shape, cursor.unfocused_shape);
+    }
+
+    #[test]
+    fn it_should_start_visible_and_toggle_visibility_via_set_visible() {
+        let mut controller = CursorController::new(Attributes::default());
+        assert!(controller.is_visible());
+
+        controller.set_visible(CursorVisibility::Hidden);
+        assert!(!controller.is_visible());
+
+        controller.set_visible(CursorVisibility::Visible);
+        assert!(controller.is_visible());
+    }
+
+    #[test]
+    fn it_should_restore_default_attributes_position_and_visibility_on_reset() {
+        let custom_attributes = {
+            let mut attrs = Attributes::default();
+            attrs.fg = crate::color::Color::Indexed(9);
+            attrs
+        };
+        let context = super::ScreenContext {
+            width: 80,
+            height: 24,
+            scroll_top: 0,
+            scroll_bot: 23,
+            origin_mode_active: false,
+        };
+        let mut controller = CursorController::new(custom_attributes);
+        controller.set_visible(CursorVisibility::Hidden);
+        controller.move_to_logical(10, 5, &context);
+        assert_eq!(controller.logical_pos(), (10, 5));
+
+        controller.reset();
+
+        assert!(controller.is_visible());
+        assert_eq!(controller.attributes(), Attributes::default());
+        assert_eq!(controller.logical_pos(), (0, 0));
     }
 }

--- a/core-term/src/term/cursor.rs
+++ b/core-term/src/term/cursor.rs
@@ -451,3 +451,88 @@ impl<'de> Deserialize<'de> for CursorShape {
         deserializer.deserialize_str(CursorShapeVisitor)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::CursorShape;
+
+    #[test]
+    fn it_should_map_each_documented_decscusr_code_to_its_own_distinct_shape() {
+        let shapes: Vec<CursorShape> = (1..=6).map(CursorShape::from_decscusr_code).collect();
+        assert_eq!(
+            shapes,
+            vec![
+                CursorShape::BlinkingBlock,
+                CursorShape::SteadyBlock,
+                CursorShape::BlinkingUnderline,
+                CursorShape::SteadyUnderline,
+                CursorShape::BlinkingBar,
+                CursorShape::SteadyBar,
+            ],
+            "each DECSCUSR code 1-6 must map to a unique CursorShape variant"
+        );
+    }
+
+    #[test]
+    fn it_should_map_decscusr_code_zero_to_the_default_shape() {
+        assert_eq!(
+            CursorShape::from_decscusr_code(0),
+            CursorShape::default()
+        );
+    }
+
+    #[test]
+    fn it_should_map_an_unrecognized_decscusr_code_to_the_default_shape() {
+        assert_eq!(
+            CursorShape::from_decscusr_code(99),
+            CursorShape::default()
+        );
+    }
+
+    #[test]
+    fn it_should_round_trip_every_shape_through_serde_json() {
+        let shapes = [
+            CursorShape::BlinkingBlock,
+            CursorShape::SteadyBlock,
+            CursorShape::BlinkingUnderline,
+            CursorShape::SteadyUnderline,
+            CursorShape::BlinkingBar,
+            CursorShape::SteadyBar,
+        ];
+        for shape in shapes {
+            let json = serde_json::to_string(&shape).expect("serialize");
+            let round_tripped: CursorShape = serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(round_tripped, shape, "round trip through {json} changed the shape");
+        }
+    }
+
+    #[test]
+    fn it_should_serialize_each_shape_to_its_own_distinct_json_string() {
+        let shapes = [
+            CursorShape::BlinkingBlock,
+            CursorShape::SteadyBlock,
+            CursorShape::BlinkingUnderline,
+            CursorShape::SteadyUnderline,
+            CursorShape::BlinkingBar,
+            CursorShape::SteadyBar,
+        ];
+        let jsons: Vec<String> = shapes
+            .iter()
+            .map(|s| serde_json::to_string(s).expect("serialize"))
+            .collect();
+        let mut unique = jsons.clone();
+        unique.sort();
+        unique.dedup();
+        assert_eq!(
+            unique.len(),
+            jsons.len(),
+            "expected each CursorShape to serialize to a distinct string, got {jsons:?}"
+        );
+    }
+
+    #[test]
+    fn it_should_reject_an_unknown_shape_name_when_deserializing() {
+        let result: Result<CursorShape, _> = serde_json::from_str("\"NotAShape\"");
+        assert!(result.is_err());
+    }
+}

--- a/core-term/src/term/emulator/key_translator.rs
+++ b/core-term/src/term/emulator/key_translator.rs
@@ -204,6 +204,103 @@ mod tests {
     }
 
     #[test]
+    fn it_should_map_ctrl_plus_bracket_group_punctuation_to_their_c0_control_codes() {
+        let modes = DecPrivateModes::default();
+        let cases = [
+            ('[', 0x1b), // Ctrl+[ is ESC
+            ('\\', 0x1c), // Ctrl+\ is FS
+            (']', 0x1d), // Ctrl+] is GS
+            ('^', 0x1e), // Ctrl+^ is RS
+            ('_', 0x1f), // Ctrl+_ is US
+            ('?', 0x7f), // Ctrl+? is DEL
+        ];
+        for (input, expected) in cases {
+            assert_eq!(
+                translate_key_input(KeySymbol::Char(input), Modifiers::CONTROL, None, &modes),
+                vec![expected],
+                "Ctrl+{input:?} should produce byte {expected:#04x}"
+            );
+        }
+    }
+
+    #[test]
+    fn it_should_translate_editing_and_navigation_keys_to_their_own_escape_sequences() {
+        let modes = DecPrivateModes::default();
+        let cases: [(KeySymbol, &[u8]); 8] = [
+            (KeySymbol::Backspace, &[0x08]),
+            (KeySymbol::Escape, &[0x1B]),
+            (KeySymbol::Home, b"\x1b[1~"),
+            (KeySymbol::End, b"\x1b[4~"),
+            (KeySymbol::PageUp, b"\x1b[5~"),
+            (KeySymbol::PageDown, b"\x1b[6~"),
+            (KeySymbol::Insert, b"\x1b[2~"),
+            (KeySymbol::Delete, b"\x1b[3~"),
+        ];
+        for (symbol, expected) in cases {
+            assert_eq!(
+                translate_key_input(symbol, Modifiers::empty(), None, &modes),
+                expected.to_vec(),
+                "{symbol:?} should produce {expected:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn it_should_translate_each_function_key_to_its_own_escape_sequence() {
+        let modes = DecPrivateModes::default();
+        let cases: [(KeySymbol, &[u8]); 12] = [
+            (KeySymbol::F1, b"\x1bOP"),
+            (KeySymbol::F2, b"\x1bOQ"),
+            (KeySymbol::F3, b"\x1bOR"),
+            (KeySymbol::F4, b"\x1bOS"),
+            (KeySymbol::F5, b"\x1b[15~"),
+            (KeySymbol::F6, b"\x1b[17~"),
+            (KeySymbol::F7, b"\x1b[18~"),
+            (KeySymbol::F8, b"\x1b[19~"),
+            (KeySymbol::F9, b"\x1b[20~"),
+            (KeySymbol::F10, b"\x1b[21~"),
+            (KeySymbol::F11, b"\x1b[23~"),
+            (KeySymbol::F12, b"\x1b[24~"),
+        ];
+        for (symbol, expected) in cases {
+            assert_eq!(
+                translate_key_input(symbol, Modifiers::empty(), None, &modes),
+                expected.to_vec(),
+                "{symbol:?} should produce {expected:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn it_should_translate_each_keypad_key_to_its_own_ascii_character() {
+        let modes = DecPrivateModes::default();
+        let cases = [
+            (KeySymbol::KeypadPlus, b'+'),
+            (KeySymbol::KeypadMinus, b'-'),
+            (KeySymbol::KeypadMultiply, b'*'),
+            (KeySymbol::KeypadDivide, b'/'),
+            (KeySymbol::KeypadDecimal, b'.'),
+            (KeySymbol::Keypad0, b'0'),
+            (KeySymbol::Keypad1, b'1'),
+            (KeySymbol::Keypad2, b'2'),
+            (KeySymbol::Keypad3, b'3'),
+            (KeySymbol::Keypad4, b'4'),
+            (KeySymbol::Keypad5, b'5'),
+            (KeySymbol::Keypad6, b'6'),
+            (KeySymbol::Keypad7, b'7'),
+            (KeySymbol::Keypad8, b'8'),
+            (KeySymbol::Keypad9, b'9'),
+        ];
+        for (symbol, expected) in cases {
+            assert_eq!(
+                translate_key_input(symbol, Modifiers::empty(), None, &modes),
+                vec![expected],
+                "{symbol:?} should produce byte {expected:?}"
+            );
+        }
+    }
+
+    #[test]
     fn arrow_keys_normal_mode() {
         let modes = DecPrivateModes {
             cursor_keys_app_mode: false,

--- a/core-term/src/term/emulator/key_translator.rs
+++ b/core-term/src/term/emulator/key_translator.rs
@@ -207,12 +207,12 @@ mod tests {
     fn it_should_map_ctrl_plus_bracket_group_punctuation_to_their_c0_control_codes() {
         let modes = DecPrivateModes::default();
         let cases = [
-            ('[', 0x1b), // Ctrl+[ is ESC
+            ('[', 0x1b),  // Ctrl+[ is ESC
             ('\\', 0x1c), // Ctrl+\ is FS
-            (']', 0x1d), // Ctrl+] is GS
-            ('^', 0x1e), // Ctrl+^ is RS
-            ('_', 0x1f), // Ctrl+_ is US
-            ('?', 0x7f), // Ctrl+? is DEL
+            (']', 0x1d),  // Ctrl+] is GS
+            ('^', 0x1e),  // Ctrl+^ is RS
+            ('_', 0x1f),  // Ctrl+_ is US
+            ('?', 0x7f),  // Ctrl+? is DEL
         ];
         for (input, expected) in cases {
             assert_eq!(

--- a/core-term/src/term/emulator/key_translator.rs
+++ b/core-term/src/term/emulator/key_translator.rs
@@ -162,7 +162,7 @@ mod tests {
     use crate::term::modes::DecPrivateModes;
 
     #[test]
-    fn simple_chars() {
+    fn it_should_translate_printable_chars_and_enter_to_their_bytes() {
         let modes = DecPrivateModes::default();
         assert_eq!(
             translate_key_input(
@@ -180,7 +180,7 @@ mod tests {
     }
 
     #[test]
-    fn ctrl_chars() {
+    fn it_should_map_ctrl_plus_char_to_its_control_code() {
         let modes = DecPrivateModes::default();
         // Test Ctrl+c
         assert_eq!(
@@ -195,7 +195,7 @@ mod tests {
     }
 
     #[test]
-    fn alt_chars() {
+    fn it_should_prefix_alt_plus_char_with_an_escape_byte() {
         let modes = DecPrivateModes::default();
         assert_eq!(
             translate_key_input(KeySymbol::Char('a'), Modifiers::ALT, None, &modes),
@@ -252,7 +252,7 @@ mod tests {
     }
 
     #[test]
-    fn shift_tab() {
+    fn it_should_translate_shift_tab_to_the_cbt_escape_sequence() {
         let modes = DecPrivateModes::default();
         assert_eq!(
             translate_key_input(KeySymbol::Tab, Modifiers::SHIFT, None, &modes),

--- a/core-term/src/term/emulator/mouse.rs
+++ b/core-term/src/term/emulator/mouse.rs
@@ -515,4 +515,161 @@ mod tests {
         .unwrap();
         assert_eq!(result, b"\x1b[<0;501;301M");
     }
+
+    fn modes_with_button_event_legacy() -> DecPrivateModes {
+        DecPrivateModes {
+            mouse_button_event_mode: true,
+            ..Default::default()
+        }
+    }
+
+    fn modes_with_any_event_legacy() -> DecPrivateModes {
+        DecPrivateModes {
+            mouse_any_event_mode: true,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn it_should_report_press_events_when_only_button_event_mode_is_enabled() {
+        let modes = modes_with_button_event_legacy();
+        let result = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Left,
+                col: 0,
+                row: 0,
+                kind: MouseEventKind::Press,
+            },
+        );
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn it_should_report_release_events_when_only_button_event_mode_is_enabled() {
+        let modes = modes_with_button_event_legacy();
+        let result = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Left,
+                col: 0,
+                row: 0,
+                kind: MouseEventKind::Release,
+            },
+        );
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn it_should_add_32_to_the_button_code_for_legacy_motion_events() {
+        let modes = modes_with_any_event_legacy();
+        let result = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Left,
+                col: 5,
+                row: 10,
+                kind: MouseEventKind::Motion,
+            },
+        )
+        .unwrap();
+        // base(Left)=0, +32 for motion = 32, then +32 legacy offset = 64
+        assert_eq!(result, vec![0x1b, b'[', b'M', 64, 38, 43]);
+    }
+
+    #[test]
+    fn it_should_use_the_raw_button_number_for_other_buttons_below_four() {
+        let modes = modes_with_sgr();
+        let result = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Other(3),
+                col: 0,
+                row: 0,
+                kind: MouseEventKind::Press,
+            },
+        )
+        .unwrap();
+        assert_eq!(result, b"\x1b[<3;1;1M");
+    }
+
+    #[test]
+    fn it_should_map_other_buttons_at_or_above_four_using_128_plus_n_minus_4() {
+        let modes = modes_with_sgr();
+        let boundary = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Other(4),
+                col: 0,
+                row: 0,
+                kind: MouseEventKind::Press,
+            },
+        )
+        .unwrap();
+        assert_eq!(boundary, b"\x1b[<128;1;1M");
+
+        let above = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Other(8),
+                col: 0,
+                row: 0,
+                kind: MouseEventKind::Press,
+            },
+        )
+        .unwrap();
+        assert_eq!(above, b"\x1b[<132;1;1M");
+    }
+
+    #[test]
+    fn it_should_accept_column_222_but_reject_223_in_legacy_encoding() {
+        let modes = modes_with_vt200();
+        let at_boundary = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Left,
+                col: 222,
+                row: 0,
+                kind: MouseEventKind::Press,
+            },
+        );
+        assert!(at_boundary.is_some());
+
+        let over_boundary = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Left,
+                col: 223,
+                row: 0,
+                kind: MouseEventKind::Press,
+            },
+        );
+        assert_eq!(over_boundary, None);
+    }
+
+    #[test]
+    fn it_should_accept_row_222_but_reject_223_in_legacy_encoding() {
+        let modes = modes_with_vt200();
+        let at_boundary = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Left,
+                col: 0,
+                row: 222,
+                kind: MouseEventKind::Press,
+            },
+        );
+        assert!(at_boundary.is_some());
+
+        let over_boundary = encode_mouse_event(
+            &modes,
+            MouseEncodingParams {
+                button: MouseButton::Left,
+                col: 0,
+                row: 223,
+                kind: MouseEventKind::Press,
+            },
+        );
+        assert_eq!(over_boundary, None);
+    }
 }

--- a/core-term/src/term/emulator/mouse.rs
+++ b/core-term/src/term/emulator/mouse.rs
@@ -430,7 +430,7 @@ mod tests {
     }
 
     #[test]
-    fn x10_reports_press_only() {
+    fn it_should_encode_only_press_events_in_x10_mouse_mode() {
         let modes = modes_with_x10();
         let press = encode_mouse_event(
             &modes,
@@ -465,7 +465,7 @@ mod tests {
     }
 
     #[test]
-    fn vt200_reports_press_and_release() {
+    fn it_should_encode_both_press_and_release_events_in_vt200_mouse_mode() {
         let modes = modes_with_vt200();
         let press = encode_mouse_event(
             &modes,

--- a/core-term/src/term/layout.rs
+++ b/core-term/src/term/layout.rs
@@ -197,7 +197,7 @@ mod tests {
     }
 
     #[test]
-    fn verify_cells_to_pixels() {
+    fn it_should_convert_cell_coordinates_to_pixel_coordinates_using_cell_size() {
         let layout = Layout {
             cols: 80,
             rows: 24,
@@ -214,7 +214,7 @@ mod tests {
     }
 
     #[test]
-    fn verify_pixel_dimensions() {
+    fn it_should_compute_total_pixel_dimensions_including_padding() {
         let layout = Layout {
             cols: 80,
             rows: 24,
@@ -230,7 +230,7 @@ mod tests {
     }
 
     #[test]
-    fn verify_resize() {
+    fn it_should_update_cols_and_rows_when_resized() {
         let mut layout = Layout::new(80, 24);
 
         assert_eq!(layout.cols, 80);

--- a/core-term/src/term/screen.rs
+++ b/core-term/src/term/screen.rs
@@ -1214,7 +1214,7 @@ mod tests {
     }
 
     #[test]
-    fn verify_start_selection() {
+    fn it_should_activate_selection_and_mark_start_line_dirty() {
         let mut screen = create_test_screen(10, 5);
         let start_point = Point { x: 1, y: 1 };
         screen.dirty.fill(0);
@@ -1231,7 +1231,7 @@ mod tests {
     }
 
     #[test]
-    fn verify_update_selection() {
+    fn it_should_extend_selection_range_and_mark_updated_line_dirty() {
         let mut screen = create_test_screen(10, 5);
         let start_point = Point { x: 1, y: 1 };
         let update_point = Point { x: 5, y: 2 };
@@ -1266,7 +1266,7 @@ mod tests {
     }
 
     #[test]
-    fn verify_end_selection() {
+    fn it_should_deactivate_selection_without_clearing_its_range() {
         let mut screen = create_test_screen(10, 5);
         screen.start_selection(Point { x: 1, y: 1 }, SelectionMode::Cell); // Replaced Normal with Cell
         screen.end_selection();
@@ -1274,7 +1274,7 @@ mod tests {
     }
 
     #[test]
-    fn verify_clear_selection() {
+    fn it_should_reset_selection_and_mark_both_endpoints_lines_dirty() {
         let mut screen = create_test_screen(10, 5);
         screen.start_selection(Point { x: 1, y: 1 }, SelectionMode::Cell); // Replaced Normal with Cell
         screen.update_selection(Point { x: 3, y: 2 });

--- a/core-term/src/term/tests.rs
+++ b/core-term/src/term/tests.rs
@@ -226,7 +226,7 @@ fn assert_screen_state(
 }
 
 #[test]
-fn simple_char_input() {
+fn it_should_print_characters_left_to_right_and_advance_the_cursor() {
     let mut term = create_test_emulator(10, 1);
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('A')));
     let snapshot = term.get_render_snapshot().expect("Snapshot was None");
@@ -239,7 +239,7 @@ fn simple_char_input() {
 }
 
 #[test]
-fn newline_input() {
+fn it_should_move_to_column_zero_of_the_next_line_when_lnm_is_set_and_lf_is_received() {
     let mut term = create_test_emulator(10, 2);
     // Enable Linefeed/Newline Mode (LNM)
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Csi(CsiCommand::SetMode(
@@ -804,7 +804,7 @@ fn key_event_arrow_up() {
 }
 
 #[test]
-fn snapshot_with_selection() {
+fn it_should_preserve_selection_range_and_mode_in_a_constructed_snapshot() {
     let num_cols = 10;
     let num_rows = 2;
     let default_glyph = Glyph::Single(ContentCell {
@@ -1257,7 +1257,7 @@ mod selection_logic_tests {
     use crate::term::snapshot::SelectionRange;
 
     #[test]
-    fn start_selection() {
+    fn it_should_activate_selection_at_the_point_the_start_action_targets() {
         let mut emu = create_test_emulator(10, 5);
         let point = Point { x: 2, y: 1 };
 
@@ -1735,7 +1735,7 @@ mod paste_text_tests {
     }
 
     #[test]
-    fn window_manipulation_report_size() {
+    fn it_should_report_current_terminal_dimensions_for_window_manipulation_ps_18() {
         let mut emu = create_test_emulator(80, 24);
 
         let report_command = AnsiCommand::Csi(CsiCommand::WindowManipulation {

--- a/core-term/src/term/unicode.rs
+++ b/core-term/src/term/unicode.rs
@@ -194,7 +194,7 @@ mod tests {
     }
 
     #[test]
-    fn zero_width_chars() {
+    fn it_should_report_zero_display_width_for_combining_and_joiner_characters() {
         assert_eq!(
             get_char_display_width('\u{200D}'),
             0,

--- a/core-term/tests/ansi_to_grid_integration.rs
+++ b/core-term/tests/ansi_to_grid_integration.rs
@@ -9,7 +9,7 @@ use core_term::ansi::commands::{AnsiCommand, C0Control, CsiCommand};
 use support::minimal_test_harness::MinimalTestHarness;
 
 #[test]
-fn single_character_print() {
+fn it_should_place_a_printed_character_at_the_cursor_and_advance_the_cursor() {
     let mut harness = MinimalTestHarness::new();
 
     // TEST: Print a single character
@@ -34,7 +34,7 @@ fn single_character_print() {
 }
 
 #[test]
-fn multiple_characters() {
+fn it_should_print_a_sequence_of_characters_left_to_right() {
     let mut harness = MinimalTestHarness::new();
 
     // TEST: Print multiple characters
@@ -95,7 +95,7 @@ fn cursor_position_command() {
 }
 
 #[test]
-fn multiline_text() {
+fn it_should_wrap_to_a_new_grid_line_on_each_lf_cr_pair() {
     let mut harness = MinimalTestHarness::new();
 
     // TEST: Print text with newlines
@@ -192,7 +192,7 @@ fn grid_checksum_stable_without_changes() {
 }
 
 #[test]
-fn multiple_characters_change_checksum() {
+fn it_should_change_the_grid_checksum_after_each_character_printed() {
     let mut harness = MinimalTestHarness::new();
 
     let mut checksums = Vec::new();


### PR DESCRIPTION
## Summary

Test-quality pass on `core-term`, scoped to that crate (it's the flagship/namesake, and the workspace has ~1834 tests across 12 crates — too much to redo in one pass).

- **Naming**: renamed ~25 tests whose names didn't say what they cover (`verify_clear_selection`, `is_deterministic`, `zero_width_chars`, `start_selection`, `simple_chars`, etc.) to `it_should_*` form, so a failing test name tells you what broke without opening the file. Swept the rest of the workspace for degenerate names (`test1`, `it_works`, `basic`, ...) — found none, so left those crates alone.
- **Public-interface check**: audited `core-term`'s test modules for tests reaching past a type's public API to poke private state. Didn't find the anti-pattern (hand-constructing a struct via private-field literals, asserting on private representation instead of behavior) — the existing `#[cfg(test)] mod tests` + `use super::*;` pattern here is normal same-crate unit testing, and higher-level flows are already tested through `TerminalEmulator`'s public API (one test even carries a `// Clear selection using public API` comment marking that intent).
- **Mutation testing** (`cargo-mutants`) against `cursor.rs`, `key_translator.rs`, and `mouse.rs` — chosen because they're self-contained protocol-encoding logic with clear observable outputs, easy to reason about in isolation. First run: **82/161 mutants caught (51%)**. Added tests targeting the gaps, re-ran: **157/161 caught (97.5%)**. Real gaps closed:
  - `cursor.rs`: `CursorShape::from_decscusr_code` had *zero* direct tests — the terminal-emulator snapshot only exposes a coarsened 3-variant `CursorShape` (Block/Underline/Bar), so it can't distinguish DECSCUSR's Blinking-vs-Steady codes at all; that distinction is only observable by calling the public `from_decscusr_code` directly. Also: `to_str`/`from_str` (serde round-trip) and `CursorController::set_visible`/`is_visible`/`reset` had no tests at all.
  - `key_translator.rs`: Ctrl+`[ \ ] ^ _ ?` control codes, Backspace/Escape/Home/End/PageUp/PageDown/Insert/Delete, all of F1–F12, and every keypad key had no byte-level assertions.
  - `mouse.rs`: `should_report`'s OR-chain had a gap hidden by operator precedence (`a||b||c||d` mutated on the last `||` to `&&` parses as `a||b||(c&&d)`, so any test with `a` or `b` true couldn't catch it — needed a mode combo isolating `button_event_mode` alone). Also added coverage for the `Other(n)` button-code formula (`128 + n - 4`) and the legacy protocol's 222-cell coordinate boundary, neither previously exercised.
  - Remaining 3 misses are non-issues: two are mutants equivalent under the current default config (an explicit match arm producing the same value the fallback `_ => CursorShape::default()` arm would produce, since default config happens to match), and one is `serde::de::Visitor::expecting`, a formatter used only for error-message text on the deserialization failure path.
- Fixed one `clippy::field_reassign_with_default` warning introduced by a new test, and ran `cargo fmt`.

Scope not covered in this pass: naming/mutation testing on the rest of the workspace (`screen.rs`, `ansi/commands.rs`, and friends have far larger mutant surfaces — 245 and 129 respectively — not attempted here to keep this change reviewable).

## Test plan
- [x] `cargo test -p core-term --lib --tests` — 459 lib tests + all integration tests pass
- [x] `cargo clippy -p core-term --lib --tests` — clean
- [x] `cargo fmt -p core-term -- --check` — clean
- [x] `cargo mutants` on the three touched files: 157/161 mutants caught (up from 82/161)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KAS5XdRtePi9dNAqCrTAcC)_