### PR TITLE
refactor(pixelflow-search): domain-modeled cleanup — encapsulate the guide behind its contract

### DIFF
--- a/docs/plans/2026-08-17-cost-model-domain.md
+++ b/docs/plans/2026-08-17-cost-model-domain.md
@@ -1,0 +1,345 @@
+# Cost-Model Domain Model and Reorganization Plan (2026-08-17)
+
+Synthesis of three independent analyses over the cost-model pipeline
+(pixelflow-search/src/{nnue,egraph}, pixelflow-pipeline/src/{training,bin,jit_bench.rs}):
+
+1. **Domain description + noun inventory** — what each stage MEANS, and whether each noun has a type, a convention, or nothing.
+2. **Name/argument analysis** — 1,330 fns parsed; namespace-in-name families and argument clusters that always travel together.
+3. **Dead inventory** — caller-verified live/dead disposition of the NNUE surface, plus the serialization consequence.
+
+**Method (the join):** the analyses are independent probes of the same missing structure. A
+candidate type is **CONFIRMED** when it appears in at least two probes — a prose noun that also
+shows up as an argument cluster and/or a name-suffix family compensating for it. A single-source
+candidate is checked against the roadmap (§0 north star of the 2026-08-05 research workflow;
+guided-saturation Phase 3, 2026-07-07; Round-2 contrastive direction; research-notes §6 adoption
+plan): roadmap-demanded → **denote now, implement only what the live path consumes**
+(ROADMAP-ADMITTED, roadmap item cited so the seam can be retired if the roadmap changes).
+Single-source without roadmap demand → unconfirmed; do not build. Disagreements between probes
+are findings in their own right (§0.2).
+
+Open P1 defect classes this reorganization must make **unrepresentable**:
+- **(a)** cached ValueSample accumulators go stale while SGD mutates embeddings each batch
+- **(b)** TRIE checkpoint schema never bumped when feature meaning changed
+- **(c)** variance computed from class-wide meet instead of the chosen nodes
+- **(d)** holdout fence keyed on structure while features collapse literals
+
+---
+
+## 0. The join table
+
+Every later section references these rows by number.
+
+| # | Candidate type | Domain noun (probe 1) | Argument cluster (probe 2) | Name family (probe 2) | Kills | Verdict |
+|---|---|---|---|---|---|---|
+| J1 | `Expr<'a>` (rooted arena) | "expression" §1 — *the* object of the whole pipeline; currently two positional params | `(arena, root)` — 37 sites, 12 files, both crates | `*_arena` suffix family (`benchmark_jit_arena`, `optimize_runtime_arena`, `from_arena_dag`, …) | argument-threading errors; the `*_arena` namespace smell | **CONFIRMED** |
+| J2 | `Extraction` | "choice map" + "well-founded choice state" — both Convention; a validated choice vector is indistinguishable from an arbitrary `Vec<Option<usize>>` | `(egraph, root, choices)` — 10 sites, 3 files | `from_dag_choices` / `from_dag_choices_with_variance` / `choices_to_arena` / `backfill_well_founded` | **P1(a)**, **P1(c)** | **CONFIRMED** |
+| J3 | `CostLabel` | "the label itself" — **Nothing**; five parts exist as separate pieces (bare f64, file-level `MintMetadata`, run-level `NormalizationStats`) | `ns` / `adjusted_ns` / `call_overhead_ns` / `SentinelContext` / `mode` traveling together on `BenchResult` | `normalized_label_ns`, `.normalization()` | drift-before-overhead ordering bug class; order-correlated label contamination | **CONFIRMED** |
+| J4 | `SessionNs` / `LocalNs` clock newtypes | "clock context" — **Nothing**; the exact CLAUDE.md pattern (one f64, several clocks) | same fields as J3 | same | wrong-clock scaling by a future caller | **CONFIRMED** |
+| J5 | `BenchRequest` | §4 measurement mechanics (mode, repetition, compile-cache state) | — | 8 `benchmark_*`/`measure_*` fns in jit_bench.rs (subject × repetition × compile spelled as suffixes) | every new measurement mode minting a new suffixed fn | **CONFIRMED** (denote now, implement next round — see §4b) |
+| J6 | `VariantSet` | "rewrite-variant family / same-expression variant set" — **Nothing**; the central missing noun: the population ranking must actually operate over | absent from code (that absence IS the finding) | absent | the ranking-target mismatch — the measured 1.8% extraction regression | **ROADMAP-ADMITTED** [Round-2 contrastive training; research notes §1.5] |
+| J7 | `Fence<T: TierMarker>` + `Family` newtype | "holdout fence" (guarantee = Convention), "generator family" (bare `(usize, u64)`), "leakage" (**Nothing**) | `report_holdout_fence(fence, live_counts, dropped, requested_synthetic, sidecar)` — 5 params | — | backwards-fence misuse (compiles fine today); family-split leakage | **CONFIRMED** |
+| J8 | `FenceKey` = feature-quotient key | leakage precisely defined: structure the model has effectively seen appearing on the certifying side | — | — | **P1(d)** | **ROADMAP/DEFECT-ADMITTED** [P1(d); Round-2 needs a sound DEV tier] |
+| J9 | `SchemaIdentity` (trait, §2) | "weights sidecar" typed but `weights_identity` is a one-off convention; "config hash" **Nothing** | — | "TRIE" magic never bumped; dead sections written unconditionally | **P1(b)** | **CONFIRMED** |
+| J10 | `SaturationGuide` contract | §5 dead apparatus: graph accumulator, mask/policy head, rule encoders — zero non-test callers, zero gradient producers | `(parent_op, child_op, emb[, depth\|pe])` ×10 | 18 `{add,remove}_{edge,op_node,2hop_edge,leaf}[_at_depth\|_with_pe]` mutators + 6 scoring methods (`*_with_hidden`/`*_graph`) | the decay-of-dead-weights defect (Phase-3 weights randomly initialized, then weight-decayed with no opposing gradient, every run) | **ROADMAP-ADMITTED** [Phase 3, 2026-07-07 guided-saturation redesign] |
+| J11 | `SaturationBudget` | saturation (implicit in §5/§7) | `(max_iters, class limits, timeout)` | `saturate_with_{budget,full_budget}` (saturate.rs) vs `saturate_with_{limit,limits}` (graph.rs) — **two independent implementations of the same loop** | silent drift between duplicate saturation loops (the `sin` anecdote, live) | **CONFIRMED** |
+| J12 | `RoundVerdict` | DEV verdict, FINAL gate, "underpowered", noise floor — all **Nothing**/Convention; DEV-vs-FINAL enforced by control flow, not type | `Option<(f64,f64)>` CI + prose precedence in `verdict_text` | three colliding "Verdict"s (`quarantine::Verdict`, `PointVerdict`, the e2e `String`) | silently swapping a DEV geomean for a FINAL one (both plain `f64`); gate-precedence bugs | **CONFIRMED** |
+| J13 | `EClassRef<'a>` | "a class inside this egraph" | `(egraph, class)` — 16 sites, 6 files | — | — | **CONFIRMED**, low priority |
+| J14 | shared `run_scalar` (one copy) | oracle cross-check §3 | `(code, x, y, z, w)` — 8 sites, byte-identical bodies in ≥3 files (quarantine.rs comment admits "Verbatim from …") | — | a fix to one copy silently not propagating — NO SILENT FAILURES violation in waiting | **CONFIRMED** |
+| J15 | `JournalEntry` + `ConfigHash` | "run-level research journal" — **Nothing**; a file-format convention two binaries could violate differently | — | — | unreproducible claims; structurally divergent journal lines | **ROADMAP-ADMITTED** [2026-08-05 workflow requires the journal for every round] |
+
+### 0.1 Anti-rows — clusters/families the join says NOT to build
+
+| # | Candidate | Why not |
+|---|---|---|
+| A1 | `Match{id, node}` for `Rewrite::apply` | Largest raw cluster (37 impls) but **already unified by the trait**. Both probes agree it needs nothing. Churn without payoff. |
+| A2 | `GraphEdit` enum for GraphAccumulator's 18 mutators | Name family with **no live domain noun** — the roadmap (Phase 3) explains the gap. Elaborating a dead surface is implementation ahead of its consumer. Encapsulate (J10); if Phase 3 wants the enum, mint it then. |
+| A3 | generic `Layer` MLP struct | The 3× hand-copied backprop (`backprop_{mask,rule,value}_mlp`) mostly **dies by deletion**: rule_mlp is legacy-dead, mask_mlp goes behind the Guide contract. Only `value_mlp` stays live — one copy, no abstraction needed. Subtract before you add. |
+| A4 | fixing `set_rule` (9 params, worst offender) | Belongs to `RuleFeatures`, which is DELETE-shaped (superseded by `encode_rule_from_arena`). The sharpest argument-count violation in the corpus is resolved by subtraction, not a struct. |
+| A5 | `GateKind` (same-form vs cross-form as one enum) | Prose-only, single-source, no cluster, no direct roadmap demand. The two gates live in different modules with different failure semantics; unifying them is a doc-level seam (§3 notes where each lives), not a type. Unconfirmed — do not build. |
+| A6 | O(Δ) incremental extraction (`EdgeAccumulator::remove_*` consumers) | Research notes defect #4: measured median edge-multiset symmetric difference is 44.9%, so a correct O(Δ) path buys ~2×, not the chess-analogy ~98%. Keep the `remove_*` API public as-is (KEEP-uncertain, adoption-plan step 5); build nothing on it now. |
+
+### 0.2 Disagreement findings (mismatches between probes)
+
+- **Code grew structure the domain doesn't need yet:** the entire Guide surface (J10). The
+  roadmap explains it; the disposition is encapsulation, not deletion and not elaboration.
+- **The domain has a vivid noun with zero code footprint:** "leakage" and the "variant set" (J6).
+  Leakage is a *property*, not a type — it becomes a theorem obligation discharged by J7+J8
+  (family-typed split + feature-quotient fence). The variant set is a genuine missing type.
+- **A convention the prose treats as load-bearing that code treats as free:** the clock a
+  nanosecond is denominated in (J4). Nothing in the type system stops scaling the wrong field;
+  the doc comment on `normalized_label_ns` is the only guard.
+- **Stale ground truth caught by the dead-inventory probe:** `RuleTemplates` (corpus
+  junkification) is LIVE and unrelated to the dead `RuleFeatures` despite the similar name —
+  the collision itself misled the earlier audit. `pixelflow-ml/src/nnue.rs` and the MCTS policy
+  samplers are already deleted; those items are closed, not open.
+
+---
+
+## 1. The denotations
+
+What each load-bearing noun IS, as a mathematical object. Types listed here are obligations; the
+implementation is then obliged to them.
+
+**Expr (J1).** An expression is a rooted term graph: a pair (arena, root) where the arena is the
+DAG storage and the root picks the term out of it. Neither half means anything alone.
+`struct Expr<'a> { arena: &'a ExprArena, root: ExprId }` (name open; `RootedExpr` if `Expr` is
+too loaded post-deletion of the old Arc `Expr`). Exactly the object threaded as two positional
+params through 37 signatures today.
+
+**Extraction (J2).** An extraction is a *witnessed selection*: (egraph, root, choices) where
+choices is a well-founded (cycle-free, bottom-up realizable) function from reachable e-class to
+chosen node. Constructing one **is** validating well-foundedness — an `Extraction` value cannot
+exist un-backfilled; `backfill_well_founded` becomes the smart constructor's internals, and a bare
+`Vec<Option<usize>>` no longer crosses a public boundary.
+- **Kills P1(c):** variance is a property *of the chosen nodes*, so `Extraction` (not the e-class)
+  is the only thing a variance analysis may be computed from. A class-wide meet is
+  unrepresentable because the class-wide view is never handed to the variance code.
+- **Kills P1(a)** (with the epoch tag): the feature vector is a pure function
+  `features(extraction, θ_emb)`. A cached feature vector is valid only for the θ it was computed
+  under, so `Features` carries an `EmbeddingsEpoch` — a counter the SGD step increments — and
+  every consumer asserts epoch equality, panicking on mismatch (NO SILENT FAILURES). Staleness
+  becomes a loud crash today and a type error once the recompute policy lands (§4b).
+
+**CostLabel (J3) + clocks (J4).** A label is a measurement *in a clock context*:
+`(expr_ref, value: SessionNs, mode: BenchMode, drift: DriftFactor, order: BenchPosition,
+calibration: SentinelContext)`. Two labels are comparable only when denominated in the same
+clock. Raw readings are `LocalNs` (the clock running when the sample was taken); the canonical
+label value is `SessionNs` (the session-opening clock); the only conversion is
+`LocalNs::normalize(drift) -> SessionNs`, and call overhead is a `SessionNs` that can only be
+subtracted from a `SessionNs` — so "apply drift, then subtract overhead" stops being an ordering
+convention and becomes the only well-typed composition. A measurement without sentinel context
+cannot be constructed at all (today it hard-panics; the type removes the branch).
+
+**BenchRequest (J5).** A benchmark is a function of a request:
+`{ subject: Arena | Compiled, repetition: Once | Repeated(n) | Both, compile: Cached | Fresh }`
+consumed by one `benchmark(req) -> BenchResult`. The 8 suffixed fns are its currying.
+Denoted now; consolidated next round (§4b) because it touches the measurement path PR #984 just
+hardened.
+
+**VariantSet (J6).** The object the search actually needs ranked: a finite set of expressions
+*known equivalent by construction* — either the two sides of a junkify pair or the members of one
+saturated e-class. `VariantSet = { class_witness, members: Vec<Expr> }`, with the invariant that
+all members denote the same function. The live training loop currently destroys this structure
+(each side of `BwdTrainingPairArena` becomes an independent absolute-regression sample); Round 2's
+contrastive objective consumes it. **This round mints the type and threads the pairing through to
+the training-data files; the loss change is next round.** Load-bearing consequence, from the
+measured program: across-expression Spearman ρ≈0.98 is saturated by size (a transcendental-count
+baseline gets 0.95) — within-VariantSet ranking is the only metric that discriminates models.
+
+**Tier fence (J7) + FenceKey (J8).** A corpus tier is a set of expressions **closed under the
+fence equivalence**. The split unit is the `Family` (one `(Band, Seed)` stream — newtype, not
+tuple), never the individual draw. The fence guarantee is directional: a fence built from
+DEV∪FINAL keys rejects TRAIN-stream candidates; today `StructuralKeySet` carries no record of
+which tiers built it, so using it backwards compiles. `Fence<Dev>` / `Fence<Final>` (phantom tier
+marker) makes direction a type.
+- **Kills P1(d):** leakage is precisely "an expression whose structure the model has effectively
+  seen, on the certifying side." "Effectively seen" is defined by the *feature map*, not by raw
+  structure: if features collapse literals, two literal-differing expressions are the same point
+  to the model. Obligation: the fence equivalence must be **at least as coarse as** the feature
+  equivalence — `FenceKey = structural_key ∘ feature_quotient`, i.e. the key is computed from the
+  same abstraction the features see, by construction (one function, imported by both, never
+  restated). The type seam lands this round; the key-function change plus corpus regeneration is
+  next round (§4b) because it changes which samples are admitted.
+
+**SchemaIdentity (J9).** See §2. Kills P1(b).
+
+**SaturationGuide (J10).** The Guide's contractual role, from the Phase-3 design: given the
+e-graph's current state and a set of candidate rule applications, produce per-candidate
+move-ordering scores; trained later, purely supervised, on hindsight provenance labels from
+`egraph::labeler`. That sentence is the entire public contract — one trait, one constructor:
+
+```rust
+pub trait SaturationGuide {
+    fn score_candidates(&self, graph: &GraphSummary, candidates: &[RuleCandidate]) -> Vec<f32>;
+}
+```
+
+(`GraphSummary` wraps today's `GraphAccumulator`; `RuleCandidate` wraps the arena-template rule
+encoding.) Everything else — the accumulator's 18 mutators, `forward_graph`,
+`compute_graph_embed`, `bilinear_score`, both `mask_score_all_rules_*` variants — is private
+machinery behind it. The Guide's parameters leave the live checkpoint (§2) and stop receiving
+weight decay. Marked ROADMAP: if Phase 3 is cancelled, this module is deleted whole.
+
+**SaturationBudget (J11).** One saturation loop: `saturate(&mut self, budget: SaturationBudget)
+-> SaturationResult` where budget = {max_iters, max_classes, timeout}. The two current
+implementations (saturate.rs:91/104 free fns; graph.rs:807/818 methods) are the "one definition,
+imported, not restated" violation, live; one of them becomes the definition, the other a caller.
+
+**RoundVerdict (J12).** A verdict is a statement *conditional on gates*, and the gate order is
+part of its meaning: correctness first (numeric gate failure ⇒ no timing claim of any kind),
+censoring second (>10% policy failure ⇒ no directional claim), margin last. As a type:
+
+```rust
+enum RoundVerdict {
+    GateFailed(GateFailure),          // numeric or censoring — no claim printable
+    Underpowered { ci: Ci, gate: f64 }, // CI straddles the line: more kernels, not a re-run
+    Promote { ci: Ci },
+    Reject  { ci: Ci },
+}
+```
+
+produced by exactly one gate pipeline; `verdict_text` becomes a Display impl. The DEV/FINAL
+asymmetry becomes structural: only DEV evaluation returns a `RoundVerdict`; FINAL evaluation
+returns a `PublicationReport` that *has no verdict field* — the type, not a CLI-flag branch, is
+what refuses to answer "should we promote" with FINAL data. The A/A noise floor is a field of the
+report, not an inline comparison.
+
+**Naming collisions (findings probe).** Two renames, both mechanical:
+- `labeler::Label` (LoadBearing/Wasted) → `HindsightLabel`. The word "label" belongs to the cost
+  target (J3); the provenance object is a different noun in a different module.
+- the e2e bench's `String` verdict → `RoundVerdict` (above). `quarantine::Verdict` and
+  `PointVerdict` keep their names — properly namespaced, distinct objects.
+
+**JournalEntry + ConfigHash (J15).** A claim's run provenance is a value:
+`JournalEntry { config: ConfigHash, weights: ArtifactId, metrics: … }`, serde-defined, appended
+by one writer function. `ConfigHash` is the SchemaIdentity-style content hash of the full run
+configuration. A number without one of these attached is not a result.
+
+---
+
+## 2. The traits
+
+**`SchemaIdentity`** — things-with-schema-identity: NNUE checkpoints, mint sidecars, corpus tier
+files, journal entries. One derived **content hash of a layout descriptor** (field names, dims,
+feature-slot meanings, magic) replaces hand-maintained version integers — the TRIE bump that
+never happened (P1(b)) cannot fail to happen when the identity is *derived from* the layout.
+Contract: every loader asserts `stored_identity == Self::schema_identity()` and fails loudly on
+mismatch; `MintMetadata::weights_identity` (content-hash-binds sidecar to weight bytes) is the
+existing instance, generalized. Deliberately **no format-evolution ceremony**: a scratch/derived
+artifact that mismatches is regenerated, not migrated. Never silently consume a stale artifact;
+never build migration machinery for files that are cheaper to remint.
+
+**`CostDag`** (exists, keep as-is) — the single seam through which features are computed
+(`ArenaCostDag`, `ChoicesCostDag`, unified per PR #984). All feature construction goes through it;
+`Extraction` (J2) plugs in as the choices-backed instance. One walker, one input function —
+now also the enforcement point for the FenceKey feature-quotient (J8).
+
+**`SaturationGuide`** (J10) — the Phase-3 seam. The only trait minted *for* the roadmap.
+
+**Deliberately not traits** (subtract before you add):
+- Bench subject/mode: closed sets → enums inside `BenchRequest` (J5).
+- Clock denomination: two newtypes (J4), not a `Clock` trait — there are exactly two clocks.
+- Tier: the existing `Tier` enum plus a phantom marker on `Fence` (J7); no tier polymorphism.
+
+---
+
+## 3. The module map
+
+### pixelflow-search
+
+`src/nnue/factored.rs` (3,782 lines) dissolves:
+
+| New module | Contents | Visibility |
+|---|---|---|
+| `nnue/embeddings.rs` | `OpEmbeddings`, `depth_pe`, `EmbeddingsEpoch`, one `InitStrategy` enum (`Zero \| Random(seed) \| LatencyPrior(seed)`) replacing the 4-fn init family | pub(crate) internals, pub type |
+| `nnue/edge.rs` | `EdgeAccumulator` + `CostDag` instances; keeps the currently-unexercised `remove_*` API (A6) | as today |
+| `nnue/head.rs` | `ExprNnue` reduced to the live extraction head: backbone + value MLP, `forward_expr_only`, `predict_log_cost_with_features`; `RandomizeScope` collapses (mask scope moves to guide) | pub |
+| `nnue/serialize.rs` | live-only checkpoint format + `SchemaIdentity` impl (§4a-2) | pub load/save |
+| `nnue/guide/` | **private**: `accumulator.rs` (GraphAccumulator + mutators), `scoring.rs` (mask MLP, bilinear, `encode_rule_from_arena`); `mod.rs` = `SaturationGuide` trait + one constructor, nothing else pub | trait-only surface |
+| `nnue/mod.rs` (gen) | stays: `BwdGenerator`, `ExprGenerator`, `BwdTrainingPairArena` → produces `VariantSet` (J6); `RuleTemplates` (LIVE — do not confuse with deleted `RuleFeatures`) | as today |
+
+Deleted outright (zero callers, zero roadmap): `Edge` struct, `ExprNnue::from_factored`,
+`RuleFeatures` + `set_rule` + `rule_mlp_*` + `encode_rule`/`encode_all_rules`/
+`encode_all_rules_from_templates` (legacy sub-tier superseded by `encode_rule_from_arena`).
+
+`src/egraph/`: one `saturate(budget)` (J11) — `saturate.rs` keeps the definition,
+`graph.rs::saturate_with_limit{,s}` become callers or die. `extract.rs` gains `Extraction` (J2)
+and loses bare `Vec<Option<usize>>` from its public signatures. `labeler.rs::Label` →
+`HindsightLabel`. `Expr<'a>` (J1) lives in pixelflow-ir-adjacent shared location — pragmatically:
+define in `pixelflow-search` (it already sits above `ExprArena`) and re-export; do **not** modify
+pixelflow-ir.
+
+### pixelflow-pipeline
+
+Bins currently re-own library logic; the library takes it back:
+
+| Module | Contents | Extracted from |
+|---|---|---|
+| `src/bench/label.rs` | `CostLabel`, `SessionNs`, `LocalNs`, `DriftFactor` (J3/J4); `SentinelContext`, `BenchMode` move here | jit_bench.rs |
+| `src/bench/request.rs` | `BenchRequest` (J5) — type this round, consolidation next | jit_bench.rs |
+| `src/eval/verdict.rs` | `RoundVerdict`, `PublicationReport`, noise-floor field, gate pipeline (J12) | bench_extraction_3way.rs (4,262 lines → thin orchestration bin) |
+| `src/eval/gates.rs` | censoring (`PolicyFailureRates` moves in), geomean-with-precondition | bench_extraction_3way.rs |
+| `src/oracle_compare.rs` | the ONE `run_scalar` (J14) — quarantine.rs, bench_extraction_3way.rs, and tests/prod_kernel_jit.rs all import it | 3 verbatim copies |
+| `src/training/split.rs` | `Family` newtype, `Band` (moves in from gen_bench_corpus.rs — it is a cross-bin noun), `Fence<T>`, `FenceKey` seam (J7/J8) | split.rs + gen_bench_corpus.rs |
+| `src/journal.rs` | `JournalEntry`, `ConfigHash` (J15) | nothing (new; currently prose-only) |
+
+The same-form gate stays in `training/quarantine.rs`; the cross-form conditioned gate stays in
+`eval/` — per A5 they share a doc cross-reference, not a type.
+
+---
+
+## 4. Ranked execution list
+
+### (a) THIS ROUND — encapsulation, deletion, mechanical moves
+
+Ordered; each item is independently landable.
+
+1. **Guide encapsulation (J10) + legacy deletion.** Create `nnue/guide/` with the
+   `SaturationGuide` trait + constructor as the entire public surface; move GraphAccumulator and
+   the mask/graph/rule-proj fields/methods behind it, private. Delete the legacy sub-tier
+   (`RuleFeatures`, `rule_mlp_*`, `encode_rule`, `encode_all_rules`,
+   `encode_all_rules_from_templates`) and the zero-caller vestiges (`Edge`, `from_factored`).
+   `apply_unified_sgd` and `UnifiedGradients` drop every `d_mask_*`/`d_graph_*` field — this
+   **fixes the confirmed decay defect** (Phase-3 weights silently decaying toward zero with no
+   opposing gradient). Keep the characterization tests, relocated with the module. This is a
+   contract boundary, NOT a code move into a side directory.
+2. **Live-only serialization + `SchemaIdentity` (J9) — kills P1(b).** The checkpoint carries only
+   the 16,897 live params (today's format is a 49%/51% live/noise split by param count). New
+   magic; identity = derived content hash of the layout descriptor; every loader asserts it.
+   The Guide gets its **own** format with an explicit trained/untrained marker when Phase 3
+   first consumes it — "Guide not yet trained" becomes *section absent*, not float noise.
+   `MintMetadata.weights_identity` generalizes onto the trait.
+3. **`Extraction` (J2) — kills P1(c), arms the P1(a) kill.** Smart constructor absorbs
+   `backfill_well_founded`; variance analysis takes `&Extraction` only; `Features` gains the
+   `EmbeddingsEpoch` tag with a loud assert on mismatch (fail-fast half of P1(a); the recompute
+   policy is 4b-5).
+4. **`Expr<'a>` adoption (J1).** Introduce the type; convert the 37 `(arena, root)` sites.
+   Purely mechanical, both crates.
+5. **`run_scalar` dedup (J14).** One shared fn in `oracle_compare.rs`; all ≥3 copies import it.
+6. **Saturation unification (J11).** `SaturationBudget` + one loop; delete the duplicate.
+7. **Verdict types + renames (J12).** `RoundVerdict` enum with gate-ordered construction;
+   `PublicationReport` without a verdict field for `--final-eval`; `labeler::Label` →
+   `HindsightLabel`. Behavior-preserving: same thresholds, same precedence, now as variants.
+8. **Fence/Family types (J7).** `Family` newtype, `Band` to the library, `Fence<Dev>`/`Fence<Final>`
+   phantom tags, fence constructor parameterized on the key function (the J8 *seam* — the key
+   function itself is unchanged this round).
+9. **`VariantSet` minting (J6).** Type + thread the junkify pairing through to training-data
+   files so the equivalence structure survives to disk. Loss function unchanged.
+10. **`JournalEntry`/`ConfigHash` (J15).** Small serde structs + one writer fn; wire the existing
+    journal-writing call sites through them.
+
+### (b) NEXT ROUND — behavior-changing or measurement-gated
+
+- **Contrastive/ranking objective over `VariantSet`** — the Round-2 experiment proper. Needs DEV
+  measurement, the ±5% CI gate, and the A/A floor; it is research, not reorganization.
+- **`FenceKey` feature-quotient change + corpus regeneration** — the behavioral half of P1(d).
+  Changes which samples are admitted to which tier; requires reminting tiers and re-baselining.
+- **`BenchRequest` consolidation** of jit_bench's 8 suffixed fns — touches the measurement path
+  PR #984 just hardened; land under A/A noise-floor verification that labels are bit-stable.
+- **bench_extraction_3way.rs harness-library split** — the large move (4,262 lines) lands after
+  the `eval/` types (4a-7) exist to receive it, so it is a move, not a rewrite.
+- **Features recompute/cache-invalidation policy** — the full P1(a) fix beyond the epoch assert
+  (recompute-per-batch vs epoch-keyed caches has a training-throughput cost to measure).
+
+### What Execute must NOT attempt
+
+- **No Guide internals work**: no `GraphEdit` enum (A2), no `Layer` abstraction (A3), no training
+  code for the mask head. Implementation ahead of its consumer is how this surface got here.
+- **No O(Δ) incremental extraction** (A6); do not delete `EdgeAccumulator::remove_*` either —
+  intended API, adoption-plan step 5, measured ceiling ~2×.
+- **No `Rewrite::apply` signature change** (A1) — 37 impls, already unified.
+- **No pixelflow-ir modifications** (read-only context; `DifferentialCheck`/`PointCheck` stay put).
+- **No changes to measured-label semantics** (drift math, overhead subtraction, sentinel cadence)
+  outside item 4b-3's gated consolidation — the newtypes in 4a must be representation-only.
+- **No renaming `quarantine::Verdict` or `PointVerdict`** — the collision is resolved by the other
+  two renames.
+- **No `GateKind` unification** (A5) and no speculative `EClassRef` sweep (J13 is approved but
+  opportunistic — convert call sites only when a touched file already changes).
+- **No deletion of Guide characterization tests** — they are the regression floor for whatever
+  Phase 3 consumes.
+
+---
+
+*Retirement notes for roadmap-admitted seams: J6/J8 fall out if Round-2 contrastive training is
+abandoned; J10 (and its tests) is deleted whole if Phase 3 is cancelled; J15 follows the 2026-08-05
+workflow's lifetime. Every other row is demanded by the live path and carries no such dependency.*

--- a/pixelflow-pipeline/src/bin/bench_extraction_3way.rs
+++ b/pixelflow-pipeline/src/bin/bench_extraction_3way.rs
@@ -111,7 +111,7 @@ use clap::Parser;
 use serde::Serialize;
 
 use pixelflow_codegen::emit::compile_arena_dag;
-use pixelflow_codegen::emit::executable::{ExecutableCode, KernelFn};
+use pixelflow_codegen::emit::executable::ExecutableCode;
 use pixelflow_ir::{
     BindingTable, DifferentialCheck, ExprArena, ExprId, MaskComparison, MaskVerdict, PointCheck,
     PointVerdict, compare_mask_root,
@@ -460,82 +460,12 @@ fn named_kernels() -> Vec<(&'static str, ExprArena, ExprId)> {
 }
 
 // ---------------------------------------------------------------------------
-// JIT execution helper — verbatim from pixelflow-search/tests/prod_kernel_jit.rs.
-// Broadcasts one coordinate to all lanes, reads lane 0.
+// JIT execution helper: `run_scalar` (broadcast to all lanes, read lane 0)
+// lives in `pixelflow_pipeline::oracle_compare` — the one copy every
+// JIT/oracle cross-check harness imports
+// (docs/plans/2026-08-17-cost-model-domain.md, J14).
 // ---------------------------------------------------------------------------
-
-#[cfg(all(
-    target_arch = "x86_64",
-    not(target_feature = "avx512f"),
-    not(target_feature = "avx2")
-))]
-fn run_scalar(code: &ExecutableCode, x: f32, y: f32, z: f32, w: f32) -> f32 {
-    use core::arch::x86_64::{_mm_cvtss_f32, _mm_set1_ps};
-    // SAFETY: SSE2 is the baseline on x86-64; the JIT emitted `__m128` ABI.
-    unsafe {
-        let f: KernelFn = code.as_fn();
-        let r = f(
-            _mm_set1_ps(x),
-            _mm_set1_ps(y),
-            _mm_set1_ps(z),
-            _mm_set1_ps(w),
-        );
-        _mm_cvtss_f32(r)
-    }
-}
-
-#[cfg(all(
-    target_arch = "x86_64",
-    target_feature = "avx2",
-    not(target_feature = "avx512f")
-))]
-fn run_scalar(code: &ExecutableCode, x: f32, y: f32, z: f32, w: f32) -> f32 {
-    use core::arch::x86_64::{_mm256_cvtss_f32, _mm256_set1_ps};
-    // SAFETY: built with +avx2 (not +avx512f), so the JIT emitted the
-    // `__m256` ABI.
-    unsafe {
-        let f: KernelFn = code.as_fn();
-        let r = f(
-            _mm256_set1_ps(x),
-            _mm256_set1_ps(y),
-            _mm256_set1_ps(z),
-            _mm256_set1_ps(w),
-        );
-        _mm256_cvtss_f32(r)
-    }
-}
-
-#[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
-fn run_scalar(code: &ExecutableCode, x: f32, y: f32, z: f32, w: f32) -> f32 {
-    use core::arch::x86_64::{_mm512_cvtss_f32, _mm512_set1_ps};
-    // SAFETY: built with +avx512f, so the JIT emitted the `__m512` ABI.
-    unsafe {
-        let f: KernelFn = code.as_fn();
-        let r = f(
-            _mm512_set1_ps(x),
-            _mm512_set1_ps(y),
-            _mm512_set1_ps(z),
-            _mm512_set1_ps(w),
-        );
-        _mm512_cvtss_f32(r)
-    }
-}
-
-#[cfg(target_arch = "aarch64")]
-fn run_scalar(code: &ExecutableCode, x: f32, y: f32, z: f32, w: f32) -> f32 {
-    use core::arch::aarch64::{vdupq_n_f32, vgetq_lane_f32};
-    // SAFETY: NEON is mandatory on aarch64; the JIT emitted the `float32x4_t` ABI.
-    unsafe {
-        let f: KernelFn = code.as_fn();
-        let r = f(
-            vdupq_n_f32(x),
-            vdupq_n_f32(y),
-            vdupq_n_f32(z),
-            vdupq_n_f32(w),
-        );
-        vgetq_lane_f32(r, 0)
-    }
-}
+use pixelflow_pipeline::oracle_compare::run_scalar;
 
 // ---------------------------------------------------------------------------
 // Oracle-referenced correctness gate (H1/H2)
@@ -2396,31 +2326,11 @@ fn corpus_identity(bytes: &[u8]) -> String {
     format!("{:016x}", fnv1a64(bytes, FNV_OFFSET))
 }
 
-/// Refuse to append to a journal that is still a Git LFS pointer.
-///
-/// `.gitattributes` sends every `*.jsonl` through LFS, so in a clone where the
-/// objects were never pulled `docs/results/journal.jsonl` is the three-line
-/// pointer stub rather than the journal. Appending there produces a file that
-/// is neither — malformed JSONL behind a pointer header — and staging it can
-/// commit that text as the tracked payload, taking the real history with it.
-/// A run that got this far has already spent its measurements, so say exactly
-/// what to run rather than failing in a way that reads as a corrupt journal.
-fn refuse_unsmudged_lfs_pointer(path: &Path) {
-    const POINTER_MAGIC: &str = "version https://git-lfs.github.com/spec/";
-    let Ok(head) = fs::read(path) else {
-        return; // Absent is fine — the append creates it.
-    };
-    // A pointer stub is a few hundred bytes; a real journal's first line is a
-    // JSON object. Only the prefix needs looking at.
-    let prefix = String::from_utf8_lossy(&head[..head.len().min(POINTER_MAGIC.len())]);
-    assert!(
-        prefix != POINTER_MAGIC,
-        "{} is an unsmudged Git LFS pointer, not the journal.\n\
-         Appending would corrupt it. Materialize it first:\n  \
-         git lfs install && git lfs pull --include docs/results/journal.jsonl",
-        path.display()
-    );
-}
+// `refuse_unsmudged_lfs_pointer` moved to
+// `pixelflow_pipeline::journal::append_record`, which now performs the whole
+// append (serialize, mkdir, LFS guard, append-or-panic) for this binary's
+// journal write below — the one writer every journal-producing binary shares
+// (docs/plans/2026-08-17-cost-model-domain.md, J15).
 
 /// The build and machine this run's numbers came off.
 ///
@@ -3233,7 +3143,7 @@ fn main() {
         env!("CARGO_MANIFEST_DIR"),
         "/../docs/results/journal.jsonl"
     ));
-    let journal_line = serde_json::to_string(&JournalRecord {
+    let journal_record = JournalRecord {
         record: "bench_extraction_3way",
         ts_unix,
         config_hash: &config_hash,
@@ -3276,25 +3186,10 @@ fn main() {
         verdict_censored: !failure_rates.censoring().is_empty(),
         verdict: &verdict,
         data_jsonl: data_path.display().to_string(),
-    })
-    .unwrap_or_else(|e| panic!("failed to serialize journal record: {e}"));
-    // `OpenOptions::create` does not create parent directories, and a run that
-    // measured everything correctly must not die on a missing folder.
-    if let Some(parent) = journal_path.parent() {
-        fs::create_dir_all(parent)
-            .unwrap_or_else(|e| panic!("failed to create {}: {e}", parent.display()));
-    }
-    refuse_unsmudged_lfs_pointer(&journal_path);
-    let mut journal = fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&journal_path)
-        .unwrap_or_else(|e| panic!("failed to open {}: {e}", journal_path.display()));
-    writeln!(journal, "{journal_line}")
-        .unwrap_or_else(|e| panic!("failed to append to {}: {e}", journal_path.display()));
+    };
+    pixelflow_pipeline::journal::append_record(&journal_path, &journal_record);
 
     println!("\nMachine-readable results: {}", data_path.display());
-    println!("Journal appended: {}", journal_path.display());
 
     // The gate alarms fire LAST, after every record is on disk: they are a
     // verdict on the run's exclusions, and the exclusions they cite must be

--- a/pixelflow-pipeline/src/bin/bootstrap_extraction_head.rs
+++ b/pixelflow-pipeline/src/bin/bootstrap_extraction_head.rs
@@ -91,7 +91,7 @@ use serde::Serialize;
 
 use pixelflow_ir::{ExprArena, ExprId};
 use pixelflow_search::egraph::all_rules;
-use pixelflow_search::nnue::factored::{EMBED_DIM, EdgeAccumulator, ExprNnue, GraphAccumulator};
+use pixelflow_search::nnue::factored::{EdgeAccumulator, ExprNnue};
 use pixelflow_search::nnue::{BwdGenConfig, BwdGenerator};
 
 use pixelflow_pipeline::extraction_head_weights_path;
@@ -1334,10 +1334,6 @@ fn main() {
         rng_state >> 33
     };
 
-    // We need a dummy rule embedding for forward_cached — value head doesn't use it
-    let dummy_rule_embed = [0.0f32; EMBED_DIM];
-    let dummy_gacc = GraphAccumulator::new();
-
     for epoch in 0..args.epochs {
         // Shuffle indices
         let mut indices: Vec<usize> = (0..samples.len()).collect();
@@ -1354,7 +1350,7 @@ fn main() {
 
             for &idx in chunk {
                 let sample = &samples[idx];
-                let cache = forward_cached(&model, &sample.acc, &dummy_gacc, &dummy_rule_embed);
+                let cache = forward_cached(&model, &sample.acc);
 
                 backward_value(
                     &model,
@@ -1512,7 +1508,7 @@ fn main() {
         samples.len() - 1,
     ] {
         let sample = &samples[i];
-        let cache = forward_cached(&model, &sample.acc, &dummy_gacc, &dummy_rule_embed);
+        let cache = forward_cached(&model, &sample.acc);
         let pred_ns = libm::expf(cache.value_pred) as f64;
         let actual_ns = libm::expf(sample.target_log_ns) as f64;
         eprintln!(

--- a/pixelflow-pipeline/src/bin/bootstrap_extraction_head.rs
+++ b/pixelflow-pipeline/src/bin/bootstrap_extraction_head.rs
@@ -383,25 +383,16 @@ struct TrainerJournalRecord {
 }
 
 /// Append one line to the research journal, loudly on any failure.
+///
+/// Mechanics (serialize, mkdir, LFS-pointer guard, append-or-panic) live in
+/// `pixelflow_pipeline::journal` — the one writer every journal-producing
+/// binary shares (docs/plans/2026-08-17-cost-model-domain.md, J15).
 fn append_journal(record: &TrainerJournalRecord) {
     let journal_path = PathBuf::from(concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/../docs/results/journal.jsonl"
     ));
-    let line = serde_json::to_string(record)
-        .unwrap_or_else(|e| panic!("failed to serialize the trainer journal record: {e}"));
-    if let Some(parent) = journal_path.parent() {
-        std::fs::create_dir_all(parent)
-            .unwrap_or_else(|e| panic!("failed to create {}: {e}", parent.display()));
-    }
-    let mut journal = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&journal_path)
-        .unwrap_or_else(|e| panic!("failed to open {}: {e}", journal_path.display()));
-    writeln!(journal, "{line}")
-        .unwrap_or_else(|e| panic!("failed to append to {}: {e}", journal_path.display()));
-    eprintln!("Journal appended: {}", journal_path.display());
+    pixelflow_pipeline::journal::append_record(&journal_path, record);
 }
 
 /// A seeded permutation of `0..len` (LCG Fisher-Yates).

--- a/pixelflow-pipeline/src/journal.rs
+++ b/pixelflow-pipeline/src/journal.rs
@@ -1,0 +1,113 @@
+//! The one research-journal writer.
+//!
+//! A journal line is a claim about a run: what config produced it, what
+//! numbers came out. Two binaries write one — `bootstrap_extraction_head`
+//! (training quality) and `bench_extraction_3way` (extraction-policy
+//! benchmarks) — each with its own record schema (the fields genuinely
+//! differ; that stays), but both need the *same* append mechanics: serialize
+//! to one JSON line, create the parent directory if it's missing, refuse to
+//! corrupt an unsmudged Git LFS pointer, append-or-panic. That mechanism was
+//! two copies (one of them missing the LFS guard) before this module
+//! (docs/plans/2026-08-17-cost-model-domain.md, J15) — a fix to one could
+//! silently fail to reach the other, the same NO-SILENT-FAILURES class as
+//! J14's `run_scalar`.
+use std::fs;
+use std::io::Write as _;
+use std::path::Path;
+
+use serde::Serialize;
+
+/// Refuse to append to a journal that is still a Git LFS pointer.
+///
+/// `.gitattributes` sends every `*.jsonl` through LFS, so in a clone where the
+/// objects were never pulled, the journal path holds the three-line pointer
+/// stub instead of the journal. Appending there produces a file that is
+/// neither — malformed JSONL behind a pointer header — and staging it can
+/// commit that text as the tracked payload, taking the real history with it.
+/// A run that got this far has already spent its measurements, so say
+/// exactly what to run rather than failing in a way that reads as a corrupt
+/// journal.
+fn refuse_unsmudged_lfs_pointer(path: &Path) {
+    const POINTER_MAGIC: &str = "version https://git-lfs.github.com/spec/";
+    let Ok(head) = fs::read(path) else {
+        return; // Absent is fine — the append creates it.
+    };
+    // A pointer stub is a few hundred bytes; a real journal's first line is a
+    // JSON object. Only the prefix needs looking at.
+    let prefix = String::from_utf8_lossy(&head[..head.len().min(POINTER_MAGIC.len())]);
+    assert!(
+        prefix != POINTER_MAGIC,
+        "{} is an unsmudged Git LFS pointer, not the journal.\n\
+         Appending would corrupt it. Materialize it first:\n  \
+         git lfs install && git lfs pull --include {}",
+        path.display(),
+        path.display()
+    );
+}
+
+/// Serialize `record` to one JSON line and append it to the journal at
+/// `path`, creating the parent directory if needed. Every failure — encode,
+/// mkdir, open, write — is a hard panic naming the path: a journal line that
+/// silently didn't land is a run whose claim can never be checked again.
+pub fn append_record<T: Serialize>(path: &Path, record: &T) {
+    let line = serde_json::to_string(record).unwrap_or_else(|e| {
+        panic!(
+            "failed to serialize journal record for {}: {e}",
+            path.display()
+        )
+    });
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .unwrap_or_else(|e| panic!("failed to create {}: {e}", parent.display()));
+    }
+    refuse_unsmudged_lfs_pointer(path);
+    let mut journal = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .unwrap_or_else(|e| panic!("failed to open {}: {e}", path.display()));
+    writeln!(journal, "{line}")
+        .unwrap_or_else(|e| panic!("failed to append to {}: {e}", path.display()));
+    eprintln!("Journal appended: {}", path.display());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Serialize)]
+    struct Rec {
+        n: u32,
+    }
+
+    #[test]
+    fn append_record_creates_parent_dir_and_appends_one_line_per_call() {
+        let mut dir = std::env::temp_dir();
+        dir.push(format!("pf_journal_test_{}", std::process::id()));
+        let path = dir.join("nested/journal.jsonl");
+        let _ = fs::remove_dir_all(&dir);
+
+        append_record(&path, &Rec { n: 1 });
+        append_record(&path, &Rec { n: 2 });
+
+        let contents = fs::read_to_string(&path).expect("journal file should exist");
+        let lines: Vec<&str> = contents.lines().collect();
+        assert_eq!(lines, vec!["{\"n\":1}", "{\"n\":2}"]);
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    #[should_panic(expected = "unsmudged Git LFS pointer")]
+    fn append_record_refuses_an_lfs_pointer_stub() {
+        let mut path = std::env::temp_dir();
+        path.push(format!("pf_journal_lfs_test_{}.jsonl", std::process::id()));
+        fs::write(
+            &path,
+            "version https://git-lfs.github.com/spec/v1\noid sha256:0\nsize 1\n",
+        )
+        .expect("write pointer stub");
+
+        append_record(&path, &Rec { n: 1 });
+    }
+}

--- a/pixelflow-pipeline/src/lib.rs
+++ b/pixelflow-pipeline/src/lib.rs
@@ -8,6 +8,8 @@
 //! to also host.
 
 pub mod jit_bench;
+pub mod journal;
+pub mod oracle_compare;
 pub mod oracle_lowering;
 
 // Training infrastructure (requires std feature)

--- a/pixelflow-pipeline/src/oracle_compare.rs
+++ b/pixelflow-pipeline/src/oracle_compare.rs
@@ -1,0 +1,97 @@
+//! The one `run_scalar`: broadcast-and-read-lane-0 execution of a JIT-compiled
+//! [`ExecutableCode`] against the oracle's scalar calling convention.
+//!
+//! Every harness that cross-checks the JIT against
+//! [`pixelflow_ir::eval_scalar`] needs to call compiled code with a single
+//! `(x, y, z, w)` tuple and read back a single `f32` — but the JIT's ABI is
+//! whatever SIMD width the build's target features selected (`__m128`,
+//! `__m256`, `__m512`, or NEON's `float32x4_t`), so "call it with a scalar"
+//! means "broadcast to every lane, then read lane 0." This used to be three
+//! byte-identical copies (`training::quarantine`, `bin::bench_extraction_3way`,
+//! `pixelflow-codegen`'s `tests/prod_kernel_jit.rs`) that a fix to one could
+//! silently fail to reach — a NO-SILENT-FAILURES violation in waiting
+//! (docs/plans/2026-08-17-cost-model-domain.md, J14). One definition here,
+//! imported everywhere, closes that.
+use pixelflow_codegen::emit::executable::{ExecutableCode, KernelFn};
+
+/// Broadcast `(x, y, z, w)` to every SIMD lane, call `code`, and read back
+/// lane 0. The lane width is whichever ABI the JIT emitted for the build's
+/// target features, so this branches on the same `target_feature`/
+/// `target_arch` cfgs the JIT's codegen does.
+#[cfg(all(
+    target_arch = "x86_64",
+    not(target_feature = "avx512f"),
+    not(target_feature = "avx2")
+))]
+pub fn run_scalar(code: &ExecutableCode, x: f32, y: f32, z: f32, w: f32) -> f32 {
+    use core::arch::x86_64::{_mm_cvtss_f32, _mm_set1_ps};
+    // SAFETY: SSE2 is the baseline on x86-64; the JIT emitted the `__m128` ABI.
+    unsafe {
+        let f: KernelFn = code.as_fn();
+        let r = f(
+            _mm_set1_ps(x),
+            _mm_set1_ps(y),
+            _mm_set1_ps(z),
+            _mm_set1_ps(w),
+        );
+        _mm_cvtss_f32(r)
+    }
+}
+
+#[cfg(all(
+    target_arch = "x86_64",
+    target_feature = "avx2",
+    not(target_feature = "avx512f")
+))]
+pub fn run_scalar(code: &ExecutableCode, x: f32, y: f32, z: f32, w: f32) -> f32 {
+    use core::arch::x86_64::{_mm256_cvtss_f32, _mm256_set1_ps};
+    // SAFETY: built with +avx2 (not +avx512f), so the JIT emitted the
+    // `__m256` ABI.
+    unsafe {
+        let f: KernelFn = code.as_fn();
+        let r = f(
+            _mm256_set1_ps(x),
+            _mm256_set1_ps(y),
+            _mm256_set1_ps(z),
+            _mm256_set1_ps(w),
+        );
+        _mm256_cvtss_f32(r)
+    }
+}
+
+#[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
+pub fn run_scalar(code: &ExecutableCode, x: f32, y: f32, z: f32, w: f32) -> f32 {
+    use core::arch::x86_64::{_mm512_cvtss_f32, _mm512_set1_ps};
+    // SAFETY: built with +avx512f, so the JIT emitted the `__m512` ABI.
+    unsafe {
+        let f: KernelFn = code.as_fn();
+        let r = f(
+            _mm512_set1_ps(x),
+            _mm512_set1_ps(y),
+            _mm512_set1_ps(z),
+            _mm512_set1_ps(w),
+        );
+        _mm512_cvtss_f32(r)
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+pub fn run_scalar(code: &ExecutableCode, x: f32, y: f32, z: f32, w: f32) -> f32 {
+    use core::arch::aarch64::{vdupq_n_f32, vgetq_lane_f32};
+    // SAFETY: NEON is mandatory on aarch64; the JIT emitted the `float32x4_t` ABI.
+    unsafe {
+        let f: KernelFn = code.as_fn();
+        let r = f(
+            vdupq_n_f32(x),
+            vdupq_n_f32(y),
+            vdupq_n_f32(z),
+            vdupq_n_f32(w),
+        );
+        vgetq_lane_f32(r, 0)
+    }
+}
+
+#[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
+pub fn run_scalar(_code: &ExecutableCode, _x: f32, _y: f32, _z: f32, _w: f32) -> f32 {
+    panic!("oracle_compare::run_scalar requires a JIT-capable architecture")
+}

--- a/pixelflow-pipeline/src/training/quarantine.rs
+++ b/pixelflow-pipeline/src/training/quarantine.rs
@@ -44,7 +44,6 @@ use std::io::Write;
 use std::path::Path;
 
 use pixelflow_codegen::emit::compile_arena_dag;
-use pixelflow_codegen::emit::executable::ExecutableCode;
 use pixelflow_ir::binding::BindingTable;
 use pixelflow_ir::{
     DifferentialCheck, ExprArena, ExprId, ExprNode, MaskVerdict, OpKind, PointVerdict,
@@ -132,90 +131,10 @@ impl QuarantineGrid {
 }
 
 // ── JIT execution helper ─────────────────────────────────────────────────────
-// Broadcasts one coordinate to all lanes, reads lane 0. Verbatim from
-// `pixelflow-search/tests/prod_kernel_jit.rs`.
-
-#[cfg(all(
-    target_arch = "x86_64",
-    not(target_feature = "avx512f"),
-    not(target_feature = "avx2")
-))]
-fn run_scalar(code: &ExecutableCode, x: f32, y: f32, z: f32, w: f32) -> f32 {
-    use core::arch::x86_64::{_mm_cvtss_f32, _mm_set1_ps};
-    use pixelflow_codegen::emit::executable::KernelFn;
-    // SAFETY: SSE2 is the baseline on x86-64; the JIT emitted the `__m128` ABI.
-    unsafe {
-        let f: KernelFn = code.as_fn();
-        let r = f(
-            _mm_set1_ps(x),
-            _mm_set1_ps(y),
-            _mm_set1_ps(z),
-            _mm_set1_ps(w),
-        );
-        _mm_cvtss_f32(r)
-    }
-}
-
-#[cfg(all(
-    target_arch = "x86_64",
-    target_feature = "avx2",
-    not(target_feature = "avx512f")
-))]
-fn run_scalar(code: &ExecutableCode, x: f32, y: f32, z: f32, w: f32) -> f32 {
-    use core::arch::x86_64::{_mm256_cvtss_f32, _mm256_set1_ps};
-    use pixelflow_codegen::emit::executable::KernelFn;
-    // SAFETY: built with +avx2 (not +avx512f), so the JIT emitted the
-    // `__m256` ABI.
-    unsafe {
-        let f: KernelFn = code.as_fn();
-        let r = f(
-            _mm256_set1_ps(x),
-            _mm256_set1_ps(y),
-            _mm256_set1_ps(z),
-            _mm256_set1_ps(w),
-        );
-        _mm256_cvtss_f32(r)
-    }
-}
-
-#[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
-fn run_scalar(code: &ExecutableCode, x: f32, y: f32, z: f32, w: f32) -> f32 {
-    use core::arch::x86_64::{_mm512_cvtss_f32, _mm512_set1_ps};
-    use pixelflow_codegen::emit::executable::KernelFn;
-    // SAFETY: built with +avx512f, so the JIT emitted the `__m512` ABI.
-    unsafe {
-        let f: KernelFn = code.as_fn();
-        let r = f(
-            _mm512_set1_ps(x),
-            _mm512_set1_ps(y),
-            _mm512_set1_ps(z),
-            _mm512_set1_ps(w),
-        );
-        _mm512_cvtss_f32(r)
-    }
-}
-
-#[cfg(target_arch = "aarch64")]
-fn run_scalar(code: &ExecutableCode, x: f32, y: f32, z: f32, w: f32) -> f32 {
-    use core::arch::aarch64::{vdupq_n_f32, vgetq_lane_f32};
-    use pixelflow_codegen::emit::executable::KernelFn;
-    // SAFETY: NEON is mandatory on aarch64; the JIT emitted the `float32x4_t` ABI.
-    unsafe {
-        let f: KernelFn = code.as_fn();
-        let r = f(
-            vdupq_n_f32(x),
-            vdupq_n_f32(y),
-            vdupq_n_f32(z),
-            vdupq_n_f32(w),
-        );
-        vgetq_lane_f32(r, 0)
-    }
-}
-
-#[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
-fn run_scalar(_code: &ExecutableCode, _x: f32, _y: f32, _z: f32, _w: f32) -> f32 {
-    panic!("numeric quarantine requires a JIT-capable architecture")
-}
+// `run_scalar` (broadcast to all lanes, read lane 0) lives in
+// `crate::oracle_compare` — the one copy every JIT/oracle cross-check harness
+// imports (docs/plans/2026-08-17-cost-model-domain.md, J14).
+use crate::oracle_compare::run_scalar;
 
 // ── Exclusions ───────────────────────────────────────────────────────────────
 

--- a/pixelflow-pipeline/src/training/unified_backward.rs
+++ b/pixelflow-pipeline/src/training/unified_backward.rs
@@ -1,6 +1,6 @@
 //! # Analytical Backward Pass Through ExprNnue's Value (Extraction) Head
 //!
-//! Hand-derived gradients through the ExprNnue forward path, value head only:
+//! Hand-derived gradients through the ExprNnue forward path:
 //!
 //! ```text
 //! Extraction: EdgeAccumulator → W1 → ReLU → trunk → ReLU → expr_proj → value_mlp → value_pred
@@ -8,25 +8,26 @@
 //!
 //! ## Why This Exists
 //!
-//! [`forward_cached`] still runs the *full* joint forward pass — both the
-//! extraction (value) tower and the saturation (mask/policy) tower share a
-//! trunk layer, and `forward_cached`'s signature (it takes a `rule_embed`)
-//! reflects that shared architecture. But the backward half of that policy
-//! path — REINFORCE with an advantage, entropy-bonus regularization, and
-//! their `backward_policy` implementation — was deleted per
-//! docs/plans/2026-07-07-guided-saturation-redesign.md: that estimator was
-//! methodologically unsound (deterministic policy scored as if it were
+//! `ExprNnue` used to also carry a saturation (mask/policy) head sharing this
+//! trunk, and this module's `forward_cached` ran both towers in one pass —
+//! its signature took a `GraphAccumulator`/`rule_embed` that the value loss
+//! never used. The policy path's backward half — REINFORCE with an
+//! advantage, entropy-bonus regularization, `backward_policy` — was deleted
+//! per docs/plans/2026-07-07-guided-saturation-redesign.md: that estimator
+//! was methodologically unsound (deterministic policy scored as if it were
 //! sampled, advantage collapse, censored failures) and its trained policy was
-//! never consumed by the compiler.
+//! never consumed by the compiler. The 2026-08-17 cost-model domain-model
+//! reorganization finished that split: the saturation head's weights moved
+//! out of `ExprNnue` entirely, into `pixelflow_search::nnue::guide` (private,
+//! its own checkpoint format, inert until Phase 3), so this trainer's
+//! gradient surface — [`UnifiedGradients`] — now mirrors exactly the
+//! parameters it can train: the shared backbone (embeddings, `w1`, `b1`,
+//! trunk) and the value head. It cannot see, and does not need a dummy value
+//! for, anything behind `SaturationGuide`.
 //!
-//! What remains is the value loss only: MSE against ground-truth JIT cost,
-//! chain-ruled through value_mlp → expr_proj → trunk → W1 (edge tower). This
-//! is what `bootstrap_extraction_head` trains with — callers that don't care
-//! about the policy output pass a dummy `GraphAccumulator`/`rule_embed` into
-//! `forward_cached` and only consume `backward_value`'s gradients.
-//! [`UnifiedGradients`] still mirrors every trainable parameter in `ExprNnue`
-//! (including the mask/policy fields), since `apply_unified_sgd` updates the
-//! whole net; those fields simply stay zero when only `backward_value` runs.
+//! What remains is the value loss: MSE against ground-truth JIT cost,
+//! chain-ruled through `value_mlp` → `expr_proj` → trunk → `w1` (edge tower).
+//! This is what `bootstrap_extraction_head` trains with.
 
 #![expect(
     clippy::needless_range_loop,
@@ -36,8 +37,7 @@
 use pixelflow_ir::OpKind;
 use pixelflow_ir::kind::{OpCode, OpMap};
 use pixelflow_search::nnue::factored::{
-    EMBED_DIM, EdgeAccumulator, ExprNnue, GRAPH_ACC_DIM, GRAPH_INPUT_DIM, GraphAccumulator,
-    HIDDEN_DIM, INPUT_DIM, K, MLP_HIDDEN, depth_pe,
+    EMBED_DIM, EdgeAccumulator, ExprNnue, HIDDEN_DIM, INPUT_DIM, K, MLP_HIDDEN, depth_pe,
 };
 
 // ============================================================================
@@ -70,32 +70,6 @@ pub struct UnifiedForwardCache {
     pub value_h: [f32; MLP_HIDDEN],
     /// Scalar value prediction.
     pub value_pred: f32,
-    /// Graph backbone input: gacc.values[0..96] + edge_count + node_count + node_budget + epoch_budget = 100 floats.
-    pub graph_input: [f32; GRAPH_INPUT_DIM],
-    /// Pre-ReLU graph tower hidden.
-    pub graph_tower_pre_relu: [f32; HIDDEN_DIM],
-    /// Post-ReLU graph tower output (pre-trunk): max(0, graph_tower_pre_relu).
-    pub graph_tower_out: [f32; HIDDEN_DIM],
-    /// Pre-ReLU shared trunk output (graph path): trunk_b + trunk_w^T @ graph_tower_out.
-    pub graph_trunk_pre_relu: [f32; HIDDEN_DIM],
-    /// Post-trunk ReLU output for graph path: max(0, graph_trunk_pre_relu).
-    pub graph_hidden: [f32; HIDDEN_DIM],
-    /// Graph embedding: graph_proj_b + graph_proj_w^T @ graph_hidden.
-    pub graph_embed: [f32; EMBED_DIM],
-    /// Mask MLP input: graph_embed (32 dims) — comes from graph backbone, not expr backbone.
-    pub mask_input: [f32; EMBED_DIM],
-    /// Mask MLP pre-ReLU.
-    pub mask_h_pre: [f32; MLP_HIDDEN],
-    /// Mask MLP post-ReLU.
-    pub mask_h: [f32; MLP_HIDDEN],
-    /// Mask features: mask_mlp_b2 + mask_mlp_w2^T @ mask_h.
-    pub mask_features: [f32; EMBED_DIM],
-    /// Transformed vector: mask_features @ interaction.
-    pub transformed: [f32; EMBED_DIM],
-    /// Raw bilinear score (pre-sigmoid).
-    pub score: f32,
-    /// sigmoid(score).
-    pub prob: f32,
 }
 
 // ============================================================================
@@ -109,20 +83,14 @@ pub struct UnifiedForwardCache {
 ///   `EdgeAccumulator::extraction_input` vector, so the trained function and
 ///   the deployed function cannot diverge in feature semantics)
 /// - `ExprNnue::compute_expr_embed` (layer 2)
-/// - `ExprNnue::value_mlp_forward` (layer 3a)
-/// - `ExprNnue::compute_mask_features` (layer 3b)
-/// - `ExprNnue::bilinear_score` (layer 4)
+/// - `ExprNnue::value_mlp_forward` (layer 3, private on `ExprNnue`; inlined
+///   here since the backward pass needs the intermediate activations)
 #[must_use]
-pub fn forward_cached(
-    net: &ExprNnue,
-    acc: &EdgeAccumulator,
-    gacc: &GraphAccumulator,
-    rule_embed: &[f32; EMBED_DIM],
-) -> UnifiedForwardCache {
+pub fn forward_cached(net: &ExprNnue, acc: &EdgeAccumulator) -> UnifiedForwardCache {
     // ---- Extraction-head input: the ONE shared feature constructor ----
     let acc_input = acc.extraction_input();
 
-    // ---- Edge Tower (for extraction head) ----
+    // ---- Edge Tower ----
     let mut edge_tower_pre_relu = net.b1;
     for i in 0..INPUT_DIM {
         for j in 0..HIDDEN_DIM {
@@ -135,7 +103,7 @@ pub fn forward_cached(
         *h = h.max(0.0);
     }
 
-    // ---- Shared trunk (edge path) ----
+    // ---- Shared trunk ----
     let mut edge_trunk_pre_relu = net.trunk_b;
     for i in 0..HIDDEN_DIM {
         for j in 0..HIDDEN_DIM {
@@ -147,7 +115,7 @@ pub fn forward_cached(
         *h = h.max(0.0);
     }
 
-    // ---- Layer 2: Expr Projection (for extraction head) ----
+    // ---- Layer 2: Expr Projection ----
     let mut expr_embed = net.expr_proj_b;
     for j in 0..HIDDEN_DIM {
         for k in 0..EMBED_DIM {
@@ -155,7 +123,7 @@ pub fn forward_cached(
         }
     }
 
-    // ---- Layer 3a: Value MLP ----
+    // ---- Layer 3: Value MLP ----
     let mut value_h_pre = net.value_mlp_b1;
     for i in 0..EMBED_DIM {
         for j in 0..MLP_HIDDEN {
@@ -173,98 +141,6 @@ pub fn forward_cached(
         value_pred += value_h[j] * net.value_mlp_w2[j];
     }
 
-    // ---- Graph Backbone (for saturation head) ----
-    // Build graph_input from GraphAccumulator: scale by 1/sqrt(node_count),
-    // use log2(1+edge_count) and log2(1+node_count) as scalars.
-    let mut graph_input = [0.0f32; GRAPH_INPUT_DIM];
-
-    let graph_scale = if gacc.node_count > 0 {
-        1.0 / libm::sqrtf(gacc.node_count as f32)
-    } else {
-        1.0
-    };
-
-    for i in 0..GRAPH_ACC_DIM {
-        graph_input[i] = gacc.values[i] * graph_scale;
-    }
-
-    graph_input[GRAPH_ACC_DIM] = libm::log2f(1.0 + gacc.edge_count as f32);
-    graph_input[GRAPH_ACC_DIM + 1] = libm::log2f(1.0 + gacc.node_count as f32);
-    graph_input[GRAPH_ACC_DIM + 2] = libm::log2f(1.0 + gacc.node_budget as f32);
-    graph_input[GRAPH_ACC_DIM + 3] = libm::log2f(1.0 + gacc.epoch_budget as f32);
-
-    // ---- Graph Tower ----
-    // graph_tower_pre_relu = graph_b1 + graph_w1^T @ graph_input
-    let mut graph_tower_pre_relu = net.graph_b1;
-    for i in 0..GRAPH_INPUT_DIM {
-        for j in 0..HIDDEN_DIM {
-            graph_tower_pre_relu[j] += graph_input[i] * net.graph_w1[i][j];
-        }
-    }
-
-    // graph_tower_out = max(0, graph_tower_pre_relu) (ReLU)
-    let mut graph_tower_out = graph_tower_pre_relu;
-    for h in &mut graph_tower_out {
-        *h = h.max(0.0);
-    }
-
-    // ---- Shared trunk (graph path) ----
-    let mut graph_trunk_pre_relu = net.trunk_b;
-    for i in 0..HIDDEN_DIM {
-        for j in 0..HIDDEN_DIM {
-            graph_trunk_pre_relu[j] += graph_tower_out[i] * net.trunk_w[i][j];
-        }
-    }
-    let mut graph_hidden = graph_trunk_pre_relu;
-    for h in &mut graph_hidden {
-        *h = h.max(0.0);
-    }
-
-    // graph_embed = graph_proj_b + graph_proj_w^T @ graph_hidden
-    let mut graph_embed = net.graph_proj_b;
-    for j in 0..HIDDEN_DIM {
-        for k in 0..EMBED_DIM {
-            graph_embed[k] += graph_hidden[j] * net.graph_proj_w[j][k];
-        }
-    }
-
-    // ---- Layer 3b: Mask MLP (fed by graph_embed, not expr_embed) ----
-    let mask_input = graph_embed;
-
-    let mut mask_h_pre = net.mask_mlp_b1;
-    for i in 0..EMBED_DIM {
-        for j in 0..MLP_HIDDEN {
-            mask_h_pre[j] += mask_input[i] * net.mask_mlp_w1[i][j];
-        }
-    }
-
-    let mut mask_h = mask_h_pre;
-    for h in &mut mask_h {
-        *h = h.max(0.0);
-    }
-
-    let mut mask_features = net.mask_mlp_b2;
-    for j in 0..MLP_HIDDEN {
-        for k in 0..EMBED_DIM {
-            mask_features[k] += mask_h[j] * net.mask_mlp_w2[j][k];
-        }
-    }
-
-    // ---- Layer 4: Bilinear Score ----
-    let mut transformed = [0.0f32; EMBED_DIM];
-    for i in 0..EMBED_DIM {
-        for j in 0..EMBED_DIM {
-            transformed[j] += mask_features[i] * net.interaction[i][j];
-        }
-    }
-
-    let mut score = 0.0f32;
-    for k in 0..EMBED_DIM {
-        score += (transformed[k] + net.mask_bias_proj[k]) * rule_embed[k];
-    }
-
-    let prob = sigmoid(score);
-
     UnifiedForwardCache {
         acc_input,
         edge_tower_pre_relu,
@@ -275,19 +151,6 @@ pub fn forward_cached(
         value_h_pre,
         value_h,
         value_pred,
-        graph_input,
-        graph_tower_pre_relu,
-        graph_tower_out,
-        graph_trunk_pre_relu,
-        graph_hidden,
-        graph_embed,
-        mask_input,
-        mask_h_pre,
-        mask_h,
-        mask_features,
-        transformed,
-        score,
-        prob,
     }
 }
 
@@ -295,11 +158,15 @@ pub fn forward_cached(
 // Gradient Buffer
 // ============================================================================
 
-/// Gradient accumulator mirroring every trainable parameter in ExprNnue.
+/// Gradient accumulator mirroring every trainable parameter in `ExprNnue`.
 ///
-/// Both policy and value losses accumulate into the same buffer. The task
-/// towers (`w1`/`b1` and `graph_w1`/`graph_b1`) stay separate, while the
-/// shared trunk (`trunk_w`/`trunk_b`) receives gradients from both heads.
+/// Exactly the parameters this trainer can train: the shared backbone
+/// (embeddings, `w1`/`b1`, trunk) and the value head. Nothing here mirrors
+/// `nnue::guide`'s saturation-head weights — that module is a separate
+/// checkpoint with its own (as-yet-nonexistent) trainer, and mirroring its
+/// fields here without a gradient producer was the confirmed defect this
+/// split closes: `apply_unified_sgd` used to weight-decay those
+/// randomly-initialized, never-trained fields toward zero on every run.
 pub struct UnifiedGradients {
     /// Backbone weight gradients: INPUT_DIM x HIDDEN_DIM.
     pub d_w1: [[f32; HIDDEN_DIM]; INPUT_DIM],
@@ -317,34 +184,12 @@ pub struct UnifiedGradients {
     pub d_value_mlp_w2: [f32; MLP_HIDDEN],
     /// Value MLP layer 2 bias gradients: scalar.
     pub d_value_mlp_b2: f32,
-    /// Mask MLP layer 1 weight gradients: EMBED_DIM x MLP_HIDDEN.
-    pub d_mask_mlp_w1: [[f32; MLP_HIDDEN]; EMBED_DIM],
-    /// Mask MLP layer 1 bias gradients: MLP_HIDDEN.
-    pub d_mask_mlp_b1: [f32; MLP_HIDDEN],
-    /// Mask MLP layer 2 weight gradients: MLP_HIDDEN x EMBED_DIM.
-    pub d_mask_mlp_w2: [[f32; EMBED_DIM]; MLP_HIDDEN],
-    /// Mask MLP layer 2 bias gradients: EMBED_DIM.
-    pub d_mask_mlp_b2: [f32; EMBED_DIM],
-    /// Interaction matrix gradients: EMBED_DIM x EMBED_DIM.
-    pub d_interaction: [[f32; EMBED_DIM]; EMBED_DIM],
-    /// Bias projection gradients: EMBED_DIM.
-    pub d_mask_bias_proj: [f32; EMBED_DIM],
     /// OpEmbedding gradients: one K-vector per op.
     pub d_embeddings: OpMap<[f32; K]>,
     /// Shared trunk weight gradients: HIDDEN_DIM x HIDDEN_DIM.
-    /// Accumulates from BOTH edge and graph backward paths.
     pub d_trunk_w: [[f32; HIDDEN_DIM]; HIDDEN_DIM],
     /// Shared trunk bias gradients: HIDDEN_DIM.
-    /// Accumulates from BOTH edge and graph backward paths.
     pub d_trunk_b: [f32; HIDDEN_DIM],
-    /// Graph backbone weight gradients: GRAPH_INPUT_DIM x HIDDEN_DIM.
-    pub d_graph_w1: [[f32; HIDDEN_DIM]; GRAPH_INPUT_DIM],
-    /// Graph backbone bias gradients: HIDDEN_DIM.
-    pub d_graph_b1: [f32; HIDDEN_DIM],
-    /// Graph projection weight gradients: HIDDEN_DIM x EMBED_DIM.
-    pub d_graph_proj_w: [[f32; EMBED_DIM]; HIDDEN_DIM],
-    /// Graph projection bias gradients: EMBED_DIM.
-    pub d_graph_proj_b: [f32; EMBED_DIM],
 }
 
 /// Per-group gradient clipping diagnostics.
@@ -357,14 +202,10 @@ pub struct GradientClipStats {
     pub clipped_norm: f32,
     pub backbone_norm: f32,
     pub value_norm: f32,
-    pub policy_norm: f32,
-    pub graph_norm: f32,
     pub embeddings_norm: f32,
     pub trunk_norm: f32,
     pub backbone_scale: f32,
     pub value_scale: f32,
-    pub policy_scale: f32,
-    pub graph_scale: f32,
     pub embeddings_scale: f32,
     pub trunk_scale: f32,
 }
@@ -382,19 +223,9 @@ impl UnifiedGradients {
             d_value_mlp_b1: [0.0; MLP_HIDDEN],
             d_value_mlp_w2: [0.0; MLP_HIDDEN],
             d_value_mlp_b2: 0.0,
-            d_mask_mlp_w1: [[0.0; MLP_HIDDEN]; EMBED_DIM],
-            d_mask_mlp_b1: [0.0; MLP_HIDDEN],
-            d_mask_mlp_w2: [[0.0; EMBED_DIM]; MLP_HIDDEN],
-            d_mask_mlp_b2: [0.0; EMBED_DIM],
-            d_interaction: [[0.0; EMBED_DIM]; EMBED_DIM],
-            d_mask_bias_proj: [0.0; EMBED_DIM],
             d_embeddings: OpMap::splat([0.0; K]),
             d_trunk_w: [[0.0; HIDDEN_DIM]; HIDDEN_DIM],
             d_trunk_b: [0.0; HIDDEN_DIM],
-            d_graph_w1: [[0.0; HIDDEN_DIM]; GRAPH_INPUT_DIM],
-            d_graph_b1: [0.0; HIDDEN_DIM],
-            d_graph_proj_w: [[0.0; EMBED_DIM]; HIDDEN_DIM],
-            d_graph_proj_b: [0.0; EMBED_DIM],
         }
     }
 
@@ -428,30 +259,6 @@ impl UnifiedGradients {
             *v *= s;
         }
         self.d_value_mlp_b2 *= s;
-        for row in &mut self.d_mask_mlp_w1 {
-            for v in row {
-                *v *= s;
-            }
-        }
-        for v in &mut self.d_mask_mlp_b1 {
-            *v *= s;
-        }
-        for row in &mut self.d_mask_mlp_w2 {
-            for v in row {
-                *v *= s;
-            }
-        }
-        for v in &mut self.d_mask_mlp_b2 {
-            *v *= s;
-        }
-        for row in &mut self.d_interaction {
-            for v in row {
-                *v *= s;
-            }
-        }
-        for v in &mut self.d_mask_bias_proj {
-            *v *= s;
-        }
         for row in self.d_embeddings.as_mut_slice() {
             for v in row {
                 *v *= s;
@@ -463,22 +270,6 @@ impl UnifiedGradients {
             }
         }
         for v in &mut self.d_trunk_b {
-            *v *= s;
-        }
-        for row in &mut self.d_graph_w1 {
-            for v in row {
-                *v *= s;
-            }
-        }
-        for v in &mut self.d_graph_b1 {
-            *v *= s;
-        }
-        for row in &mut self.d_graph_proj_w {
-            for v in row {
-                *v *= s;
-            }
-        }
-        for v in &mut self.d_graph_proj_b {
             *v *= s;
         }
     }
@@ -515,30 +306,6 @@ impl UnifiedGradients {
             sum += (v as f64) * (v as f64);
         }
         sum += (self.d_value_mlp_b2 as f64) * (self.d_value_mlp_b2 as f64);
-        for row in &self.d_mask_mlp_w1 {
-            for &v in row {
-                sum += (v as f64) * (v as f64);
-            }
-        }
-        for &v in &self.d_mask_mlp_b1 {
-            sum += (v as f64) * (v as f64);
-        }
-        for row in &self.d_mask_mlp_w2 {
-            for &v in row {
-                sum += (v as f64) * (v as f64);
-            }
-        }
-        for &v in &self.d_mask_mlp_b2 {
-            sum += (v as f64) * (v as f64);
-        }
-        for row in &self.d_interaction {
-            for &v in row {
-                sum += (v as f64) * (v as f64);
-            }
-        }
-        for &v in &self.d_mask_bias_proj {
-            sum += (v as f64) * (v as f64);
-        }
         for row in self.d_embeddings.as_slice() {
             for &v in row {
                 sum += (v as f64) * (v as f64);
@@ -550,22 +317,6 @@ impl UnifiedGradients {
             }
         }
         for &v in &self.d_trunk_b {
-            sum += (v as f64) * (v as f64);
-        }
-        for row in &self.d_graph_w1 {
-            for &v in row {
-                sum += (v as f64) * (v as f64);
-            }
-        }
-        for &v in &self.d_graph_b1 {
-            sum += (v as f64) * (v as f64);
-        }
-        for row in &self.d_graph_proj_w {
-            for &v in row {
-                sum += (v as f64) * (v as f64);
-            }
-        }
-        for &v in &self.d_graph_proj_b {
             sum += (v as f64) * (v as f64);
         }
         libm::sqrt(sum) as f32
@@ -611,58 +362,6 @@ impl UnifiedGradients {
         libm::sqrt(sum) as f32
     }
 
-    /// L2 norm of the saturation head (mask_mlp_*, interaction, mask_bias_proj).
-    pub fn norm_policy_head(&self) -> f32 {
-        let mut sum = 0.0f64;
-        for row in &self.d_mask_mlp_w1 {
-            for &v in row {
-                sum += (v as f64) * (v as f64);
-            }
-        }
-        for &v in &self.d_mask_mlp_b1 {
-            sum += (v as f64) * (v as f64);
-        }
-        for row in &self.d_mask_mlp_w2 {
-            for &v in row {
-                sum += (v as f64) * (v as f64);
-            }
-        }
-        for &v in &self.d_mask_mlp_b2 {
-            sum += (v as f64) * (v as f64);
-        }
-        for row in &self.d_interaction {
-            for &v in row {
-                sum += (v as f64) * (v as f64);
-            }
-        }
-        for &v in &self.d_mask_bias_proj {
-            sum += (v as f64) * (v as f64);
-        }
-        libm::sqrt(sum) as f32
-    }
-
-    /// L2 norm of the graph backbone (graph_w1, graph_b1, graph_proj_w, graph_proj_b).
-    pub fn norm_graph_backbone(&self) -> f32 {
-        let mut sum = 0.0f64;
-        for row in &self.d_graph_w1 {
-            for &v in row {
-                sum += (v as f64) * (v as f64);
-            }
-        }
-        for &v in &self.d_graph_b1 {
-            sum += (v as f64) * (v as f64);
-        }
-        for row in &self.d_graph_proj_w {
-            for &v in row {
-                sum += (v as f64) * (v as f64);
-            }
-        }
-        for &v in &self.d_graph_proj_b {
-            sum += (v as f64) * (v as f64);
-        }
-        libm::sqrt(sum) as f32
-    }
-
     /// L2 norm of the op embeddings table.
     pub fn norm_embeddings(&self) -> f32 {
         let mut sum = 0.0f64;
@@ -693,23 +392,17 @@ impl UnifiedGradients {
     pub fn clip_stats(&self, max_norm: f32) -> GradientClipStats {
         let backbone_norm = self.norm_backbone();
         let value_norm = self.norm_value_head();
-        let policy_norm = self.norm_policy_head();
-        let graph_norm = self.norm_graph_backbone();
         let embeddings_norm = self.norm_embeddings();
         let trunk_norm = self.norm_trunk();
 
         let backbone_scale = group_clip_scale(backbone_norm, max_norm);
         let value_scale = group_clip_scale(value_norm, max_norm);
-        let policy_scale = group_clip_scale(policy_norm, max_norm);
-        let graph_scale = group_clip_scale(graph_norm, max_norm);
         let embeddings_scale = group_clip_scale(embeddings_norm, max_norm);
         let trunk_scale = group_clip_scale(trunk_norm, max_norm);
 
         let clipped_sq = [
             backbone_norm * backbone_scale,
             value_norm * value_scale,
-            policy_norm * policy_scale,
-            graph_norm * graph_scale,
             embeddings_norm * embeddings_scale,
             trunk_norm * trunk_scale,
         ]
@@ -722,14 +415,10 @@ impl UnifiedGradients {
             clipped_norm: libm::sqrt(clipped_sq) as f32,
             backbone_norm,
             value_norm,
-            policy_norm,
-            graph_norm,
             embeddings_norm,
             trunk_norm,
             backbone_scale,
             value_scale,
-            policy_scale,
-            graph_scale,
             embeddings_scale,
             trunk_scale,
         }
@@ -765,30 +454,6 @@ impl UnifiedGradients {
             self.d_value_mlp_w2[j] += other.d_value_mlp_w2[j];
         }
         self.d_value_mlp_b2 += other.d_value_mlp_b2;
-        for i in 0..EMBED_DIM {
-            for j in 0..MLP_HIDDEN {
-                self.d_mask_mlp_w1[i][j] += other.d_mask_mlp_w1[i][j];
-            }
-        }
-        for j in 0..MLP_HIDDEN {
-            self.d_mask_mlp_b1[j] += other.d_mask_mlp_b1[j];
-        }
-        for j in 0..MLP_HIDDEN {
-            for k in 0..EMBED_DIM {
-                self.d_mask_mlp_w2[j][k] += other.d_mask_mlp_w2[j][k];
-            }
-        }
-        for k in 0..EMBED_DIM {
-            self.d_mask_mlp_b2[k] += other.d_mask_mlp_b2[k];
-        }
-        for i in 0..EMBED_DIM {
-            for j in 0..EMBED_DIM {
-                self.d_interaction[i][j] += other.d_interaction[i][j];
-            }
-        }
-        for k in 0..EMBED_DIM {
-            self.d_mask_bias_proj[k] += other.d_mask_bias_proj[k];
-        }
         for op in OpKind::all() {
             for i in 0..K {
                 self.d_embeddings[op][i] += other.d_embeddings[op][i];
@@ -801,22 +466,6 @@ impl UnifiedGradients {
         }
         for j in 0..HIDDEN_DIM {
             self.d_trunk_b[j] += other.d_trunk_b[j];
-        }
-        for i in 0..GRAPH_INPUT_DIM {
-            for j in 0..HIDDEN_DIM {
-                self.d_graph_w1[i][j] += other.d_graph_w1[i][j];
-            }
-        }
-        for j in 0..HIDDEN_DIM {
-            self.d_graph_b1[j] += other.d_graph_b1[j];
-        }
-        for j in 0..HIDDEN_DIM {
-            for k in 0..EMBED_DIM {
-                self.d_graph_proj_w[j][k] += other.d_graph_proj_w[j][k];
-            }
-        }
-        for k in 0..EMBED_DIM {
-            self.d_graph_proj_b[k] += other.d_graph_proj_b[k];
         }
     }
 }
@@ -1102,8 +751,6 @@ pub fn apply_unified_sgd(
     let clip_stats = grads.clip_stats(grad_clip);
     let scale_backbone = clip_stats.backbone_scale;
     let scale_value = clip_stats.value_scale;
-    let scale_policy = clip_stats.policy_scale;
-    let scale_graph = clip_stats.graph_scale;
     let scale_embeddings = clip_stats.embeddings_scale;
     let scale_trunk = clip_stats.trunk_scale;
 
@@ -1205,74 +852,6 @@ pub fn apply_unified_sgd(
         scale_value
     );
 
-    // ── Saturation head (scale_policy) ───────────────────────────────────────
-
-    // mask_mlp_w1: [EMBED_DIM][MLP_HIDDEN]
-    for i in 0..EMBED_DIM {
-        for j in 0..MLP_HIDDEN {
-            sgd_scalar!(
-                net.mask_mlp_w1[i][j],
-                grads.d_mask_mlp_w1[i][j],
-                momentum_buf.d_mask_mlp_w1[i][j],
-                scale_policy
-            );
-        }
-    }
-
-    // mask_mlp_b1: [MLP_HIDDEN]
-    for j in 0..MLP_HIDDEN {
-        sgd_scalar!(
-            net.mask_mlp_b1[j],
-            grads.d_mask_mlp_b1[j],
-            momentum_buf.d_mask_mlp_b1[j],
-            scale_policy
-        );
-    }
-
-    // mask_mlp_w2: [MLP_HIDDEN][EMBED_DIM]
-    for j in 0..MLP_HIDDEN {
-        for k in 0..EMBED_DIM {
-            sgd_scalar!(
-                net.mask_mlp_w2[j][k],
-                grads.d_mask_mlp_w2[j][k],
-                momentum_buf.d_mask_mlp_w2[j][k],
-                scale_policy
-            );
-        }
-    }
-
-    // mask_mlp_b2: [EMBED_DIM]
-    for k in 0..EMBED_DIM {
-        sgd_scalar!(
-            net.mask_mlp_b2[k],
-            grads.d_mask_mlp_b2[k],
-            momentum_buf.d_mask_mlp_b2[k],
-            scale_policy
-        );
-    }
-
-    // interaction: [EMBED_DIM][EMBED_DIM]
-    for i in 0..EMBED_DIM {
-        for j in 0..EMBED_DIM {
-            sgd_scalar!(
-                net.interaction[i][j],
-                grads.d_interaction[i][j],
-                momentum_buf.d_interaction[i][j],
-                scale_policy
-            );
-        }
-    }
-
-    // mask_bias_proj: [EMBED_DIM]
-    for k in 0..EMBED_DIM {
-        sgd_scalar!(
-            net.mask_bias_proj[k],
-            grads.d_mask_bias_proj[k],
-            momentum_buf.d_mask_bias_proj[k],
-            scale_policy
-        );
-    }
-
     // ── Embeddings (scale_embeddings) ─────────────────────────────────────────
 
     // embeddings: one K-vector per op
@@ -1285,52 +864,6 @@ pub fn apply_unified_sgd(
                 scale_embeddings
             );
         }
-    }
-
-    // ── Graph backbone (scale_graph) ──────────────────────────────────────────
-
-    // graph_w1: [GRAPH_INPUT_DIM][HIDDEN_DIM]
-    for i in 0..GRAPH_INPUT_DIM {
-        for j in 0..HIDDEN_DIM {
-            sgd_scalar!(
-                net.graph_w1[i][j],
-                grads.d_graph_w1[i][j],
-                momentum_buf.d_graph_w1[i][j],
-                scale_graph
-            );
-        }
-    }
-
-    // graph_b1: [HIDDEN_DIM]
-    for j in 0..HIDDEN_DIM {
-        sgd_scalar!(
-            net.graph_b1[j],
-            grads.d_graph_b1[j],
-            momentum_buf.d_graph_b1[j],
-            scale_graph
-        );
-    }
-
-    // graph_proj_w: [HIDDEN_DIM][EMBED_DIM]
-    for j in 0..HIDDEN_DIM {
-        for k in 0..EMBED_DIM {
-            sgd_scalar!(
-                net.graph_proj_w[j][k],
-                grads.d_graph_proj_w[j][k],
-                momentum_buf.d_graph_proj_w[j][k],
-                scale_graph
-            );
-        }
-    }
-
-    // graph_proj_b: [EMBED_DIM]
-    for k in 0..EMBED_DIM {
-        sgd_scalar!(
-            net.graph_proj_b[k],
-            grads.d_graph_proj_b[k],
-            momentum_buf.d_graph_proj_b[k],
-            scale_graph
-        );
     }
 
     // ── Shared trunk (scale_trunk) ───────────────────────────────────────────
@@ -1381,15 +914,6 @@ pub fn apply_unified_sgd(
 }
 
 // ============================================================================
-// Helpers
-// ============================================================================
-
-#[inline]
-fn sigmoid(x: f32) -> f32 {
-    1.0 / (1.0 + libm::expf(-x))
-}
-
-// ============================================================================
 // Tests: Numerical Gradient Checking
 // ============================================================================
 
@@ -1411,12 +935,10 @@ mod tests {
         }
     }
 
-    /// Initialize a network with small random weights everywhere (not just mask).
+    /// Initialize a network with small random weights everywhere.
     fn make_test_net() -> ExprNnue {
         let mut net = ExprNnue::new();
-        net.randomize_mask_only(42);
 
-        // Also randomize backbone + expr_proj + value_mlp so gradients are nonzero
         let mut rng = Lcg::new(9999);
         let scale_input = libm::sqrtf(2.0 / INPUT_DIM as f32);
         let scale_hidden = libm::sqrtf(2.0 / HIDDEN_DIM as f32);
@@ -1462,25 +984,6 @@ mod tests {
             net.trunk_b[j] = 0.0;
         }
 
-        // Randomize graph backbone (for saturation head)
-        let scale_graph = libm::sqrtf(2.0 / GRAPH_INPUT_DIM as f32);
-        for i in 0..GRAPH_INPUT_DIM {
-            for j in 0..HIDDEN_DIM {
-                net.graph_w1[i][j] = rng.next_f32() * scale_graph;
-            }
-        }
-        for j in 0..HIDDEN_DIM {
-            net.graph_b1[j] = rng.next_f32() * 0.1;
-        }
-        for j in 0..HIDDEN_DIM {
-            for k in 0..EMBED_DIM {
-                net.graph_proj_w[j][k] = rng.next_f32() * scale_hidden;
-            }
-        }
-        for k in 0..EMBED_DIM {
-            net.graph_proj_b[k] = rng.next_f32() * 0.1;
-        }
-
         net
     }
 
@@ -1503,38 +1006,10 @@ mod tests {
         acc
     }
 
-    /// Create a test graph accumulator with nonzero values.
-    fn make_test_gacc() -> GraphAccumulator {
-        let mut gacc = GraphAccumulator::new();
-        let mut rng = Lcg::new(3333);
-        for v in &mut gacc.values {
-            *v = rng.next_f32() * 0.5;
-        }
-        gacc.edge_count = 7;
-        gacc.node_count = 5;
-        gacc
-    }
-
-    /// Create a test rule embedding.
-    fn make_test_rule_embed() -> [f32; EMBED_DIM] {
-        let mut embed = [0.0f32; EMBED_DIM];
-        let mut rng = Lcg::new(5555);
-        for v in &mut embed {
-            *v = rng.next_f32() * 0.3;
-        }
-        embed
-    }
-
     /// Compute value loss: (value_pred - target)^2 * value_coeff.
-    fn value_loss(
-        net: &ExprNnue,
-        acc: &EdgeAccumulator,
-        gacc: &GraphAccumulator,
-        rule_embed: &[f32; EMBED_DIM],
-        target: (f32, f32),
-    ) -> f64 {
+    fn value_loss(net: &ExprNnue, acc: &EdgeAccumulator, target: (f32, f32)) -> f64 {
         let (target_cost, value_coeff) = target;
-        let cache = forward_cached(net, acc, gacc, rule_embed);
+        let cache = forward_cached(net, acc);
         let diff = cache.value_pred as f64 - target_cost as f64;
         diff * diff * value_coeff as f64
     }
@@ -1572,12 +1047,10 @@ mod tests {
     fn numerical_gradient_check_value_body() {
         let net = make_test_net();
         let acc = make_test_acc();
-        let gacc = make_test_gacc();
-        let rule_embed = make_test_rule_embed();
         let target_cost = 3.5f32;
         let value_coeff = 0.5f32;
 
-        let cache = forward_cached(&net, &acc, &gacc, &rule_embed);
+        let cache = forward_cached(&net, &acc);
         let mut grads = Box::new(UnifiedGradients::zero());
         backward_value(&net, &cache, target_cost, value_coeff, &mut grads);
 
@@ -1589,13 +1062,11 @@ mod tests {
         for j in [0, 8, 15] {
             let mut net_p = net.clone();
             net_p.value_mlp_w2[j] += eps;
-            let loss_plus =
-                value_loss(&net_p, &acc, &gacc, &rule_embed, (target_cost, value_coeff));
+            let loss_plus = value_loss(&net_p, &acc, (target_cost, value_coeff));
 
             let mut net_m = net.clone();
             net_m.value_mlp_w2[j] -= eps;
-            let loss_minus =
-                value_loss(&net_m, &acc, &gacc, &rule_embed, (target_cost, value_coeff));
+            let loss_minus = value_loss(&net_m, &acc, (target_cost, value_coeff));
 
             let num_grad = (loss_plus - loss_minus) / (2.0 * eps as f64);
             let (a, n, err) = check_gradient(grads.d_value_mlp_w2[j], num_grad);
@@ -1613,13 +1084,11 @@ mod tests {
         {
             let mut net_p = net.clone();
             net_p.value_mlp_b2 += eps;
-            let loss_plus =
-                value_loss(&net_p, &acc, &gacc, &rule_embed, (target_cost, value_coeff));
+            let loss_plus = value_loss(&net_p, &acc, (target_cost, value_coeff));
 
             let mut net_m = net.clone();
             net_m.value_mlp_b2 -= eps;
-            let loss_minus =
-                value_loss(&net_m, &acc, &gacc, &rule_embed, (target_cost, value_coeff));
+            let loss_minus = value_loss(&net_m, &acc, (target_cost, value_coeff));
 
             let num_grad = (loss_plus - loss_minus) / (2.0 * eps as f64);
             let (a, n, err) = check_gradient(grads.d_value_mlp_b2, num_grad);
@@ -1638,13 +1107,11 @@ mod tests {
             for j in [0, 8, 15] {
                 let mut net_p = net.clone();
                 net_p.value_mlp_w1[i][j] += eps;
-                let loss_plus =
-                    value_loss(&net_p, &acc, &gacc, &rule_embed, (target_cost, value_coeff));
+                let loss_plus = value_loss(&net_p, &acc, (target_cost, value_coeff));
 
                 let mut net_m = net.clone();
                 net_m.value_mlp_w1[i][j] -= eps;
-                let loss_minus =
-                    value_loss(&net_m, &acc, &gacc, &rule_embed, (target_cost, value_coeff));
+                let loss_minus = value_loss(&net_m, &acc, (target_cost, value_coeff));
 
                 let num_grad = (loss_plus - loss_minus) / (2.0 * eps as f64);
                 let (a, n, err) = check_gradient(grads.d_value_mlp_w1[i][j], num_grad);
@@ -1681,13 +1148,11 @@ mod tests {
             for k in [0, 12, 23] {
                 let mut net_p = net.clone();
                 net_p.expr_proj_w[j][k] += proj_eps;
-                let loss_plus =
-                    value_loss(&net_p, &acc, &gacc, &rule_embed, (target_cost, value_coeff));
+                let loss_plus = value_loss(&net_p, &acc, (target_cost, value_coeff));
 
                 let mut net_m = net.clone();
                 net_m.expr_proj_w[j][k] -= proj_eps;
-                let loss_minus =
-                    value_loss(&net_m, &acc, &gacc, &rule_embed, (target_cost, value_coeff));
+                let loss_minus = value_loss(&net_m, &acc, (target_cost, value_coeff));
 
                 let num_grad = (loss_plus - loss_minus) / (2.0 * proj_eps as f64);
                 let (a, n, err) = check_gradient(grads.d_expr_proj_w[j][k], num_grad);
@@ -1707,13 +1172,11 @@ mod tests {
             for j in [0, 32, 63] {
                 let mut net_p = net.clone();
                 net_p.trunk_w[i][j] += eps;
-                let loss_plus =
-                    value_loss(&net_p, &acc, &gacc, &rule_embed, (target_cost, value_coeff));
+                let loss_plus = value_loss(&net_p, &acc, (target_cost, value_coeff));
 
                 let mut net_m = net.clone();
                 net_m.trunk_w[i][j] -= eps;
-                let loss_minus =
-                    value_loss(&net_m, &acc, &gacc, &rule_embed, (target_cost, value_coeff));
+                let loss_minus = value_loss(&net_m, &acc, (target_cost, value_coeff));
 
                 let num_grad = (loss_plus - loss_minus) / (2.0 * eps as f64);
                 let (a, n, err) = check_gradient(grads.d_trunk_w[i][j], num_grad);
@@ -1733,13 +1196,11 @@ mod tests {
         for j in [0, 32, 63] {
             let mut net_p = net.clone();
             net_p.trunk_b[j] += eps;
-            let loss_plus =
-                value_loss(&net_p, &acc, &gacc, &rule_embed, (target_cost, value_coeff));
+            let loss_plus = value_loss(&net_p, &acc, (target_cost, value_coeff));
 
             let mut net_m = net.clone();
             net_m.trunk_b[j] -= eps;
-            let loss_minus =
-                value_loss(&net_m, &acc, &gacc, &rule_embed, (target_cost, value_coeff));
+            let loss_minus = value_loss(&net_m, &acc, (target_cost, value_coeff));
 
             let num_grad = (loss_plus - loss_minus) / (2.0 * eps as f64);
             let (a, n, err) = check_gradient(grads.d_trunk_b[j], num_grad);
@@ -1759,13 +1220,11 @@ mod tests {
             for j in [0, 32, 63] {
                 let mut net_p = net.clone();
                 net_p.w1[i][j] += eps;
-                let loss_plus =
-                    value_loss(&net_p, &acc, &gacc, &rule_embed, (target_cost, value_coeff));
+                let loss_plus = value_loss(&net_p, &acc, (target_cost, value_coeff));
 
                 let mut net_m = net.clone();
                 net_m.w1[i][j] -= eps;
-                let loss_minus =
-                    value_loss(&net_m, &acc, &gacc, &rule_embed, (target_cost, value_coeff));
+                let loss_minus = value_loss(&net_m, &acc, (target_cost, value_coeff));
 
                 let num_grad = (loss_plus - loss_minus) / (2.0 * eps as f64);
                 let (a, n, err) = check_gradient(grads.d_w1[i][j], num_grad);
@@ -1785,37 +1244,15 @@ mod tests {
     }
 
     // ========================================================================
-    // Test 6: Forward cache score matches public ExprNnue::bilinear_score
+    // Test 6: forward_cached's acc_input IS EdgeAccumulator::extraction_input
     // ========================================================================
 
     #[test]
-    fn forward_cached_matches_bilinear_score() {
+    fn forward_cached_acc_input_matches_extraction_input() {
         let net = make_test_net();
         let acc = make_test_acc();
-        let gacc = make_test_gacc();
-        let rule_embed = make_test_rule_embed();
 
-        let cache = forward_cached(&net, &acc, &gacc, &rule_embed);
-
-        // bilinear_score is public — verify our cached mask_features + score agree
-        let score_from_public = net.bilinear_score(&cache.mask_features, &rule_embed);
-        assert!(
-            (cache.score - score_from_public).abs() < 1e-5,
-            "score mismatch: cached={}, bilinear_score={}",
-            cache.score,
-            score_from_public
-        );
-
-        // Verify prob = sigmoid(score); computed independently rather than by
-        // calling the private `sigmoid` helper, so this checks the documented
-        // score->prob contract rather than the helper's own implementation.
-        let expected_prob = 1.0 / (1.0 + libm::expf(-cache.score));
-        assert!(
-            (cache.prob - expected_prob).abs() < 1e-6,
-            "prob mismatch: cached={}, sigmoid(score)={}",
-            cache.prob,
-            expected_prob
-        );
+        let cache = forward_cached(&net, &acc);
 
         // Verify acc_input IS the shared extraction_input vector — the whole
         // train/deploy skew guard is that this cannot be built any other way.
@@ -1855,30 +1292,6 @@ mod tests {
             (cache.acc_input[4 * K + 3] - acc.variance_frac_pixel).abs() < 1e-6,
             "acc_input[4K+3] must be variance_frac_pixel"
         );
-
-        // Verify graph_input was built correctly from the graph accumulator
-        let graph_scale = if gacc.node_count > 0 {
-            1.0 / libm::sqrtf(gacc.node_count as f32)
-        } else {
-            1.0
-        };
-        for i in 0..GRAPH_ACC_DIM {
-            assert!(
-                (cache.graph_input[i] - gacc.values[i] * graph_scale).abs() < 1e-6,
-                "graph_input[{i}] should match scaled gacc.values"
-            );
-        }
-        assert!(
-            (cache.graph_input[GRAPH_ACC_DIM] - libm::log2f(1.0 + gacc.edge_count as f32)).abs()
-                < 1e-6,
-            "graph_input edge_count mismatch"
-        );
-        assert!(
-            (cache.graph_input[GRAPH_ACC_DIM + 1] - libm::log2f(1.0 + gacc.node_count as f32))
-                .abs()
-                < 1e-6,
-            "graph_input node_count mismatch"
-        );
     }
 
     // ========================================================================
@@ -1894,10 +1307,8 @@ mod tests {
     fn forward_cached_value_matches_deployed_prediction() {
         let net = make_test_net();
         let acc = make_test_acc();
-        let gacc = make_test_gacc();
-        let rule_embed = make_test_rule_embed();
 
-        let cache = forward_cached(&net, &acc, &gacc, &rule_embed);
+        let cache = forward_cached(&net, &acc);
         let deployed = net.predict_log_cost_with_features(&acc);
 
         assert!(
@@ -1917,10 +1328,8 @@ mod tests {
     fn gradient_norm_nonzero() {
         let net = make_test_net();
         let acc = make_test_acc();
-        let gacc = make_test_gacc();
-        let rule_embed = make_test_rule_embed();
 
-        let cache = forward_cached(&net, &acc, &gacc, &rule_embed);
+        let cache = forward_cached(&net, &acc);
 
         let mut grads = UnifiedGradients::zero();
         backward_value(&net, &cache, 3.0, 1.0, &mut grads);
@@ -1941,13 +1350,11 @@ mod tests {
     fn sgd_moves_parameters() {
         let mut net = make_test_net();
         let acc = make_test_acc();
-        let gacc = make_test_gacc();
-        let rule_embed = make_test_rule_embed();
 
         let w1_before = net.w1[0][0];
         let trunk_w_before = net.trunk_w[0][0];
 
-        let cache = forward_cached(&net, &acc, &gacc, &rule_embed);
+        let cache = forward_cached(&net, &acc);
         let mut grads = UnifiedGradients::zero();
         backward_value(&net, &cache, 3.0, 0.5, &mut grads);
 
@@ -1967,11 +1374,8 @@ mod tests {
         let w1_after = net.w1[0][0];
         let trunk_w_after = net.trunk_w[0][0];
 
-        // w1 (edge tower) and trunk_w (shared, fed by the value path here since
-        // no policy gradient was computed) are both on the value loss's chain
-        // and should move. interaction/graph_w1 are policy-only params — with no
-        // backward_policy call, their gradients (and momentum) are legitimately
-        // zero, so they're not asserted here.
+        // w1 (edge tower) and trunk_w (shared) are both on the value loss's
+        // chain and should move.
         assert!(
             (w1_after - w1_before).abs() > 1e-10,
             "w1[0][0] should have moved: before={w1_before}, after={w1_after}"
@@ -2034,9 +1438,7 @@ mod tests {
     fn scale_and_accumulate() {
         let net = make_test_net();
         let acc = make_test_acc();
-        let gacc = make_test_gacc();
-        let rule_embed = make_test_rule_embed();
-        let cache = forward_cached(&net, &acc, &gacc, &rule_embed);
+        let cache = forward_cached(&net, &acc);
 
         let mut g1 = UnifiedGradients::zero();
         backward_value(&net, &cache, 3.0, 1.0, &mut g1);

--- a/pixelflow-pipeline/tests/judge_weights_load.rs
+++ b/pixelflow-pipeline/tests/judge_weights_load.rs
@@ -1,6 +1,7 @@
 //! Verifies the Judge extraction-head weights round-trip through the
-//! production serializer: `ExprNnue::save` (which writes the current "TRIE"
-//! format) followed by `ExprNnue::from_bytes` (which only accepts TRIE).
+//! production serializer: `ExprNnue::save` (which writes the current "TRIF"
+//! live-only format) followed by `ExprNnue::from_bytes` (which only accepts
+//! TRIF).
 //!
 //! Phase 2 of docs/plans/2026-07-07-guided-saturation-redesign.md: the
 //! shipped state before the retrain was NO weights (old TRIC-format file
@@ -13,11 +14,17 @@
 //! `.bin`, so it passes on a fresh checkout and in CI. Whether an *actually
 //! retrained* model beats the latency prior is the job of the
 //! `bench_extraction_3way` benchmark, not a unit test.
+//!
+//! TRIE (this test's name before 2026-08-17) also serialized the saturation
+//! head's untrained parameters; TRIF is live-only (extraction head + shared
+//! backbone), per docs/plans/2026-08-17-cost-model-domain.md item 2 — TRIE
+//! files require retrain, not migration (deliberately no format-evolution
+//! ceremony for a scratch artifact cheaper to remint than to migrate).
 
 use pixelflow_search::nnue::factored::ExprNnue;
 
 #[test]
-fn judge_weights_round_trip_via_trie() {
+fn judge_weights_round_trip_via_trif() {
     // A latency-prior-initialized model is well-formed and non-zero — the
     // same code path `bootstrap_extraction_head` starts from before training.
     let model = ExprNnue::new_with_latency_prior(0xF00D_2026);
@@ -33,10 +40,10 @@ fn judge_weights_round_trip_via_trie() {
         std::fs::read(&path).unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
     let _ = std::fs::remove_file(&path);
 
-    // The magic must be TRIE (not a stale TRID/TRIC), and the loader must accept it.
-    assert_eq!(&bytes[0..4], b"TRIE", "saved file is not TRIE-format");
+    // The magic must be TRIF (not a stale TRIE/TRID/TRIC), and the loader must accept it.
+    assert_eq!(&bytes[0..4], b"TRIF", "saved file is not TRIF-format");
     let loaded = ExprNnue::from_bytes(&bytes)
-        .unwrap_or_else(|e| panic!("ExprNnue::from_bytes rejected a freshly-saved TRIE file: {e}"));
+        .unwrap_or_else(|e| panic!("ExprNnue::from_bytes rejected a freshly-saved TRIF file: {e}"));
 
     // Beyond "magic matched": a model whose embeddings are all zero/non-finite
     // would still parse as valid TRIE but carry no signal. Guard against a

--- a/pixelflow-search/src/egraph/extraction.rs
+++ b/pixelflow-search/src/egraph/extraction.rs
@@ -89,7 +89,7 @@ fn load_opt_in_weights(path: &str) -> ExprNnue {
         )
     });
 
-    const EXPECTED_MAGIC: &[u8; 4] = b"TRIE";
+    const EXPECTED_MAGIC: &[u8; 4] = b"TRIF";
     let found_magic = bytes.get(0..4);
     match ExprNnue::from_bytes(&bytes) {
         Ok(model) => model,

--- a/pixelflow-search/src/egraph/graph.rs
+++ b/pixelflow-search/src/egraph/graph.rs
@@ -109,6 +109,17 @@ pub struct ApplyResult {
     pub evals: usize,
 }
 
+/// Result of one [`EGraph::saturate_with_limits`] run: how many rounds it
+/// took and how many rule applications fired in total, whichever limit
+/// (iteration count, class count, timeout, or convergence) ended the run.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SaturationStats {
+    /// Number of rewrite rounds completed before the run stopped.
+    pub iterations: usize,
+    /// Sum of `ApplyResult::changes` across every round.
+    pub total_unions: usize,
+}
+
 impl EGraph {
     /// Create an empty e-graph with no rewrite rules.
     ///
@@ -798,14 +809,14 @@ impl EGraph {
     /// - 10000 class limit (prevent memory explosion)
     /// - 100 iteration limit (budget control)
     pub fn saturate(&mut self) {
-        self.saturate_with_limits(100, 10_000, std::time::Duration::from_millis(500))
+        self.saturate_with_limits(100, 10_000, std::time::Duration::from_millis(500));
     }
 
     /// Saturate with just an iteration limit (simple compatibility API).
     ///
     /// Warning: This can hang on complex expressions. Prefer `saturate_with_limits`.
     pub fn saturate_with_limit(&mut self, max_iters: usize) {
-        self.saturate_with_limits(max_iters, 10_000, std::time::Duration::from_millis(500))
+        self.saturate_with_limits(max_iters, 10_000, std::time::Duration::from_millis(500));
     }
 
     /// Saturate with full time and size control.
@@ -815,22 +826,31 @@ impl EGraph {
     /// - `max_classes` e-classes reached (memory protection)
     /// - `timeout` elapsed (time protection)
     /// - Saturation achieved (no more changes)
+    ///
+    /// This is the one rewrite-until-budget-exhausted loop
+    /// (docs/plans/2026-08-17-cost-model-domain.md, J11) — the training-data
+    /// policy layer in `super::saturate` drives its whole multi-iteration run
+    /// through a single call here rather than re-deciding, in a second copy,
+    /// when to stop.
     pub fn saturate_with_limits(
         &mut self,
         max_iters: usize,
         max_classes: usize,
         timeout: std::time::Duration,
-    ) {
+    ) -> SaturationStats {
         let start = std::time::Instant::now();
         let deadline = start + timeout;
+        let mut iterations = 0;
+        let mut total_unions = 0;
 
         for _ in 0..max_iters {
             if start.elapsed() >= timeout {
-                return;
+                break;
             }
             if self.classes.len() > max_classes {
-                return;
+                break;
             }
+            iterations += 1;
 
             // Advance the provenance step counter once per saturation
             // iteration — every ApplicationRecord/UnionEvent produced by
@@ -852,9 +872,15 @@ impl EGraph {
                 total
                 // rebuild happens here on drop
             };
+            total_unions += unions;
             if unions == 0 {
-                return; // Saturated
+                break; // Saturated
             }
+        }
+
+        SaturationStats {
+            iterations,
+            total_unions,
         }
     }
 

--- a/pixelflow-search/src/egraph/mod.rs
+++ b/pixelflow-search/src/egraph/mod.rs
@@ -47,7 +47,7 @@ pub use extract::{
     compute_ref_counts, extract, extract_dag, extract_neural_to_arena,
 };
 pub use extraction::{ExtractionPolicy, env_extraction_policy};
-pub use graph::{ApplyResult, EGraph, EGraphBatch, RewriteTarget};
+pub use graph::{ApplyResult, EGraph, EGraphBatch, RewriteTarget, SaturationStats};
 pub use labeler::{EpisodeLabels, EpisodeResult, Label, RuleStats, run_episode};
 pub use node::{EClassId, ENode};
 pub use ops::Op;

--- a/pixelflow-search/src/egraph/saturate.rs
+++ b/pixelflow-search/src/egraph/saturate.rs
@@ -110,55 +110,28 @@ pub fn saturate_with_full_budget(
     let classes_before = egraph.classes.len();
     egraph.match_counts.clear();
 
-    let start = std::time::Instant::now();
-    let mut iterations = 0;
-    let mut total_unions = 0;
+    // One call drives the entire multi-round run — the loop that decides
+    // when to stop (timeout, class limit, or convergence) lives exactly
+    // once, in `EGraph::saturate_with_limits`
+    // (docs/plans/2026-08-17-cost-model-domain.md, J11). This module
+    // previously re-decided the same stopping conditions in a second,
+    // hand-rolled outer loop that drove the e-graph one round at a time —
+    // the duplicate-loop drift the domain model doc calls out by name.
+    let stats = egraph.saturate_with_limits(max_iterations, max_classes, timeout);
 
-    for _ in 0..max_iterations {
-        // Global time limit
-        if start.elapsed() >= timeout {
-            break;
-        }
-        // Global class limit
-        if egraph.classes.len() > max_classes {
-            break;
-        }
-
-        iterations += 1;
-        let remaining = timeout.saturating_sub(start.elapsed());
-        let unions = apply_rules_counted_with_limits(egraph, max_classes, remaining);
-        total_unions += unions;
-
-        if unions == 0 {
-            break;
-        }
-    }
-
-    let saturated = iterations < max_iterations || total_unions == 0;
+    let saturated = stats.iterations < max_iterations || stats.total_unions == 0;
     let classes_after = egraph.classes.len();
     let rule_matches = egraph.match_counts.clone();
 
     SaturationResult {
-        iterations,
-        total_unions,
+        iterations: stats.iterations,
+        total_unions: stats.total_unions,
         saturated,
         classes_before,
         classes_after,
         rule_matches,
         budget: max_iterations,
     }
-}
-
-/// Apply all rules once and count new classes, with safety limits.
-fn apply_rules_counted_with_limits(
-    egraph: &mut EGraph,
-    max_classes: usize,
-    timeout: std::time::Duration,
-) -> usize {
-    let classes_before = egraph.classes.len();
-    egraph.saturate_with_limits(1, max_classes, timeout);
-    let classes_after = egraph.classes.len();
-    classes_after.saturating_sub(classes_before)
 }
 
 // ============================================================================

--- a/pixelflow-search/src/nnue/factored.rs
+++ b/pixelflow-search/src/nnue/factored.rs
@@ -59,21 +59,15 @@ pub const K: usize = 32;
 /// For the edge tower (`w1`, [`INPUT_DIM`]) these four slots carry the
 /// variance histogram (const / frame / scanline / pixel fractions) — see
 /// [`EdgeAccumulator::extraction_input`], the single place that builds them.
-/// For the graph tower (`graph_w1`, [`GRAPH_INPUT_DIM`]) they carry
-/// log2-compressed search-resource scalars (edge_count, node_count,
-/// node_budget, epoch_budget).
+/// `nnue::guide`'s graph tower reuses this constant for the same reason
+/// (log2-compressed search-resource scalars), so it stays `pub` rather than
+/// `pub(crate)`.
 pub const SCALAR_FEATURE_COUNT: usize = 4;
 
 /// Total input dimension to the hidden layer:
 /// 4K (dual accumulator: 2K flat + 2K depth-encoded) + 4 scalars
 /// (the variance histogram — see [`EdgeAccumulator::extraction_input`]).
 pub const INPUT_DIM: usize = 4 * K + SCALAR_FEATURE_COUNT;
-
-/// Graph accumulator dimension: marginals (2K) + 1-hop VSA binding (K) + 2-hop VSA binding (K).
-pub const GRAPH_ACC_DIM: usize = 4 * K; // 128
-
-/// Graph backbone input: 4K + 4 scalars (edge_count, node_count, node_budget, epoch_budget).
-pub const GRAPH_INPUT_DIM: usize = GRAPH_ACC_DIM + SCALAR_FEATURE_COUNT; // 132
 
 /// Maximum arity for child-index encoding.
 /// Effective depth = `depth * MAX_ARITY + child_index`, where child_index ∈ [0, MAX_ARITY).
@@ -89,110 +83,17 @@ pub const MAX_DEPTH: usize = 192;
 pub const HIDDEN_DIM: usize = 64;
 
 // ============================================================================
-// Unified Mask Architecture Constants
+// Shared Embedding Constants
 // ============================================================================
 
-/// Embedding dimension for expr/rule factorization in the unified mask architecture.
+/// Embedding dimension for the expr/rule/graph embedding space. Shared by the
+/// live extraction head (`expr_proj`, `value_mlp`) and by `nnue::guide`'s
+/// saturation head (mask MLP, rule projection) — one embedding space, two
+/// downstream heads.
 pub const EMBED_DIM: usize = 32;
 
-/// Hidden dimension for private MLPs (value, mask, rule).
+/// Hidden dimension for private per-head MLPs.
 pub const MLP_HIDDEN: usize = 16;
-
-/// Rule feature dimension (hand-crafted features describing each rule).
-pub const RULE_FEATURE_DIM: usize = 8;
-
-/// Maximum rules supported in the unified mask architecture.
-/// Designed to scale to 1000+ rules.
-pub const MASK_MAX_RULES: usize = 1024;
-
-/// Concatenated rule features: [z_LHS | z_RHS | z_LHS-z_RHS | z_LHS*z_RHS] (4 × EMBED_DIM).
-/// Used when encoding rules from their LHS/RHS expression templates.
-pub const RULE_CONCAT_DIM: usize = 4 * EMBED_DIM;
-
-/// Mask MLP input dimension: expr_embed directly (EMBED_DIM = 32 dims).
-/// value_pred was removed — it is a deterministic function of expr_embed and adds zero information.
-pub const MASK_INPUT_DIM: usize = EMBED_DIM;
-
-// NOTE: SEARCH_INPUT_DIM removed - mask IS the policy.
-// See plan: "Idea 4B: Mask IS the search/policy ✅ CHOSEN"
-
-// ============================================================================
-// Rule Features
-// ============================================================================
-
-/// Hand-crafted features describing each rule.
-///
-/// These features are mostly static (computed once when rules are defined)
-/// and allow the Rule MLP to generalize across rules without learning
-/// individual embeddings for each rule.
-///
-/// # Features (RULE_FEATURE_DIM = 8)
-///
-/// 1. `category`: Rule type (algebraic=0, peephole=0.25, domain=0.5, cross-cutting=0.75)
-/// 2. `lhs_nodes`: Pattern complexity (normalized by 10)
-/// 3. `typical_depth_delta`: Usually -1, 0, or 1
-/// 4. `commutative`: Does rule exploit commutativity? (0 or 1)
-/// 5. `associative`: Does rule exploit associativity? (0 or 1)
-/// 6. `creates_sharing`: Does rule typically enable CSE? (0 or 1)
-/// 7. `historical_match_rate`: Running average [0, 1]
-/// 8. `expensive_op_related`: Touches div/sqrt/transcendental? (0 or 1)
-#[derive(Clone)]
-pub struct RuleFeatures {
-    /// Features for each rule: [rule_idx][feature_dim]
-    pub features: [[f32; RULE_FEATURE_DIM]; MASK_MAX_RULES],
-}
-
-impl Default for RuleFeatures {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl RuleFeatures {
-    /// Create zero-initialized rule features.
-    #[must_use]
-    pub fn new() -> Self {
-        Self {
-            features: [[0.0; RULE_FEATURE_DIM]; MASK_MAX_RULES],
-        }
-    }
-
-    /// Get features for a specific rule.
-    #[must_use]
-    pub fn get(&self, rule_idx: usize) -> &[f32; RULE_FEATURE_DIM] {
-        &self.features[rule_idx]
-    }
-
-    /// Set features for a specific rule.
-    pub fn set(&mut self, rule_idx: usize, features: [f32; RULE_FEATURE_DIM]) {
-        self.features[rule_idx] = features;
-    }
-
-    /// Set feature by name for easier initialization.
-    pub fn set_rule(
-        &mut self,
-        rule_idx: usize,
-        category: f32,
-        lhs_nodes: usize,
-        depth_delta: i8,
-        commutative: bool,
-        associative: bool,
-        creates_sharing: bool,
-        match_rate: f32,
-        expensive_op: bool,
-    ) {
-        self.features[rule_idx] = [
-            category,
-            lhs_nodes as f32 / 10.0,
-            depth_delta as f32,
-            if commutative { 1.0 } else { 0.0 },
-            if associative { 1.0 } else { 0.0 },
-            if creates_sharing { 1.0 } else { 0.0 },
-            match_rate.clamp(0.0, 1.0),
-            if expensive_op { 1.0 } else { 0.0 },
-        ];
-    }
-}
 
 // ============================================================================
 // Rule Templates (LHS/RHS Expression Templates)
@@ -654,32 +555,6 @@ const fn const_cos(x: f64) -> f64 {
 #[inline]
 pub fn depth_pe(depth: u32) -> &'static [f32; K] {
     &DEPTH_PE[depth.min((MAX_DEPTH - 1) as u32) as usize]
-}
-
-/// Cyclic rotation by `amount % K` positions (generalised VSA permutation).
-///
-/// `shift_by(emb, 0)` is the identity, `shift_by(emb, 1)` is the original
-/// `shift1`, and higher amounts encode hierarchical depth in VSA bindings:
-/// `parent ⊙ shift_by(child, depth)` produces a distinct binding per depth
-/// level, so `Add(Add(X,Y),Z)` and `Add(X,Add(Y,Z))` yield different
-/// accumulators.
-#[inline]
-fn shift_by(emb: &[f32; K], amount: usize) -> [f32; K] {
-    let amount = amount % K;
-    let mut out = [0.0f32; K];
-    for i in 0..K {
-        out[i] = emb[(i + amount) % K];
-    }
-    out
-}
-
-/// Cyclic shift by 1 position (VSA permutation for breaking commutativity).
-///
-/// Used by `GraphAccumulator` to ensure `parent ⊙ shift₁(child)` produces a
-/// different binding vector than `child ⊙ shift₁(parent)`, i.e. `Mul→Add ≠ Add→Mul`.
-#[inline]
-fn shift1(emb: &[f32; K]) -> [f32; K] {
-    shift_by(emb, 1)
 }
 
 // ============================================================================
@@ -1293,369 +1168,27 @@ impl CostDag for ChoicesCostDag<'_> {
 }
 
 // ============================================================================
-// Graph Accumulator (VSA encoding of e-graph state for saturation head)
+// Extraction (Value) Head
 // ============================================================================
 
-/// VSA accumulator for e-graph state (rebuilt each epoch).
-///
-/// Three-section encoding captures both marginal and joint op distributions:
-///
-/// | Section | Dim | Operation | Signal |
-/// |---------|-----|-----------|--------|
-/// | `[0..K]` | K | `Σ E[parent]` | Marginal: which ops appear as parents |
-/// | `[K..2K]` | K | `Σ E[child]` | Marginal: which ops appear as children |
-/// | `[2K..3K]` | K | `Σ E[parent] ⊙ shift₁(E[child])` | **1-hop VSA binding**: which ops are connected |
-/// | `[3K..4K]` | K | `Σ E[gp] ⊙ shift₁(E[par]) ⊙ shift²(E[child])` | **2-hop VSA binding**: 3-node path patterns |
-///
-/// The 1-hop binding section uses element-wise Hadamard product with a cyclic shift to
-/// break commutativity (`Mul→Add ≠ Add→Mul`). This captures the **joint**
-/// distribution of parent-child pairs — strictly more informative than marginals
-/// alone.
-///
-/// The 2-hop binding section extends this to 3-node paths (grandparent→parent→child),
-/// capturing patterns like "Mul feeding Add feeding Sqrt" which is exactly what
-/// rewrite rules match on. This turns the accumulator from a 0-round GNN into
-/// a 1-round GNN.
-///
-/// The downstream backbone learns to decode the bundled representation.
-///
-/// Shares `OpEmbeddings` with the extraction head — same learned op embeddings,
-/// different downstream pathway.
-#[derive(Clone)]
-pub struct GraphAccumulator {
-    /// `[0..K]`:    marginal parent sum     `Σ E[parent]`
-    /// `[K..2K]`:   marginal child sum      `Σ E[child]`
-    /// `[2K..3K]`:  1-hop VSA binding sum   `Σ E[parent] ⊙ shift_by(E[child], depth)`
-    /// `[3K..4K]`:  2-hop VSA binding sum   `Σ E[gp] ⊙ shift₁(E[par]) ⊙ shift²(E[child])`
-    pub values: [f32; GRAPH_ACC_DIM],
-    /// Number of edges added to the accumulator.
-    pub edge_count: u32,
-    /// Number of nodes (ops + leaves) in the graph.
-    pub node_count: u32,
-    /// E-graph node budget for this trajectory (how many nodes the saturator may create).
-    pub node_budget: u32,
-    /// Epoch budget for this trajectory (max saturation epochs).
-    pub epoch_budget: u32,
-}
-
-impl Default for GraphAccumulator {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl GraphAccumulator {
-    /// Create a zero-initialized graph accumulator.
-    #[must_use]
-    pub fn new() -> Self {
-        Self {
-            values: [0.0; GRAPH_ACC_DIM],
-            edge_count: 0,
-            node_count: 0,
-            node_budget: 0,
-            epoch_budget: 0,
-        }
-    }
-
-    /// Reset to zero state.
-    ///
-    /// Budget fields are intentionally NOT reset — they are trajectory-level
-    /// properties that should persist across epoch rebuilds.
-    pub fn reset(&mut self) {
-        self.values = [0.0; GRAPH_ACC_DIM];
-        self.edge_count = 0;
-        self.node_count = 0;
-    }
-
-    /// Add a single edge with depth-aware VSA encoding.
-    ///
-    /// Updates all three sections: marginal parent, marginal child, and
-    /// VSA binding (`E[parent] ⊙ shift_by(E[child], depth % K)`).
-    ///
-    /// At `depth == 0` the shift is the identity (root edges), `depth == 1`
-    /// shifts by 1 (matching the original `shift1` behavior), `depth == 2`
-    /// shifts by 2, etc. This encodes hierarchical position into the binding
-    /// without any extra parameters.
-    #[inline]
-    pub fn add_edge_at_depth(
-        &mut self,
-        emb: &OpEmbeddings,
-        parent_op: OpKind,
-        child_op: OpKind,
-        depth: usize,
-    ) {
-        let p = emb.get(parent_op);
-        let c = emb.get(child_op);
-        let c_shifted = shift_by(c, depth);
-        for i in 0..K {
-            self.values[i] += p[i]; // marginal parent
-            self.values[K + i] += c[i]; // marginal child
-            self.values[2 * K + i] += p[i] * c_shifted[i]; // VSA binding
-        }
-        self.edge_count += 1;
-    }
-
-    /// Add a single edge with VSA encoding (backward-compatible, depth = 1).
-    ///
-    /// Equivalent to `add_edge_at_depth(emb, parent_op, child_op, 1)`.
-    /// Preserves the original `shift1` behavior for callers that do not
-    /// track depth.
-    #[inline]
-    pub fn add_edge(&mut self, emb: &OpEmbeddings, parent_op: OpKind, child_op: OpKind) {
-        self.add_edge_at_depth(emb, parent_op, child_op, 1);
-    }
-
-    /// Add a leaf node (Var/Const) — no edges, just increment node count.
-    pub fn add_leaf(&mut self) {
-        self.node_count += 1;
-    }
-
-    /// Add an Op node and all its edges to children, with depth-aware VSA.
-    ///
-    /// Emits one `add_edge_at_depth` per child and increments `node_count`
-    /// once.  The `depth` parameter is the depth of `op` in the expression
-    /// tree (0 = root).
-    pub fn add_op_node_at_depth(
-        &mut self,
-        emb: &OpEmbeddings,
-        op: OpKind,
-        child_ops: &[OpKind],
-        depth: usize,
-    ) {
-        for &child_op in child_ops {
-            self.add_edge_at_depth(emb, op, child_op, depth);
-        }
-        self.node_count += 1;
-    }
-
-    /// Add an Op node and all its edges to children (backward-compatible, depth = 1).
-    ///
-    /// Equivalent to `add_op_node_at_depth(emb, op, child_ops, 1)`.
-    pub fn add_op_node(&mut self, emb: &OpEmbeddings, op: OpKind, child_ops: &[OpKind]) {
-        self.add_op_node_at_depth(emb, op, child_ops, 1);
-    }
-
-    // ========== Incremental Removal (inverse of addition) ==========
-
-    /// Remove a single edge with depth-aware VSA encoding — the exact
-    /// inverse of [`add_edge_at_depth`].
-    ///
-    /// Subtracts (instead of adds) the parent, child, and VSA binding
-    /// contributions from each section. Decrements `edge_count` via
-    /// saturating subtraction so underflow clamps to zero rather than
-    /// wrapping.
-    ///
-    /// # Contract
-    ///
-    /// Callers must only remove edges that were previously added at the
-    /// same `depth`. Removing an edge that was never added will corrupt
-    /// the accumulator values (negative contributions) and is a logic
-    /// error.
-    #[inline]
-    pub fn remove_edge_at_depth(
-        &mut self,
-        emb: &OpEmbeddings,
-        parent_op: OpKind,
-        child_op: OpKind,
-        depth: usize,
-    ) {
-        let p = emb.get(parent_op);
-        let c = emb.get(child_op);
-        let c_shifted = shift_by(c, depth);
-        for i in 0..K {
-            self.values[i] -= p[i]; // marginal parent
-            self.values[K + i] -= c[i]; // marginal child
-            self.values[2 * K + i] -= p[i] * c_shifted[i]; // VSA binding
-        }
-        self.edge_count = self.edge_count.saturating_sub(1);
-    }
-
-    /// Remove a single edge (backward-compatible, depth = 1) — the exact
-    /// inverse of [`add_edge`].
-    ///
-    /// Equivalent to `remove_edge_at_depth(emb, parent_op, child_op, 1)`.
-    #[inline]
-    pub fn remove_edge(&mut self, emb: &OpEmbeddings, parent_op: OpKind, child_op: OpKind) {
-        self.remove_edge_at_depth(emb, parent_op, child_op, 1);
-    }
-
-    /// Remove an Op node and all its edges to children with depth-aware
-    /// VSA — the exact inverse of [`add_op_node_at_depth`].
-    ///
-    /// Calls [`remove_edge_at_depth`] for each child and decrements
-    /// `node_count`.
-    pub fn remove_op_node_at_depth(
-        &mut self,
-        emb: &OpEmbeddings,
-        op: OpKind,
-        child_ops: &[OpKind],
-        depth: usize,
-    ) {
-        for &child_op in child_ops {
-            self.remove_edge_at_depth(emb, op, child_op, depth);
-        }
-        self.node_count = self.node_count.saturating_sub(1);
-    }
-
-    /// Remove an Op node and all its edges (backward-compatible, depth = 1)
-    /// — the exact inverse of [`add_op_node`].
-    ///
-    /// Equivalent to `remove_op_node_at_depth(emb, op, child_ops, 1)`.
-    pub fn remove_op_node(&mut self, emb: &OpEmbeddings, op: OpKind, child_ops: &[OpKind]) {
-        self.remove_op_node_at_depth(emb, op, child_ops, 1);
-    }
-
-    /// Remove a leaf node — the exact inverse of [`add_leaf`].
-    ///
-    /// Decrements `node_count` only (leaves contribute no edges).
-    pub fn remove_leaf(&mut self) {
-        self.node_count = self.node_count.saturating_sub(1);
-    }
-
-    // ========== 2-hop Message Passing (1-round GNN) ==========
-
-    /// Add a 2-hop (grandparent→parent→child) binding to the `[3K..4K]` section.
-    ///
-    /// Encodes 3-node path patterns like "Mul feeding Add feeding Sqrt" using
-    /// the VSA triple product `E[grandparent] ⊙ shift₁(E[parent]) ⊙ shift²(E[child])`.
-    /// The shift amounts break commutativity: `A→B→C` produces a different
-    /// binding than any permutation of {A, B, C}.
-    ///
-    /// Does NOT modify the `[0..3K]` sections or `edge_count`/`node_count` —
-    /// those are maintained by `add_edge*` / `add_op_node*`.
-    #[inline]
-    pub fn add_2hop_edge(
-        &mut self,
-        emb: &OpEmbeddings,
-        grandparent_op: OpKind,
-        parent_op: OpKind,
-        child_op: OpKind,
-    ) {
-        let gp = emb.get(grandparent_op);
-        let p = shift1(emb.get(parent_op));
-        let c = shift_by(emb.get(child_op), 2);
-        for i in 0..K {
-            self.values[3 * K + i] += gp[i] * p[i] * c[i];
-        }
-    }
-
-    /// Remove a 2-hop (grandparent→parent→child) binding — the exact inverse
-    /// of [`add_2hop_edge`].
-    ///
-    /// Subtracts the triple-product contribution from the `[3K..4K]` section.
-    ///
-    /// # Contract
-    ///
-    /// Callers must only remove 2-hop edges that were previously added with
-    /// the same (grandparent, parent, child) triple. Removing a path that was
-    /// never added will corrupt the accumulator values and is a logic error.
-    #[inline]
-    pub fn remove_2hop_edge(
-        &mut self,
-        emb: &OpEmbeddings,
-        grandparent_op: OpKind,
-        parent_op: OpKind,
-        child_op: OpKind,
-    ) {
-        let gp = emb.get(grandparent_op);
-        let p = shift1(emb.get(parent_op));
-        let c = shift_by(emb.get(child_op), 2);
-        for i in 0..K {
-            self.values[3 * K + i] -= gp[i] * p[i] * c[i];
-        }
-    }
-
-    /// Return a copy with each of the four sections independently L2-normalized.
-    ///
-    /// Raw sums grow proportionally to edge count, so a 200-edge graph has
-    /// values ~20x larger than a 10-edge graph.  Normalizing makes the
-    /// embedding scale-invariant: small rewrites on large graphs become visible
-    /// instead of being swamped by magnitude.
-    ///
-    /// Each section is normalized independently because they represent different
-    /// quantities with different natural scales:
-    /// - `[0..K]`    marginal parent sums
-    /// - `[K..2K]`   marginal child sums
-    /// - `[2K..3K]`  1-hop VSA binding sums
-    /// - `[3K..4K]`  2-hop VSA binding sums
-    ///
-    /// Scalar fields (`edge_count`, `node_count`, etc.) are copied as-is.
-    ///
-    /// A zero-norm section (no edges accumulated) is left as all-zeros rather
-    /// than producing NaN/Inf.
-    #[must_use]
-    pub fn normalized(&self) -> Self {
-        let mut out = self.clone();
-        out.normalize_in_place();
-        out
-    }
-
-    /// L2-normalize each of the four sections in place.
-    ///
-    /// See [`normalized`](Self::normalized) for rationale.
-    pub fn normalize_in_place(&mut self) {
-        l2_normalize_section(&mut self.values, 0, K);
-        l2_normalize_section(&mut self.values, K, 2 * K);
-        l2_normalize_section(&mut self.values, 2 * K, 3 * K);
-        l2_normalize_section(&mut self.values, 3 * K, 4 * K);
-    }
-}
-
-/// L2-normalize a contiguous slice `values[start..end]` in place.
-///
-/// If the section norm is zero (or negligibly small), it is left untouched
-/// to avoid division by zero.
-fn l2_normalize_section(values: &mut [f32], start: usize, end: usize) {
-    let mut sum_sq: f32 = 0.0;
-    for i in start..end {
-        sum_sq += values[i] * values[i];
-    }
-    let norm = sqrtf(sum_sq);
-    // Guard: skip normalization for zero/near-zero sections to avoid NaN/Inf.
-    if norm < 1e-12 {
-        return;
-    }
-    let inv_norm = 1.0 / norm;
-    for i in start..end {
-        values[i] *= inv_norm;
-    }
-}
-
-// ============================================================================
-// Structural Hashing
-// ============================================================================
-
-// ============================================================================
-// Edge Extraction Utilities
-// ============================================================================
-
-/// An edge in the expression tree: (parent_op, child_op).
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct Edge {
-    /// The parent operation type.
-    pub parent: OpKind,
-    /// The child operation type.
-    pub child: OpKind,
-}
-
-// ============================================================================
-// Dual-Head NNUE (AlphaZero-style)
-// ============================================================================
-
-/// ExprNnue: shared backbone with one extraction head (Value MLP) and one saturation head (bilinear mask).
+/// `ExprNnue`: the shared backbone plus the extraction (value) head.
 ///
 /// ## Architecture
 ///
 /// ```text
-/// expr → OpEmbeddings → EdgeAccumulator → hidden [64] → expr_proj → expr_embed [32]
-///                                                            ├─→ value_mlp → cost (extraction head)
-///                                                            └─→ [embed, cost] → mask_mlp → bilinear → score (saturation head)
+/// expr → OpEmbeddings → EdgeAccumulator → hidden [64] → trunk → expr_proj → expr_embed [32] → value_mlp → cost
 /// ```
 ///
-/// **Extraction head**: `expr_embed → value_mlp (32→16→1)` predicts log-nanosecond cost.
-/// **Saturation head**: `[expr_embed, value_pred] → mask_mlp → bilinear(mask_features, rule_embed)` scores rules.
+/// `expr_embed → value_mlp (32→16→1)` predicts log-nanosecond cost.
 ///
-/// Rule embeddings come from LHS/RHS templates via `rule_proj`, not from learned per-rule embeddings.
+/// This struct is deliberately extraction-only: it is the live NNUE
+/// checkpoint format ("TRIF" — see [`Self::save`]), and every param in it is
+/// trained by `bootstrap_extraction_head`. The saturation (mask/policy) head
+/// that used to share this struct — inert, zero non-test callers, Phase-3
+/// gated — now lives behind [`crate::nnue::guide::SaturationGuide`], which
+/// holds its own weights and reads this struct's shared trunk (`trunk_w`,
+/// `trunk_b`), embeddings, and `expr_proj`/`forward_expr_only` by reference
+/// rather than duplicating them.
 #[derive(Clone)]
 pub struct ExprNnue {
     // ========== SHARED (Expression Backbone) ==========
@@ -1669,17 +1202,14 @@ pub struct ExprNnue {
     pub b1: [f32; HIDDEN_DIM],
 
     /// Shared trunk weights: [HIDDEN_DIM][HIDDEN_DIM] (64 x 64 = 4,096 params).
-    /// Both edge tower and graph tower outputs pass through this layer before
-    /// reaching their task-specific projection heads.
-    /// This is the "deep conceptual representation" shared between extraction and saturation.
+    /// Read by `nnue::guide`'s graph tower too (see `apply_trunk`), so this
+    /// remains "the deep conceptual representation" shared across both heads
+    /// even though the mask/graph tower's own weights moved out.
     pub trunk_w: [[f32; HIDDEN_DIM]; HIDDEN_DIM],
     /// Shared trunk biases: [HIDDEN_DIM] (64 params).
     pub trunk_b: [f32; HIDDEN_DIM],
 
-    // ========== UNIFIED MASK ARCHITECTURE ==========
-    // These fields support the new bilinear expr-rule interaction model
-    // that scales to 1000+ rules.
-    /// Projects backbone hidden (64) to shared expr embedding (EMBED_DIM=32).
+    /// Projects backbone hidden (64) to the shared expr embedding (`EMBED_DIM`=32).
     /// Weights: [HIDDEN_DIM x EMBED_DIM]
     pub expr_proj_w: [[f32; EMBED_DIM]; HIDDEN_DIM],
     /// Expr projection bias: [EMBED_DIM]
@@ -1693,57 +1223,6 @@ pub struct ExprNnue {
     pub value_mlp_w2: [f32; MLP_HIDDEN],
     /// Value MLP layer 2 bias
     pub value_mlp_b2: f32,
-
-    /// Mask MLP layer 1 weights: expr_embed (32) → hidden (16).
-    /// value_pred was removed from the input — it is a deterministic function
-    /// of expr_embed and adds zero information (see `MASK_INPUT_DIM`).
-    pub mask_mlp_w1: [[f32; MLP_HIDDEN]; MASK_INPUT_DIM],
-    /// Mask MLP layer 1 bias
-    pub mask_mlp_b1: [f32; MLP_HIDDEN],
-    /// Mask MLP layer 2 weights: hidden (16) → mask_features (32)
-    pub mask_mlp_w2: [[f32; EMBED_DIM]; MLP_HIDDEN],
-    /// Mask MLP layer 2 bias
-    pub mask_mlp_b2: [f32; EMBED_DIM],
-
-    /// Rule MLP layer 1 weights: rule_features (8) → hidden (16).
-    /// Shared across all rules - scales sublinearly with rule count.
-    /// (Legacy: used with hand-crafted RuleFeatures)
-    pub rule_mlp_w1: [[f32; MLP_HIDDEN]; RULE_FEATURE_DIM],
-    /// Rule MLP layer 1 bias
-    pub rule_mlp_b1: [f32; MLP_HIDDEN],
-    /// Rule MLP layer 2 weights: hidden (16) → rule_embed (32)
-    pub rule_mlp_w2: [[f32; EMBED_DIM]; MLP_HIDDEN],
-    /// Rule MLP layer 2 bias
-    pub rule_mlp_b2: [f32; EMBED_DIM],
-
-    // ========== RULE TEMPLATE PROJECTION (LHS/RHS embeddings) ==========
-    // These fields support encoding rules from their LHS/RHS expression
-    // templates using the SAME expr_embed as extraction/saturation heads.
-    //
-    // 4-way concat: [z_LHS | z_RHS | z_LHS-z_RHS | z_LHS*z_RHS] (128) → rule_embed (32)
-    /// Rule projection weights: [RULE_CONCAT_DIM x EMBED_DIM] = [128 x 32] = 4,096 params.
-    /// Projects 4-way concatenation to rule embedding.
-    pub rule_proj_w: [[f32; EMBED_DIM]; RULE_CONCAT_DIM],
-    /// Rule projection bias: [EMBED_DIM] = 32 params
-    pub rule_proj_b: [f32; EMBED_DIM],
-
-    /// Bilinear interaction matrix: mask_features @ interaction @ rule_embed
-    pub interaction: [[f32; EMBED_DIM]; EMBED_DIM],
-
-    /// Learned bias projection: produces per-rule bias via dot(mask_bias_proj, rule_embed)
-    pub mask_bias_proj: [f32; EMBED_DIM],
-
-    // ========== GRAPH STATE BACKBONE (for saturation head) ==========
-    // Separate pathway: GraphAccumulator (VSA e-graph state) → graph_w1 → graph_proj → mask_mlp → bilinear
-    // The extraction head path (EdgeAccumulator → w1 → expr_proj) is completely unchanged.
-    /// Graph backbone weights: [GRAPH_INPUT_DIM][HIDDEN_DIM] (132 × 64 = 8,448 params)
-    pub graph_w1: [[f32; HIDDEN_DIM]; GRAPH_INPUT_DIM],
-    /// Graph backbone biases: [HIDDEN_DIM] (64 params)
-    pub graph_b1: [f32; HIDDEN_DIM],
-    /// Graph → embed projection weights: [HIDDEN_DIM][EMBED_DIM] (64 × 32 = 2,048 params)
-    pub graph_proj_w: [[f32; EMBED_DIM]; HIDDEN_DIM],
-    /// Graph → embed projection bias: [EMBED_DIM] (32 params)
-    pub graph_proj_b: [f32; EMBED_DIM],
 }
 
 impl Default for ExprNnue {
@@ -1753,20 +1232,17 @@ impl Default for ExprNnue {
 }
 
 impl ExprNnue {
-    /// Create a zero-initialized dual-head network.
+    /// Create a zero-initialized extraction head.
     #[must_use]
     pub fn new() -> Self {
         Self {
-            // Backbone
             embeddings: OpEmbeddings::new(),
             w1: [[0.0; HIDDEN_DIM]; INPUT_DIM],
             b1: [0.0; HIDDEN_DIM],
 
-            // Shared trunk (zero-init)
             trunk_w: [[0.0; HIDDEN_DIM]; HIDDEN_DIM],
             trunk_b: [0.0; HIDDEN_DIM],
 
-            // Unified mask architecture
             expr_proj_w: [[0.0; EMBED_DIM]; HIDDEN_DIM],
             expr_proj_b: [0.0; EMBED_DIM],
 
@@ -1774,33 +1250,10 @@ impl ExprNnue {
             value_mlp_b1: [0.0; MLP_HIDDEN],
             value_mlp_w2: [0.0; MLP_HIDDEN],
             value_mlp_b2: 5.0, // Start near typical log-cost
-
-            mask_mlp_w1: [[0.0; MLP_HIDDEN]; MASK_INPUT_DIM], // 24 × 16
-            mask_mlp_b1: [0.0; MLP_HIDDEN],
-            mask_mlp_w2: [[0.0; EMBED_DIM]; MLP_HIDDEN],
-            mask_mlp_b2: [0.0; EMBED_DIM],
-
-            rule_mlp_w1: [[0.0; MLP_HIDDEN]; RULE_FEATURE_DIM],
-            rule_mlp_b1: [0.0; MLP_HIDDEN],
-            rule_mlp_w2: [[0.0; EMBED_DIM]; MLP_HIDDEN],
-            rule_mlp_b2: [0.0; EMBED_DIM],
-
-            // Rule template projection (LHS/RHS embeddings)
-            rule_proj_w: [[0.0; EMBED_DIM]; RULE_CONCAT_DIM],
-            rule_proj_b: [0.0; EMBED_DIM],
-
-            interaction: [[0.0; EMBED_DIM]; EMBED_DIM],
-            mask_bias_proj: [0.0; EMBED_DIM],
-
-            // Graph state backbone (zero-init)
-            graph_w1: [[0.0; HIDDEN_DIM]; GRAPH_INPUT_DIM],
-            graph_b1: [0.0; HIDDEN_DIM],
-            graph_proj_w: [[0.0; EMBED_DIM]; HIDDEN_DIM],
-            graph_proj_b: [0.0; EMBED_DIM],
         }
     }
 
-    /// Create a randomly initialized dual-head network.
+    /// Create a randomly initialized extraction head.
     #[must_use]
     pub fn new_random(seed: u64) -> Self {
         let mut net = Self::new();
@@ -1818,64 +1271,6 @@ impl ExprNnue {
         let mut net = Self::new();
         net.embeddings.init_with_latency_prior(seed);
         net.randomize_weights_only(seed);
-        net
-    }
-
-    /// Convert an older extraction-first model into the unified architecture.
-    ///
-    /// This preserves the edge tower exactly by initializing the shared trunk
-    /// to identity, so pre-trunk hidden activations pass through unchanged.
-    /// Task-specific unified-head weights remain zero-initialized and require
-    /// training.
-    #[must_use]
-    pub fn from_factored(factored: &ExprNnue) -> Self {
-        let mut net = Self {
-            embeddings: factored.embeddings.clone(),
-            w1: factored.w1,
-            b1: factored.b1,
-
-            // Shared trunk starts as identity so the migrated edge tower
-            // preserves its pre-trunk representation exactly.
-            trunk_w: [[0.0; HIDDEN_DIM]; HIDDEN_DIM],
-            trunk_b: [0.0; HIDDEN_DIM],
-
-            // Unified mask architecture - zero-initialized (needs training)
-            expr_proj_w: [[0.0; EMBED_DIM]; HIDDEN_DIM],
-            expr_proj_b: [0.0; EMBED_DIM],
-
-            value_mlp_w1: [[0.0; MLP_HIDDEN]; EMBED_DIM],
-            value_mlp_b1: [0.0; MLP_HIDDEN],
-            value_mlp_w2: [0.0; MLP_HIDDEN],
-            value_mlp_b2: 5.0,
-
-            mask_mlp_w1: [[0.0; MLP_HIDDEN]; MASK_INPUT_DIM], // 24 × 16
-            mask_mlp_b1: [0.0; MLP_HIDDEN],
-            mask_mlp_w2: [[0.0; EMBED_DIM]; MLP_HIDDEN],
-            mask_mlp_b2: [0.0; EMBED_DIM],
-
-            rule_mlp_w1: [[0.0; MLP_HIDDEN]; RULE_FEATURE_DIM],
-            rule_mlp_b1: [0.0; MLP_HIDDEN],
-            rule_mlp_w2: [[0.0; EMBED_DIM]; MLP_HIDDEN],
-            rule_mlp_b2: [0.0; EMBED_DIM],
-
-            // Rule template projection - zero-initialized (needs training)
-            rule_proj_w: [[0.0; EMBED_DIM]; RULE_CONCAT_DIM],
-            rule_proj_b: [0.0; EMBED_DIM],
-
-            interaction: [[0.0; EMBED_DIM]; EMBED_DIM],
-            mask_bias_proj: [0.0; EMBED_DIM],
-
-            // Graph state backbone - zero-initialized (needs training)
-            graph_w1: [[0.0; HIDDEN_DIM]; GRAPH_INPUT_DIM],
-            graph_b1: [0.0; HIDDEN_DIM],
-            graph_proj_w: [[0.0; EMBED_DIM]; HIDDEN_DIM],
-            graph_proj_b: [0.0; EMBED_DIM],
-        };
-
-        for i in 0..HIDDEN_DIM {
-            net.trunk_w[i][i] = 1.0;
-        }
-
         net
     }
 
@@ -1910,20 +1305,18 @@ impl ExprNnue {
             *b = 0.0;
         }
 
-        // Initialize unified mask architecture (full init - includes shared projection + value mlp)
-        self.randomize_unified_arch_with_rng(&mut next_f32);
+        // Initialize the shared projection + value MLP.
+        self.randomize_extraction_head_with_rng(&mut next_f32);
     }
 
-    /// Internal helper to randomize ALL unified architecture weights.
+    /// Internal helper to randomize the expr projection + value MLP.
     ///
-    /// ONLY used during full random init (randomize_weights_only).
-    /// Do NOT call this when bootstrapping from extraction head weights - use randomize_mask_only instead.
-    fn randomize_unified_arch_with_rng<F: FnMut() -> f32>(&mut self, next_f32: &mut F) {
+    /// ONLY used during full random init (`randomize_weights_only`).
+    fn randomize_extraction_head_with_rng<F: FnMut() -> f32>(&mut self, next_f32: &mut F) {
         // He initialization scales
         let scale_proj = sqrtf(2.0 / HIDDEN_DIM as f32);
         let scale_embed = sqrtf(2.0 / EMBED_DIM as f32);
         let scale_hidden = sqrtf(2.0 / MLP_HIDDEN as f32);
-        let scale_rule_feat = sqrtf(2.0 / RULE_FEATURE_DIM as f32);
 
         // Expr projection: HIDDEN_DIM → EMBED_DIM
         for j in 0..HIDDEN_DIM {
@@ -1948,90 +1341,6 @@ impl ExprNnue {
             self.value_mlp_w2[j] = next_f32() * scale_hidden;
         }
         self.value_mlp_b2 = 5.0; // Start near typical log-cost
-
-        // Mask MLP: EMBED_DIM (24) → MLP_HIDDEN → EMBED_DIM
-        let scale_mask_input = sqrtf(2.0 / MASK_INPUT_DIM as f32);
-        for i in 0..MASK_INPUT_DIM {
-            for j in 0..MLP_HIDDEN {
-                self.mask_mlp_w1[i][j] = next_f32() * scale_mask_input;
-            }
-        }
-        for b in &mut self.mask_mlp_b1 {
-            *b = next_f32().abs() * 0.1;
-        }
-        for j in 0..MLP_HIDDEN {
-            for k in 0..EMBED_DIM {
-                self.mask_mlp_w2[j][k] = next_f32() * scale_hidden;
-            }
-        }
-        for b in &mut self.mask_mlp_b2 {
-            *b = 0.0; // Neutral
-        }
-
-        // Rule MLP: RULE_FEATURE_DIM → MLP_HIDDEN → EMBED_DIM (hand-crafted features)
-        for i in 0..RULE_FEATURE_DIM {
-            for j in 0..MLP_HIDDEN {
-                self.rule_mlp_w1[i][j] = next_f32() * scale_rule_feat;
-            }
-        }
-        for b in &mut self.rule_mlp_b1 {
-            *b = next_f32().abs() * 0.1;
-        }
-        for j in 0..MLP_HIDDEN {
-            for k in 0..EMBED_DIM {
-                self.rule_mlp_w2[j][k] = next_f32() * scale_hidden;
-            }
-        }
-        for b in &mut self.rule_mlp_b2 {
-            *b = 0.0; // Neutral
-        }
-
-        // Rule Projection: RULE_CONCAT_DIM (96) → EMBED_DIM (24)
-        // Linear projection from 4-way concat [z_LHS | z_RHS | z_LHS-z_RHS | z_LHS*z_RHS]
-        let scale_concat = sqrtf(2.0 / RULE_CONCAT_DIM as f32);
-        for i in 0..RULE_CONCAT_DIM {
-            for k in 0..EMBED_DIM {
-                self.rule_proj_w[i][k] = next_f32() * scale_concat;
-            }
-        }
-        for b in &mut self.rule_proj_b {
-            *b = 0.0; // Neutral
-        }
-
-        // Interaction matrix: start near identity (simple dot product baseline)
-        for i in 0..EMBED_DIM {
-            for j in 0..EMBED_DIM {
-                self.interaction[i][j] = if i == j { 1.0 } else { next_f32() * 0.1 };
-            }
-        }
-
-        // Bias projection: neutral
-        for b in &mut self.mask_bias_proj {
-            *b = 0.0;
-        }
-
-        // Graph backbone: GRAPH_INPUT_DIM → HIDDEN_DIM
-        let scale_graph = sqrtf(2.0 / GRAPH_INPUT_DIM as f32);
-        for row in 0..GRAPH_INPUT_DIM {
-            for col in 0..HIDDEN_DIM {
-                self.graph_w1[row][col] = next_f32() * scale_graph;
-            }
-        }
-        for b in &mut self.graph_b1 {
-            *b = next_f32().abs() * 0.1;
-        }
-
-        // Graph projection: HIDDEN_DIM → EMBED_DIM
-        for j in 0..HIDDEN_DIM {
-            for k in 0..EMBED_DIM {
-                self.graph_proj_w[j][k] = next_f32() * scale_proj;
-            }
-        }
-        for b in &mut self.graph_proj_b {
-            *b = next_f32().abs() * 0.1;
-        }
-
-        // NOTE: search_mlp randomization removed - mask IS the policy
     }
 
     /// Randomize all weights including embeddings.
@@ -2040,130 +1349,16 @@ impl ExprNnue {
         self.randomize_weights_only(seed);
     }
 
-    /// Create a copy with trained backbone but randomized mask weights.
+    /// Apply the shared trunk: `HIDDEN_DIM -> HIDDEN_DIM` with ReLU.
     ///
-    /// This is the key method for embedding sharing: load a trained extraction head,
-    /// then create a new model that:
-    /// - Keeps: embeddings, w1, b1 (trained backbone)
-    /// - Keeps: expr_proj_w, expr_proj_b (shared projection - trained with extraction head)
-    /// - Keeps: value_mlp_* (extraction head weights)
-    /// - Randomizes: mask_mlp, rule_mlp, rule_proj, interaction, mask_bias_proj (saturation head specific)
-    ///
-    /// Use this when bootstrapping saturation head training from a pre-trained extraction head.
-    #[must_use]
-    pub fn with_randomized_mask_weights(&self, seed: u64) -> Self {
-        let mut model = self.clone();
-        model.randomize_mask_only(seed);
-        model
-    }
-
-    /// Randomize ONLY mask-specific weights, preserving shared backbone and value MLP.
-    ///
-    /// Randomizes: mask_mlp, rule_mlp, rule_proj, interaction, mask_bias_proj
-    /// Preserves: embeddings, w1, b1, expr_proj, value_mlp
-    pub fn randomize_mask_only(&mut self, seed: u64) {
-        let mut rng_state = seed.wrapping_add(54321);
-
-        let mut next_f32 = || {
-            rng_state = rng_state.wrapping_mul(6364136223846793005).wrapping_add(1);
-            (rng_state >> 33) as f32 / (1u64 << 31) as f32 * 2.0 - 1.0
-        };
-
-        // He initialization scales
-        let scale_embed = sqrtf(2.0 / EMBED_DIM as f32);
-        let scale_mask_input = sqrtf(2.0 / MASK_INPUT_DIM as f32); // 24 dims
-        let scale_hidden = sqrtf(2.0 / MLP_HIDDEN as f32);
-        let scale_rule_feat = sqrtf(2.0 / RULE_FEATURE_DIM as f32);
-        let scale_concat = sqrtf(2.0 / RULE_CONCAT_DIM as f32);
-
-        // Mask MLP: EMBED_DIM (24) → MLP_HIDDEN → EMBED_DIM
-        for i in 0..MASK_INPUT_DIM {
-            for j in 0..MLP_HIDDEN {
-                self.mask_mlp_w1[i][j] = next_f32() * scale_mask_input;
-            }
-        }
-        for b in &mut self.mask_mlp_b1 {
-            *b = next_f32().abs() * 0.1;
-        }
-        for j in 0..MLP_HIDDEN {
-            for k in 0..EMBED_DIM {
-                self.mask_mlp_w2[j][k] = next_f32() * scale_hidden;
-            }
-        }
-        for b in &mut self.mask_mlp_b2 {
-            *b = 0.0;
-        }
-
-        // Rule MLP: RULE_FEATURE_DIM → MLP_HIDDEN → EMBED_DIM (hand-crafted features)
-        for i in 0..RULE_FEATURE_DIM {
-            for j in 0..MLP_HIDDEN {
-                self.rule_mlp_w1[i][j] = next_f32() * scale_rule_feat;
-            }
-        }
-        for b in &mut self.rule_mlp_b1 {
-            *b = next_f32().abs() * 0.1;
-        }
-        for j in 0..MLP_HIDDEN {
-            for k in 0..EMBED_DIM {
-                self.rule_mlp_w2[j][k] = next_f32() * scale_hidden;
-            }
-        }
-        for b in &mut self.rule_mlp_b2 {
-            *b = 0.0;
-        }
-
-        // Rule Projection: RULE_CONCAT_DIM (96) → EMBED_DIM (24)
-        for i in 0..RULE_CONCAT_DIM {
-            for k in 0..EMBED_DIM {
-                self.rule_proj_w[i][k] = next_f32() * scale_concat;
-            }
-        }
-        for b in &mut self.rule_proj_b {
-            *b = 0.0;
-        }
-
-        // Interaction matrix: start near identity
-        for i in 0..EMBED_DIM {
-            for j in 0..EMBED_DIM {
-                self.interaction[i][j] = if i == j { 1.0 } else { next_f32() * 0.1 };
-            }
-        }
-
-        // Bias projection: neutral
-        for b in &mut self.mask_bias_proj {
-            *b = 0.0;
-        }
-
-        // Graph backbone: GRAPH_INPUT_DIM → HIDDEN_DIM (mask-specific pathway)
-        let scale_graph = sqrtf(2.0 / GRAPH_INPUT_DIM as f32);
-        let scale_proj = sqrtf(2.0 / HIDDEN_DIM as f32);
-        for row in 0..GRAPH_INPUT_DIM {
-            for col in 0..HIDDEN_DIM {
-                self.graph_w1[row][col] = next_f32() * scale_graph;
-            }
-        }
-        for b in &mut self.graph_b1 {
-            *b = next_f32().abs() * 0.1;
-        }
-
-        // Graph projection: HIDDEN_DIM → EMBED_DIM
-        for j in 0..HIDDEN_DIM {
-            for k in 0..EMBED_DIM {
-                self.graph_proj_w[j][k] = next_f32() * scale_proj;
-            }
-        }
-        for b in &mut self.graph_proj_b {
-            *b = next_f32().abs() * 0.1;
-        }
-    }
-
-    /// Apply shared trunk: HIDDEN_DIM -> HIDDEN_DIM with ReLU.
-    ///
-    /// Both the edge tower and graph tower pass through this layer before
-    /// reaching their task-specific projection heads. Initialized near-identity
-    /// so the trunk preserves tower signal until training pulls it away.
+    /// Both this struct's edge tower and `nnue::guide`'s graph tower pass
+    /// through this layer before reaching their task-specific projection
+    /// heads — `pub(crate)` rather than private so the guide module (same
+    /// crate, different module) can share it instead of duplicating it.
+    /// Initialized near-identity so the trunk preserves tower signal until
+    /// training pulls it away.
     #[inline]
-    fn apply_trunk(&self, tower_output: &[f32; HIDDEN_DIM]) -> [f32; HIDDEN_DIM] {
+    pub(crate) fn apply_trunk(&self, tower_output: &[f32; HIDDEN_DIM]) -> [f32; HIDDEN_DIM] {
         let mut out = self.trunk_b;
         for i in 0..HIDDEN_DIM {
             for j in 0..HIDDEN_DIM {
@@ -2221,30 +1416,6 @@ impl ExprNnue {
         hidden
     }
 
-    // ========================================================================
-    // Unified Mask Architecture Forward Pass
-    //
-    // New bilinear interaction model that scales to 1000+ rules.
-    //
-    // Architecture:
-    //   expr → backbone → hidden → expr_proj → expr_embed (shared)
-    //                                              │
-    //          ┌───────────────────────────────────┼───────────────────┐
-    //          │                                   │                   │
-    //          ▼                                   ▼                   ▼
-    //    value_mlp (private)               mask_mlp (private)    rule_features
-    //          │                                   │                   │
-    //          ▼                                   │             rule_mlp (shared)
-    //       cost (1)                               │                   │
-    //                                              ▼                   ▼
-    //                                        mask_features       rule_embed
-    //                                              │                   │
-    //                                              └──── bilinear ─────┘
-    //                                                       │
-    //                                                       ▼
-    //                                              score + rule_bias
-    // ========================================================================
-
     /// Project backbone hidden to shared expr embedding (EMBED_DIM).
     #[inline]
     pub fn compute_expr_embed(&self, hidden: &[f32; HIDDEN_DIM]) -> [f32; EMBED_DIM] {
@@ -2255,129 +1426,6 @@ impl ExprNnue {
             }
         }
         embed
-    }
-
-    // ========================================================================
-    // Graph State Backbone Forward Pass
-    //
-    // Separate pathway for saturation head: GraphAccumulator → graph_w1 → graph_proj
-    // Feeds into the SAME mask_mlp + bilinear scoring as the expr pathway.
-    // ========================================================================
-
-    /// Graph state forward pass (for saturation head).
-    ///
-    /// Same structure as `forward_shared` but with `graph_w1`/`graph_b1` and
-    /// `GRAPH_INPUT_DIM` input (132). Uses `1/sqrt(node_count)` scaling
-    /// and log2 scalars, matching the `forward_shared` conventions.
-    #[inline]
-    pub fn forward_graph(&self, gacc: &GraphAccumulator) -> [f32; HIDDEN_DIM] {
-        let mut hidden = self.graph_b1;
-
-        // Scale factor: 1/sqrt(N) prevents variance explosion from summing N embeddings.
-        let scale = if gacc.node_count > 0 {
-            1.0 / libm::sqrtf(gacc.node_count as f32)
-        } else {
-            1.0
-        };
-
-        // Process graph accumulator (128 dims: 4K sections)
-        for (i, &val) in gacc.values.iter().enumerate() {
-            let scaled_val = val * scale;
-            for (j, h) in hidden.iter_mut().enumerate() {
-                *h += scaled_val * self.graph_w1[i][j];
-            }
-        }
-
-        // Process scalar features (4 dims: edge_count, node_count, node_budget, epoch_budget).
-        // Use log2 to compress the range for large e-graphs.
-        let base = GRAPH_ACC_DIM;
-        let ec = libm::log2f(1.0 + gacc.edge_count as f32);
-        let nc = libm::log2f(1.0 + gacc.node_count as f32);
-        let nb = libm::log2f(1.0 + gacc.node_budget as f32);
-        let eb = libm::log2f(1.0 + gacc.epoch_budget as f32);
-        for (j, h) in hidden.iter_mut().enumerate() {
-            *h += ec * self.graph_w1[base][j];
-            *h += nc * self.graph_w1[base + 1][j];
-            *h += nb * self.graph_w1[base + 2][j];
-            *h += eb * self.graph_w1[base + 3][j];
-        }
-
-        // ReLU activation
-        for h in &mut hidden {
-            *h = h.max(0.0);
-        }
-
-        // Shared trunk
-        let hidden = self.apply_trunk(&hidden);
-
-        hidden
-    }
-
-    /// Project graph hidden to graph embedding (EMBED_DIM).
-    ///
-    /// Same structure as `compute_expr_embed` but with `graph_proj_w`/`graph_proj_b`.
-    #[inline]
-    pub fn compute_graph_embed(&self, hidden: &[f32; HIDDEN_DIM]) -> [f32; EMBED_DIM] {
-        let mut embed = self.graph_proj_b;
-        for j in 0..HIDDEN_DIM {
-            for k in 0..EMBED_DIM {
-                embed[k] += hidden[j] * self.graph_proj_w[j][k];
-            }
-        }
-        embed
-    }
-
-    /// Score all rules using graph state (not expression state).
-    ///
-    /// `forward_graph → compute_graph_embed → compute_mask_features → bilinear_score`
-    ///
-    /// The mask_mlp, interaction matrix, and bilinear_score are **shared** with the
-    /// expression pathway — only the input pathway changes.
-    #[must_use]
-    pub fn mask_score_all_rules_graph(
-        &self,
-        gacc: &GraphAccumulator,
-        rule_embeds: &[[f32; EMBED_DIM]],
-    ) -> Vec<f32> {
-        let hidden = self.forward_graph(gacc);
-        let graph_embed = self.compute_graph_embed(&hidden);
-        let mask_features = self.compute_mask_features(&graph_embed);
-        rule_embeds
-            .iter()
-            .map(|re| self.bilinear_score(&mask_features, re))
-            .collect()
-    }
-
-    /// Compute mask features from expr embedding and value prediction (for bilinear scoring).
-    ///
-    /// Transform expr_embed through mask MLP to produce mask features for bilinear scoring.
-    ///
-    /// Input: expr_embed (24 dims) directly — value_pred was removed as redundant.
-    /// MLP: EMBED_DIM (24) → MLP_HIDDEN (ReLU) → EMBED_DIM (24)
-    #[inline]
-    fn compute_mask_features(&self, expr_embed: &[f32; EMBED_DIM]) -> [f32; EMBED_DIM] {
-        // First layer: EMBED_DIM → MLP_HIDDEN
-        let mut h = self.mask_mlp_b1;
-
-        for i in 0..EMBED_DIM {
-            for j in 0..MLP_HIDDEN {
-                h[j] += expr_embed[i] * self.mask_mlp_w1[i][j];
-            }
-        }
-
-        // ReLU
-        for j in 0..MLP_HIDDEN {
-            h[j] = h[j].max(0.0);
-        }
-
-        // Second layer: MLP_HIDDEN → EMBED_DIM
-        let mut out = self.mask_mlp_b2;
-        for j in 0..MLP_HIDDEN {
-            for k in 0..EMBED_DIM {
-                out[k] += h[j] * self.mask_mlp_w2[j][k];
-            }
-        }
-        out
     }
 
     /// Forward pass through value MLP from expr embedding.
@@ -2407,165 +1455,6 @@ impl ExprNnue {
         cost
     }
 
-    /// Encode rule features to rule embedding.
-    ///
-    /// MLP: RULE_FEATURE_DIM → MLP_HIDDEN (ReLU) → EMBED_DIM
-    /// This MLP is shared across all rules - scales sublinearly with rule count.
-    #[must_use]
-    pub fn encode_rule(&self, rule_features: &[f32; RULE_FEATURE_DIM]) -> [f32; EMBED_DIM] {
-        // First layer: RULE_FEATURE_DIM → MLP_HIDDEN
-        let mut h = self.rule_mlp_b1;
-        for i in 0..RULE_FEATURE_DIM {
-            for j in 0..MLP_HIDDEN {
-                h[j] += rule_features[i] * self.rule_mlp_w1[i][j];
-            }
-        }
-
-        // ReLU
-        for j in 0..MLP_HIDDEN {
-            h[j] = h[j].max(0.0);
-        }
-
-        // Second layer: MLP_HIDDEN → EMBED_DIM
-        let mut out = self.rule_mlp_b2;
-        for j in 0..MLP_HIDDEN {
-            for k in 0..EMBED_DIM {
-                out[k] += h[j] * self.rule_mlp_w2[j][k];
-            }
-        }
-        out
-    }
-
-    /// Pre-encode all rules (call once, cache results).
-    ///
-    /// Returns a Vec of rule embeddings that can be reused across multiple
-    /// expressions during saturation.
-    #[must_use]
-    pub fn encode_all_rules(
-        &self,
-        rule_features: &RuleFeatures,
-        num_rules: usize,
-    ) -> Vec<[f32; EMBED_DIM]> {
-        (0..num_rules)
-            .map(|r| self.encode_rule(&rule_features.features[r]))
-            .collect()
-    }
-
-    // =========================================================================
-    // Rule Encoding from LHS/RHS Templates
-    //
-    // Uses the SAME expr_embed as extraction/saturation heads. 4-way concatenation:
-    // [z_LHS | z_RHS | z_LHS-z_RHS | z_LHS*z_RHS] → linear → rule_embed
-    //
-    // This provides richer semantic features than hand-crafted rule descriptors.
-    // =========================================================================
-
-    /// Pre-encode all rules from templates (call once at init, cache results).
-    ///
-    /// Rules without templates fall back to zero embedding.
-    /// Rule embeddings don't change during search - they're computed from
-    /// LHS/RHS templates which are static.
-    #[must_use]
-    pub fn encode_all_rules_from_templates(
-        &self,
-        templates: &RuleTemplates,
-    ) -> Vec<[f32; EMBED_DIM]> {
-        (0..templates.len())
-            .map(|r| match templates.get(r) {
-                Some(t) => match (t.lhs, t.rhs) {
-                    (Some(lhs), Some(rhs)) => self.encode_rule_from_arena(&t.arena, lhs, rhs),
-                    _ => [0.0f32; EMBED_DIM],
-                },
-                None => [0.0f32; EMBED_DIM], // No template - zero embedding
-            })
-            .collect()
-    }
-
-    /// Encode a single rule's LHS/RHS arena subtrees into a rule embedding.
-    ///
-    /// 4-way concatenation `[z_LHS | z_RHS | z_LHS-z_RHS | z_LHS*z_RHS]` projected
-    /// to `EMBED_DIM`, using the same shared backbone as the extraction head.
-    #[must_use]
-    pub fn encode_rule_from_arena(
-        &self,
-        arena: &ExprArena,
-        lhs: ExprId,
-        rhs: ExprId,
-    ) -> [f32; EMBED_DIM] {
-        // Same feature path as everything else that touches `w1`: the slot
-        // semantics of `extraction_input` (variance fractions in 4K..4K+4)
-        // must have exactly one meaning across the whole net.
-        let lhs_acc = EdgeAccumulator::from_arena_dag(arena, lhs, &self.embeddings);
-        let lhs_hidden = self.forward_expr_only(&lhs_acc);
-        let z_lhs = self.compute_expr_embed(&lhs_hidden);
-
-        let rhs_acc = EdgeAccumulator::from_arena_dag(arena, rhs, &self.embeddings);
-        let rhs_hidden = self.forward_expr_only(&rhs_acc);
-        let z_rhs = self.compute_expr_embed(&rhs_hidden);
-
-        let mut concat = [0.0f32; RULE_CONCAT_DIM];
-        for i in 0..EMBED_DIM {
-            concat[i] = z_lhs[i];
-            concat[EMBED_DIM + i] = z_rhs[i];
-            concat[2 * EMBED_DIM + i] = z_lhs[i] - z_rhs[i];
-            concat[3 * EMBED_DIM + i] = z_lhs[i] * z_rhs[i];
-        }
-
-        let mut out = self.rule_proj_b;
-        for i in 0..RULE_CONCAT_DIM {
-            for k in 0..EMBED_DIM {
-                out[k] += concat[i] * self.rule_proj_w[i][k];
-            }
-        }
-        out
-    }
-
-    /// Bilinear score: mask_features @ interaction @ rule_embed + bias.
-    ///
-    /// Efficient O(1) scoring with pre-computed mask_features.
-    #[inline]
-    #[must_use]
-    pub fn bilinear_score(
-        &self,
-        mask_features: &[f32; EMBED_DIM],
-        rule_embed: &[f32; EMBED_DIM],
-    ) -> f32 {
-        // transformed = mask_features @ interaction
-        let mut transformed = [0.0f32; EMBED_DIM];
-        for i in 0..EMBED_DIM {
-            for j in 0..EMBED_DIM {
-                transformed[j] += mask_features[i] * self.interaction[i][j];
-            }
-        }
-
-        // score = dot(transformed + mask_bias_proj, rule_embed)
-        let mut score = 0.0f32;
-        for k in 0..EMBED_DIM {
-            score += (transformed[k] + self.mask_bias_proj[k]) * rule_embed[k];
-        }
-        score
-    }
-
-    /// Score all rules with pre-computed backbone hidden state.
-    ///
-    /// More efficient when you have multiple expressions sharing the same
-    /// feature extraction.
-    #[must_use]
-    pub fn mask_score_all_rules_with_hidden(
-        &self,
-        hidden: &[f32; HIDDEN_DIM],
-        rule_embeds: &[[f32; EMBED_DIM]],
-    ) -> Vec<f32> {
-        let expr_embed = self.compute_expr_embed(hidden);
-
-        let mask_features = self.compute_mask_features(&expr_embed);
-
-        rule_embeds
-            .iter()
-            .map(|rule_embed| self.bilinear_score(&mask_features, rule_embed))
-            .collect()
-    }
-
     /// Total parameter count.
     #[must_use]
     pub const fn param_count() -> usize {
@@ -2582,28 +1471,7 @@ impl ExprNnue {
             + EMBED_DIM * MLP_HIDDEN          // value_mlp_w1: 32 * 16 = 512
             + MLP_HIDDEN                      // value_mlp_b1: 16
             + MLP_HIDDEN                      // value_mlp_w2: 16
-            + 1                               // value_mlp_b2: 1
-            // mask MLP
-            + MASK_INPUT_DIM * MLP_HIDDEN     // mask_mlp_w1: 32 * 16 = 512
-            + MLP_HIDDEN                      // mask_mlp_b1: 16
-            + MLP_HIDDEN * EMBED_DIM          // mask_mlp_w2: 16 * 32 = 512
-            + EMBED_DIM                       // mask_mlp_b2: 32
-            // rule MLP
-            + RULE_FEATURE_DIM * MLP_HIDDEN   // rule_mlp_w1: 8 * 16 = 128
-            + MLP_HIDDEN                      // rule_mlp_b1: 16
-            + MLP_HIDDEN * EMBED_DIM          // rule_mlp_w2: 16 * 32 = 512
-            + EMBED_DIM                       // rule_mlp_b2: 32
-            // rule projection
-            + RULE_CONCAT_DIM * EMBED_DIM     // rule_proj_w: 128 * 32 = 4,096
-            + EMBED_DIM                       // rule_proj_b: 32
-            // bilinear
-            + EMBED_DIM * EMBED_DIM           // interaction: 32 * 32 = 1,024
-            + EMBED_DIM                        // mask_bias_proj: 32
-            // graph state backbone
-            + GRAPH_INPUT_DIM * HIDDEN_DIM    // graph_w1: 132 * 64 = 8,448
-            + HIDDEN_DIM                      // graph_b1: 64
-            + HIDDEN_DIM * EMBED_DIM          // graph_proj_w: 64 * 32 = 2,048
-            + EMBED_DIM // graph_proj_b: 32
+            + 1 // value_mlp_b2: 1
     }
 
     /// Memory size in bytes (f32 weights).
@@ -2618,13 +1486,21 @@ impl ExprNnue {
     // in the workspace, and they were the last consumers of the old
     // `forward_shared` path that fed log2 count/budget scalars into the same
     // `w1` slots the extraction head uses for the variance histogram — the
-    // exact train/deploy skew this round removed. The saturation head scores
-    // rules through the graph tower (`forward_graph`), not the edge tower.
+    // exact train/deploy skew this round removed. The saturation head (now
+    // `nnue::guide`, its own weights entirely) scores rules through its own
+    // graph tower, not this struct's edge tower.
 
     /// Save weights to a binary file.
     ///
-    /// Format: magic "TRIE" + all weights as little-endian f32.
-    /// TRIE: op embeddings are one row per op, in `OpKind`'s order.
+    /// Format: magic "TRIF" + all weights as little-endian f32.
+    /// TRIF: **live-only** — this checkpoint holds exactly the params
+    /// [`Self::param_count`] counts (the extraction head + shared backbone,
+    /// 16,897 params / 67,588 bytes). Earlier formats (TRIE and before) also
+    /// serialized the saturation head's mask/rule/graph weights — untrained
+    /// noise that made up roughly half the file by byte count and drifted
+    /// toward zero every training run under weight decay with no gradient
+    /// ever opposing it, since nothing trained them. Op embeddings are one
+    /// row per op, in `OpKind`'s order.
     #[cfg(feature = "std")]
     pub fn save(&self, path: &std::path::Path) -> std::io::Result<()> {
         use std::io::Write;
@@ -2632,7 +1508,7 @@ impl ExprNnue {
 
         // Magic header. Bump it whenever these bytes change meaning — including
         // when `OpKind`'s order changes, since the embedding rows follow it.
-        file.write_all(b"TRIE")?;
+        file.write_all(b"TRIF")?;
 
         // ===== Backbone =====
         // Embeddings
@@ -2662,7 +1538,6 @@ impl ExprNnue {
             file.write_all(&val.to_le_bytes())?;
         }
 
-        // ===== Unified mask architecture =====
         // Expr projection
         for row in &self.expr_proj_w {
             for &val in row {
@@ -2687,82 +1562,6 @@ impl ExprNnue {
         }
         file.write_all(&self.value_mlp_b2.to_le_bytes())?;
 
-        // Mask MLP
-        for row in &self.mask_mlp_w1 {
-            for &val in row {
-                file.write_all(&val.to_le_bytes())?;
-            }
-        }
-        for &val in &self.mask_mlp_b1 {
-            file.write_all(&val.to_le_bytes())?;
-        }
-        for row in &self.mask_mlp_w2 {
-            for &val in row {
-                file.write_all(&val.to_le_bytes())?;
-            }
-        }
-        for &val in &self.mask_mlp_b2 {
-            file.write_all(&val.to_le_bytes())?;
-        }
-
-        // Rule MLP for hand-crafted rule features.
-        for row in &self.rule_mlp_w1 {
-            for &val in row {
-                file.write_all(&val.to_le_bytes())?;
-            }
-        }
-        for &val in &self.rule_mlp_b1 {
-            file.write_all(&val.to_le_bytes())?;
-        }
-        for row in &self.rule_mlp_w2 {
-            for &val in row {
-                file.write_all(&val.to_le_bytes())?;
-            }
-        }
-        for &val in &self.rule_mlp_b2 {
-            file.write_all(&val.to_le_bytes())?;
-        }
-
-        // Rule Projection (TRI3: LHS/RHS template encoding)
-        for row in &self.rule_proj_w {
-            for &val in row {
-                file.write_all(&val.to_le_bytes())?;
-            }
-        }
-        for &val in &self.rule_proj_b {
-            file.write_all(&val.to_le_bytes())?;
-        }
-
-        // Interaction matrix
-        for row in &self.interaction {
-            for &val in row {
-                file.write_all(&val.to_le_bytes())?;
-            }
-        }
-
-        // Mask bias projection
-        for &val in &self.mask_bias_proj {
-            file.write_all(&val.to_le_bytes())?;
-        }
-
-        // Graph state backbone
-        for row in &self.graph_w1 {
-            for &val in row {
-                file.write_all(&val.to_le_bytes())?;
-            }
-        }
-        for &val in &self.graph_b1 {
-            file.write_all(&val.to_le_bytes())?;
-        }
-        for row in &self.graph_proj_w {
-            for &val in row {
-                file.write_all(&val.to_le_bytes())?;
-            }
-        }
-        for &val in &self.graph_proj_b {
-            file.write_all(&val.to_le_bytes())?;
-        }
-
         Ok(())
     }
 
@@ -2776,7 +1575,7 @@ impl ExprNnue {
 
     /// Load weights from a binary file.
     ///
-    /// Only supports "TRIE" format. Older formats (TRID and earlier) require retrain.
+    /// Only supports "TRIF" format. Older formats (TRIE and earlier) require retrain.
     #[cfg(feature = "std")]
     pub fn load(path: &std::path::Path) -> std::io::Result<Self> {
         let file = std::io::BufReader::with_capacity(256 * 1024, std::fs::File::open(path)?);
@@ -2789,10 +1588,19 @@ impl ExprNnue {
         let mut magic = [0u8; 4];
         file.read_exact(&mut magic)?;
 
-        // TRIE: op embeddings are one row per op, in `OpKind`'s order. That
+        // TRIF: live-only — extraction head + shared backbone ONLY. Op
+        //       embeddings are one row per op, in `OpKind`'s order. That
         //       order is `pixelflow-ir`'s to change, and changing it silently
         //       re-attaches every row to a different operation — so a change
         //       there means a new magic here.
+        // TRIE: incompatible — also serialized the saturation head's
+        //       mask/rule/graph weights (untrained noise, since nothing
+        //       trained them — see the 2026-08-17 cost-model domain-model
+        //       reorganization). Those params now live behind
+        //       `nnue::guide::SaturationGuide`, with their own (unused until
+        //       Phase 3) checkpoint format — retrain the extraction head from
+        //       this file's raw bytes is not possible; a TRIE file is simply
+        //       a different, incompatible layout.
         // TRID: incompatible — op embeddings are indexed by `OpKind::index()`,
         //       and the pre-2026-08-02 discriminants had gaps at 17/31/39. The
         //       shapes still match, so a TRID file would load without error and
@@ -2801,17 +1609,21 @@ impl ExprNnue {
         // TRIB: incompatible — GRAPH_ACC_DIM was 3K (96), GRAPH_INPUT_DIM was 100
         // TRIA: incompatible — had mask_rule_bias[1024] instead of mask_bias_proj[32]
         // TRI5-TRI9: incompatible — EMBED_DIM was 24, all weight shapes differ
-        if &magic != b"TRIE" {
+        if &magic != b"TRIF" {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
                 format!(
-                    "Incompatible ExprNnue format {:?}. Expected 'TRIE'. {}",
+                    "Incompatible ExprNnue format {:?}. Expected 'TRIF'. {}",
                     std::str::from_utf8(&magic).unwrap_or("????"),
-                    if &magic == b"TRID" {
+                    if &magic == b"TRIE" {
+                        "'TRIE' predates the live-only checkpoint split (2026-08-17): it also \
+                         carries the (untrained) saturation-head weights this format dropped. \
+                         Retrain required."
+                    } else if &magic == b"TRID" {
                         "'TRID' predates the dense op numbering; its embeddings are \
                          attributed to the wrong operations. Retrain required."
                     } else {
-                        "Old formats (TRIC, TRIB, TRIA, TRI5-TRI9) require retrain."
+                        "Old formats (TRIE, TRIC, TRIB, TRIA, TRI5-TRI9) require retrain."
                     }
                 ),
             ));
@@ -2857,7 +1669,6 @@ impl ExprNnue {
             *val = f32::from_le_bytes(buf);
         }
 
-        // ===== Unified mask architecture =====
         // Expr projection
         for row in &mut net.expr_proj_w {
             for val in row {
@@ -2896,467 +1707,7 @@ impl ExprNnue {
             net.value_mlp_b2 = f32::from_le_bytes(buf);
         }
 
-        // Mask MLP
-        for row in &mut net.mask_mlp_w1 {
-            for val in row {
-                let mut buf = [0u8; 4];
-                file.read_exact(&mut buf)?;
-                *val = f32::from_le_bytes(buf);
-            }
-        }
-        for val in &mut net.mask_mlp_b1 {
-            let mut buf = [0u8; 4];
-            file.read_exact(&mut buf)?;
-            *val = f32::from_le_bytes(buf);
-        }
-        for row in &mut net.mask_mlp_w2 {
-            for val in row {
-                let mut buf = [0u8; 4];
-                file.read_exact(&mut buf)?;
-                *val = f32::from_le_bytes(buf);
-            }
-        }
-        for val in &mut net.mask_mlp_b2 {
-            let mut buf = [0u8; 4];
-            file.read_exact(&mut buf)?;
-            *val = f32::from_le_bytes(buf);
-        }
-
-        // Rule MLP
-        for row in &mut net.rule_mlp_w1 {
-            for val in row {
-                let mut buf = [0u8; 4];
-                file.read_exact(&mut buf)?;
-                *val = f32::from_le_bytes(buf);
-            }
-        }
-        for val in &mut net.rule_mlp_b1 {
-            let mut buf = [0u8; 4];
-            file.read_exact(&mut buf)?;
-            *val = f32::from_le_bytes(buf);
-        }
-        for row in &mut net.rule_mlp_w2 {
-            for val in row {
-                let mut buf = [0u8; 4];
-                file.read_exact(&mut buf)?;
-                *val = f32::from_le_bytes(buf);
-            }
-        }
-        for val in &mut net.rule_mlp_b2 {
-            let mut buf = [0u8; 4];
-            file.read_exact(&mut buf)?;
-            *val = f32::from_le_bytes(buf);
-        }
-
-        // Rule Projection (LHS/RHS template encoding)
-        for row in &mut net.rule_proj_w {
-            for val in row {
-                let mut buf = [0u8; 4];
-                file.read_exact(&mut buf)?;
-                *val = f32::from_le_bytes(buf);
-            }
-        }
-        for val in &mut net.rule_proj_b {
-            let mut buf = [0u8; 4];
-            file.read_exact(&mut buf)?;
-            *val = f32::from_le_bytes(buf);
-        }
-
-        // Interaction matrix
-        for row in &mut net.interaction {
-            for val in row {
-                let mut buf = [0u8; 4];
-                file.read_exact(&mut buf)?;
-                *val = f32::from_le_bytes(buf);
-            }
-        }
-
-        // Mask bias projection
-        for val in &mut net.mask_bias_proj {
-            let mut buf = [0u8; 4];
-            file.read_exact(&mut buf)?;
-            *val = f32::from_le_bytes(buf);
-        }
-
-        // Graph state backbone (TRIE format: mandatory, no backward compat)
-        for row in &mut net.graph_w1 {
-            for val in row {
-                let mut buf = [0u8; 4];
-                file.read_exact(&mut buf)?;
-                *val = f32::from_le_bytes(buf);
-            }
-        }
-        for val in &mut net.graph_b1 {
-            let mut buf = [0u8; 4];
-            file.read_exact(&mut buf)?;
-            *val = f32::from_le_bytes(buf);
-        }
-        for row in &mut net.graph_proj_w {
-            for val in row {
-                let mut buf = [0u8; 4];
-                file.read_exact(&mut buf)?;
-                *val = f32::from_le_bytes(buf);
-            }
-        }
-        for val in &mut net.graph_proj_b {
-            let mut buf = [0u8; 4];
-            file.read_exact(&mut buf)?;
-            *val = f32::from_le_bytes(buf);
-        }
-
         Ok(net)
-    }
-
-    // =========================================================================
-    // Training Methods
-    // =========================================================================
-
-    // =========================================================================
-    // Unified Mask Architecture Training
-    //
-    // Backprop path: score → bilinear → mask_mlp → expr_embed → expr_proj
-    // Also updates: rule_mlp, interaction, rule_bias
-    // Backbone (embeddings, w1, b1) is FROZEN during mask training.
-    // =========================================================================
-
-    // =========================================================================
-    // Forward with Hidden (for backprop)
-    // =========================================================================
-
-    /// Mask MLP forward storing hidden activations.
-    fn mask_mlp_forward_with_hidden(
-        &self,
-        expr_embed: &[f32; EMBED_DIM],
-    ) -> ([f32; EMBED_DIM], [f32; MLP_HIDDEN]) {
-        // First layer
-        let mut h = self.mask_mlp_b1;
-        for i in 0..EMBED_DIM {
-            for j in 0..MLP_HIDDEN {
-                h[j] += expr_embed[i] * self.mask_mlp_w1[i][j];
-            }
-        }
-
-        // Store pre-ReLU for backprop (we need to know which neurons were active)
-        let h_pre_relu = h;
-
-        // ReLU
-        for j in 0..MLP_HIDDEN {
-            h[j] = h[j].max(0.0);
-        }
-
-        // Second layer
-        let mut out = self.mask_mlp_b2;
-        for j in 0..MLP_HIDDEN {
-            for k in 0..EMBED_DIM {
-                out[k] += h[j] * self.mask_mlp_w2[j][k];
-            }
-        }
-
-        (out, h_pre_relu)
-    }
-
-    /// Rule MLP forward storing hidden activations.
-    fn rule_mlp_forward_with_hidden(
-        &self,
-        rule_features: &[f32; RULE_FEATURE_DIM],
-    ) -> ([f32; EMBED_DIM], [f32; MLP_HIDDEN]) {
-        // First layer
-        let mut h = self.rule_mlp_b1;
-        for i in 0..RULE_FEATURE_DIM {
-            for j in 0..MLP_HIDDEN {
-                h[j] += rule_features[i] * self.rule_mlp_w1[i][j];
-            }
-        }
-
-        let h_pre_relu = h;
-
-        // ReLU
-        for j in 0..MLP_HIDDEN {
-            h[j] = h[j].max(0.0);
-        }
-
-        // Second layer
-        let mut out = self.rule_mlp_b2;
-        for j in 0..MLP_HIDDEN {
-            for k in 0..EMBED_DIM {
-                out[k] += h[j] * self.rule_mlp_w2[j][k];
-            }
-        }
-
-        (out, h_pre_relu)
-    }
-
-    /// Value MLP forward storing hidden activations.
-    fn value_mlp_forward_with_hidden(
-        &self,
-        expr_embed: &[f32; EMBED_DIM],
-    ) -> (f32, [f32; MLP_HIDDEN]) {
-        // First layer
-        let mut h = self.value_mlp_b1;
-        for i in 0..EMBED_DIM {
-            for j in 0..MLP_HIDDEN {
-                h[j] += expr_embed[i] * self.value_mlp_w1[i][j];
-            }
-        }
-
-        let h_pre_relu = h;
-
-        // ReLU
-        for j in 0..MLP_HIDDEN {
-            h[j] = h[j].max(0.0);
-        }
-
-        // Second layer
-        let mut cost = self.value_mlp_b2;
-        for j in 0..MLP_HIDDEN {
-            cost += h[j] * self.value_mlp_w2[j];
-        }
-
-        (cost, h_pre_relu)
-    }
-
-    /// Bilinear forward storing transformed vector.
-    fn bilinear_forward_with_hidden(
-        &self,
-        mask_features: &[f32; EMBED_DIM],
-        rule_embed: &[f32; EMBED_DIM],
-    ) -> (f32, [f32; EMBED_DIM]) {
-        // transformed = mask_features @ interaction
-        let mut transformed = [0.0f32; EMBED_DIM];
-        for i in 0..EMBED_DIM {
-            for j in 0..EMBED_DIM {
-                transformed[j] += mask_features[i] * self.interaction[i][j];
-            }
-        }
-
-        // score = dot(transformed + mask_bias_proj, rule_embed)
-        let mut score = 0.0f32;
-        for k in 0..EMBED_DIM {
-            score += (transformed[k] + self.mask_bias_proj[k]) * rule_embed[k];
-        }
-
-        (score, transformed)
-    }
-
-    // =========================================================================
-    // Backpropagation Helpers
-    // =========================================================================
-
-    /// Backprop through bilinear layer.
-    ///
-    /// Returns (d_mask_features, d_rule_embed) and updates interaction matrix.
-    fn backprop_bilinear(
-        &mut self,
-        d_score: f32,
-        mask_features: &[f32; EMBED_DIM],
-        rule_embed: &[f32; EMBED_DIM],
-        transformed: &[f32; EMBED_DIM],
-        lr: f32,
-    ) -> ([f32; EMBED_DIM], [f32; EMBED_DIM]) {
-        // d_score/d_transformed = rule_embed
-        // d_score/d_rule_embed = transformed
-        let mut d_transformed = [0.0f32; EMBED_DIM];
-        let mut d_rule_embed = [0.0f32; EMBED_DIM];
-
-        for k in 0..EMBED_DIM {
-            d_transformed[k] = d_score * rule_embed[k];
-            d_rule_embed[k] = d_score * transformed[k];
-        }
-
-        // d_transformed/d_mask_features = interaction^T
-        // d_transformed/d_interaction = outer(mask_features, I)
-        let mut d_mask_features = [0.0f32; EMBED_DIM];
-        for i in 0..EMBED_DIM {
-            for j in 0..EMBED_DIM {
-                d_mask_features[i] += d_transformed[j] * self.interaction[i][j];
-                // Update interaction: d_loss/d_interaction[i][j] = mask_features[i] * d_transformed[j]
-                self.interaction[i][j] -= lr * mask_features[i] * d_transformed[j];
-            }
-        }
-
-        (d_mask_features, d_rule_embed)
-    }
-
-    /// Backprop through mask MLP.
-    ///
-    /// Returns d_expr_embed and updates mask_mlp weights.
-    fn backprop_mask_mlp(
-        &mut self,
-        d_out: &[f32; EMBED_DIM],
-        expr_embed: &[f32; EMBED_DIM],
-        h_pre_relu: &[f32; MLP_HIDDEN],
-        lr: f32,
-    ) -> [f32; EMBED_DIM] {
-        // d_out → w2, b2
-        // d_h (post-ReLU) = d_out @ w2^T
-        let mut d_h = [0.0f32; MLP_HIDDEN];
-        for j in 0..MLP_HIDDEN {
-            for k in 0..EMBED_DIM {
-                d_h[j] += d_out[k] * self.mask_mlp_w2[j][k];
-                // Update w2
-                let h_relu = h_pre_relu[j].max(0.0);
-                self.mask_mlp_w2[j][k] -= lr * h_relu * d_out[k];
-            }
-        }
-
-        // Update b2
-        for k in 0..EMBED_DIM {
-            self.mask_mlp_b2[k] -= lr * d_out[k];
-        }
-
-        // ReLU backward
-        for j in 0..MLP_HIDDEN {
-            if h_pre_relu[j] <= 0.0 {
-                d_h[j] = 0.0;
-            }
-        }
-
-        // d_h → w1, b1, d_expr_embed
-        let mut d_expr_embed = [0.0f32; EMBED_DIM];
-        for i in 0..EMBED_DIM {
-            for j in 0..MLP_HIDDEN {
-                d_expr_embed[i] += d_h[j] * self.mask_mlp_w1[i][j];
-                // Update w1
-                self.mask_mlp_w1[i][j] -= lr * expr_embed[i] * d_h[j];
-            }
-        }
-
-        // Update b1
-        for j in 0..MLP_HIDDEN {
-            self.mask_mlp_b1[j] -= lr * d_h[j];
-        }
-
-        d_expr_embed
-    }
-
-    /// Backprop through rule MLP.
-    ///
-    /// Updates rule_mlp weights. Rule features are fixed, so no gradient returned.
-    fn backprop_rule_mlp(
-        &mut self,
-        d_out: &[f32; EMBED_DIM],
-        rule_features: &[f32; RULE_FEATURE_DIM],
-        h_pre_relu: &[f32; MLP_HIDDEN],
-        lr: f32,
-    ) {
-        // d_out → w2, b2
-        let mut d_h = [0.0f32; MLP_HIDDEN];
-        for j in 0..MLP_HIDDEN {
-            for k in 0..EMBED_DIM {
-                d_h[j] += d_out[k] * self.rule_mlp_w2[j][k];
-                let h_relu = h_pre_relu[j].max(0.0);
-                self.rule_mlp_w2[j][k] -= lr * h_relu * d_out[k];
-            }
-        }
-
-        // Update b2
-        for k in 0..EMBED_DIM {
-            self.rule_mlp_b2[k] -= lr * d_out[k];
-        }
-
-        // ReLU backward
-        for j in 0..MLP_HIDDEN {
-            if h_pre_relu[j] <= 0.0 {
-                d_h[j] = 0.0;
-            }
-        }
-
-        // d_h → w1, b1
-        for i in 0..RULE_FEATURE_DIM {
-            for j in 0..MLP_HIDDEN {
-                self.rule_mlp_w1[i][j] -= lr * rule_features[i] * d_h[j];
-            }
-        }
-
-        for j in 0..MLP_HIDDEN {
-            self.rule_mlp_b1[j] -= lr * d_h[j];
-        }
-    }
-
-    /// Backprop through value MLP.
-    ///
-    /// Returns d_expr_embed and updates value_mlp weights.
-    fn backprop_value_mlp(
-        &mut self,
-        d_cost: f32,
-        expr_embed: &[f32; EMBED_DIM],
-        h_pre_relu: &[f32; MLP_HIDDEN],
-        lr: f32,
-    ) -> [f32; EMBED_DIM] {
-        // d_cost → w2, b2
-        let mut d_h = [0.0f32; MLP_HIDDEN];
-        for j in 0..MLP_HIDDEN {
-            d_h[j] = d_cost * self.value_mlp_w2[j];
-            let h_relu = h_pre_relu[j].max(0.0);
-            self.value_mlp_w2[j] -= lr * h_relu * d_cost;
-        }
-
-        self.value_mlp_b2 -= lr * d_cost;
-
-        // ReLU backward
-        for j in 0..MLP_HIDDEN {
-            if h_pre_relu[j] <= 0.0 {
-                d_h[j] = 0.0;
-            }
-        }
-
-        // d_h → w1, b1, d_expr_embed
-        let mut d_expr_embed = [0.0f32; EMBED_DIM];
-        for i in 0..EMBED_DIM {
-            for j in 0..MLP_HIDDEN {
-                d_expr_embed[i] += d_h[j] * self.value_mlp_w1[i][j];
-                self.value_mlp_w1[i][j] -= lr * expr_embed[i] * d_h[j];
-            }
-        }
-
-        for j in 0..MLP_HIDDEN {
-            self.value_mlp_b1[j] -= lr * d_h[j];
-        }
-
-        d_expr_embed
-    }
-}
-
-/// Dot product of two arrays.
-#[inline]
-fn dot(a: &[f32; HIDDEN_DIM], b: &[f32; HIDDEN_DIM]) -> f32 {
-    let mut sum = 0.0;
-    for i in 0..HIDDEN_DIM {
-        sum += a[i] * b[i];
-    }
-    sum
-}
-
-/// Sigmoid activation.
-#[inline]
-fn sigmoid(x: f32) -> f32 {
-    1.0 / (1.0 + libm::expf(-x))
-}
-
-/// Softmax with temperature scaling.
-///
-/// `softmax(x_i / temp)` - higher temperature = more uniform distribution.
-#[must_use]
-fn softmax_with_temperature(logits: &[f32], temperature: f32) -> Vec<f32> {
-    if logits.is_empty() {
-        return Vec::new();
-    }
-
-    let temp = temperature.max(0.01); // Avoid division by zero
-
-    // Scale by temperature
-    let scaled: Vec<f32> = logits.iter().map(|&x| x / temp).collect();
-
-    // Numerical stability: subtract max
-    let max_val = scaled.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
-    let exps: Vec<f32> = scaled.iter().map(|&x| libm::expf(x - max_val)).collect();
-    let sum: f32 = exps.iter().sum();
-
-    if sum < 1e-10 {
-        // Uniform fallback
-        vec![1.0 / logits.len() as f32; logits.len()]
-    } else {
-        exps.iter().map(|&e| e / sum).collect()
     }
 }
 
@@ -3388,193 +1739,18 @@ mod tests {
 
     #[test]
     fn consolidated_param_count() {
-        // Param count should include backbone + all unified heads
+        // Param count should include the whole backbone + value head.
         let count = ExprNnue::param_count();
-        // Backbone: embeddings + w1 + b1 = ~9,728
-        // Plus: expr_proj + value_mlp + mask_mlp + rule_mlp + rule_proj + interaction + bias
+        // Backbone (embeddings + w1 + b1 + trunk) ~13,808, plus expr_proj +
+        // value_mlp ~3,089 = 16,897 live params (67,588 bytes) — see
+        // `Self::save`'s doc for the split from the saturation head's
+        // (separately-checkpointed) weights.
         assert!(count > 10_000, "Should have >10k params, got {}", count);
         assert!(
             ExprNnue::memory_bytes() < 200_000,
             "NNUE should use < 200KB, got {} bytes",
             ExprNnue::memory_bytes()
         );
-    }
-
-    // ========================================================================
-    // Unified Mask Architecture Tests
-    // ========================================================================
-
-    #[test]
-    fn rule_features_initialization() {
-        let mut rule_features = RuleFeatures::new();
-
-        // All features should be zero initially
-        for r in 0..10 {
-            for f in rule_features.get(r) {
-                assert!(*f == 0.0, "Initial features should be zero");
-            }
-        }
-
-        // Set features for a rule
-        rule_features.set(0, [0.25, 0.3, 1.0, 1.0, 0.0, 1.0, 0.5, 1.0]);
-        let features = rule_features.get(0);
-        assert!((features[0] - 0.25).abs() < 1e-6, "Category should be set");
-        assert!(
-            (features[3] - 1.0).abs() < 1e-6,
-            "Commutative flag should be set"
-        );
-    }
-
-    #[test]
-    fn encode_rule_deterministic() {
-        let net = ExprNnue::new_random(42);
-        let features = [0.25, 0.3, 1.0, 1.0, 0.0, 1.0, 0.5, 1.0];
-
-        let embed1 = net.encode_rule(&features);
-        let embed2 = net.encode_rule(&features);
-
-        // Same input should produce same output
-        for i in 0..EMBED_DIM {
-            assert!(
-                (embed1[i] - embed2[i]).abs() < 1e-6,
-                "encode_rule should be deterministic at dim {}",
-                i
-            );
-        }
-
-        // Embedding should be finite
-        for i in 0..EMBED_DIM {
-            assert!(
-                embed1[i].is_finite(),
-                "Rule embedding should be finite at dim {}",
-                i
-            );
-        }
-    }
-
-    #[test]
-    fn verify_encode_all_rules() {
-        let net = ExprNnue::new_random(42);
-        let mut rule_features = RuleFeatures::new();
-
-        // Set up a few rules with different features
-        rule_features.set(0, [0.0, 0.2, 0.0, 1.0, 0.0, 0.0, 0.1, 0.0]); // algebraic
-        rule_features.set(1, [0.25, 0.5, -1.0, 0.0, 1.0, 1.0, 0.3, 0.0]); // peephole
-        rule_features.set(2, [0.75, 0.8, 1.0, 0.0, 0.0, 0.0, 0.05, 1.0]); // cross-cutting
-
-        let embeds = net.encode_all_rules(&rule_features, 3);
-
-        assert_eq!(embeds.len(), 3, "Should encode exactly 3 rules");
-
-        // Each embedding should be finite
-        for (r, embed) in embeds.iter().enumerate() {
-            for (d, &val) in embed.iter().enumerate() {
-                assert!(val.is_finite(), "Rule {} dim {} should be finite", r, d);
-            }
-        }
-
-        // Different features should produce different embeddings
-        let diff_01: f32 = embeds[0]
-            .iter()
-            .zip(embeds[1].iter())
-            .map(|(a, b)| (a - b).abs())
-            .sum();
-        let diff_02: f32 = embeds[0]
-            .iter()
-            .zip(embeds[2].iter())
-            .map(|(a, b)| (a - b).abs())
-            .sum();
-
-        assert!(
-            diff_01 > 1e-3,
-            "Different rules should have different embeddings"
-        );
-        assert!(
-            diff_02 > 1e-3,
-            "Different rules should have different embeddings"
-        );
-    }
-
-    #[test]
-    fn bilinear_score_computation() {
-        let net = ExprNnue::new_random(42);
-
-        // Create test vectors
-        let mask_features = [1.0f32; EMBED_DIM];
-        let rule_embed = [1.0f32; EMBED_DIM];
-
-        let score = net.bilinear_score(&mask_features, &rule_embed);
-
-        assert!(score.is_finite(), "Bilinear score should be finite");
-
-        // Manual verification: score = dot(mask @ interaction + bias_proj, rule)
-        // With all-ones vectors: sum of interaction matrix + sum of bias_proj
-        let mut expected = 0.0f32;
-        for i in 0..EMBED_DIM {
-            for j in 0..EMBED_DIM {
-                expected += net.interaction[i][j];
-            }
-        }
-        for k in 0..EMBED_DIM {
-            expected += net.mask_bias_proj[k];
-        }
-        assert!(
-            (score - expected).abs() < 1e-4,
-            "Bilinear computation mismatch: got {}, expected {}",
-            score,
-            expected
-        );
-    }
-
-    #[test]
-    fn verify_randomize_mask_only() {
-        let mut net = ExprNnue::new();
-
-        // Set some backbone values that should be preserved
-        net.embeddings.e[OpKind::Var][0] = 1.234;
-        net.w1[0][0] = 5.678;
-        net.b1[0] = 0.999;
-        net.expr_proj_w[0][0] = 2.345; // shared projection - should be preserved
-
-        // Initially mask-specific weights should be zero
-        let initial_mask_sum: f32 = net.mask_mlp_w1.iter().flatten().map(|x| x.abs()).sum();
-        assert!(
-            initial_mask_sum < 1e-6,
-            "Initial mask weights should be zero"
-        );
-
-        // Randomize mask-only
-        net.randomize_mask_only(42);
-
-        // Backbone should be PRESERVED
-        assert!(
-            (net.embeddings.e[OpKind::Var][0] - 1.234).abs() < 1e-6,
-            "Embeddings should be preserved"
-        );
-        assert!(
-            (net.w1[0][0] - 5.678).abs() < 1e-6,
-            "w1 should be preserved"
-        );
-        assert!((net.b1[0] - 0.999).abs() < 1e-6, "b1 should be preserved");
-        assert!(
-            (net.expr_proj_w[0][0] - 2.345).abs() < 1e-6,
-            "expr_proj should be preserved"
-        );
-
-        // Mask-specific weights should now be non-zero
-        let final_mask_sum: f32 = net.mask_mlp_w1.iter().flatten().map(|x| x.abs()).sum();
-        assert!(
-            final_mask_sum > 1.0,
-            "Randomized mask weights should be non-zero"
-        );
-
-        // Interaction matrix should be near identity diagonal
-        for i in 0..EMBED_DIM {
-            assert!(
-                (net.interaction[i][i] - 1.0).abs() < 0.5,
-                "Diagonal of interaction should be near 1.0"
-            );
-        }
     }
 
     // ========================================================================
@@ -3606,177 +1782,5 @@ mod tests {
             );
         }
         assert_eq!(acc.edge_count, 0);
-    }
-
-    // ========================================================================
-    // structural_hash and from_expr_dedup tests
-    // ========================================================================
-
-    // ========================================================================
-    // GraphAccumulator normalization tests
-    // ========================================================================
-
-    #[test]
-    fn graph_acc_normalize_unit_norm_per_section() {
-        let emb = OpEmbeddings::new_random(42);
-        let mut gacc = GraphAccumulator::new();
-        // Build a non-trivial accumulator: several edges
-        gacc.add_edge(&emb, OpKind::Add, OpKind::Mul);
-        gacc.add_edge(&emb, OpKind::Mul, OpKind::Var);
-        gacc.add_edge(&emb, OpKind::Mul, OpKind::Var);
-        gacc.add_edge(&emb, OpKind::Add, OpKind::Var);
-
-        let normed = gacc.normalized();
-
-        // Each section should have L2 norm ~1.0
-        let section_norm = |start: usize, end: usize| -> f32 {
-            let sum_sq: f32 = normed.values[start..end].iter().map(|v| v * v).sum();
-            sqrtf(sum_sq)
-        };
-        let eps = 1e-5;
-        assert!(
-            (section_norm(0, K) - 1.0).abs() < eps,
-            "parent section norm should be 1.0"
-        );
-        assert!(
-            (section_norm(K, 2 * K) - 1.0).abs() < eps,
-            "child section norm should be 1.0"
-        );
-        assert!(
-            (section_norm(2 * K, 3 * K) - 1.0).abs() < eps,
-            "1-hop VSA section norm should be 1.0"
-        );
-        // 2-hop section is zero (no 2-hop edges added) — normalization should leave it as zeros.
-        let hop2_norm = section_norm(3 * K, 4 * K);
-        assert!(
-            hop2_norm < eps,
-            "2-hop VSA section should be zero when no 2-hop edges added, got {hop2_norm}"
-        );
-    }
-
-    #[test]
-    fn graph_acc_normalize_scalars_preserved() {
-        let emb = OpEmbeddings::new_random(42);
-        let mut gacc = GraphAccumulator::new();
-        gacc.add_edge(&emb, OpKind::Add, OpKind::Mul);
-        gacc.add_leaf();
-        gacc.add_leaf();
-        gacc.node_budget = 100;
-        gacc.epoch_budget = 50;
-
-        let normed = gacc.normalized();
-        assert_eq!(
-            normed.edge_count, gacc.edge_count,
-            "edge_count must be preserved"
-        );
-        assert_eq!(
-            normed.node_count, gacc.node_count,
-            "node_count must be preserved"
-        );
-        assert_eq!(
-            normed.node_budget, gacc.node_budget,
-            "node_budget must be preserved"
-        );
-        assert_eq!(
-            normed.epoch_budget, gacc.epoch_budget,
-            "epoch_budget must be preserved"
-        );
-    }
-
-    #[test]
-    fn graph_acc_normalize_zero_is_safe() {
-        // A fresh (zero) accumulator should normalize without NaN/Inf.
-        let gacc = GraphAccumulator::new();
-        let normed = gacc.normalized();
-        for (i, &v) in normed.values.iter().enumerate() {
-            assert!(v.is_finite(), "values[{i}] must be finite, got {v}");
-            assert_eq!(
-                v, 0.0,
-                "zero accumulator must stay zero after normalization"
-            );
-        }
-    }
-
-    #[test]
-    fn graph_acc_normalize_in_place_matches_normalized() {
-        let emb = OpEmbeddings::new_random(42);
-        let mut gacc = GraphAccumulator::new();
-        gacc.add_edge(&emb, OpKind::Add, OpKind::Mul);
-        gacc.add_edge(&emb, OpKind::Mul, OpKind::Var);
-
-        let copy_normed = gacc.normalized();
-
-        let mut in_place = gacc.clone();
-        in_place.normalize_in_place();
-
-        for i in 0..GRAPH_ACC_DIM {
-            assert!(
-                (copy_normed.values[i] - in_place.values[i]).abs() < 1e-9,
-                "values[{i}] mismatch: normalized()={} vs normalize_in_place()={}",
-                copy_normed.values[i],
-                in_place.values[i]
-            );
-        }
-    }
-
-    #[test]
-    fn graph_acc_normalize_scale_invariance() {
-        // Doubling all edges (adding each edge twice) should yield the same
-        // normalized vector, proving scale invariance.
-        let emb = OpEmbeddings::new_random(42);
-
-        let mut small = GraphAccumulator::new();
-        small.add_edge(&emb, OpKind::Add, OpKind::Mul);
-        small.add_edge(&emb, OpKind::Mul, OpKind::Var);
-
-        let mut large = GraphAccumulator::new();
-        for _ in 0..10 {
-            large.add_edge(&emb, OpKind::Add, OpKind::Mul);
-            large.add_edge(&emb, OpKind::Mul, OpKind::Var);
-        }
-
-        let small_n = small.normalized();
-        let large_n = large.normalized();
-
-        for i in 0..GRAPH_ACC_DIM {
-            assert!(
-                (small_n.values[i] - large_n.values[i]).abs() < 1e-5,
-                "normalized vectors should match regardless of scale: values[{i}] small={} large={}",
-                small_n.values[i],
-                large_n.values[i]
-            );
-        }
-    }
-
-    #[test]
-    fn graph_acc_normalize_idempotent() {
-        // Normalizing twice should produce the same result.
-        let emb = OpEmbeddings::new_random(42);
-        let mut gacc = GraphAccumulator::new();
-        gacc.add_edge(&emb, OpKind::Add, OpKind::Mul);
-        gacc.add_edge(&emb, OpKind::Mul, OpKind::Var);
-
-        let once = gacc.normalized();
-        let twice = once.normalized();
-
-        for i in 0..GRAPH_ACC_DIM {
-            assert!(
-                (once.values[i] - twice.values[i]).abs() < 1e-6,
-                "normalization must be idempotent: values[{i}] once={} twice={}",
-                once.values[i],
-                twice.values[i]
-            );
-        }
-    }
-
-    // ========================================================================
-    // GraphAccumulator incremental remove tests
-    // ========================================================================
-
-    #[test]
-    fn graph_acc_remove_leaf_saturates_at_zero() {
-        let mut acc = GraphAccumulator::new();
-        acc.remove_leaf();
-        assert_eq!(acc.node_count, 0, "node_count must not underflow");
     }
 }

--- a/pixelflow-search/src/nnue/guide/accumulator.rs
+++ b/pixelflow-search/src/nnue/guide/accumulator.rs
@@ -1,0 +1,518 @@
+//! `GraphAccumulator`: VSA encoding of e-graph state.
+//!
+//! Private implementation detail of the [`super::SaturationGuide`] contract —
+//! nothing outside `nnue::guide` names this type. See the module doc on
+//! [`super`] for why it exists and why it is inert today.
+//!
+//! `#![allow(dead_code)]`: every mutator below is exercised only by this
+//! module's own characterization tests (see `docs/plans/2026-07-07-guided-
+//! saturation-redesign.md`, Phase 3 — not started). That is a fact about the
+//! roadmap, not a bug in this file; suppressing the lint here says exactly
+//! that, rather than a `pub` visibility silently hiding the same truth the
+//! way the pre-encapsulation code did.
+#![allow(dead_code)]
+
+use libm::sqrtf;
+
+use super::{shift_by, shift1};
+use crate::nnue::factored::{K, OpEmbeddings, OpKind};
+
+/// Graph accumulator dimension: marginals (2K) + 1-hop VSA binding (K) + 2-hop VSA binding (K).
+pub(crate) const GRAPH_ACC_DIM: usize = 4 * K; // 128
+
+/// VSA accumulator for e-graph state (rebuilt each epoch).
+///
+/// Three-section encoding captures both marginal and joint op distributions:
+///
+/// | Section | Dim | Operation | Signal |
+/// |---------|-----|-----------|--------|
+/// | `[0..K]` | K | `Σ E[parent]` | Marginal: which ops appear as parents |
+/// | `[K..2K]` | K | `Σ E[child]` | Marginal: which ops appear as children |
+/// | `[2K..3K]` | K | `Σ E[parent] ⊙ shift₁(E[child])` | **1-hop VSA binding**: which ops are connected |
+/// | `[3K..4K]` | K | `Σ E[gp] ⊙ shift₁(E[par]) ⊙ shift²(E[child])` | **2-hop VSA binding**: 3-node path patterns |
+///
+/// The 1-hop binding section uses element-wise Hadamard product with a cyclic shift to
+/// break commutativity (`Mul→Add ≠ Add→Mul`). This captures the **joint**
+/// distribution of parent-child pairs — strictly more informative than marginals
+/// alone.
+///
+/// The 2-hop binding section extends this to 3-node paths (grandparent→parent→child),
+/// capturing patterns like "Mul feeding Add feeding Sqrt" which is exactly what
+/// rewrite rules match on. This turns the accumulator from a 0-round GNN into
+/// a 1-round GNN.
+///
+/// Shares `OpEmbeddings` with the extraction head — same learned op embeddings,
+/// different downstream pathway.
+#[derive(Clone)]
+pub(crate) struct GraphAccumulator {
+    /// `[0..K]`:    marginal parent sum     `Σ E[parent]`
+    /// `[K..2K]`:   marginal child sum      `Σ E[child]`
+    /// `[2K..3K]`:  1-hop VSA binding sum   `Σ E[parent] ⊙ shift_by(E[child], depth)`
+    /// `[3K..4K]`:  2-hop VSA binding sum   `Σ E[gp] ⊙ shift₁(E[par]) ⊙ shift²(E[child])`
+    pub(crate) values: [f32; GRAPH_ACC_DIM],
+    /// Number of edges added to the accumulator.
+    pub(crate) edge_count: u32,
+    /// Number of nodes (ops + leaves) in the graph.
+    pub(crate) node_count: u32,
+    /// E-graph node budget for this trajectory (how many nodes the saturator may create).
+    pub(crate) node_budget: u32,
+    /// Epoch budget for this trajectory (max saturation epochs).
+    pub(crate) epoch_budget: u32,
+}
+
+impl Default for GraphAccumulator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GraphAccumulator {
+    /// Create a zero-initialized graph accumulator.
+    #[must_use]
+    pub(crate) fn new() -> Self {
+        Self {
+            values: [0.0; GRAPH_ACC_DIM],
+            edge_count: 0,
+            node_count: 0,
+            node_budget: 0,
+            epoch_budget: 0,
+        }
+    }
+
+    /// Reset to zero state.
+    ///
+    /// Budget fields are intentionally NOT reset — they are trajectory-level
+    /// properties that should persist across epoch rebuilds.
+    pub(crate) fn reset(&mut self) {
+        self.values = [0.0; GRAPH_ACC_DIM];
+        self.edge_count = 0;
+        self.node_count = 0;
+    }
+
+    /// Add a single edge with depth-aware VSA encoding.
+    ///
+    /// Updates all three sections: marginal parent, marginal child, and
+    /// VSA binding (`E[parent] ⊙ shift_by(E[child], depth % K)`).
+    ///
+    /// At `depth == 0` the shift is the identity (root edges), `depth == 1`
+    /// shifts by 1 (matching the original `shift1` behavior), `depth == 2`
+    /// shifts by 2, etc. This encodes hierarchical position into the binding
+    /// without any extra parameters.
+    #[inline]
+    pub(crate) fn add_edge_at_depth(
+        &mut self,
+        emb: &OpEmbeddings,
+        parent_op: OpKind,
+        child_op: OpKind,
+        depth: usize,
+    ) {
+        let p = emb.get(parent_op);
+        let c = emb.get(child_op);
+        let c_shifted = shift_by(c, depth);
+        for i in 0..K {
+            self.values[i] += p[i]; // marginal parent
+            self.values[K + i] += c[i]; // marginal child
+            self.values[2 * K + i] += p[i] * c_shifted[i]; // VSA binding
+        }
+        self.edge_count += 1;
+    }
+
+    /// Add a single edge with VSA encoding (backward-compatible, depth = 1).
+    ///
+    /// Equivalent to `add_edge_at_depth(emb, parent_op, child_op, 1)`.
+    /// Preserves the original `shift1` behavior for callers that do not
+    /// track depth.
+    #[inline]
+    pub(crate) fn add_edge(&mut self, emb: &OpEmbeddings, parent_op: OpKind, child_op: OpKind) {
+        self.add_edge_at_depth(emb, parent_op, child_op, 1);
+    }
+
+    /// Add a leaf node (Var/Const) — no edges, just increment node count.
+    pub(crate) fn add_leaf(&mut self) {
+        self.node_count += 1;
+    }
+
+    /// Add an Op node and all its edges to children, with depth-aware VSA.
+    ///
+    /// Emits one `add_edge_at_depth` per child and increments `node_count`
+    /// once.  The `depth` parameter is the depth of `op` in the expression
+    /// tree (0 = root).
+    pub(crate) fn add_op_node_at_depth(
+        &mut self,
+        emb: &OpEmbeddings,
+        op: OpKind,
+        child_ops: &[OpKind],
+        depth: usize,
+    ) {
+        for &child_op in child_ops {
+            self.add_edge_at_depth(emb, op, child_op, depth);
+        }
+        self.node_count += 1;
+    }
+
+    /// Add an Op node and all its edges to children (backward-compatible, depth = 1).
+    ///
+    /// Equivalent to `add_op_node_at_depth(emb, op, child_ops, 1)`.
+    pub(crate) fn add_op_node(&mut self, emb: &OpEmbeddings, op: OpKind, child_ops: &[OpKind]) {
+        self.add_op_node_at_depth(emb, op, child_ops, 1);
+    }
+
+    // ========== Incremental Removal (inverse of addition) ==========
+
+    /// Remove a single edge with depth-aware VSA encoding — the exact
+    /// inverse of [`Self::add_edge_at_depth`].
+    ///
+    /// Subtracts (instead of adds) the parent, child, and VSA binding
+    /// contributions from each section. Decrements `edge_count` via
+    /// saturating subtraction so underflow clamps to zero rather than
+    /// wrapping.
+    ///
+    /// # Contract
+    ///
+    /// Callers must only remove edges that were previously added at the
+    /// same `depth`. Removing an edge that was never added will corrupt
+    /// the accumulator values (negative contributions) and is a logic
+    /// error.
+    #[inline]
+    pub(crate) fn remove_edge_at_depth(
+        &mut self,
+        emb: &OpEmbeddings,
+        parent_op: OpKind,
+        child_op: OpKind,
+        depth: usize,
+    ) {
+        let p = emb.get(parent_op);
+        let c = emb.get(child_op);
+        let c_shifted = shift_by(c, depth);
+        for i in 0..K {
+            self.values[i] -= p[i]; // marginal parent
+            self.values[K + i] -= c[i]; // marginal child
+            self.values[2 * K + i] -= p[i] * c_shifted[i]; // VSA binding
+        }
+        self.edge_count = self.edge_count.saturating_sub(1);
+    }
+
+    /// Remove a single edge (backward-compatible, depth = 1) — the exact
+    /// inverse of [`Self::add_edge`].
+    ///
+    /// Equivalent to `remove_edge_at_depth(emb, parent_op, child_op, 1)`.
+    #[inline]
+    pub(crate) fn remove_edge(&mut self, emb: &OpEmbeddings, parent_op: OpKind, child_op: OpKind) {
+        self.remove_edge_at_depth(emb, parent_op, child_op, 1);
+    }
+
+    /// Remove an Op node and all its edges to children with depth-aware
+    /// VSA — the exact inverse of [`Self::add_op_node_at_depth`].
+    ///
+    /// Calls `remove_edge_at_depth` for each child and decrements
+    /// `node_count`.
+    pub(crate) fn remove_op_node_at_depth(
+        &mut self,
+        emb: &OpEmbeddings,
+        op: OpKind,
+        child_ops: &[OpKind],
+        depth: usize,
+    ) {
+        for &child_op in child_ops {
+            self.remove_edge_at_depth(emb, op, child_op, depth);
+        }
+        self.node_count = self.node_count.saturating_sub(1);
+    }
+
+    /// Remove an Op node and all its edges (backward-compatible, depth = 1)
+    /// — the exact inverse of [`Self::add_op_node`].
+    ///
+    /// Equivalent to `remove_op_node_at_depth(emb, op, child_ops, 1)`.
+    pub(crate) fn remove_op_node(&mut self, emb: &OpEmbeddings, op: OpKind, child_ops: &[OpKind]) {
+        self.remove_op_node_at_depth(emb, op, child_ops, 1);
+    }
+
+    /// Remove a leaf node — the exact inverse of [`Self::add_leaf`].
+    ///
+    /// Decrements `node_count` only (leaves contribute no edges).
+    pub(crate) fn remove_leaf(&mut self) {
+        self.node_count = self.node_count.saturating_sub(1);
+    }
+
+    // ========== 2-hop Message Passing (1-round GNN) ==========
+
+    /// Add a 2-hop (grandparent→parent→child) binding to the `[3K..4K]` section.
+    ///
+    /// Encodes 3-node path patterns like "Mul feeding Add feeding Sqrt" using
+    /// the VSA triple product `E[grandparent] ⊙ shift₁(E[parent]) ⊙ shift²(E[child])`.
+    /// The shift amounts break commutativity: `A→B→C` produces a different
+    /// binding than any permutation of {A, B, C}.
+    ///
+    /// Does NOT modify the `[0..3K]` sections or `edge_count`/`node_count` —
+    /// those are maintained by `add_edge*` / `add_op_node*`.
+    #[inline]
+    pub(crate) fn add_2hop_edge(
+        &mut self,
+        emb: &OpEmbeddings,
+        grandparent_op: OpKind,
+        parent_op: OpKind,
+        child_op: OpKind,
+    ) {
+        let gp = emb.get(grandparent_op);
+        let p = shift1(emb.get(parent_op));
+        let c = shift_by(emb.get(child_op), 2);
+        for i in 0..K {
+            self.values[3 * K + i] += gp[i] * p[i] * c[i];
+        }
+    }
+
+    /// Remove a 2-hop (grandparent→parent→child) binding — the exact inverse
+    /// of [`Self::add_2hop_edge`].
+    ///
+    /// Subtracts the triple-product contribution from the `[3K..4K]` section.
+    ///
+    /// # Contract
+    ///
+    /// Callers must only remove 2-hop edges that were previously added with
+    /// the same (grandparent, parent, child) triple. Removing a path that was
+    /// never added will corrupt the accumulator values and is a logic error.
+    #[inline]
+    pub(crate) fn remove_2hop_edge(
+        &mut self,
+        emb: &OpEmbeddings,
+        grandparent_op: OpKind,
+        parent_op: OpKind,
+        child_op: OpKind,
+    ) {
+        let gp = emb.get(grandparent_op);
+        let p = shift1(emb.get(parent_op));
+        let c = shift_by(emb.get(child_op), 2);
+        for i in 0..K {
+            self.values[3 * K + i] -= gp[i] * p[i] * c[i];
+        }
+    }
+
+    /// Return a copy with each of the four sections independently L2-normalized.
+    ///
+    /// Raw sums grow proportionally to edge count, so a 200-edge graph has
+    /// values ~20x larger than a 10-edge graph.  Normalizing makes the
+    /// embedding scale-invariant: small rewrites on large graphs become visible
+    /// instead of being swamped by magnitude.
+    ///
+    /// Each section is normalized independently because they represent different
+    /// quantities with different natural scales:
+    /// - `[0..K]`    marginal parent sums
+    /// - `[K..2K]`   marginal child sums
+    /// - `[2K..3K]`  1-hop VSA binding sums
+    /// - `[3K..4K]`  2-hop VSA binding sums
+    ///
+    /// Scalar fields (`edge_count`, `node_count`, etc.) are copied as-is.
+    ///
+    /// A zero-norm section (no edges accumulated) is left as all-zeros rather
+    /// than producing NaN/Inf.
+    #[must_use]
+    pub(crate) fn normalized(&self) -> Self {
+        let mut out = self.clone();
+        out.normalize_in_place();
+        out
+    }
+
+    /// L2-normalize each of the four sections in place.
+    ///
+    /// See [`Self::normalized`] for rationale.
+    pub(crate) fn normalize_in_place(&mut self) {
+        l2_normalize_section(&mut self.values, 0, K);
+        l2_normalize_section(&mut self.values, K, 2 * K);
+        l2_normalize_section(&mut self.values, 2 * K, 3 * K);
+        l2_normalize_section(&mut self.values, 3 * K, 4 * K);
+    }
+}
+
+/// L2-normalize a contiguous slice `values[start..end]` in place.
+///
+/// If the section norm is zero (or negligibly small), it is left untouched
+/// to avoid division by zero.
+fn l2_normalize_section(values: &mut [f32], start: usize, end: usize) {
+    let mut sum_sq: f32 = 0.0;
+    for i in start..end {
+        sum_sq += values[i] * values[i];
+    }
+    let norm = sqrtf(sum_sq);
+    // Guard: skip normalization for zero/near-zero sections to avoid NaN/Inf.
+    if norm < 1e-12 {
+        return;
+    }
+    let inv_norm = 1.0 / norm;
+    for i in start..end {
+        values[i] *= inv_norm;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use libm::sqrtf;
+
+    // ========================================================================
+    // GraphAccumulator normalization tests
+    // ========================================================================
+
+    #[test]
+    fn graph_acc_normalize_unit_norm_per_section() {
+        let emb = OpEmbeddings::new_random(42);
+        let mut gacc = GraphAccumulator::new();
+        // Build a non-trivial accumulator: several edges
+        gacc.add_edge(&emb, OpKind::Add, OpKind::Mul);
+        gacc.add_edge(&emb, OpKind::Mul, OpKind::Var);
+        gacc.add_edge(&emb, OpKind::Mul, OpKind::Var);
+        gacc.add_edge(&emb, OpKind::Add, OpKind::Var);
+
+        let normed = gacc.normalized();
+
+        // Each section should have L2 norm ~1.0
+        let section_norm = |start: usize, end: usize| -> f32 {
+            let sum_sq: f32 = normed.values[start..end].iter().map(|v| v * v).sum();
+            sqrtf(sum_sq)
+        };
+        let eps = 1e-5;
+        assert!(
+            (section_norm(0, K) - 1.0).abs() < eps,
+            "parent section norm should be 1.0"
+        );
+        assert!(
+            (section_norm(K, 2 * K) - 1.0).abs() < eps,
+            "child section norm should be 1.0"
+        );
+        assert!(
+            (section_norm(2 * K, 3 * K) - 1.0).abs() < eps,
+            "1-hop VSA section norm should be 1.0"
+        );
+        // 2-hop section is zero (no 2-hop edges added) — normalization should leave it as zeros.
+        let hop2_norm = section_norm(3 * K, 4 * K);
+        assert!(
+            hop2_norm < eps,
+            "2-hop VSA section should be zero when no 2-hop edges added, got {hop2_norm}"
+        );
+    }
+
+    #[test]
+    fn graph_acc_normalize_scalars_preserved() {
+        let emb = OpEmbeddings::new_random(42);
+        let mut gacc = GraphAccumulator::new();
+        gacc.add_edge(&emb, OpKind::Add, OpKind::Mul);
+        gacc.add_leaf();
+        gacc.add_leaf();
+        gacc.node_budget = 100;
+        gacc.epoch_budget = 50;
+
+        let normed = gacc.normalized();
+        assert_eq!(
+            normed.edge_count, gacc.edge_count,
+            "edge_count must be preserved"
+        );
+        assert_eq!(
+            normed.node_count, gacc.node_count,
+            "node_count must be preserved"
+        );
+        assert_eq!(
+            normed.node_budget, gacc.node_budget,
+            "node_budget must be preserved"
+        );
+        assert_eq!(
+            normed.epoch_budget, gacc.epoch_budget,
+            "epoch_budget must be preserved"
+        );
+    }
+
+    #[test]
+    fn graph_acc_normalize_zero_is_safe() {
+        // A fresh (zero) accumulator should normalize without NaN/Inf.
+        let gacc = GraphAccumulator::new();
+        let normed = gacc.normalized();
+        for (i, &v) in normed.values.iter().enumerate() {
+            assert!(v.is_finite(), "values[{i}] must be finite, got {v}");
+            assert_eq!(
+                v, 0.0,
+                "zero accumulator must stay zero after normalization"
+            );
+        }
+    }
+
+    #[test]
+    fn graph_acc_normalize_in_place_matches_normalized() {
+        let emb = OpEmbeddings::new_random(42);
+        let mut gacc = GraphAccumulator::new();
+        gacc.add_edge(&emb, OpKind::Add, OpKind::Mul);
+        gacc.add_edge(&emb, OpKind::Mul, OpKind::Var);
+
+        let copy_normed = gacc.normalized();
+
+        let mut in_place = gacc.clone();
+        in_place.normalize_in_place();
+
+        for i in 0..GRAPH_ACC_DIM {
+            assert!(
+                (copy_normed.values[i] - in_place.values[i]).abs() < 1e-9,
+                "values[{i}] mismatch: normalized()={} vs normalize_in_place()={}",
+                copy_normed.values[i],
+                in_place.values[i]
+            );
+        }
+    }
+
+    #[test]
+    fn graph_acc_normalize_scale_invariance() {
+        // Doubling all edges (adding each edge twice) should yield the same
+        // normalized vector, proving scale invariance.
+        let emb = OpEmbeddings::new_random(42);
+
+        let mut small = GraphAccumulator::new();
+        small.add_edge(&emb, OpKind::Add, OpKind::Mul);
+        small.add_edge(&emb, OpKind::Mul, OpKind::Var);
+
+        let mut large = GraphAccumulator::new();
+        for _ in 0..10 {
+            large.add_edge(&emb, OpKind::Add, OpKind::Mul);
+            large.add_edge(&emb, OpKind::Mul, OpKind::Var);
+        }
+
+        let small_n = small.normalized();
+        let large_n = large.normalized();
+
+        for i in 0..GRAPH_ACC_DIM {
+            assert!(
+                (small_n.values[i] - large_n.values[i]).abs() < 1e-5,
+                "normalized vectors should match regardless of scale: values[{i}] small={} large={}",
+                small_n.values[i],
+                large_n.values[i]
+            );
+        }
+    }
+
+    #[test]
+    fn graph_acc_normalize_idempotent() {
+        // Normalizing twice should produce the same result.
+        let emb = OpEmbeddings::new_random(42);
+        let mut gacc = GraphAccumulator::new();
+        gacc.add_edge(&emb, OpKind::Add, OpKind::Mul);
+        gacc.add_edge(&emb, OpKind::Mul, OpKind::Var);
+
+        let once = gacc.normalized();
+        let twice = once.normalized();
+
+        for i in 0..GRAPH_ACC_DIM {
+            assert!(
+                (once.values[i] - twice.values[i]).abs() < 1e-6,
+                "normalization must be idempotent: values[{i}] once={} twice={}",
+                once.values[i],
+                twice.values[i]
+            );
+        }
+    }
+
+    // ========================================================================
+    // GraphAccumulator incremental remove tests
+    // ========================================================================
+
+    #[test]
+    fn graph_acc_remove_leaf_saturates_at_zero() {
+        let mut acc = GraphAccumulator::new();
+        acc.remove_leaf();
+        assert_eq!(acc.node_count, 0, "node_count must not underflow");
+    }
+}

--- a/pixelflow-search/src/nnue/guide/mod.rs
+++ b/pixelflow-search/src/nnue/guide/mod.rs
@@ -1,0 +1,163 @@
+//! # Saturation Guide (Phase 3 — not started)
+//!
+//! Given an e-graph's current state and a set of candidate rewrite-rule
+//! applications, produce per-candidate move-ordering scores to guide equality
+//! saturation. That sentence is the entire contract; see
+//! `docs/plans/2026-07-07-guided-saturation-redesign.md` for the design this
+//! module exists to satisfy once training lands, purely supervised on
+//! hindsight rule-provenance labels from `crate::egraph::labeler` — no
+//! REINFORCE, no self-play.
+//!
+//! **This module is inert today.** `GraphAccumulator::new()` appears in
+//! production only as an unused placeholder value; nothing calls
+//! [`SaturationGuide::score_candidates`] outside this module's own tests. The
+//! public surface below — the trait and [`Guide`]'s constructor — is
+//! deliberately the entire contract: every mask/graph/rule-projection weight,
+//! the VSA accumulator, and the bilinear scorer are private machinery behind
+//! it (`accumulator.rs`, `scoring.rs`), so a future Phase-3 trainer has one
+//! seam to fill in rather than a dozen public methods to pick from.
+//!
+//! Kept, not deleted: the 2026-08-17 disposition inventory confirmed zero
+//! non-test callers for this whole surface but a live roadmap role
+//! (ROADMAP-ADMITTED, `docs/plans/2026-08-17-cost-model-domain.md` §0 row J10).
+//! Encapsulating it here — rather than continuing to expose it as `pub` API
+//! on [`crate::nnue::factored::ExprNnue`] — is also what closes a real bug:
+//! before this change, `apply_unified_sgd` weight-decayed these
+//! randomly-initialized, never-trained parameters toward zero on every
+//! training run, and the shared "TRIE" checkpoint format serialized them as
+//! if they were live (roughly half the file's bytes). Neither is possible
+//! now: this module's weights are outside the trainer's gradient surface
+//! (`pixelflow-pipeline`'s `unified_backward` no longer imports anything from
+//! here) and outside the extraction head's checkpoint format entirely.
+
+mod accumulator;
+mod scoring;
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+
+use accumulator::GraphAccumulator;
+use scoring::SaturationHead;
+
+use crate::nnue::factored::{EMBED_DIM, ExprNnue, K};
+
+/// Cyclic rotation by `amount % K` positions (generalised VSA permutation).
+///
+/// Shared by [`accumulator::GraphAccumulator`]'s VSA bindings. `shift_by(emb,
+/// 0)` is the identity; higher amounts encode hierarchical depth so that
+/// `Add(Add(X,Y),Z)` and `Add(X,Add(Y,Z))` bind to different vectors.
+#[inline]
+fn shift_by(emb: &[f32; K], amount: usize) -> [f32; K] {
+    let amount = amount % K;
+    let mut out = [0.0f32; K];
+    for i in 0..K {
+        out[i] = emb[(i + amount) % K];
+    }
+    out
+}
+
+/// Cyclic shift by 1 position — the depth-1 case of [`shift_by`], used by
+/// [`accumulator::GraphAccumulator`]'s 2-hop binding.
+#[inline]
+fn shift1(emb: &[f32; K]) -> [f32; K] {
+    shift_by(emb, 1)
+}
+
+/// Opaque view of e-graph state, as [`SaturationGuide::score_candidates`]
+/// consumes it. Wraps a [`GraphAccumulator`] — the VSA encoding is private;
+/// nothing outside this module names that type.
+pub struct GraphSummary {
+    pub(crate) gacc: GraphAccumulator,
+}
+
+/// One candidate rewrite-rule application, as
+/// [`SaturationGuide::score_candidates`] scores it. Wraps a pre-encoded rule
+/// embedding (see `scoring::SaturationHead::encode_rule_from_arena`, the
+/// arena-template encoder that replaced the legacy hand-crafted
+/// `RuleFeatures` path).
+pub struct RuleCandidate {
+    pub(crate) rule_embed: [f32; EMBED_DIM],
+}
+
+/// Given the current e-graph state and a set of candidate rewrite-rule
+/// applications, produce per-candidate move-ordering scores.
+///
+/// The only public contract of the saturation head. See the module doc for
+/// why an implementation of this trait is, today, necessarily untrained.
+pub trait SaturationGuide {
+    /// Score `candidates` against `graph`, one score per candidate, in order.
+    fn score_candidates(&self, graph: &GraphSummary, candidates: &[RuleCandidate]) -> Vec<f32>;
+}
+
+/// The (untrained, Phase-3-gated) saturation guide: a snapshot of the shared
+/// extraction backbone plus this head's own mask/graph/rule-projection
+/// weights.
+///
+/// Owns its backbone by value rather than borrowing
+/// [`crate::nnue::factored::ExprNnue`] because nothing today keeps a `Guide`
+/// alive across backbone updates — Phase 3 training will need to decide how
+/// the two stay in sync (the domain model doc's `EmbeddingsEpoch` seam,
+/// `Extraction`, is the shape that answer will likely take; out of scope for
+/// this round).
+pub struct Guide {
+    backbone: ExprNnue,
+    head: SaturationHead,
+}
+
+impl Guide {
+    /// Build a guide with a randomly-initialized saturation head over the
+    /// given (already-trained-or-not) backbone.
+    #[must_use]
+    pub fn new_random(backbone: ExprNnue, seed: u64) -> Self {
+        let mut head = SaturationHead::new();
+        head.randomize(seed);
+        Self { backbone, head }
+    }
+}
+
+impl SaturationGuide for Guide {
+    fn score_candidates(&self, graph: &GraphSummary, candidates: &[RuleCandidate]) -> Vec<f32> {
+        let rule_embeds: Vec<[f32; EMBED_DIM]> = candidates.iter().map(|c| c.rule_embed).collect();
+        self.head
+            .mask_score_all_rules_graph(&self.backbone, &graph.gacc, &rule_embeds)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn guide_score_candidates_is_finite_and_ordered() {
+        let backbone = ExprNnue::new_random(1);
+        let guide = Guide::new_random(backbone, 2);
+
+        let mut gacc = GraphAccumulator::new();
+        gacc.node_count = 1;
+        let graph = GraphSummary { gacc };
+
+        let candidates = alloc::vec![
+            RuleCandidate {
+                rule_embed: [0.1; EMBED_DIM],
+            },
+            RuleCandidate {
+                rule_embed: [0.9; EMBED_DIM],
+            },
+        ];
+
+        let scores = guide.score_candidates(&graph, &candidates);
+        assert_eq!(scores.len(), candidates.len(), "one score per candidate");
+        assert!(scores.iter().all(|s| s.is_finite()));
+    }
+
+    #[test]
+    fn guide_score_candidates_empty_is_empty() {
+        let backbone = ExprNnue::new_random(1);
+        let guide = Guide::new_random(backbone, 2);
+        let graph = GraphSummary {
+            gacc: GraphAccumulator::new(),
+        };
+        assert!(guide.score_candidates(&graph, &[]).is_empty());
+    }
+}

--- a/pixelflow-search/src/nnue/guide/scoring.rs
+++ b/pixelflow-search/src/nnue/guide/scoring.rs
@@ -1,0 +1,481 @@
+//! Saturation-head scoring: the mask MLP + bilinear (mask, rule) scorer,
+//! and the graph-state tower that feeds it from a [`GraphAccumulator`].
+//!
+//! Private implementation detail of the [`super::SaturationGuide`] contract.
+//! See the module doc on [`super`] for why this is inert today.
+//!
+//! `#![allow(dead_code)]`: see the same note in `accumulator.rs` — every
+//! method here is exercised only by this module's characterization tests
+//! until Phase 3 (docs/plans/2026-07-07-guided-saturation-redesign.md) trains
+//! it and a real caller reaches through [`super::Guide`].
+#![allow(dead_code)]
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+use libm::{log2f, sqrtf};
+use pixelflow_ir::arena::{ExprArena, ExprId};
+
+use super::accumulator::{GRAPH_ACC_DIM, GraphAccumulator};
+use crate::nnue::factored::{
+    EMBED_DIM, EdgeAccumulator, ExprNnue, HIDDEN_DIM, MLP_HIDDEN, SCALAR_FEATURE_COUNT,
+};
+
+/// Mask MLP input dimension: expr_embed / graph_embed directly (`EMBED_DIM`).
+/// `value_pred` was removed — it is a deterministic function of the
+/// embedding and adds zero information.
+pub(crate) const MASK_INPUT_DIM: usize = EMBED_DIM;
+
+/// Graph backbone input: `GRAPH_ACC_DIM` + 4 scalars (edge_count, node_count,
+/// node_budget, epoch_budget).
+pub(crate) const GRAPH_INPUT_DIM: usize = GRAPH_ACC_DIM + SCALAR_FEATURE_COUNT;
+
+/// Concatenated rule features: `[z_LHS | z_RHS | z_LHS-z_RHS | z_LHS*z_RHS]` (4 × `EMBED_DIM`).
+pub(crate) const RULE_CONCAT_DIM: usize = 4 * EMBED_DIM;
+
+/// The saturation head's own weights: mask MLP, bilinear interaction, rule
+/// projection, and the graph-state tower that feeds them.
+///
+/// Deliberately **not** part of [`ExprNnue`] — that struct is the live
+/// extraction-head checkpoint (its own "TRIF" format); these weights are
+/// untrained noise until Phase 3 gives them a training loop, and keeping them
+/// in a separate struct is what lets that checkpoint carry only live params
+/// (see `nnue/factored.rs`'s save/load doc).
+///
+/// Shares the backbone (`OpEmbeddings`, the shared trunk, `expr_proj`) with
+/// the extraction head — every method below that needs backbone state takes
+/// `&ExprNnue` explicitly rather than owning a copy, so there is exactly one
+/// trunk in memory.
+#[derive(Clone)]
+pub(crate) struct SaturationHead {
+    /// Mask MLP layer 1 weights: embed (32) → hidden (16).
+    mask_mlp_w1: [[f32; MLP_HIDDEN]; MASK_INPUT_DIM],
+    /// Mask MLP layer 1 bias.
+    mask_mlp_b1: [f32; MLP_HIDDEN],
+    /// Mask MLP layer 2 weights: hidden (16) → mask_features (32).
+    mask_mlp_w2: [[f32; EMBED_DIM]; MLP_HIDDEN],
+    /// Mask MLP layer 2 bias.
+    mask_mlp_b2: [f32; EMBED_DIM],
+
+    /// Rule projection weights: [`RULE_CONCAT_DIM`] x `EMBED_DIM`. Projects the
+    /// 4-way LHS/RHS concatenation to a rule embedding.
+    rule_proj_w: [[f32; EMBED_DIM]; RULE_CONCAT_DIM],
+    /// Rule projection bias.
+    rule_proj_b: [f32; EMBED_DIM],
+
+    /// Bilinear interaction matrix: `mask_features @ interaction @ rule_embed`.
+    interaction: [[f32; EMBED_DIM]; EMBED_DIM],
+    /// Learned bias projection: per-rule bias via `dot(mask_bias_proj, rule_embed)`.
+    mask_bias_proj: [f32; EMBED_DIM],
+
+    /// Graph backbone weights: [`GRAPH_INPUT_DIM`] x `HIDDEN_DIM`.
+    graph_w1: [[f32; HIDDEN_DIM]; GRAPH_INPUT_DIM],
+    /// Graph backbone biases.
+    graph_b1: [f32; HIDDEN_DIM],
+    /// Graph → embed projection weights: `HIDDEN_DIM` x `EMBED_DIM`.
+    graph_proj_w: [[f32; EMBED_DIM]; HIDDEN_DIM],
+    /// Graph → embed projection bias.
+    graph_proj_b: [f32; EMBED_DIM],
+}
+
+impl Default for SaturationHead {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SaturationHead {
+    /// Zero-initialized saturation head.
+    #[must_use]
+    pub(crate) fn new() -> Self {
+        Self {
+            mask_mlp_w1: [[0.0; MLP_HIDDEN]; MASK_INPUT_DIM],
+            mask_mlp_b1: [0.0; MLP_HIDDEN],
+            mask_mlp_w2: [[0.0; EMBED_DIM]; MLP_HIDDEN],
+            mask_mlp_b2: [0.0; EMBED_DIM],
+            rule_proj_w: [[0.0; EMBED_DIM]; RULE_CONCAT_DIM],
+            rule_proj_b: [0.0; EMBED_DIM],
+            interaction: [[0.0; EMBED_DIM]; EMBED_DIM],
+            mask_bias_proj: [0.0; EMBED_DIM],
+            graph_w1: [[0.0; HIDDEN_DIM]; GRAPH_INPUT_DIM],
+            graph_b1: [0.0; HIDDEN_DIM],
+            graph_proj_w: [[0.0; EMBED_DIM]; HIDDEN_DIM],
+            graph_proj_b: [0.0; EMBED_DIM],
+        }
+    }
+
+    /// Randomize all saturation-head weights (mask MLP, rule proj,
+    /// interaction, graph backbone). Does not touch the shared backbone —
+    /// that lives on [`ExprNnue`] and has its own `randomize`.
+    pub(crate) fn randomize(&mut self, seed: u64) {
+        let mut rng_state = seed.wrapping_add(54321);
+
+        let mut next_f32 = || {
+            rng_state = rng_state.wrapping_mul(6364136223846793005).wrapping_add(1);
+            (rng_state >> 33) as f32 / (1u64 << 31) as f32 * 2.0 - 1.0
+        };
+
+        // He initialization scales
+        let scale_mask_input = sqrtf(2.0 / MASK_INPUT_DIM as f32);
+        let scale_hidden = sqrtf(2.0 / MLP_HIDDEN as f32);
+        let scale_concat = sqrtf(2.0 / RULE_CONCAT_DIM as f32);
+        let scale_graph = sqrtf(2.0 / GRAPH_INPUT_DIM as f32);
+        let scale_proj = sqrtf(2.0 / HIDDEN_DIM as f32);
+
+        // Mask MLP: MASK_INPUT_DIM → MLP_HIDDEN → EMBED_DIM
+        for i in 0..MASK_INPUT_DIM {
+            for j in 0..MLP_HIDDEN {
+                self.mask_mlp_w1[i][j] = next_f32() * scale_mask_input;
+            }
+        }
+        for b in &mut self.mask_mlp_b1 {
+            *b = next_f32().abs() * 0.1;
+        }
+        for j in 0..MLP_HIDDEN {
+            for k in 0..EMBED_DIM {
+                self.mask_mlp_w2[j][k] = next_f32() * scale_hidden;
+            }
+        }
+        for b in &mut self.mask_mlp_b2 {
+            *b = 0.0;
+        }
+
+        // Rule Projection: RULE_CONCAT_DIM → EMBED_DIM
+        for i in 0..RULE_CONCAT_DIM {
+            for k in 0..EMBED_DIM {
+                self.rule_proj_w[i][k] = next_f32() * scale_concat;
+            }
+        }
+        for b in &mut self.rule_proj_b {
+            *b = 0.0;
+        }
+
+        // Interaction matrix: start near identity
+        for i in 0..EMBED_DIM {
+            for j in 0..EMBED_DIM {
+                self.interaction[i][j] = if i == j { 1.0 } else { next_f32() * 0.1 };
+            }
+        }
+
+        // Bias projection: neutral
+        for b in &mut self.mask_bias_proj {
+            *b = 0.0;
+        }
+
+        // Graph backbone: GRAPH_INPUT_DIM → HIDDEN_DIM
+        for row in 0..GRAPH_INPUT_DIM {
+            for col in 0..HIDDEN_DIM {
+                self.graph_w1[row][col] = next_f32() * scale_graph;
+            }
+        }
+        for b in &mut self.graph_b1 {
+            *b = next_f32().abs() * 0.1;
+        }
+
+        // Graph projection: HIDDEN_DIM → EMBED_DIM
+        for j in 0..HIDDEN_DIM {
+            for k in 0..EMBED_DIM {
+                self.graph_proj_w[j][k] = next_f32() * scale_proj;
+            }
+        }
+        for b in &mut self.graph_proj_b {
+            *b = next_f32().abs() * 0.1;
+        }
+    }
+
+    /// Graph state forward pass: `GraphAccumulator` → hidden (`HIDDEN_DIM`).
+    ///
+    /// Uses `1/sqrt(node_count)` scaling and log2 scalars, matching
+    /// `EdgeAccumulator::extraction_input`'s conventions, then routes through
+    /// `backbone`'s shared trunk — the same trunk the extraction head's
+    /// `forward_expr_only` uses.
+    #[inline]
+    pub(crate) fn forward_graph(
+        &self,
+        backbone: &ExprNnue,
+        gacc: &GraphAccumulator,
+    ) -> [f32; HIDDEN_DIM] {
+        let mut hidden = self.graph_b1;
+
+        // Scale factor: 1/sqrt(N) prevents variance explosion from summing N embeddings.
+        let scale = if gacc.node_count > 0 {
+            1.0 / sqrtf(gacc.node_count as f32)
+        } else {
+            1.0
+        };
+
+        // Process graph accumulator (128 dims: 4K sections)
+        for (i, &val) in gacc.values.iter().enumerate() {
+            let scaled_val = val * scale;
+            for (j, h) in hidden.iter_mut().enumerate() {
+                *h += scaled_val * self.graph_w1[i][j];
+            }
+        }
+
+        // Process scalar features (4 dims: edge_count, node_count, node_budget, epoch_budget).
+        // Use log2 to compress the range for large e-graphs.
+        let base = GRAPH_ACC_DIM;
+        let ec = log2f(1.0 + gacc.edge_count as f32);
+        let nc = log2f(1.0 + gacc.node_count as f32);
+        let nb = log2f(1.0 + gacc.node_budget as f32);
+        let eb = log2f(1.0 + gacc.epoch_budget as f32);
+        for (j, h) in hidden.iter_mut().enumerate() {
+            *h += ec * self.graph_w1[base][j];
+            *h += nc * self.graph_w1[base + 1][j];
+            *h += nb * self.graph_w1[base + 2][j];
+            *h += eb * self.graph_w1[base + 3][j];
+        }
+
+        // ReLU activation
+        for h in &mut hidden {
+            *h = h.max(0.0);
+        }
+
+        // Shared trunk
+        backbone.apply_trunk(&hidden)
+    }
+
+    /// Project graph hidden to graph embedding (`EMBED_DIM`).
+    ///
+    /// Same structure as `ExprNnue::compute_expr_embed` but with this head's
+    /// own `graph_proj_w`/`graph_proj_b`.
+    #[inline]
+    pub(crate) fn compute_graph_embed(&self, hidden: &[f32; HIDDEN_DIM]) -> [f32; EMBED_DIM] {
+        let mut embed = self.graph_proj_b;
+        for j in 0..HIDDEN_DIM {
+            for k in 0..EMBED_DIM {
+                embed[k] += hidden[j] * self.graph_proj_w[j][k];
+            }
+        }
+        embed
+    }
+
+    /// Compute mask features from an embedding (expr or graph) for bilinear scoring.
+    ///
+    /// MLP: `MASK_INPUT_DIM` → `MLP_HIDDEN` (ReLU) → `EMBED_DIM`.
+    #[inline]
+    fn compute_mask_features(&self, embed: &[f32; EMBED_DIM]) -> [f32; EMBED_DIM] {
+        let mut h = self.mask_mlp_b1;
+        for i in 0..EMBED_DIM {
+            for j in 0..MLP_HIDDEN {
+                h[j] += embed[i] * self.mask_mlp_w1[i][j];
+            }
+        }
+        for j in 0..MLP_HIDDEN {
+            h[j] = h[j].max(0.0);
+        }
+
+        let mut out = self.mask_mlp_b2;
+        for j in 0..MLP_HIDDEN {
+            for k in 0..EMBED_DIM {
+                out[k] += h[j] * self.mask_mlp_w2[j][k];
+            }
+        }
+        out
+    }
+
+    /// Score all rules using graph state (not expression state).
+    ///
+    /// `forward_graph → compute_graph_embed → compute_mask_features → bilinear_score`.
+    #[must_use]
+    pub(crate) fn mask_score_all_rules_graph(
+        &self,
+        backbone: &ExprNnue,
+        gacc: &GraphAccumulator,
+        rule_embeds: &[[f32; EMBED_DIM]],
+    ) -> Vec<f32> {
+        let hidden = self.forward_graph(backbone, gacc);
+        let graph_embed = self.compute_graph_embed(&hidden);
+        let mask_features = self.compute_mask_features(&graph_embed);
+        rule_embeds
+            .iter()
+            .map(|re| self.bilinear_score(&mask_features, re))
+            .collect()
+    }
+
+    /// Score all rules with a pre-computed shared-backbone hidden state
+    /// (e.g. the extraction head's own `forward_expr_only` output).
+    #[must_use]
+    pub(crate) fn mask_score_all_rules_with_hidden(
+        &self,
+        backbone: &ExprNnue,
+        hidden: &[f32; HIDDEN_DIM],
+        rule_embeds: &[[f32; EMBED_DIM]],
+    ) -> Vec<f32> {
+        let expr_embed = backbone.compute_expr_embed(hidden);
+        let mask_features = self.compute_mask_features(&expr_embed);
+        rule_embeds
+            .iter()
+            .map(|rule_embed| self.bilinear_score(&mask_features, rule_embed))
+            .collect()
+    }
+
+    /// Encode a single rule's LHS/RHS arena subtrees into a rule embedding.
+    ///
+    /// 4-way concatenation `[z_LHS | z_RHS | z_LHS-z_RHS | z_LHS*z_RHS]`
+    /// projected to `EMBED_DIM`, using the same shared backbone as the
+    /// extraction head (`backbone.forward_expr_only` / `compute_expr_embed`)
+    /// — the design that replaced the legacy hand-crafted `RuleFeatures` path.
+    #[must_use]
+    pub(crate) fn encode_rule_from_arena(
+        &self,
+        backbone: &ExprNnue,
+        arena: &ExprArena,
+        lhs: ExprId,
+        rhs: ExprId,
+    ) -> [f32; EMBED_DIM] {
+        let lhs_acc = EdgeAccumulator::from_arena_dag(arena, lhs, &backbone.embeddings);
+        let lhs_hidden = backbone.forward_expr_only(&lhs_acc);
+        let z_lhs = backbone.compute_expr_embed(&lhs_hidden);
+
+        let rhs_acc = EdgeAccumulator::from_arena_dag(arena, rhs, &backbone.embeddings);
+        let rhs_hidden = backbone.forward_expr_only(&rhs_acc);
+        let z_rhs = backbone.compute_expr_embed(&rhs_hidden);
+
+        let mut concat = [0.0f32; RULE_CONCAT_DIM];
+        for i in 0..EMBED_DIM {
+            concat[i] = z_lhs[i];
+            concat[EMBED_DIM + i] = z_rhs[i];
+            concat[2 * EMBED_DIM + i] = z_lhs[i] - z_rhs[i];
+            concat[3 * EMBED_DIM + i] = z_lhs[i] * z_rhs[i];
+        }
+
+        let mut out = self.rule_proj_b;
+        for i in 0..RULE_CONCAT_DIM {
+            for k in 0..EMBED_DIM {
+                out[k] += concat[i] * self.rule_proj_w[i][k];
+            }
+        }
+        out
+    }
+
+    /// Bilinear score: `mask_features @ interaction @ rule_embed + bias`.
+    #[inline]
+    #[must_use]
+    pub(crate) fn bilinear_score(
+        &self,
+        mask_features: &[f32; EMBED_DIM],
+        rule_embed: &[f32; EMBED_DIM],
+    ) -> f32 {
+        let mut transformed = [0.0f32; EMBED_DIM];
+        for i in 0..EMBED_DIM {
+            for j in 0..EMBED_DIM {
+                transformed[j] += mask_features[i] * self.interaction[i][j];
+            }
+        }
+
+        let mut score = 0.0f32;
+        for k in 0..EMBED_DIM {
+            score += (transformed[k] + self.mask_bias_proj[k]) * rule_embed[k];
+        }
+        score
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::nnue::factored::OpKind;
+
+    fn test_backbone() -> ExprNnue {
+        ExprNnue::new_random(42)
+    }
+
+    #[test]
+    fn bilinear_score_computation() {
+        let head = SaturationHead::new();
+        let mut randomized = head.clone();
+        randomized.randomize(42);
+
+        let mask_features = [1.0f32; EMBED_DIM];
+        let rule_embed = [1.0f32; EMBED_DIM];
+
+        let score = randomized.bilinear_score(&mask_features, &rule_embed);
+        assert!(score.is_finite(), "Bilinear score should be finite");
+
+        // Manual verification: score = dot(mask @ interaction + bias_proj, rule)
+        // With all-ones vectors: sum of interaction matrix + sum of bias_proj
+        let mut expected = 0.0f32;
+        for i in 0..EMBED_DIM {
+            for j in 0..EMBED_DIM {
+                expected += randomized.interaction[i][j];
+            }
+        }
+        for k in 0..EMBED_DIM {
+            expected += randomized.mask_bias_proj[k];
+        }
+        assert!(
+            (score - expected).abs() < 1e-4,
+            "Bilinear computation mismatch: got {}, expected {}",
+            score,
+            expected
+        );
+    }
+
+    #[test]
+    fn verify_randomize_is_deterministic_and_finite() {
+        let mut a = SaturationHead::new();
+        a.randomize(42);
+        let mut b = SaturationHead::new();
+        b.randomize(42);
+
+        for i in 0..EMBED_DIM {
+            for j in 0..EMBED_DIM {
+                assert!(
+                    (a.interaction[i][j] - b.interaction[i][j]).abs() < 1e-9,
+                    "randomize(seed) must be deterministic"
+                );
+                assert!(a.interaction[i][j].is_finite());
+            }
+        }
+        // Interaction matrix should be near identity diagonal.
+        for i in 0..EMBED_DIM {
+            assert!(
+                (a.interaction[i][i] - 1.0).abs() < 0.5,
+                "Diagonal of interaction should be near 1.0"
+            );
+        }
+    }
+
+    #[test]
+    fn forward_graph_uses_backbone_trunk() {
+        let backbone = test_backbone();
+        let mut head = SaturationHead::new();
+        head.randomize(7);
+
+        let mut gacc = GraphAccumulator::new();
+        gacc.add_edge(&backbone.embeddings, OpKind::Add, OpKind::Mul);
+        gacc.node_count = 2;
+        gacc.edge_count = 1;
+
+        let hidden = head.forward_graph(&backbone, &gacc);
+        assert!(hidden.iter().all(|v| v.is_finite()));
+
+        let embed = head.compute_graph_embed(&hidden);
+        assert!(embed.iter().all(|v| v.is_finite()));
+
+        let scores = head.mask_score_all_rules_graph(&backbone, &gacc, &[[0.5f32; EMBED_DIM]]);
+        assert_eq!(scores.len(), 1);
+        assert!(scores[0].is_finite());
+    }
+
+    #[test]
+    fn encode_rule_from_arena_deterministic() {
+        let backbone = test_backbone();
+        let mut head = SaturationHead::new();
+        head.randomize(3);
+
+        let mut arena = ExprArena::with_capacity(4);
+        let x = arena.push_var(0);
+        let one = arena.push_const(1.0);
+        let lhs = arena.push_binary(OpKind::Add, x, one);
+        let rhs = arena.push_binary(OpKind::Mul, x, one);
+
+        let e1 = head.encode_rule_from_arena(&backbone, &arena, lhs, rhs);
+        let e2 = head.encode_rule_from_arena(&backbone, &arena, lhs, rhs);
+        for i in 0..EMBED_DIM {
+            assert!((e1[i] - e2[i]).abs() < 1e-6, "must be deterministic");
+            assert!(e1[i].is_finite());
+        }
+    }
+}

--- a/pixelflow-search/src/nnue/mod.rs
+++ b/pixelflow-search/src/nnue/mod.rs
@@ -11,6 +11,7 @@
 extern crate alloc;
 
 pub mod factored;
+pub mod guide;
 
 use alloc::collections::BTreeMap;
 use alloc::sync::Arc;
@@ -21,17 +22,19 @@ use pixelflow_ir::kind::OpMap;
 /// Re-export canonical IR types as the source of truth.
 pub use pixelflow_ir::{ExprArena, ExprId, ExprNode, OpKind};
 
-/// Re-export ExprNnue for dual-head AlphaZero-style architecture.
+/// Re-export ExprNnue: the shared backbone + extraction (value) head.
 pub use factored::ExprNnue;
 
 /// Re-export key types from factored module.
-pub use factored::{EdgeAccumulator, GraphAccumulator, OpEmbeddings};
+pub use factored::{EdgeAccumulator, OpEmbeddings};
 
-/// Re-export unified mask architecture constants and types.
-pub use factored::{
-    ArenaRuleTemplates, EMBED_DIM, GRAPH_ACC_DIM, GRAPH_INPUT_DIM, MASK_INPUT_DIM, MASK_MAX_RULES,
-    MLP_HIDDEN, RULE_CONCAT_DIM, RULE_FEATURE_DIM, RuleFeatures, RuleTemplates,
-};
+/// Re-export shared embedding-space constants and rule-template types.
+///
+/// `RuleTemplates`/`ArenaRuleTemplates` feed `BwdGenerator`'s corpus
+/// junkification below — unrelated to `nnue::guide` despite the similarly
+/// named (and now-deleted) `RuleFeatures`, whose hand-crafted 8-dim feature
+/// vector `encode_rule_from_arena` superseded.
+pub use factored::{ArenaRuleTemplates, EMBED_DIM, MLP_HIDDEN, RuleTemplates};
 
 // Note: ExprGenConfig, ExprGenerator, BwdGenConfig, and BwdGenerator are already
 // public structs defined in this module - no re-export needed.


### PR DESCRIPTION
## Summary

Two-commit reorganization of the e-graph/NNUE cost-model pipeline
(`pixelflow-search/src/{nnue,egraph}`, `pixelflow-pipeline/src/{training,bin}`),
executed from `docs/plans/2026-08-17-cost-model-domain.md` — a domain-model doc
synthesizing three independent analyses (what each stage MEANS, an
argument/name-cluster survey of 1,330 fns, and a caller-verified live/dead
inventory) into 15 candidate types (the "join table," §0) plus 6 anti-rows the
join says *not* to build.

1. `refactor(pixelflow-search): encapsulate the guide behind its contract; prune the dead remainder`
2. `refactor(pixelflow-pipeline): dedupe the JIT/oracle harness and journal writer; document the domain model`

### The Guide's contract, and what went behind it

The `SaturationGuide` trait (J10) is the entire public surface now:

```rust
pub trait SaturationGuide {
    fn score_candidates(&self, graph: &GraphSummary, candidates: &[RuleCandidate]) -> Vec<f32>;
}
```

— given the e-graph's current state and a set of candidate rewrite applications,
produce per-candidate move-ordering scores. Everything that implements it moved
behind `nnue/guide/` (private except that trait): `accumulator.rs` (518 lines,
`GraphAccumulator` + its 18 mutators) and `scoring.rs` (481 lines, mask MLP,
bilinear scoring, `encode_rule_from_arena`), plus `mod.rs` (163 lines). **1,162
lines moved**, not rewritten — JP's standing instruction is that if we're going
to want something later, we keep it rather than delete-and-rewrite it. This
surface stays inert until Phase 3 of the guided-saturation redesign
(2026-07-07) starts training it.

The **small true deletion** — zero callers, zero roadmap role — accounts for
the rest: the `Edge` struct, `ExprNnue::from_factored`, and the legacy
`RuleFeatures`/`set_rule`/`rule_mlp_*`/`encode_rule`/`encode_all_rules`/
`encode_all_rules_from_templates` sub-tier, superseded by the arena-based
`encode_rule_from_arena` that the encapsulation keeps live.

`factored.rs`: **3,782 → 1,786 lines** (−1,996). Of that: 1,162 moved into
`guide/`, ~834 actually deleted.

A forced, load-bearing consequence: `apply_unified_sgd`/`UnifiedGradients`
(`pixelflow-pipeline/src/training/unified_backward.rs`, 2,077 → 1,479 lines)
drop every `d_mask_*`/`d_graph_*` field, because there's no longer a struct
field for them to occupy. This *is* the fix for a confirmed defect: Phase-3
weights were randomly initialized, then weight-decayed every training run with
no opposing gradient ever produced for them — pure decay toward zero,
silently, forever. There is now no gradient struct through which that can
happen.

### Organization moves (the small, mechanical half)

- **J14** — `run_scalar` (broadcast-to-lanes JIT invocation helper) existed as
  three byte-identical per-ISA copies (`quarantine.rs`, `bench_extraction_3way.rs`,
  `pixelflow-search/tests/prod_kernel_jit.rs` — one comment admitted "Verbatim
  from ..."). Now one copy in `pixelflow-pipeline/src/oracle_compare.rs`,
  imported by both binaries.
- **J15** — the research-journal append mechanics (serialize, mkdir, refuse an
  unsmudged Git LFS pointer, append-or-panic) were two copies, one missing the
  LFS guard. Now one `pixelflow-pipeline/src/journal.rs::append_record`, called
  by both `bench_extraction_3way` and `bootstrap_extraction_head` for their
  (structurally different, and staying different) record types.
- **J11** — `EGraph::saturate_with_limits` is now the one rewrite-until-budget
  loop (returns `SaturationStats`); `egraph::saturate`'s
  `saturate_with_full_budget` calls it instead of re-deciding the same
  timeout/class-limit/convergence conditions in a second, hand-rolled outer
  loop — the exact duplicate-saturation-loop drift the domain doc calls out.

`bench_extraction_3way.rs`: 4,262 → 4,157 lines (−105; harness-library split
is explicitly deferred to next round per the plan, since the receiving `eval/`
types don't exist yet — landing it now would be a rewrite, not a move).

### The four P1 defect classes

Only one is actually killed by this PR; the other three are **denoted** (§1 of
the doc — a type is specified as the obligation) but implementing them is next
round's work, per the plan's explicit ranked list (§4):

| # | Defect | Status | How |
|---|---|---|---|
| P1(b) | TRIE checkpoint schema never bumped when feature meaning changed | **Killed this round** | Live-only format, magic bumped `TRIE`→`TRIF`. Every loader hard-fails on mismatch — verified against both a fabricated stale-`TRIE` file (panics naming both magics) and the `judge_weights_load.rs` round-trip test. |
| P1(a) | Cached `ValueSample` accumulators go stale while SGD mutates embeddings each batch | Denoted, not built | `Extraction` (J2) gains an `EmbeddingsEpoch` tag; every consumer asserts epoch equality and panics on mismatch — the fail-fast half lands with `Extraction` next round (§4a-3). |
| P1(c) | Variance computed from class-wide meet instead of the chosen nodes | Denoted, not built | `Extraction` (J2) makes a class-wide view impossible to compute variance from — only `&Extraction` (chosen nodes) is accepted, next round. |
| P1(d) | Holdout fence keyed on structure while features collapse literals | Denoted, not built | `Fence<T: TierMarker>` + `FenceKey = structural_key ∘ feature_quotient` (J7/J8); the type seam is next round, the key-function change is round-after (it changes which samples are admitted, so it needs its own re-baselining). |

### Verification

- `cargo build --workspace`, `cargo test --workspace` (102 suites / 2,132
  passed / 0 failed / 140 ignored — the pre-existing baseline was 102 suites /
  2,129 tests / 0 failures; the +3 net is explained fully below, not just
  asserted), `cargo test -p pixelflow-pipeline --features training`,
  `cargo test -p pixelflow-ir`, `cargo check -p pixelflow-ir --no-default-features`,
  `cargo clippy --workspace --all-targets --all-features` — all green.
- Diffed the full `--list` test-name sets against `be4f98df` (pre-branch main):
  15 baseline test names disappear, 18 appear. Every one reconciles: 2
  same-name doctest relocations (line-number-only, from the `SaturationStats`
  insertion), 1 filename rename (`judge_weights_round_trip_via_trie` →
  `_trif`), 8 tests relocated verbatim into `nnue::guide::*` (6
  `graph_acc_normalize_*`/`graph_acc_remove_leaf_*`, `bilinear_score_computation`),
  2 genuine dead-code-test deletions (`rule_features_initialization`,
  `verify_encode_all_rules` — both tested legacy code deleted in this PR), 2
  tests rewritten for their new (smaller) signatures rather than deleted
  outright (`verify_randomize_mask_only`→`verify_randomize_is_deterministic_and_finite`,
  `forward_cached_matches_bilinear_score`→`forward_cached_acc_input_matches_extraction_input`),
  and 4 genuinely new tests (2 for `journal::append_record`, 1 covering
  `encode_rule_from_arena` — the live function the deleted legacy test never
  actually exercised, 1 already counted above). **No live coverage was lost.**
- Cold-regeneration sanity: `gen_bench_corpus --target 3000` (a `--target 200`
  run first, correctly rejected by the per-family integrity gate — that gate's
  statistical floor needs more than 1-2 samples per family, unrelated to this
  PR's changes) writes all three corpus tiers cleanly; `bootstrap_extraction_head
  --synthetic 200 --epochs 2` against that corpus runs cold-start end-to-end
  (random init → train → DEV eval → save → journal). A repo checkout has no
  committed `data/extraction_head.bin`, so the stale-weights refusal case was
  built by hand: pointing `--model` at a fabricated `TRIE`-magic file produces
  a loud panic naming both magics and the reason, and never reaches the save
  step. (Both sanity runs used scratch output directories; the real
  `docs/results/journal.jsonl` was untouched — an accidental write during
  testing was reverted before committing.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
