### PR TITLE
test: 2026-08-17 test-quality audit (naming fixes + backend/x86.rs mutation gaps)

### DIFF
--- a/docs/bugs/2026-08-17-test-quality-audit-followup.md
+++ b/docs/bugs/2026-08-17-test-quality-audit-followup.md
@@ -1,0 +1,173 @@
+# Test quality control follow-up — 2026-08-17
+
+Scope: scheduled continuation of
+`docs/bugs/2026-08-15-test-quality-audit-followup.md`. Since that pass landed
+(`ce2df0e8`), `main` moved by three commits: `addb79de` (`core-term`
+descriptive-names + mutation pass, itself a prior run of this routine),
+`5436ed73` (`pixelflow-ir`: rewrote `OpKind::index`/`from_index` to make the
+op numbering a compile-time-checked table), and `be4f98df` (`pixelflow-pipeline`:
+hardened the e-graph NNUE measurement pipeline — ~150 new tests across 26
+files).
+
+## Delta audit: tests added by `5436ed73` and `be4f98df`
+
+Delegated to a sub-agent: diff each commit's test-function set, skim all
+~230 new/renamed names for the "it should" sentence property, read the body
+of anything that looked like a bare label, and confirm public-API-only
+access for the two new cross-crate integration-test files.
+
+**Public-API-only: clean.** Every new test lives in same-crate
+`#[cfg(test)] mod tests` (the project's normal same-crate unit-testing
+convention) or, for the two new integration-test files
+(`pixelflow-codegen/tests/oracle_reference.rs`,
+`pixelflow-search/tests/latency_prior_regression.rs`), goes exclusively
+through `pub` items (`ExprArena`, `ExprId`, `OpKind`, `eval_scalar`,
+`JitManifold`, `jit_cache::compile_cached`, `optimize_runtime_arena`). No
+private-field or `pub(crate)` reach-through from outside a defining crate.
+
+**Naming: 9 violations found and fixed**, all bare noun-phrase labels
+(STYLE.md's `min_max`/`handles_edge_case` failure mode — no verb, doesn't
+say what's being asserted):
+
+| File | Old name | New name |
+|---|---|---|
+| `pixelflow-ir/src/eval.rs` | `mask_valued_root_detection` | `is_mask_valued_classifies_comparisons_bitwise_ops_select_and_trunc` |
+| `pixelflow-ir/src/eval.rs` | `trunc_divergence_predicate_boundaries` | `trunc_input_is_divergent_beyond_the_i32_range_and_convergent_within_it` |
+| `pixelflow-pipeline/src/training/split.rs` | `seed_range_helpers` | `seed_range_contains_count_and_overlaps_match_their_definitions` |
+| `pixelflow-pipeline/src/jit_bench.rs` | `iqr_computation` | `iqr_is_order_independent_and_zero_for_constant_samples` |
+| `pixelflow-pipeline/src/jit_bench.rs` | `sentinel_regime_change_detection` | `sentinel_drift_exceeded_trips_only_beyond_the_fifty_percent_band` |
+| `pixelflow-pipeline/src/bin/bootstrap_extraction_head.rs` | `size_distribution_quartiles` | `size_distribution_of_reports_count_min_median_max_and_renders_them` |
+| `pixelflow-pipeline/src/bin/bootstrap_extraction_head.rs` | `spearman_known_small_example` | `spearman_rho_matches_a_hand_computed_example` |
+| `pixelflow-pipeline/src/bin/bootstrap_extraction_head.rs` | `average_ranks_no_ties` (borderline) | `average_ranks_assigns_distinct_ranks_when_there_are_no_ties` |
+| `pixelflow-pipeline/src/bin/bootstrap_extraction_head.rs` | `average_ranks_with_ties` (borderline) | `average_ranks_splits_the_average_rank_across_tied_values` |
+
+Renames only — no behavior change. Verified each renamed test still passes
+under its new name, per-crate (`pixelflow-ir`'s via `--lib eval::`,
+`pixelflow-pipeline`'s via `--lib training::split`/`--lib jit_bench::`, the
+two `bin/bootstrap_extraction_head.rs` ones via `--bin
+bootstrap_extraction_head`), and grepped the whole tree for the old names to
+confirm nothing else referenced them. Landed in `037071da`.
+
+All other ~215 new-test names (the bulk of `be4f98df`'s additions —
+`oracle_reference.rs`, `bench_extraction_3way.rs`, `quarantine.rs`,
+`mint.rs`, `episodes.rs`, `structural.rs`, `unified_backward.rs`,
+`extract.rs`, etc.) already read as complete sentences.
+
+## Mutation testing: `pixelflow-core/src/backend/x86.rs`
+
+Picked up backlog item 5 from the 08-15 audit: the file's *required*
+`SimdOps`/`SimdU32Ops`/`MaskOps` per-ISA primitives (F32x4/F32x8/F32x16,
+U32x4/U32x8/U32x16, Mask4/Mask8/Mask16 — the SSE2/AVX2/AVX-512 tiers) had
+never been swept as a whole file. The prior pass closed the *provided*
+default-method half of the same trait family for `backend/mod.rs`; this is
+the other half.
+
+**First run made the exact mistake the 08-08 and 08-15 audits already
+documented**: scoped to `-- --lib`, which hides
+`pixelflow-core/tests/x86_backend_tests.rs` (an integration-test binary) from
+the mutant test runner. 229 mutants, only 42 caught — the tool wasn't
+running the tests that actually cover this file. **Re-run without `--lib`**:
+229 mutants, **172 missed, 57 caught**. This host is `x86_64-unknown-linux-gnu`
+with no AVX-512, so `arm.rs`'s NEON backend (recommended alongside x86.rs in
+the 08-15 backlog) doesn't even compile here — dropped from scope, noted
+below.
+
+172 missed is too large to close in one pass (structurally, F32x8/AVX2 and
+F32x16/AVX-512 duplicate F32x4/SSE2's shape three times over). Scoped this
+pass to the **F32x4/U32x4/Mask4 tier** — the always-compiled SSE2 baseline,
+independent of any `target-feature` flag, and the highest-value slice since
+every other backend falls back to it.
+
+### Fixed: 15 new tests in `pixelflow-core/tests/x86_backend_tests.rs`
+
+Against the public `SimdOps`/`SimdU32Ops` traits on `F32x4`/`U32x4`, matching
+the file's established convention. Each input was chosen to distinguish the
+real formula from its mutants, not just from zero:
+
+- **`gather`**: an out-of-range index (99) on a 4-element slice kills both
+  the `len - 1` → `len + 1` and `len - 1` → `len / 1` mutants — either one
+  clamps to an index at or past `slice.len()`, and the resulting
+  out-of-bounds scalar load panics rather than silently returning the
+  wrong-but-plausible value.
+- **`from_u32_bits`/`shr_u32`/`i32_to_f32`**: chained off each other
+  (`from_u32_bits(8).shr_u32(2)` should read back bit-pattern `2`) since bit
+  reinterpretation is opaque to `f32` equality — asserted via `.to_bits()`,
+  not `==`.
+- **`add_masked`**: asserted both the true-mask (adds) and false-mask
+  (no-op) cases — a `Default::default()` mutant would return `0.0` for both,
+  the select-based miscompile pattern the codebase's Floating-point-at-the-
+  edges section warns about generally.
+- **`U32x4`'s Debug output** (`u32x4_debug_output_shows_each_lane_value`):
+  `U32x4::to_array` is a private helper reachable only through `Debug::fmt`,
+  so asserting the formatted string (`"U32x4([7, 7, 7, 7])"`) is the only
+  public-API way to observe it — and incidentally kills the `Debug::fmt ->
+  Ok(Default::default())` mutant too, since a mutated `fmt` writes nothing
+  and the formatted string comes back empty rather than wrong-but-present.
+- **`U32x4 Not`**: `_mm_set1_epi32(-1)` → `_mm_set1_epi32(1)` (the "delete
+  `-`" mutant) would XOR with `1` instead of all-ones, leaving every lane at
+  `1` instead of `u32::MAX` — asserted the full inverted bit pattern, not
+  just non-equality to the input.
+- **`pack_rgba`**: red-and-alpha-only input (`r=1.0, g=0, b=0, a=1.0`) packs
+  to `0xFF0000FF`, which is non-zero in exactly the R and A byte lanes —
+  distinguishes the real `r | (g<<8) | (b<<16) | (a<<24)` formula from a
+  `Default::default()` collapse.
+
+**Left as non-issues (3 remaining misses, confirmed by a targeted re-run
+filtered to `F32x4|U32x4|Mask4`, 74/77 caught):**
+
+1. `Debug for Mask4`/`Debug for F32x4` — formatters, not load-bearing,
+   consistent with every prior audit's treatment of `Debug::fmt` mutants
+   (the U32x4 case above was fixable cheaply because `to_array` had no
+   other caller to hang a test on; these two don't have that same
+   opportunity — `F32x4::to_array` is already covered indirectly via
+   `gather`, and `Mask4` has no analogous private-helper angle).
+2. `U32x4::from_f32_scaled -> Default::default()` — **genuinely
+   equivalent**, not a coverage gap: the function's real body already *is*
+   `Self::default()` (a documented placeholder — "actual packing is done via
+   `pack_rgba`"), so the mutant produces byte-identical output to the
+   original. No test can distinguish them because there is no behavioral
+   difference to observe.
+
+### Verified
+
+- `cargo test -p pixelflow-core --test x86_backend_tests`: 33 passed (18
+  pre-existing + 15 new), 0 failed.
+- `cargo test -p pixelflow-core` (all targets incl. doctests): passed, 0
+  failed.
+- `cargo test --workspace --lib`: 1446 passed, 4 ignored, 0 failed (per-crate
+  breakdown: 149/0/459/78/48/123/152/136/9/107/65/120, ~161s wall clock,
+  dominated by `pixelflow-search`'s NNUE training tests as in every prior
+  pass).
+- `cargo clippy -p pixelflow-core --tests`: clean.
+- `cargo fmt -p pixelflow-core -- --check`: clean.
+- `cargo mutants -p pixelflow-core --file pixelflow-core/src/backend/x86.rs
+  -F 'F32x4|U32x4|Mask4'` (post-fix, targeted re-run): 74/77 caught, 3
+  missed (the non-issues above).
+
+## Recommended next steps (not done here)
+
+1. `pixelflow-core/src/backend/x86.rs`'s **F32x8 (AVX2)** and **F32x16
+   (AVX-512)** tiers — same file, same structural gaps as F32x4 (roughly
+   150 of the 172 original misses), just never reached this pass. AVX-512
+   needs a host with that target-feature to even compile `F32x16`'s cfg'd-in
+   code; AVX2 doesn't have that restriction and could go first.
+2. `pixelflow-core/src/backend/arm.rs` (NEON) — still untested as a whole-file
+   sweep; cannot be mutation-tested on this `x86_64` host at all (the file is
+   `cfg(target_arch = "aarch64")`-gated and won't even build here). Needs an
+   aarch64 runner.
+3. `pixelflow-search/src/egraph/cost.rs` — still open per the 08-08 audit
+   (partial run found and fixed one real gap before a slow `--lib` baseline
+   timed out); not revisited this pass.
+4. `pixelflow-codegen/src/emit/*` (~1,400 lines, mod.rs alone is 5,779) —
+   still flagged as never mutation-tested under its post-crate-split
+   location; large enough to warrant its own scoped pass rather than a
+   whole-file sweep.
+5. `pixelflow-graphics/src/spatial_bsp.rs` — confirmed still open per 08-15:
+   19 tests reach into private `bsp.interiors[...]` fields with no public
+   accessor. Still a design call (test-only introspection API vs. property
+   tests over `eval()` vs. documented rule-break), not independently
+   re-verified this pass.
+6. `actor-scheduler/src/lib.rs`'s `backoff_unit_tests` — confirmed still
+   present per every prior audit; mutation findings against the private
+   `backoff_with_jitter`/`send_with_backoff` functions not re-verified this
+   pass.

--- a/pixelflow-core/tests/x86_backend_tests.rs
+++ b/pixelflow-core/tests/x86_backend_tests.rs
@@ -2,8 +2,8 @@
 #[cfg(test)]
 mod tests {
     extern crate std;
-    use pixelflow_core::backend::x86::F32x4;
-    use pixelflow_core::backend::{MaskOps, SimdOps};
+    use pixelflow_core::backend::x86::{F32x4, U32x4};
+    use pixelflow_core::backend::{MaskOps, SimdOps, SimdU32Ops};
     use std::prelude::v1::*;
 
     #[test]
@@ -252,5 +252,144 @@ mod tests {
             lanes(F32x4::splat(15.0).clamp(F32x4::splat(0.0), F32x4::splat(10.0))),
             [10.0; 4]
         );
+    }
+
+    // ── SimdOps required primitives with no direct coverage ────────────────
+    //
+    // 2026-08-17 mutation sweep of the whole file (`cargo mutants -p
+    // pixelflow-core --file .../backend/x86.rs`, no `--lib` restriction —
+    // scoping to `--lib` hides this integration-test file and silently
+    // reports every mutant here as caught vacuously). These are `SimdOps`
+    // *required* per-ISA primitives that had zero coverage anywhere, so a
+    // "replace the whole function with `Default::default()`" (or an
+    // arithmetic-operator swap inside it) mutant survived for each.
+
+    #[test]
+    fn gather_clamps_out_of_range_indices_to_the_last_valid_slot() {
+        // idx=99 is out of range for a 4-element slice either way, so this
+        // also kills the `len - 1` -> `len + 1` / `len / 1` mutants: both
+        // would clamp to an index at or past `slice.len()` and panic on the
+        // out-of-bounds scalar load, rather than silently returning 40.0.
+        let slice = [10.0f32, 20.0, 30.0, 40.0];
+        let got = lanes(F32x4::gather(&slice, F32x4::splat(99.0)));
+        assert_eq!(got, [40.0; 4]);
+    }
+
+    #[test]
+    fn add_masked_adds_only_where_the_mask_is_true() {
+        let base = F32x4::splat(1.0);
+        let addend = F32x4::splat(2.0);
+        let all_true = F32x4::splat(1.0).cmp_gt(F32x4::splat(0.0));
+        let all_false = F32x4::splat(0.0).cmp_gt(F32x4::splat(0.0));
+        assert_eq!(lanes(base.add_masked(addend, all_true)), [3.0; 4]);
+        assert_eq!(lanes(base.add_masked(addend, all_false)), [1.0; 4]);
+    }
+
+    #[test]
+    fn from_u32_bits_reinterprets_the_bit_pattern_as_f32() {
+        let got = lanes(F32x4::from_u32_bits(2.0f32.to_bits()));
+        assert_eq!(got, [2.0; 4]);
+    }
+
+    #[test]
+    fn shr_u32_performs_a_logical_right_shift_on_the_bit_pattern() {
+        let shifted = F32x4::from_u32_bits(8).shr_u32(2);
+        for x in lanes(shifted) {
+            assert_eq!(x.to_bits(), 2);
+        }
+    }
+
+    #[test]
+    fn i32_to_f32_converts_the_reinterpreted_bits_as_a_signed_integer() {
+        let got = lanes(F32x4::from_u32_bits(5).i32_to_f32());
+        assert_eq!(got, [5.0; 4]);
+    }
+
+    #[test]
+    fn f32x4_bitor_combines_lane_bits() {
+        let a = F32x4::from_u32_bits(0b0110);
+        let b = F32x4::from_u32_bits(0b1001);
+        for x in lanes(a | b) {
+            assert_eq!(x.to_bits(), 0b1111);
+        }
+    }
+
+    #[test]
+    fn f32x4_not_flips_every_bit() {
+        for x in lanes(!F32x4::from_u32_bits(0)) {
+            assert_eq!(x.to_bits(), u32::MAX);
+        }
+    }
+
+    // ── U32x4 (packed RGBA lanes) ────────────────────────────────────────
+
+    #[test]
+    fn u32x4_debug_output_shows_each_lane_value() {
+        // U32x4::to_array is private and reachable only through Debug, so
+        // this is the only public-API way to observe it; also kills the
+        // Debug::fmt -> Ok(Default::default()) mutant, since a mutated fmt
+        // writes nothing and the formatted string comes back empty.
+        let v = U32x4::splat(7);
+        assert_eq!(format!("{v:?}"), "U32x4([7, 7, 7, 7])");
+    }
+
+    #[test]
+    fn u32x4_store_writes_every_lane_into_the_output_slice() {
+        let mut out = [0u32; 4];
+        U32x4::splat(42).store(&mut out);
+        assert_eq!(out, [42; 4]);
+    }
+
+    #[test]
+    fn u32x4_bitand_combines_lane_bits() {
+        let a = U32x4::splat(0b0110);
+        let b = U32x4::splat(0b0011);
+        let mut out = [0u32; 4];
+        (a & b).store(&mut out);
+        assert_eq!(out, [0b0010; 4]);
+    }
+
+    #[test]
+    fn u32x4_bitor_combines_lane_bits() {
+        let a = U32x4::splat(0b0110);
+        let b = U32x4::splat(0b1001);
+        let mut out = [0u32; 4];
+        (a | b).store(&mut out);
+        assert_eq!(out, [0b1111; 4]);
+    }
+
+    #[test]
+    fn u32x4_not_flips_every_bit() {
+        // Also kills the `_mm_set1_epi32(-1)` -> `_mm_set1_epi32(1)` mutant
+        // (delete `-`): that would XOR with 1 instead of all-ones, leaving
+        // every lane at 1 rather than u32::MAX.
+        let mut out = [0u32; 4];
+        (!U32x4::splat(0)).store(&mut out);
+        assert_eq!(out, [u32::MAX; 4]);
+    }
+
+    #[test]
+    fn u32x4_shl_shifts_bits_left() {
+        let mut out = [0u32; 4];
+        (U32x4::splat(1) << 4).store(&mut out);
+        assert_eq!(out, [16; 4]);
+    }
+
+    #[test]
+    fn u32x4_shr_shifts_bits_right() {
+        let mut out = [0u32; 4];
+        (U32x4::splat(16) >> 4).store(&mut out);
+        assert_eq!(out, [1; 4]);
+    }
+
+    #[test]
+    fn pack_rgba_packs_channels_as_r_or_g_shl8_or_b_shl16_or_a_shl24() {
+        let r = F32x4::splat(1.0);
+        let g = F32x4::splat(0.0);
+        let b = F32x4::splat(0.0);
+        let a = F32x4::splat(1.0);
+        let mut out = [0u32; 4];
+        U32x4::pack_rgba(r, g, b, a).store(&mut out);
+        assert_eq!(out, [0xFF0000FF; 4]);
     }
 }

--- a/pixelflow-ir/src/eval.rs
+++ b/pixelflow-ir/src/eval.rs
@@ -2135,7 +2135,7 @@ mod tests {
     }
 
     #[test]
-    fn mask_valued_root_detection() {
+    fn is_mask_valued_classifies_comparisons_bitwise_ops_select_and_trunc() {
         let mut arena = ExprArena::new();
         let x = arena.push_var(0);
         let y = arena.push_var(1);
@@ -2190,7 +2190,7 @@ mod tests {
     }
 
     #[test]
-    fn trunc_divergence_predicate_boundaries() {
+    fn trunc_input_is_divergent_beyond_the_i32_range_and_convergent_within_it() {
         const TWO_POW_31: f32 = 2_147_483_648.0;
         // Divergent: NaN, infinities, and everything at/above 2^31 or below
         // -2^31 — where cvttps2dq's 0x80000000 parts ways with saturation.

--- a/pixelflow-pipeline/src/bin/bootstrap_extraction_head.rs
+++ b/pixelflow-pipeline/src/bin/bootstrap_extraction_head.rs
@@ -1736,12 +1736,12 @@ mod tests {
     }
 
     #[test]
-    fn average_ranks_no_ties() {
+    fn average_ranks_assigns_distinct_ranks_when_there_are_no_ties() {
         assert_eq!(average_ranks(&[10.0, 30.0, 20.0]), vec![1.0, 3.0, 2.0]);
     }
 
     #[test]
-    fn average_ranks_with_ties() {
+    fn average_ranks_splits_the_average_rank_across_tied_values() {
         // 2.0 occupies ranks 2 and 3 → both get 2.5.
         assert_eq!(
             average_ranks(&[1.0, 2.0, 2.0, 4.0]),
@@ -1763,7 +1763,7 @@ mod tests {
     }
 
     #[test]
-    fn spearman_known_small_example() {
+    fn spearman_rho_matches_a_hand_computed_example() {
         // Ranks: a=[1,2,3], b=[3,1,2]; d²=[4,1,1] → ρ = 1 − 6·6/(3·8) = −0.5.
         let rho = spearman_rho(&[1.0, 2.0, 3.0], &[3.0, 1.0, 2.0]).expect("defined");
         assert!((rho + 0.5).abs() < 1e-12, "got {rho}");
@@ -1952,7 +1952,7 @@ mod tests {
     }
 
     #[test]
-    fn size_distribution_quartiles() {
+    fn size_distribution_of_reports_count_min_median_max_and_renders_them() {
         let d = SizeDistribution::of(&[7, 1, 3, 9, 5]).expect("non-empty");
         assert_eq!(d.count, 5);
         assert_eq!(d.min, 1);

--- a/pixelflow-pipeline/src/jit_bench.rs
+++ b/pixelflow-pipeline/src/jit_bench.rs
@@ -1362,7 +1362,7 @@ mod tests {
     }
 
     #[test]
-    fn iqr_computation() {
+    fn iqr_is_order_independent_and_zero_for_constant_samples() {
         // 0..20: q25 = sorted[5] = 5, q75 = sorted[15] = 15.
         let samples: Vec<f64> = (0..20).map(f64::from).collect();
         assert_eq!(iqr(&samples), 10.0);
@@ -1531,7 +1531,7 @@ mod tests {
     }
 
     #[test]
-    fn sentinel_regime_change_detection() {
+    fn sentinel_drift_exceeded_trips_only_beyond_the_fifty_percent_band() {
         let frac = SENTINEL_REGIME_CHANGE_FRAC;
         // The observed benign band (macOS post-build daemons measured 11–19%
         // drift) must NOT abort: it is recorded and post-hoc corrected.

--- a/pixelflow-pipeline/src/training/split.rs
+++ b/pixelflow-pipeline/src/training/split.rs
@@ -827,7 +827,7 @@ kernels = ["swirl"]
     }
 
     #[test]
-    fn seed_range_helpers() {
+    fn seed_range_contains_count_and_overlaps_match_their_definitions() {
         let r = SeedRange { start: 2, end: 5 };
         assert!(r.contains(2) && r.contains(5) && !r.contains(6));
         assert_eq!(r.count(), 4);


### PR DESCRIPTION
## Summary

Scheduled test-quality control pass, continuing
`docs/bugs/2026-08-15-test-quality-audit-followup.md`.

- **Delta audit**: reviewed every test added since the last pass (commits
  `5436ed73`, `be4f98df`) against `docs/STYLE.md`'s testing rules
  (public-API-only, descriptive "it should" names). Public-API access was
  clean throughout. Found and fixed 9 test names that were bare noun-phrase
  labels rather than sentences (e.g. `iqr_computation` →
  `iqr_is_order_independent_and_zero_for_constant_samples`). Renames only,
  no behavior change.
- **Mutation testing** (`cargo-mutants`) against
  `pixelflow-core/src/backend/x86.rs` — the `SimdOps`/`SimdU32Ops` *required*
  per-ISA primitives had never been swept as a whole file (backlog item from
  the prior audit). First run repeated a documented `--lib`-scoping mistake
  (hides the integration-test file, silently inflates the catch rate);
  re-run correctly: 229 mutants, 172 missed. Scoped this pass to the
  F32x4/U32x4/Mask4 tier (the always-compiled SSE2 baseline — F32x8/AVX2 and
  F32x16/AVX-512 are follow-up work, noted in the doc). Added 15 tests
  closing 16 real gaps (`gather`, `add_masked`, `from_u32_bits`, `shr_u32`,
  `i32_to_f32`, F32x4 `BitOr`/`Not`, and U32x4's
  Debug/store/BitAnd/BitOr/Not/Shl/Shr/`pack_rgba`). Re-verified: 74/77
  caught; the 3 remaining misses are documented non-issues (2 `Debug::fmt`
  formatters, 1 genuinely equivalent mutant on an already-`Self::default()`
  placeholder function).

Full writeup, including the equivalence reasoning and the updated backlog
for the next scheduled pass: `docs/bugs/2026-08-17-test-quality-audit-followup.md`.

## Test plan

- [x] `cargo test -p pixelflow-core --test x86_backend_tests` — 33 passed (18 pre-existing + 15 new)
- [x] `cargo test -p pixelflow-core` (all targets incl. doctests) — passed
- [x] `cargo test --workspace --lib` — 1446 passed, 4 ignored, 0 failed
- [x] `cargo clippy -p pixelflow-core --tests` — clean
- [x] `cargo fmt -p pixelflow-core -- --check` — clean
- [x] `cargo mutants -p pixelflow-core --file pixelflow-core/src/backend/x86.rs -F 'F32x4|U32x4|Mask4'` — 74/77 caught

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GyRyYLryxPrkaG8p9N8h3P)_