### PR TITLE
refactor: the four P1 defect classes die to denotations (J2-J4, J7-J9, J14, J15)

### DIFF
--- a/pixelflow-codegen/tests/prod_kernel_jit.rs
+++ b/pixelflow-codegen/tests/prod_kernel_jit.rs
@@ -61,8 +61,8 @@ fn optimize(arena: &ExprArena, root: ExprId, tag: &str) -> (ExprArena, ExprId) {
     // The learned "ML filter": NNUE-guided extraction of the cheapest DAG.
     let nnue = ExprNnue::new_with_latency_prior(0xC0FFEE);
     let extractor = IncrementalExtractor::new(&nnue, 8);
-    let (cost, choices) = extractor.extract_choices_only(&eg, root_class);
-    let (out_arena, out_root) = choices_to_arena(&eg, root_class, &choices);
+    let (cost, extraction) = extractor.extract_choices_only(&eg, root_class);
+    let (out_arena, out_root) = choices_to_arena(&extraction);
 
     eprintln!(
         "[{tag}] egraph {classes_before} -> {classes_after} classes, \

--- a/pixelflow-pipeline/src/bin/bench_extraction_3way.rs
+++ b/pixelflow-pipeline/src/bin/bench_extraction_3way.rs
@@ -6,7 +6,7 @@
 //! On the SAME saturated e-graph, compares three extraction policies with
 //! real JIT wall-clock:
 //!   (a) NNUE      — `IncrementalExtractor` guided by the trained Judge
-//!   (b) STATIC    — `extract_dag` + `CostModel::latency_prior()`
+//!   (b) STATIC    — `extract` + `CostModel::latency_prior()`
 //!   (c) NO-SWAP   — the original expression form, un-extracted
 //! plus a fourth A/A arm (STATIC measured twice, `static_aa`) whose delta is
 //! the run's noise floor: any verdict inside that floor is INCONCLUSIVE.
@@ -104,7 +104,7 @@
 
 use std::fs;
 use std::io::Write as _;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use clap::Parser;
@@ -117,7 +117,7 @@ use pixelflow_ir::{
     PointVerdict, compare_mask_root,
 };
 use pixelflow_search::egraph::{
-    CostModel, EGraph, IncrementalExtractor, all_rules, choices_to_arena, extract_dag,
+    CostModel, EGraph, IncrementalExtractor, all_rules, choices_to_arena, extract,
 };
 use pixelflow_search::nnue::ExprNnue;
 
@@ -286,20 +286,19 @@ impl SeededRng {
 }
 
 // ---------------------------------------------------------------------------
-// Config hash: FNV-1a over the weights bytes then the key parameters, so a
-// journal line identifies exactly which (weights, protocol) produced it.
+// Config hash: source revision + corpus identity + weights identity +
+// environment + this binary's protocol params, composed into one journal
+// line's provenance. The composition itself (`SourceVersion`,
+// `environment_fingerprint`, `ConfigHash::compose`, the FNV-1a primitive) now
+// lives in `pixelflow_pipeline::journal` — `bootstrap_extraction_head` needs
+// the exact same shape, and hand-rolling it independently in each binary was
+// the structurally-divergent-journal-line risk J15 exists to close
+// (docs/plans/2026-08-17-cost-model-domain.md).
 // ---------------------------------------------------------------------------
 
-const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
-const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
-
-fn fnv1a64(bytes: &[u8], mut hash: u64) -> u64 {
-    for &b in bytes {
-        hash ^= u64::from(b);
-        hash = hash.wrapping_mul(FNV_PRIME);
-    }
-    hash
-}
+use pixelflow_pipeline::journal::{
+    ArtifactId, ConfigHash, DIFF_HASH_EXCLUDES, JournalEntry, SourceVersion, fnv1a64_hex,
+};
 
 // ---------------------------------------------------------------------------
 // The four measurement arms. STATIC appears twice: the `static_aa` arm is the
@@ -1284,14 +1283,17 @@ fn prepare_kernel(
     let t_nnue = Instant::now();
     let extractor = IncrementalExtractor::new(ctx.nnue, EXTRACT_TOP_K);
     let (_cost, nnue_choices) = extractor.extract_choices_only(&eg, root_class);
-    let (nnue_arena, nnue_root) = choices_to_arena(&eg, root_class, &nnue_choices);
+    let (nnue_arena, nnue_root) = choices_to_arena(&nnue_choices);
     let extract_us_nnue = t_nnue.elapsed().as_secs_f64() * 1e6;
 
-    // (b) STATIC extraction — CostModel::latency_prior() via extract_dag.
+    // (b) STATIC extraction — CostModel::latency_prior() via `extract`, which
+    // seals its DP choices into an `Extraction` and calls `choices_to_arena`
+    // itself (one definition, imported, not restated). `extract_dag`'s extra
+    // DAG-sharing metadata (`.shared`/`.schedule`, for codegen let-binding)
+    // is unused here — this call site only ever wanted the arena.
     let t_static = Instant::now();
     let static_costs = CostModel::latency_prior();
-    let static_dag = extract_dag(&eg, root_class, &static_costs);
-    let (static_arena, static_root) = choices_to_arena(&eg, root_class, &static_dag.choices);
+    let (static_arena, static_root, _static_cost) = extract(&eg, root_class, &static_costs);
     let extract_us_static = t_static.elapsed().as_secs_f64() * 1e6;
 
     let mut gate = |policy: &'static str,
@@ -1595,21 +1597,15 @@ struct RunSummaryRecord<'a> {
 }
 
 #[derive(Serialize)]
-struct JournalRecord<'a> {
-    record: &'static str,
-    ts_unix: u64,
-    config_hash: &'a str,
-    /// The revision the measurement logic itself came from (Codex P2). A
-    /// journal line without this cannot be attributed to a commit.
-    source_rev: &'a str,
-    /// Hash of the uncommitted diff behind a `-dirty` revision (Codex
-    /// 3741889899).
-    source_diff_hash: Option<&'a str>,
+/// This binary's own metrics for one line of `docs/results/journal.jsonl` —
+/// wrapped by [`pixelflow_pipeline::journal::JournalEntry`] for the
+/// provenance envelope (`record`, `ts_unix`, `config: ConfigHash`, `weights:
+/// ArtifactId`) every journal-writing binary now shares
+/// (docs/plans/2026-08-17-cost-model-domain.md, J15) — `config` already
+/// carries the corpus identity and source revision this struct used to
+/// duplicate as flat fields.
+struct BenchMetrics<'a> {
     tier: &'static str,
-    /// Corpus identity, its own field beside the hash it now feeds (Codex
-    /// 3744586352): two runs of the same executable over regenerated tiers are
-    /// different experiments and must be distinguishable here at a glance.
-    corpus_hash: &'a str,
     corpus_path: String,
     corpus_entries: usize,
     final_eval: bool,
@@ -2144,123 +2140,6 @@ fn verdict_text(inputs: &VerdictInputs<'_>) -> String {
     )
 }
 
-/// Paths excluded from the dirty-tree diff hash: a run WRITES into these, so
-/// including them would make the hash depend on the run's own output — the
-/// second invocation of an unchanged tree would hash differently from the
-/// first, which is the opposite of an identity.
-const DIFF_HASH_EXCLUDES: [&str; 2] = [
-    ":(exclude)pixelflow-pipeline/data",
-    ":(exclude)docs/results",
-];
-
-/// What source this measurement came from.
-///
-/// `rev` alone was not enough (Codex 3741889899): every uncommitted variant of
-/// the same HEAD collapsed onto the single string `"<sha>-dirty"`, so two
-/// working trees measuring different code produced identical config hashes and
-/// indistinguishable journal lines. `diff_hash` restores the distinction by
-/// hashing the actual uncommitted diff over tracked source.
-#[derive(Clone, Debug)]
-struct SourceVersion {
-    /// `git rev-parse HEAD`, suffixed `-dirty`, or `"unversioned"`.
-    rev: String,
-    /// FNV-1a of `git diff HEAD` over tracked source, excluding the run's own
-    /// outputs — `None` on a clean tree. FNV rather than SHA-256 because the
-    /// job is *distinguishing* working trees in a local research journal, and
-    /// a cryptographic hash would be a new dependency for no added property.
-    diff_hash: Option<String>,
-}
-
-impl SourceVersion {
-    /// Resolve the working tree's version. Runs git in the crate's manifest
-    /// directory so the answer names THIS repo regardless of cwd.
-    ///
-    /// On any git failure the revision is `"unversioned"` — after printing the
-    /// failure loudly on stderr, never silently.
-    fn resolve() -> Self {
-        let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
-        let unversioned = |why: &str| -> SourceVersion {
-            eprintln!(
-                "WARNING: could not resolve the source revision ({why}) — the journal line will \
-                 record source_rev=\"unversioned\", which makes this run UNATTRIBUTABLE to a \
-                 commit. Fix git availability before trusting cross-run comparisons."
-            );
-            SourceVersion {
-                rev: "unversioned".to_string(),
-                diff_hash: None,
-            }
-        };
-        let git = |args: &[&str]| -> Result<String, String> {
-            match std::process::Command::new("git")
-                .args(args)
-                .current_dir(manifest_dir)
-                .output()
-            {
-                Ok(out) if out.status.success() => {
-                    Ok(String::from_utf8_lossy(&out.stdout).to_string())
-                }
-                Ok(out) => Err(format!(
-                    "`git {}` exited {}: {}",
-                    args.join(" "),
-                    out.status,
-                    String::from_utf8_lossy(&out.stderr).trim()
-                )),
-                Err(e) => Err(format!("failed to spawn git: {e}")),
-            }
-        };
-
-        let head = match git(&["rev-parse", "HEAD"]) {
-            Ok(s) => s.trim().to_string(),
-            Err(why) => return unversioned(&why),
-        };
-        if head.is_empty() {
-            return unversioned("`git rev-parse HEAD` produced no output");
-        }
-        let status = match git(&["status", "--porcelain"]) {
-            Ok(s) => s,
-            Err(why) => return unversioned(&why),
-        };
-        if !status.bytes().any(|b| !b.is_ascii_whitespace()) {
-            return SourceVersion {
-                rev: head,
-                diff_hash: None,
-            };
-        }
-
-        let mut diff_args = vec!["diff", "HEAD", "--"];
-        diff_args.extend(DIFF_HASH_EXCLUDES);
-        let diff = match git(&diff_args) {
-            Ok(s) => s,
-            Err(why) => {
-                // The tree IS dirty and the diff could not be read: say so and
-                // record no hash rather than pretending the variants are one.
-                eprintln!(
-                    "WARNING: the working tree is dirty but the diff could not be hashed ({why}) \
-                     — this run's config hash cannot distinguish it from other uncommitted \
-                     variants of {head}."
-                );
-                return SourceVersion {
-                    rev: format!("{head}-dirty"),
-                    diff_hash: None,
-                };
-            }
-        };
-        SourceVersion {
-            rev: format!("{head}-dirty"),
-            diff_hash: Some(format!("{:016x}", fnv1a64(diff.as_bytes(), FNV_OFFSET))),
-        }
-    }
-
-    /// The string that enters the config hash: revision plus, when dirty, the
-    /// diff's own hash.
-    fn config_hash_input(&self) -> String {
-        match &self.diff_hash {
-            Some(h) => format!("{};diff={h}", self.rev),
-            None => self.rev.clone(),
-        }
-    }
-}
-
 // ---------------------------------------------------------------------------
 // main
 // ---------------------------------------------------------------------------
@@ -2320,73 +2199,37 @@ fn subsample<T>(
 /// expressions were measured: `gen_bench_corpus` rewrites a tier in place, and
 /// a tier regenerated from a different seed, target, or manifest is a different
 /// experiment (Codex 3744586352). FNV rather than a cryptographic hash for the
-/// same reason `SourceVersion::diff_hash` uses it — the job is distinguishing
-/// setups in a local research journal, not resisting an adversary.
+/// same reason [`pixelflow_pipeline::journal::SourceVersion::diff_hash`] uses
+/// it — the job is distinguishing setups in a local research journal, not
+/// resisting an adversary. A thin, semantically-named wrapper around
+/// [`fnv1a64_hex`] (`pixelflow_pipeline::journal`'s shared primitive) rather
+/// than a second hash implementation.
 fn corpus_identity(bytes: &[u8]) -> String {
-    format!("{:016x}", fnv1a64(bytes, FNV_OFFSET))
+    fnv1a64_hex(bytes)
 }
 
-// `refuse_unsmudged_lfs_pointer` moved to
-// `pixelflow_pipeline::journal::append_record`, which now performs the whole
-// append (serialize, mkdir, LFS guard, append-or-panic) for this binary's
-// journal write below — the one writer every journal-producing binary shares
-// (docs/plans/2026-08-17-cost-model-domain.md, J15).
+// `refuse_unsmudged_lfs_pointer`, `SourceVersion`, `environment_fingerprint`,
+// and the FNV-1a primitive all moved to `pixelflow_pipeline::journal`, which
+// now performs the whole append (serialize, mkdir, LFS guard, append-or-panic)
+// AND composes the `ConfigHash` below — the one writer/composer every
+// journal-producing binary shares (docs/plans/2026-08-17-cost-model-domain.md,
+// J15).
 
-/// The build and machine this run's numbers came off.
-///
-/// Source, weights, corpus, and flags describe the *experiment*; they do not
-/// describe where it ran, and a latency benchmark's result is a property of
-/// both. The same source on aarch64 and on x86-64-with-AVX-512 emits different
-/// instructions for the same expression, and a debug build times nothing like a
-/// release one — yet without this the journal files all of those under one
-/// `config_hash` and invites a cross-machine comparison that means nothing.
-///
-/// Compile-time facts only: `target_arch`/`target_feature` are what actually
-/// select the emitter (the `#[cfg]` blocks above), and the profile decides
-/// whether the timings are meaningful at all. The specific CPU model is
-/// deliberately not read here — it needs a syscall or `/proc`, it varies across
-/// otherwise-identical cloud instances, and the sentinel calibration already
-/// records per-run clock behavior.
-fn environment_fingerprint() -> String {
-    let isa = if cfg!(target_feature = "avx512f") {
-        "avx512f"
-    } else if cfg!(target_feature = "avx2") {
-        "avx2"
-    } else if cfg!(target_feature = "fma") {
-        "fma"
-    } else {
-        "baseline"
-    };
-    format!(
-        "arch={};os={};ptr={};isa={};profile={}",
-        std::env::consts::ARCH,
-        std::env::consts::OS,
-        usize::BITS,
-        isa,
-        if cfg!(debug_assertions) {
-            "debug"
-        } else {
-            "release"
-        },
-    )
-}
-
-/// Everything that shapes the measurement, as the string the config hash is
-/// taken over: the protocol constants, the run's flags, the source revision,
-/// the corpus identity, and the environment the numbers were produced on.
-fn config_params(tier: Tier, args: &Args, source: &SourceVersion, corpus_hash: &str) -> String {
+/// This binary's own protocol parameters, as the free-text `protocol` field
+/// [`ConfigHash::compose`] folds in beside the source revision, corpus
+/// identity, weights identity, and environment it composes generically. Only
+/// what's specific to THIS measurement protocol lives here now — the shared
+/// parts moved to `pixelflow_pipeline::journal`.
+fn config_params(tier: Tier, args: &Args) -> String {
     format!(
         "saturate={SATURATE_LIMIT};top_k={EXTRACT_TOP_K};tier={};max_kernels={};\
          sample_seed={:#x};repeats={TIMED_REPEATS};order_seed={ORDER_SEED:#x};\
-         boot={BOOTSTRAP_ITERS}:{BOOTSTRAP_SEED:#x};\
-         mode={};tuples={INPUT_TUPLES};grid={};rev={};corpus={corpus_hash};{}",
+         boot={BOOTSTRAP_ITERS}:{BOOTSTRAP_SEED:#x};mode={};tuples={INPUT_TUPLES};grid={}",
         tier.name(),
         args.max_kernels,
         args.sample_seed,
         bench_mode_slug(BENCH_MODE),
         GRID.len(),
-        source.config_hash_input(),
-        environment_fingerprint(),
     )
 }
 
@@ -2479,13 +2322,16 @@ fn main() {
         mint.weights_fnv64
     );
 
-    // Config hash: weights bytes + the parameters that shape the measurement
-    // protocol + the SOURCE VERSION, so every journal line is attributable to
-    // one exact setup. Without the revision (Codex P2) two commits that change
-    // the measurement logic itself — the grid, the gate, the timing loop —
-    // hash identically while measuring different things; without the diff hash
-    // (Codex 3741889899) every uncommitted variant of one commit does.
-    let source = SourceVersion::resolve();
+    // Config hash: source revision + corpus identity + weights identity +
+    // environment + this binary's protocol params, composed by
+    // `pixelflow_pipeline::journal::ConfigHash` so every journal line is
+    // attributable to one exact setup the same way `bootstrap_extraction_head`
+    // now composes its own. Without the revision (Codex P2) two commits that
+    // change the measurement logic itself — the grid, the gate, the timing
+    // loop — hash identically while measuring different things; without the
+    // diff hash (Codex 3741889899) every uncommitted variant of one commit
+    // does.
+    let source = SourceVersion::current(&DIFF_HASH_EXCLUDES);
     eprintln!("Source revision: {}", source.rev);
     if let Some(h) = &source.diff_hash {
         eprintln!("Uncommitted diff hash: {h}");
@@ -2513,11 +2359,14 @@ fn main() {
         corpus_path.display(),
         corpus_bytes.len()
     );
-    let params = config_params(tier, &args, &source, &corpus_hash);
-    let config_hash = format!(
-        "{:016x}",
-        fnv1a64(params.as_bytes(), fnv1a64(&weights_bytes, FNV_OFFSET))
-    );
+    let protocol = config_params(tier, &args);
+    // `mint.weights_fnv64` is already this exact FNV-1a hash of
+    // `weights_bytes` (Codex 3758853787's `weights_identity`, asserted equal
+    // to these bytes above by `require_weights`) — reusing it here means the
+    // config hash names the weights the sidecar itself vouches for, not a
+    // second independently-computed hash of the same bytes.
+    let config = ConfigHash::compose(&source, &corpus_hash, &mint.weights_fnv64, &protocol);
+    let config_hash = config.value.clone();
     eprintln!("Config hash: {config_hash}");
 
     let ts_unix = SystemTime::now()
@@ -2689,7 +2538,7 @@ fn main() {
                 let sentinel = bench
                     .sentinel
                     .expect("session-minted BenchResult always carries a SentinelContext");
-                let normalization = sentinel.normalization();
+                let normalization = sentinel.normalization().get();
                 out.write(&MeasurementRecord {
                     record: "measurement",
                     kernel: &kernel.name,
@@ -3143,51 +2992,54 @@ fn main() {
         env!("CARGO_MANIFEST_DIR"),
         "/../docs/results/journal.jsonl"
     ));
-    let journal_record = JournalRecord {
-        record: "bench_extraction_3way",
-        ts_unix,
-        config_hash: &config_hash,
-        source_rev: &source.rev,
-        source_diff_hash: source.diff_hash.as_deref(),
-        tier: tier.name(),
-        corpus_hash: &corpus_hash,
-        corpus_path: corpus_path.display().to_string(),
-        corpus_entries,
-        final_eval: args.final_eval,
-        mode: bench_mode_slug(BENCH_MODE),
-        weights_mint_mode: mint.bench_mode.clone(),
-        geomean_nnue_static: finite_or_none(geomean_nnue_static),
-        geomean_nnue_static_ci_lo: ratio_ci.map(|(lo, _)| lo),
-        geomean_nnue_static_ci_hi: ratio_ci.map(|(_, hi)| hi),
-        nnue_static_pairs: all_nnue_static.len(),
-        ratio_median: ratio_dist.as_ref().map(|d| d.median),
-        ratio_q1: ratio_dist.as_ref().map(|d| d.q1),
-        ratio_q3: ratio_dist.as_ref().map(|d| d.q3),
-        ratio_wins: ratio_dist.as_ref().map_or(0, |d| d.wins),
-        ratio_losses: ratio_dist.as_ref().map_or(0, |d| d.losses),
-        loo_geomean_min: loo.as_ref().map(|l| l.min),
-        loo_geomean_max: loo.as_ref().map(|l| l.max),
-        loo_most_influential: loo.as_ref().map(|l| l.most_influential.clone()),
-        geomean_static_noswap: finite_or_none(geomean_static_noswap),
-        noise_floor_pct: finite_or_none(noise_floor_pct),
-        kernels_excluded,
-        named_static_fail,
-        named_nnue_fail,
-        syn_static_fail,
-        syn_nnue_fail,
-        failure_rate_noswap: failure_rates.noswap,
-        failure_rate_static: failure_rates.static_,
-        failure_rate_nnue: failure_rates.nnue,
-        same_form_miscompile_rate: gate_tally.same_form_rate(),
-        cross_form_divergence_rate: gate_tally.cross_form_rate(),
-        correctness_gate_failed: !gate_alarms.is_empty(),
-        gate_alarms: gate_alarms.clone(),
-        bound_coverage_mean_pct,
-        verdict_censored: !failure_rates.censoring().is_empty(),
-        verdict: &verdict,
-        data_jsonl: data_path.display().to_string(),
-    };
-    pixelflow_pipeline::journal::append_record(&journal_path, &journal_record);
+    let weights_artifact = ArtifactId::with_identity(
+        weights_path.display().to_string(),
+        mint.weights_fnv64.clone(),
+    );
+    let journal_entry = JournalEntry::new(
+        "bench_extraction_3way",
+        config,
+        weights_artifact,
+        BenchMetrics {
+            tier: tier.name(),
+            corpus_path: corpus_path.display().to_string(),
+            corpus_entries,
+            final_eval: args.final_eval,
+            mode: bench_mode_slug(BENCH_MODE),
+            weights_mint_mode: mint.bench_mode.clone(),
+            geomean_nnue_static: finite_or_none(geomean_nnue_static),
+            geomean_nnue_static_ci_lo: ratio_ci.map(|(lo, _)| lo),
+            geomean_nnue_static_ci_hi: ratio_ci.map(|(_, hi)| hi),
+            nnue_static_pairs: all_nnue_static.len(),
+            ratio_median: ratio_dist.as_ref().map(|d| d.median),
+            ratio_q1: ratio_dist.as_ref().map(|d| d.q1),
+            ratio_q3: ratio_dist.as_ref().map(|d| d.q3),
+            ratio_wins: ratio_dist.as_ref().map_or(0, |d| d.wins),
+            ratio_losses: ratio_dist.as_ref().map_or(0, |d| d.losses),
+            loo_geomean_min: loo.as_ref().map(|l| l.min),
+            loo_geomean_max: loo.as_ref().map(|l| l.max),
+            loo_most_influential: loo.as_ref().map(|l| l.most_influential.clone()),
+            geomean_static_noswap: finite_or_none(geomean_static_noswap),
+            noise_floor_pct: finite_or_none(noise_floor_pct),
+            kernels_excluded,
+            named_static_fail,
+            named_nnue_fail,
+            syn_static_fail,
+            syn_nnue_fail,
+            failure_rate_noswap: failure_rates.noswap,
+            failure_rate_static: failure_rates.static_,
+            failure_rate_nnue: failure_rates.nnue,
+            same_form_miscompile_rate: gate_tally.same_form_rate(),
+            cross_form_divergence_rate: gate_tally.cross_form_rate(),
+            correctness_gate_failed: !gate_alarms.is_empty(),
+            gate_alarms: gate_alarms.clone(),
+            bound_coverage_mean_pct,
+            verdict_censored: !failure_rates.censoring().is_empty(),
+            verdict: &verdict,
+            data_jsonl: data_path.display().to_string(),
+        },
+    );
+    pixelflow_pipeline::journal::append_record(&journal_path, &journal_entry);
 
     println!("\nMachine-readable results: {}", data_path.display());
 
@@ -3448,8 +3300,7 @@ mod tests {
         let root_class = eg.add_arena(&arena, root);
         eg.saturate_with_limit(SATURATE_LIMIT);
         let costs = CostModel::latency_prior();
-        let dag = extract_dag(&eg, root_class, &costs);
-        let (static_arena, static_root) = choices_to_arena(&eg, root_class, &dag.choices);
+        let (static_arena, static_root, _cost) = extract(&eg, root_class, &costs);
         let (code, check) = check_policy(
             "poly/static",
             (&arena, root),
@@ -4040,10 +3891,12 @@ mod tests {
     }
 
     #[test]
-    fn config_params_change_when_only_the_corpus_changed() {
+    fn config_hash_changes_when_only_the_corpus_changed() {
         // The regression: same executable, same flags, same revision, a tier
         // regenerated from a different seed. Before the fix these two runs
         // were one `config_hash`, and the journal called them the same setup.
+        // `config_params` now supplies only the protocol half; the corpus
+        // identity is a `ConfigHash::compose` argument in its own right.
         let args = Args {
             corpus_dir: "pixelflow-pipeline/data".into(),
             final_eval: false,
@@ -4054,26 +3907,19 @@ mod tests {
             rev: "0".repeat(40),
             diff_hash: None,
         };
-        let before = config_params(Tier::Dev, &args, &source, "1111111111111111");
-        let after = config_params(Tier::Dev, &args, &source, "2222222222222222");
-        assert_ne!(before, after);
-        assert!(before.contains("corpus=1111111111111111"), "{before}");
-        // And the hash over them differs, which is what the journal records.
-        let weights = b"weights";
-        let hash = |p: &str| {
-            format!(
-                "{:016x}",
-                fnv1a64(p.as_bytes(), fnv1a64(weights, FNV_OFFSET))
-            )
-        };
-        assert_ne!(hash(&before), hash(&after));
+        let protocol = config_params(Tier::Dev, &args);
+        let before = ConfigHash::compose(&source, "1111111111111111", "weights", &protocol);
+        let after = ConfigHash::compose(&source, "2222222222222222", "weights", &protocol);
+        assert_ne!(before.value, after.value);
+        assert_eq!(before.corpus_identity, "1111111111111111");
+        assert_eq!(after.corpus_identity, "2222222222222222");
     }
 
     // ── Source version in the config hash (Codex P2 + 3741889899) ───────────
 
     #[test]
     fn source_revision_is_a_sha_or_a_loud_unversioned() {
-        let source = SourceVersion::resolve();
+        let source = SourceVersion::current(&DIFF_HASH_EXCLUDES);
         if source.rev == "unversioned" {
             return; // git unavailable in this environment; the warning printed.
         }
@@ -4108,7 +3954,8 @@ mod tests {
             rev: "abc-dirty".into(),
             diff_hash: Some("2222".into()),
         };
-        let hash = |s: &SourceVersion| fnv1a64(s.config_hash_input().as_bytes(), FNV_OFFSET);
+        let hash =
+            |s: &SourceVersion| ConfigHash::compose(s, "corpus", "weights", "protocol").value;
         assert_ne!(hash(&dirty_a), hash(&dirty_b));
         assert_ne!(hash(&clean), hash(&dirty_a));
         assert_eq!(hash(&dirty_a), hash(&dirty_a));
@@ -4124,13 +3971,19 @@ mod tests {
     }
 
     #[test]
-    fn config_hash_input_changes_with_the_revision() {
-        let weights = [1u8, 2, 3];
-        let params_a = "mode=latency;rev=aaaaaaa";
-        let params_b = "mode=latency;rev=bbbbbbb";
-        let hash = |p: &str| fnv1a64(p.as_bytes(), fnv1a64(&weights, FNV_OFFSET));
-        assert_ne!(hash(params_a), hash(params_b));
-        assert_eq!(hash(params_a), hash(params_a));
+    fn config_hash_changes_with_the_revision() {
+        let source_a = SourceVersion {
+            rev: "aaaaaaa".into(),
+            diff_hash: None,
+        };
+        let source_b = SourceVersion {
+            rev: "bbbbbbb".into(),
+            diff_hash: None,
+        };
+        let hash =
+            |s: &SourceVersion| ConfigHash::compose(s, "corpus", "weights", "mode=latency").value;
+        assert_ne!(hash(&source_a), hash(&source_b));
+        assert_eq!(hash(&source_a), hash(&source_a));
     }
 
     #[test]

--- a/pixelflow-pipeline/src/bin/bench_extraction_3way.rs
+++ b/pixelflow-pipeline/src/bin/bench_extraction_3way.rs
@@ -3966,8 +3966,16 @@ mod tests {
         // A run writes its JSONL under pixelflow-pipeline/data and appends to
         // docs/results/journal.jsonl. If those counted, a second run of an
         // otherwise unchanged tree would hash differently from the first.
-        assert!(DIFF_HASH_EXCLUDES.contains(&":(exclude)pixelflow-pipeline/data"));
-        assert!(DIFF_HASH_EXCLUDES.contains(&":(exclude)docs/results"));
+        //
+        // `top,` is load-bearing, not decoration: `git()` runs with
+        // current_dir set to this crate's own manifest directory, so a bare
+        // `:(exclude)pixelflow-pipeline/data` resolves relative to THAT
+        // directory (i.e. `pixelflow-pipeline/pixelflow-pipeline/data`,
+        // which never exists) and excludes nothing — see the real
+        // behavioral regression in journal.rs's own test module
+        // (`diff_hash_exclusions_survive_running_from_a_subdirectory`).
+        assert!(DIFF_HASH_EXCLUDES.contains(&":(top,exclude)pixelflow-pipeline/data"));
+        assert!(DIFF_HASH_EXCLUDES.contains(&":(top,exclude)docs/results"));
     }
 
     #[test]

--- a/pixelflow-pipeline/src/bin/bench_jit_corpus.rs
+++ b/pixelflow-pipeline/src/bin/bench_jit_corpus.rs
@@ -29,7 +29,9 @@ use std::time::Instant;
 use clap::Parser;
 use serde::Serialize;
 
-use pixelflow_pipeline::jit_bench::{BenchError, BenchMode, BenchResult, BenchSession};
+use pixelflow_pipeline::jit_bench::{
+    BenchError, BenchMode, BenchPosition, BenchResult, BenchSession, CostLabel,
+};
 use pixelflow_pipeline::training::corpus;
 use pixelflow_pipeline::training::factored::arena_to_kernel_code;
 
@@ -64,7 +66,11 @@ struct Args {
 }
 
 /// One benchmark mode's measurement, with the dispersion and scaling metadata
-/// the audit found being thrown away (M5) or unrecorded (H5/M1).
+/// the audit found being thrown away (M5) or unrecorded (H5/M1), plus the
+/// [`CostLabel`] (docs/plans/2026-08-17-cost-model-domain.md, J3) minted from
+/// it: `value_ns` and `position` are the drift-corrected, order-tagged label
+/// a training consumer should use, computed once here rather than re-derived
+/// (and potentially re-ordered) downstream.
 #[derive(Serialize)]
 struct ModeRecord {
     mode: &'static str,
@@ -77,28 +83,26 @@ struct ModeRecord {
     local_sentinel_ns: f64,
     /// The session's opening sentinel calibration.
     sentinel_calibration_ns: f64,
-    /// `sentinel_calibration_ns / local_sentinel_ns` — the factor that
-    /// re-expresses a measurement in the run's opening clock (slow drift is a
-    /// correction, not an exclusion).
-    ///
-    /// Apply it to `ns`, then subtract `call_overhead_ns`:
-    /// `ns * sentinel_normalization - call_overhead_ns`, which is what
-    /// `training::mint::normalized_label_ns` computes. Order matters, and the
-    /// tempting shortcut is wrong: `adjusted_ns` has *already* had the
-    /// overhead subtracted, and that overhead is denominated in the opening
-    /// clock, so scaling it a second time leaves a drift-dependent
-    /// `call_overhead_ns * (1 - factor)` residue in the label. With a ~4 ns
-    /// call overhead and drift anywhere near the accepted limit that is more
-    /// than a nanosecond of collection-order-correlated bias — small in
-    /// absolute terms, and a large fraction of a small kernel.
+    /// `sentinel_calibration_ns / local_sentinel_ns` — the factor
+    /// [`CostLabel::mint`] applied to reach `value_ns`, persisted so training
+    /// can down-weight heavily-corrected samples.
     sentinel_normalization: f64,
+    /// [`CostLabel::value`]: `ns` normalized by `sentinel_normalization`,
+    /// THEN `call_overhead_ns` subtracted (`CostLabel::mint`'s ordering, not
+    /// `adjusted_ns * sentinel_normalization` — that scales a value that
+    /// already mixes two clocks and leaves a drift-dependent residue; see
+    /// `training::mint::normalized_label_ns`).
+    value_ns: f64,
+    /// [`CostLabel::position`]: this expression's index in the corpus file
+    /// (this binary benchmarks in stored order, unshuffled), the axis timing
+    /// drift correlates with.
+    position: usize,
 }
 
-impl From<&BenchResult> for ModeRecord {
-    fn from(b: &BenchResult) -> Self {
-        let sentinel = b
-            .sentinel
-            .expect("session-minted BenchResult always carries a SentinelContext");
+impl ModeRecord {
+    fn mint(b: &BenchResult, position: BenchPosition) -> Self {
+        let label = CostLabel::mint(b, position, "bench_jit_corpus");
+        let sentinel = label.calibration();
         Self {
             mode: match b.mode {
                 BenchMode::Throughput => "throughput",
@@ -111,7 +115,9 @@ impl From<&BenchResult> for ModeRecord {
             repeat_batches: b.repeat_batches,
             local_sentinel_ns: sentinel.local_sentinel_ns,
             sentinel_calibration_ns: sentinel.calibration_ns,
-            sentinel_normalization: sentinel.normalization(),
+            sentinel_normalization: label.drift().get(),
+            value_ns: label.value().get(),
+            position: position.0,
         }
     }
 }
@@ -177,15 +183,19 @@ fn main() {
     let mut excluded = 0usize;
     let total_start = Instant::now();
 
-    for (name, arena, root) in &entries {
+    for (position, (name, arena, root)) in entries.iter().enumerate() {
         let expression = arena_to_kernel_code(arena, *root);
         match session.benchmark_arena_both(arena, *root) {
             Ok((throughput, latency)) => {
+                // Both modes were measured for the same expression at the
+                // same point in the (unshuffled, stored-order) corpus walk,
+                // so they share one CostLabel position.
+                let position = BenchPosition(position);
                 let record = BenchRecord {
                     name,
                     expression: &expression,
-                    throughput: ModeRecord::from(&throughput),
-                    latency: ModeRecord::from(&latency),
+                    throughput: ModeRecord::mint(&throughput, position),
+                    latency: ModeRecord::mint(&latency, position),
                 };
                 let json = serde_json::to_string(&record).unwrap_or_else(|e| {
                     panic!("Failed to serialize bench record for '{name}': {e}")

--- a/pixelflow-pipeline/src/bin/bootstrap_extraction_head.rs
+++ b/pixelflow-pipeline/src/bin/bootstrap_extraction_head.rs
@@ -924,6 +924,42 @@ fn load_model(path: &Path, seed: u64) -> ExprNnue {
     model
 }
 
+/// Compose the journal's corpus identity from every tier file in
+/// `corpus_dir` — not just TRAIN.
+///
+/// DEV is measured unconditionally (Phase 3) and both DEV and FINAL seed the
+/// holdout fence (Phase 1, `HoldoutFence::build`) before a single expression
+/// is queued, so a run against a different DEV or FINAL tier is a materially
+/// different experiment even when TRAIN and every CLI flag are identical — a
+/// TRAIN-only identity records the same config value for both (P2 finding on
+/// PR #1019). Each tier is hashed independently and named
+/// (`"train=<hash>;dev=<hash>;final=<hash>"`) rather than concatenated raw,
+/// so one missing/unreadable tier degrades to a named "unreadable" component
+/// instead of silently shifting every other tier's bytes in the hash input.
+fn corpus_tier_identity(corpus_dir: &Path) -> String {
+    Tier::ALL
+        .iter()
+        .map(|tier| {
+            let path = corpus_dir.join(format!("corpus_{}.bin", tier.name()));
+            let hash = std::fs::read(&path)
+                .map(|bytes| pixelflow_pipeline::journal::fnv1a64_hex(&bytes))
+                .unwrap_or_else(|e| {
+                    // A tier not being readable at journal time is a fact
+                    // about this run, not a reason to lose the rest of the
+                    // line — the weights and DEV quality are already on
+                    // disk by the time this is composed.
+                    eprintln!(
+                        "WARNING: could not hash {} for the journal's corpus identity: {e}",
+                        path.display()
+                    );
+                    "unreadable".to_string()
+                });
+            format!("{}={hash}", tier.name())
+        })
+        .collect::<Vec<_>>()
+        .join(";")
+}
+
 fn main() {
     let args = Args::parse();
 
@@ -1620,32 +1656,27 @@ fn main() {
     // cross-round history. Written last — after the weights and sidecar — so
     // the line always names a checkpoint that exists.
     //
-    // Config hash (J15): this run's source revision, the TRAIN corpus this
-    // run actually trained on, the weights it produced, and the build
+    // Config hash (J15): this run's source revision, EVERY corpus tier this
+    // run actually loaded, the weights it produced, and the build
     // environment — the same provenance shape `bench_extraction_3way` composes,
     // shared via `pixelflow_pipeline::journal` rather than reimplemented here.
     // Before this, a `bootstrap_extraction_head` journal line carried none of
     // it: two runs against different corpora or different commits were
     // indistinguishable in the journal.
+    //
+    // TRAIN alone is not enough (P2 finding on PR #1019): DEV is measured
+    // unconditionally in Phase 3, and both DEV and FINAL seed the holdout
+    // fence in Phase 1 before a single expression is queued — so a DEV or
+    // FINAL tier swap changes which candidates the fence admits and what the
+    // reported DEV metrics mean, a materially different experiment a
+    // TRAIN-only identity could not distinguish. Every tier this run loaded
+    // (all three, always — see `HoldoutFence::build` and the DEV load below;
+    // TRAIN degrades to "unreadable" under `--skip-corpus`) is folded in.
     use pixelflow_pipeline::journal::{
         ArtifactId, ConfigHash, DIFF_HASH_EXCLUDES, JournalEntry, SourceVersion,
     };
     let source = SourceVersion::current(&DIFF_HASH_EXCLUDES);
-    let train_corpus_path = args
-        .corpus_dir
-        .join(format!("corpus_{}.bin", Tier::Train.name()));
-    let corpus_identity = std::fs::read(&train_corpus_path)
-        .map(|bytes| pixelflow_pipeline::journal::fnv1a64_hex(&bytes))
-        .unwrap_or_else(|e| {
-            // The corpus not being readable at journal time is a fact about
-            // this run, not a reason to lose the rest of the line — the
-            // weights and DEV quality above are already on disk.
-            eprintln!(
-                "WARNING: could not hash {} for the journal's corpus identity: {e}",
-                train_corpus_path.display()
-            );
-            "unreadable".to_string()
-        });
+    let corpus_identity = corpus_tier_identity(&args.corpus_dir);
     let protocol = format!(
         "epochs={};lr={};batch_size={};momentum={};weight_decay={};grad_clip={};\
          value_coeff={};synthetic={};skip_corpus={};seed={};order_seed={order_seed}",
@@ -1773,6 +1804,69 @@ mod tests {
         let c = arena.push_const(2.0);
         let add = arena.push_binary(OpKind::Add, x, c);
         assert!(!fence.blocks(&arena, add));
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    // ── Journal corpus identity covers every loaded tier (P2, PR #1019) ────
+
+    #[test]
+    fn corpus_tier_identity_changes_when_dev_changes_with_train_and_final_fixed() {
+        let dir = scratch_dir("tier_identity_dev");
+        write_tier(&dir, Tier::Train, &[scaled_var(1.0)]);
+        write_tier(&dir, Tier::Dev, &[scaled_var(2.0)]);
+        write_tier(&dir, Tier::Final, &[scaled_var(3.0)]);
+        let before = corpus_tier_identity(&dir);
+
+        // Rewrite ONLY DEV — the exact scenario the finding named: TRAIN
+        // (and FINAL) unchanged, DEV different, same directory.
+        write_tier(&dir, Tier::Dev, &[scaled_var(20.0)]);
+        let after = corpus_tier_identity(&dir);
+
+        assert_ne!(
+            before, after,
+            "corpus_tier_identity must change when DEV changes, even though TRAIN and \
+             FINAL did not — DEV shapes the holdout fence and supplies the reported \
+             quality metrics, so this is a materially different run"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn corpus_tier_identity_changes_when_final_changes_with_train_and_dev_fixed() {
+        let dir = scratch_dir("tier_identity_final");
+        write_tier(&dir, Tier::Train, &[scaled_var(1.0)]);
+        write_tier(&dir, Tier::Dev, &[scaled_var(2.0)]);
+        write_tier(&dir, Tier::Final, &[scaled_var(3.0)]);
+        let before = corpus_tier_identity(&dir);
+
+        write_tier(&dir, Tier::Final, &[scaled_var(30.0)]);
+        let after = corpus_tier_identity(&dir);
+
+        assert_ne!(
+            before, after,
+            "corpus_tier_identity must change when FINAL changes — FINAL shapes the \
+             holdout fence exactly as DEV does"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn corpus_tier_identity_names_a_missing_tier_rather_than_shifting_the_others() {
+        let dir = scratch_dir("tier_identity_missing");
+        write_tier(&dir, Tier::Dev, &[scaled_var(2.0)]);
+        write_tier(&dir, Tier::Final, &[scaled_var(3.0)]);
+        // TRAIN never written — the `--skip-corpus` case.
+
+        let identity = corpus_tier_identity(&dir);
+        assert!(
+            identity.contains("train=unreadable"),
+            "missing TRAIN must be named, not silently dropped: {identity}"
+        );
+        assert!(identity.contains("dev="), "{identity}");
+        assert!(identity.contains("final="), "{identity}");
 
         std::fs::remove_dir_all(&dir).ok();
     }

--- a/pixelflow-pipeline/src/bin/bootstrap_extraction_head.rs
+++ b/pixelflow-pipeline/src/bin/bootstrap_extraction_head.rs
@@ -1679,7 +1679,8 @@ fn main() {
     let corpus_identity = corpus_tier_identity(&args.corpus_dir);
     let protocol = format!(
         "epochs={};lr={};batch_size={};momentum={};weight_decay={};grad_clip={};\
-         value_coeff={};synthetic={};skip_corpus={};seed={};order_seed={order_seed}",
+         value_coeff={};synthetic={};skip_corpus={};seed={};order_seed={order_seed};\
+         dev_eval_max={}",
         args.epochs,
         args.lr,
         args.batch_size,
@@ -1690,6 +1691,13 @@ fn main() {
         args.synthetic,
         args.skip_corpus,
         args.seed,
+        // Two runs differing only in --dev-eval-max select different DEV
+        // subsets (load_corpus_exprs) and so measure different populations —
+        // without this, `--epochs 0` makes that a real ConfigHash collision:
+        // identical weights, identical corpus_identity/weights_fnv64, but
+        // different reported DEV metrics (P2 finding on the fix commit for
+        // PR #1019).
+        args.dev_eval_max,
     );
     let config = ConfigHash::compose(
         &source,

--- a/pixelflow-pipeline/src/bin/bootstrap_extraction_head.rs
+++ b/pixelflow-pipeline/src/bin/bootstrap_extraction_head.rs
@@ -34,12 +34,15 @@
 //!
 //! # One clock, one order
 //!
-//! Every label — synthetic, TRAIN corpus, DEV — is minted through
-//! [`normalized_label_ns`], which re-expresses the measurement in the
-//! session's opening clock using the sentinel's measured drift. And all three
-//! sources are pooled into one queue and benchmarked in a seeded shuffle of
-//! it rather than source-by-source in generation order. The two are
-//! complementary:
+//! Every label — synthetic, TRAIN corpus, DEV — is minted as a
+//! [`CostLabel`](pixelflow_pipeline::jit_bench::CostLabel)
+//! (docs/plans/2026-08-17-cost-model-domain.md, J3/J4), which re-expresses
+//! the measurement in the session's opening clock using the sentinel's
+//! measured drift — normalize, then subtract call overhead, the only order
+//! [`LocalNs`](pixelflow_pipeline::jit_bench::LocalNs)/[`SessionNs`](pixelflow_pipeline::jit_bench::SessionNs)
+//! type-check. And all three sources are pooled into one queue and
+//! benchmarked in a seeded shuffle of it rather than source-by-source in
+//! generation order. The two are complementary:
 //! normalization removes slow drift, shuffling decorrelates whatever it
 //! cannot remove from expression structure. Without the shuffle, generation
 //! order emits size and family bands sequentially, so residual drift is
@@ -50,14 +53,21 @@
 //! # The holdout fence
 //!
 //! The TRAIN corpus is fenced off from DEV/FINAL by `gen_bench_corpus`'s
-//! cross-tier structural ledger, but the live [`BwdGenerator`] stream in
-//! Phase 1 consults nothing: a shallow motif it happens to redraw may already
-//! live in `corpus_dev.bin`, in which case the same structure is trained on
-//! and then "held out", and the DEV MAE/Spearman stop measuring a holdout.
-//! So the DEV and FINAL tiers are loaded up front, hashed with the *same*
-//! [`arena_structural_key`](pixelflow_pipeline::training::structural) the
+//! cross-tier dedup ledger, but the live [`BwdGenerator`] stream in Phase 1
+//! consults nothing: a shallow motif it happens to redraw may already live in
+//! `corpus_dev.bin` — or merely be a literal-differing twin of something that
+//! does (P1(d): the extraction head collapses literals, so `X * 2.0` and
+//! `X * 3.0` are the identical input) — in which case the same structure is
+//! trained on and then "held out", and the DEV MAE/Spearman stop measuring a
+//! holdout. So the DEV and FINAL tiers are loaded up front into a
+//! [`Fence`](pixelflow_pipeline::training::split::Fence) per tier, keyed by
+//! the *same*
+//! [`FenceKey`](pixelflow_pipeline::training::structural::FenceKey) the
 //! corpus ledger uses, and every colliding live expression is dropped —
-//! counted, written to the exclusion sidecar, and reported loudly.
+//! counted, written to the exclusion sidecar, and reported loudly. The loaded
+//! TRAIN corpus is re-checked against the same fence for the same reason: a
+//! TRAIN tier built before this key existed (or by another build) could hold
+//! an entry the current fence would have refused.
 //!
 //! The fence reports the node-size distribution of BOTH populations, because
 //! its headline number is otherwise unreadable: the first end-to-end run saw
@@ -95,17 +105,17 @@ use pixelflow_search::nnue::factored::{EdgeAccumulator, ExprNnue};
 use pixelflow_search::nnue::{BwdGenConfig, BwdGenerator};
 
 use pixelflow_pipeline::extraction_head_weights_path;
-use pixelflow_pipeline::jit_bench::{BenchError, BenchMode, BenchResult, BenchSession, log_ns};
-use pixelflow_pipeline::training::corpus::read_corpus;
+use pixelflow_pipeline::jit_bench::{
+    BenchError, BenchMode, BenchPosition, BenchResult, BenchSession, CostLabel,
+};
 use pixelflow_pipeline::training::episodes::{build_rule_templates, load_corpus_exprs};
 use pixelflow_pipeline::training::factored::arena_to_kernel_code;
 use pixelflow_pipeline::training::mint::{
-    MintMetadata, NormalizationStats, bench_mode_slug, file_mtime_report, label_normalization,
-    normalized_label_ns, unix_now_s, weights_identity,
+    MintMetadata, NormalizationStats, bench_mode_slug, file_mtime_report, unix_now_s,
+    weights_identity,
 };
 use pixelflow_pipeline::training::quarantine::Quarantine;
-use pixelflow_pipeline::training::split::Tier;
-use pixelflow_pipeline::training::structural::StructuralKeySet;
+use pixelflow_pipeline::training::split::{DevSide, Fence, FinalSide, Tier, blocked_by_either};
 use pixelflow_pipeline::training::unified_backward::{
     UnifiedGradients, apply_unified_sgd, backward_value, forward_cached,
 };
@@ -305,7 +315,7 @@ impl WorkItem {
 
 /// A benchmark measurement turned into a training target.
 struct MintedLabel {
-    /// `log_ns` of the drift-corrected measurement.
+    /// [`CostLabel::target_log_ns`] of the drift-corrected measurement.
     target_log_ns: f32,
     /// The correction factor that was applied, kept for the sample.
     normalization: f64,
@@ -319,29 +329,43 @@ struct MintedLabel {
 /// correlated with collection position, and collection position correlates
 /// with expression structure unless something breaks the correlation. Both
 /// halves are here — this function removes the drift the sentinel measured,
-/// and [`shuffled_order`] decorrelates whatever is left.
+/// via [`CostLabel::mint`], and [`shuffled_order`] decorrelates whatever is
+/// left.
 ///
 /// All three label sources (the synthetic stream, the TRAIN corpus, and DEV)
 /// are minted here, so they sit on one clock by construction — including the
-/// order in which [`normalized_label_ns`] applies the factor and subtracts the
+/// order in which [`CostLabel::mint`] applies the factor and subtracts the
 /// opening-clock call overhead, which is not commutative and biases small
-/// kernels if swapped.
+/// kernels if swapped. That ordering used to be a doc comment a future edit
+/// could reorder; `CostLabel::mint` builds it through
+/// [`pixelflow_pipeline::jit_bench::LocalNs::normalize`], which has no `Sub`
+/// impl to subtract overhead through before normalizing, so the wrong order
+/// no longer compiles.
+///
+/// `position` is this measurement's index in [`shuffled_order`]'s benchmark
+/// order (not corpus/generation order) — the axis [`CostLabel`] persists so a
+/// downstream consumer can verify residual drift isn't confounded with
+/// expression structure.
 ///
 /// # Panics
 ///
 /// Panics when the measurement carries no sentinel context (see
-/// [`normalized_label_ns`]).
-fn mint_label(bench: &BenchResult, context: &str) -> MintedLabel {
+/// [`CostLabel::mint`]).
+fn mint_label(bench: &BenchResult, position: usize, context: &str) -> MintedLabel {
+    let label = CostLabel::mint(bench, BenchPosition(position), context);
     MintedLabel {
-        target_log_ns: log_ns(normalized_label_ns(bench, context)),
-        normalization: label_normalization(bench, context),
+        target_log_ns: label.target_log_ns(),
+        normalization: label.drift().get(),
     }
 }
 
 // ── Research journal (plan 0.3b) ────────────────────────────────────────────
 
-/// One line appended to `docs/results/journal.jsonl` per completed training
-/// run.
+/// This binary's own metrics for one line of `docs/results/journal.jsonl` —
+/// the fields that are specific to a training run, wrapped by
+/// [`pixelflow_pipeline::journal::JournalEntry`] for the provenance envelope
+/// (config hash, weights identity, timestamp) every journal-writing binary
+/// shares (docs/plans/2026-08-17-cost-model-domain.md, J15).
 ///
 /// Until this record existed, `bench_extraction_3way` was the journal's ONLY
 /// writer, so DEV model quality (Spearman, MAE) was printed to a scrollback
@@ -351,10 +375,7 @@ fn mint_label(bench: &BenchResult, context: &str) -> MintedLabel {
 /// AND their mint sidecar are on disk, so every journal line names a
 /// checkpoint that actually exists.
 #[derive(Serialize)]
-struct TrainerJournalRecord {
-    record: &'static str,
-    ts_unix: u64,
-    weights_path: String,
+struct TrainerMetrics {
     corpus_dir: String,
     bench_mode: &'static str,
     /// Training samples the head was actually fit on (post-exclusion).
@@ -387,12 +408,12 @@ struct TrainerJournalRecord {
 /// Mechanics (serialize, mkdir, LFS-pointer guard, append-or-panic) live in
 /// `pixelflow_pipeline::journal` — the one writer every journal-producing
 /// binary shares (docs/plans/2026-08-17-cost-model-domain.md, J15).
-fn append_journal(record: &TrainerJournalRecord) {
+fn append_journal(entry: &pixelflow_pipeline::journal::JournalEntry<TrainerMetrics>) {
     let journal_path = PathBuf::from(concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/../docs/results/journal.jsonl"
     ));
-    pixelflow_pipeline::journal::append_record(&journal_path, record);
+    pixelflow_pipeline::journal::append_record(&journal_path, entry);
 }
 
 /// A seeded permutation of `0..len` (LCG Fisher-Yates).
@@ -582,9 +603,13 @@ impl ExclusionLog {
     /// buffered away by a mid-run abort) but NOT echoed per line to stderr:
     /// drops are expected in the hundreds on a 50k stream, and the loud
     /// signal is the phase-1 summary plus this sidecar.
-    fn record_holdout_drop(&mut self, name: &str, expression: &str) {
+    ///
+    /// `phase` distinguishes a live-generated drop from a loaded-TRAIN
+    /// revalidation drop — both fence against the same DEV/FINAL structures,
+    /// but only the live stream's rate is folded into the phase-1 summary.
+    fn record_holdout_drop(&mut self, phase: &'static str, name: &str, expression: &str) {
         let record = HoldoutDropRecord {
-            phase: "synthetic",
+            phase,
             name,
             expression,
             reason: "holdout_structural_collision",
@@ -623,98 +648,91 @@ impl ExclusionLog {
     }
 }
 
-// ── Holdout fence (DEV/FINAL leakage, plan 0.2) ─────────────────────────────
+// ── Holdout fence (DEV/FINAL leakage, plan 0.2 / P1(d)) ─────────────────────
 
-/// The path of a tier's corpus file inside `corpus_dir`.
-fn tier_corpus_path(corpus_dir: &Path, tier: Tier) -> PathBuf {
-    corpus_dir.join(format!("corpus_{}.bin", tier.name()))
-}
-
-/// Every structure owned by the held-out tiers, so the live generator stream
-/// can be filtered against it.
+/// Every feature-quotient structure owned by the held-out tiers (DEV and
+/// FINAL, each its own [`Fence`]), so the live generator stream and the
+/// loaded TRAIN corpus can both be filtered against it.
 ///
-/// Built from the *complete* tier files (`read_corpus`), not the sampled and
-/// size-filtered [`load_corpus_exprs`]: a structure that exists anywhere in
-/// DEV or FINAL is holdout, whether or not this run's DEV evaluation happens
-/// to draw it. Sampling the fence would leak exactly the expressions the
-/// sampler skipped.
+/// Built from the *complete* tier files (`Fence::build` reads the whole
+/// corpus, not the sampled and size-filtered [`load_corpus_exprs`]): a
+/// structure that exists anywhere in DEV or FINAL is holdout, whether or not
+/// this run's DEV evaluation happens to draw it. Sampling the fence would
+/// leak exactly the expressions the sampler skipped.
 struct HoldoutFence {
-    keys: StructuralKeySet,
-    dev_entries: usize,
-    final_entries: usize,
-    /// Node count of every fenced structure, so the fence's drop count can be
-    /// read against the size range it could possibly have matched (see
-    /// [`disjointness_note`]).
+    dev: Fence<DevSide>,
+    final_: Fence<FinalSide>,
+    /// Node count of every fenced *entry* (DEV then FINAL), so the fence's
+    /// drop count can be read against the size range it could possibly have
+    /// matched (see [`disjointness_note`]).
     node_counts: Vec<usize>,
 }
 
 impl HoldoutFence {
-    /// Load DEV and FINAL and hash every expression.
+    /// Load DEV and FINAL and key every expression.
     ///
     /// # Panics
     ///
-    /// Panics when either tier file is missing. `gen_bench_corpus` writes all
-    /// three tiers in one loop, so a directory holding DEV but not FINAL is a
-    /// partial artifact; and DEV's absence is already fatal at the
-    /// held-out-evaluation phase — failing here rather than after an hour of
-    /// benchmarking is the same verdict, delivered sooner.
+    /// Panics when either tier file is missing — see [`Fence::build`].
     fn build(corpus_dir: &Path) -> Self {
-        let mut keys = StructuralKeySet::new();
-        let mut counts = [0usize; 2];
-        let mut node_counts: Vec<usize> = Vec::new();
-        for (slot, tier) in [Tier::Dev, Tier::Final].into_iter().enumerate() {
-            let path = tier_corpus_path(corpus_dir, tier);
-            assert!(
-                path.exists(),
-                "{} tier corpus not found at {} — the live-generation holdout fence cannot be \
-                 built without it, and training an unfenced stream would put DEV/FINAL \
-                 structures into the training set (the DEV metrics would stop being held out). \
-                 Run gen_bench_corpus (--output {}), which writes all three tiers together",
-                tier,
-                path.display(),
-                corpus_dir.display()
-            );
-            let entries = read_corpus(&path).unwrap_or_else(|e| {
-                panic!("failed to read {} corpus {}: {e}", tier, path.display())
-            });
-            counts[slot] = entries.len();
-            for (_name, arena, root) in &entries {
-                keys.insert(arena, *root);
-                node_counts.push(arena.node_count_subtree(*root));
-            }
-        }
+        let dev = Fence::<DevSide>::build(corpus_dir);
+        let final_ = Fence::<FinalSide>::build(corpus_dir);
+        let node_counts: Vec<usize> = dev
+            .node_counts()
+            .iter()
+            .chain(final_.node_counts())
+            .copied()
+            .collect();
         Self {
-            keys,
-            dev_entries: counts[0],
-            final_entries: counts[1],
+            dev,
+            final_,
             node_counts,
         }
     }
 
+    fn dev_entries(&self) -> usize {
+        self.dev.entries()
+    }
+
+    fn final_entries(&self) -> usize {
+        self.final_.entries()
+    }
+
+    /// Distinct feature-quotient structures fenced, DEV plus FINAL (a
+    /// structure shared by both sides counts twice — informational only).
+    fn distinct_structures(&self) -> usize {
+        self.dev.len() + self.final_.len()
+    }
+
     /// Whether this structure is already owned by a holdout tier.
     fn blocks(&self, arena: &ExprArena, root: ExprId) -> bool {
-        self.keys.contains(arena, root)
+        blocked_by_either(&self.dev, &self.final_, arena, root)
     }
+}
+
+/// What Phase 1 (live generation) did against the fence: node sizes of what
+/// survived, and how many of the total requested were dropped. Bundled so
+/// [`report_holdout_fence`] stays under the 4-argument limit (J7).
+struct FenceOutcome {
+    kept_node_counts: Vec<usize>,
+    dropped: usize,
+    requested: usize,
 }
 
 /// Report what the fence did, with enough context that its headline number
 /// cannot be misread (see [`disjointness_note`]).
-fn report_holdout_fence(
-    fence: &HoldoutFence,
-    live_counts: &[usize],
-    dropped: usize,
-    requested_synthetic: usize,
-    sidecar: &Path,
-) {
+fn report_holdout_fence(fence: &HoldoutFence, outcome: &FenceOutcome, sidecar: &Path) {
     let fenced = SizeDistribution::of(&fence.node_counts);
-    let live = SizeDistribution::of(live_counts);
+    let live = SizeDistribution::of(&outcome.kept_node_counts);
 
     eprintln!(
-        "\nHoldout fence: dropped {dropped}/{requested_synthetic} live-generated expressions \
-         ({:.2}%) whose structure already lives in DEV or FINAL — every one is a \
+        "\nHoldout fence: dropped {}/{} live-generated expressions ({:.2}%) whose \
+         feature-quotient structure already lives in DEV or FINAL — every one is a \
          `holdout_structural_collision` record in {}. Without this the DEV metrics would not \
          measure a holdout.",
-        100.0 * dropped as f64 / requested_synthetic.max(1) as f64,
+        outcome.dropped,
+        outcome.requested,
+        100.0 * outcome.dropped as f64 / outcome.requested.max(1) as f64,
         sidecar.display()
     );
 
@@ -738,9 +756,9 @@ fn report_holdout_fence(
             }
         }
         (None, Some(fenced)) => eprintln!(
-            "  No live expressions survived to be sized (--synthetic {requested_synthetic}), so \
-             the drop count is 0 by construction and says nothing about the fence. Fenced \
-             structures: {}",
+            "  No live expressions survived to be sized (--synthetic {}), so the drop count is \
+             0 by construction and says nothing about the fence. Fenced structures: {}",
+            outcome.requested,
             fenced.render()
         ),
         (_, None) => eprintln!(
@@ -921,10 +939,11 @@ fn main() {
     // so no unfenced expression can reach the training set.
     let fence = HoldoutFence::build(&args.corpus_dir);
     eprintln!(
-        "Holdout fence: {} distinct structures from DEV ({} entries) + FINAL ({} entries) in {}",
-        fence.keys.len(),
-        fence.dev_entries,
-        fence.final_entries,
+        "Holdout fence: {} distinct feature-quotient structures from DEV ({} entries) + FINAL \
+         ({} entries) in {}",
+        fence.distinct_structures(),
+        fence.dev_entries(),
+        fence.final_entries(),
         args.corpus_dir.display()
     );
 
@@ -970,7 +989,7 @@ fn main() {
         // become a label, and recorded structurally in the sidecar.
         if fence.blocks(&pair.arena, pair.unoptimized) {
             let expression = arena_to_kernel_code(&pair.arena, pair.unoptimized);
-            exclusions.record_holdout_drop(&name, &expression);
+            exclusions.record_holdout_drop(Source::Synthetic.phase(), &name, &expression);
             continue;
         }
 
@@ -1011,9 +1030,11 @@ fn main() {
 
     report_holdout_fence(
         &fence,
-        &live_counts,
-        exclusions.holdout_dropped,
-        args.synthetic,
+        &FenceOutcome {
+            kept_node_counts: live_counts,
+            dropped: exclusions.holdout_dropped,
+            requested: args.synthetic,
+        },
         &args.exclusions,
     );
 
@@ -1056,6 +1077,13 @@ fn main() {
     // broken backend as held-out truth (DEV). The same-form gate is re-run
     // with THIS build's JIT and oracle; drops are recorded in their own
     // sidecar, and the rate alarms in `finish` judge the corpus afterward.
+    //
+    // TRAIN entries also cross the SAME holdout fence the live stream does
+    // (P1(d)): `gen_bench_corpus` dedups at build time, but a TRAIN tier
+    // built before the feature-quotient key existed — or by a build whose
+    // corpus predates it — can still hold an entry that is feature-identical
+    // to something in DEV/FINAL. Loading it unchecked would train on exactly
+    // the structure the fence exists to hold out.
     let revalidation_path = args.corpus_revalidation.to_str().unwrap_or_else(|| {
         panic!(
             "--corpus-revalidation path {} is not valid UTF-8",
@@ -1082,7 +1110,14 @@ fn main() {
             corpus_exprs.len()
         );
         let mut train_revalidation_drops = 0usize;
+        let mut train_fence_drops = 0usize;
         for (name, arena, root) in corpus_exprs {
+            if fence.blocks(&arena, root) {
+                let expression = arena_to_kernel_code(&arena, root);
+                exclusions.record_holdout_drop(Source::TrainCorpus.phase(), &name, &expression);
+                train_fence_drops += 1;
+                continue;
+            }
             if corpus_revalidation.verdict(&name, &arena, root).0.is_some() {
                 train_revalidation_drops += 1;
                 continue;
@@ -1093,6 +1128,14 @@ fn main() {
                 arena: Some(arena),
                 root,
             });
+        }
+        if train_fence_drops > 0 {
+            eprintln!(
+                "  TRAIN holdout fence dropped {train_fence_drops} stored entries whose \
+                 feature-quotient structure already lives in DEV or FINAL (recorded as \
+                 `holdout_structural_collision` in {})",
+                args.exclusions.display()
+            );
         }
         if train_revalidation_drops > 0 {
             eprintln!(
@@ -1192,7 +1235,7 @@ fn main() {
         // the distribution instead of having it censored away.
         match session.benchmark_arena(queue[idx].arena(), root, MINT_MODE) {
             Ok(bench) => {
-                let label = mint_label(&bench, source.phase());
+                let label = mint_label(&bench, position, source.phase());
                 match source {
                     Source::Dev => dev_measurements.push((idx, label.target_log_ns)),
                     Source::Synthetic | Source::TrainCorpus => {
@@ -1544,6 +1587,7 @@ fn main() {
         )
     });
     let metadata = MintMetadata {
+        schema_identity: MintMetadata::current_schema_identity(),
         bench_mode: bench_mode_slug(MINT_MODE).to_string(),
         trainer: "bootstrap_extraction_head".to_string(),
         samples: samples.len(),
@@ -1575,33 +1619,87 @@ fn main() {
     // bench was the only journal writer, so intrinsic quality never had a
     // cross-round history. Written last — after the weights and sidecar — so
     // the line always names a checkpoint that exists.
-    append_journal(&TrainerJournalRecord {
-        record: "bootstrap_extraction_head",
-        ts_unix: unix_now_s(),
-        weights_path: args.output.display().to_string(),
-        corpus_dir: args.corpus_dir.display().to_string(),
-        bench_mode: bench_mode_slug(MINT_MODE),
-        train_samples: samples.len(),
-        synthetic_requested: args.synthetic,
-        epochs: args.epochs,
-        lr: args.lr,
-        seed: args.seed,
-        order_seed,
-        dev_samples: measured.len(),
-        dev_mae_log_ns: dev_mae,
-        dev_spearman_rho: dev_spearman,
-        dev_pred_bias_log_ns: dev_bias,
-        dev_pred_std_ratio: if meas_std > 0.0 {
-            pred_std / meas_std
-        } else {
-            f64::NAN
+    //
+    // Config hash (J15): this run's source revision, the TRAIN corpus this
+    // run actually trained on, the weights it produced, and the build
+    // environment — the same provenance shape `bench_extraction_3way` composes,
+    // shared via `pixelflow_pipeline::journal` rather than reimplemented here.
+    // Before this, a `bootstrap_extraction_head` journal line carried none of
+    // it: two runs against different corpora or different commits were
+    // indistinguishable in the journal.
+    use pixelflow_pipeline::journal::{
+        ArtifactId, ConfigHash, DIFF_HASH_EXCLUDES, JournalEntry, SourceVersion,
+    };
+    let source = SourceVersion::current(&DIFF_HASH_EXCLUDES);
+    let train_corpus_path = args
+        .corpus_dir
+        .join(format!("corpus_{}.bin", Tier::Train.name()));
+    let corpus_identity = std::fs::read(&train_corpus_path)
+        .map(|bytes| pixelflow_pipeline::journal::fnv1a64_hex(&bytes))
+        .unwrap_or_else(|e| {
+            // The corpus not being readable at journal time is a fact about
+            // this run, not a reason to lose the rest of the line — the
+            // weights and DEV quality above are already on disk.
+            eprintln!(
+                "WARNING: could not hash {} for the journal's corpus identity: {e}",
+                train_corpus_path.display()
+            );
+            "unreadable".to_string()
+        });
+    let protocol = format!(
+        "epochs={};lr={};batch_size={};momentum={};weight_decay={};grad_clip={};\
+         value_coeff={};synthetic={};skip_corpus={};seed={};order_seed={order_seed}",
+        args.epochs,
+        args.lr,
+        args.batch_size,
+        args.momentum,
+        args.weight_decay,
+        args.grad_clip,
+        args.value_coeff,
+        args.synthetic,
+        args.skip_corpus,
+        args.seed,
+    );
+    let config = ConfigHash::compose(
+        &source,
+        &corpus_identity,
+        &metadata.weights_fnv64,
+        &protocol,
+    );
+    let weights = ArtifactId::with_identity(
+        args.output.display().to_string(),
+        metadata.weights_fnv64.clone(),
+    );
+
+    append_journal(&JournalEntry::new(
+        "bootstrap_extraction_head",
+        config,
+        weights,
+        TrainerMetrics {
+            corpus_dir: args.corpus_dir.display().to_string(),
+            bench_mode: bench_mode_slug(MINT_MODE),
+            train_samples: samples.len(),
+            synthetic_requested: args.synthetic,
+            epochs: args.epochs,
+            lr: args.lr,
+            seed: args.seed,
+            order_seed,
+            dev_samples: measured.len(),
+            dev_mae_log_ns: dev_mae,
+            dev_spearman_rho: dev_spearman,
+            dev_pred_bias_log_ns: dev_bias,
+            dev_pred_std_ratio: if meas_std > 0.0 {
+                pred_std / meas_std
+            } else {
+                f64::NAN
+            },
+            dev_pred_p90p10_ratio: if meas_spread > 0.0 {
+                pred_spread / meas_spread
+            } else {
+                f64::NAN
+            },
         },
-        dev_pred_p90p10_ratio: if meas_spread > 0.0 {
-            pred_spread / meas_spread
-        } else {
-            f64::NAN
-        },
-    });
+    ));
 }
 
 #[cfg(test)]
@@ -1609,6 +1707,7 @@ mod tests {
     use super::*;
 
     use pixelflow_ir::OpKind;
+    use pixelflow_pipeline::jit_bench::{SessionNs, log_ns};
     use pixelflow_pipeline::training::corpus::write_corpus;
 
     // ── Holdout fence ───────────────────────────────────────────────────────
@@ -1640,7 +1739,7 @@ mod tests {
             .enumerate()
             .map(|(i, (a, r))| (format!("{}_{i}", tier.name()), a.clone(), *r))
             .collect();
-        write_corpus(&tier_corpus_path(dir, tier), &entries)
+        write_corpus(&dir.join(format!("corpus_{}.bin", tier.name())), &entries)
             .unwrap_or_else(|e| panic!("failed to write {} corpus: {e}", tier.name()));
     }
 
@@ -1651,9 +1750,8 @@ mod tests {
         write_tier(&dir, Tier::Final, &[scaled_var(3.0)]);
 
         let fence = HoldoutFence::build(&dir);
-        assert_eq!(fence.dev_entries, 1);
-        assert_eq!(fence.final_entries, 1);
-        assert_eq!(fence.keys.len(), 2);
+        assert_eq!(fence.dev_entries(), 1);
+        assert_eq!(fence.final_entries(), 1);
 
         // A freshly built arena with the SAME structure as a DEV expression
         // is the leak: different arena, different ids, same computation.
@@ -1662,11 +1760,14 @@ mod tests {
         // FINAL is fenced identically.
         let (final_shape, final_root) = scaled_var(3.0);
         assert!(fence.blocks(&final_shape, final_root));
-        // A different constant is a different structure (Const compares by
-        // bits) and must survive.
+        // P1(d): a DIFFERENT literal is not a different structure to the
+        // extraction head — `OpKind::Const` carries no value — so it must
+        // ALSO be blocked, even though it matches neither fenced entry
+        // byte-for-byte. This is the exact review case (X*2.0 fencing out
+        // X*3.0), restated with a third literal for good measure.
         let (other, other_root) = scaled_var(4.0);
-        assert!(!fence.blocks(&other, other_root));
-        // So must a different operator over the same leaves.
+        assert!(fence.blocks(&other, other_root));
+        // A genuinely different operator over the same leaves must survive.
         let mut arena = ExprArena::new();
         let x = arena.push_var(0);
         let c = arena.push_const(2.0);
@@ -1700,8 +1801,8 @@ mod tests {
         let dir = scratch_dir("log");
         let sidecar = dir.join("exclusions.jsonl");
         let mut log = ExclusionLog::create(&sidecar);
-        log.record_holdout_drop("synthetic_7", "X * 2.0");
-        log.record_holdout_drop("synthetic_9", "X * 3.0");
+        log.record_holdout_drop("synthetic", "synthetic_7", "X * 2.0");
+        log.record_holdout_drop("synthetic", "synthetic_9", "X * 3.0");
 
         // A fence drop is not a measurement exclusion: the censoring alarm's
         // counter must be untouched, or a working fence would look like a
@@ -1856,7 +1957,7 @@ mod tests {
             .enumerate()
             .map(|(position, &expr)| {
                 let bench = drifted(truth[expr], drift[position]);
-                (expr, mint_label(&bench, "test").target_log_ns)
+                (expr, mint_label(&bench, position, "test").target_log_ns)
             })
             .collect()
     }
@@ -1886,7 +1987,7 @@ mod tests {
                      another — drift is still correlated with collection order"
                 );
                 assert!(
-                    (target - log_ns(truth[expr])).abs() < 1e-6,
+                    (target - log_ns(SessionNs::new(truth[expr]))).abs() < 1e-6,
                     "the normalized target must be the undrifted truth"
                 );
             }
@@ -1900,19 +2001,27 @@ mod tests {
         // two different targets.
         let early = drifted(100.0, 1.0);
         let late = drifted(100.0, 2.0);
+        // Deliberately wraps the uncorrected `adjusted_ns` as if it were
+        // already a `SessionNs` — exactly the WRONG usage `log_ns`'s
+        // signature exists to make hard to reach by accident on the real
+        // label-minting path. This is the control the test below needs to
+        // mean anything.
         assert!(
-            (log_ns(early.adjusted_ns) - log_ns(late.adjusted_ns)).abs() > 0.5,
+            (log_ns(SessionNs::new(early.adjusted_ns)) - log_ns(SessionNs::new(late.adjusted_ns)))
+                .abs()
+                > 0.5,
             "the drift profile must actually move an uncorrected target"
         );
         assert!(
-            (mint_label(&early, "t").target_log_ns - mint_label(&late, "t").target_log_ns).abs()
+            (mint_label(&early, 0, "t").target_log_ns - mint_label(&late, 1, "t").target_log_ns)
+                .abs()
                 < 1e-6
         );
     }
 
     #[test]
     fn mint_label_reports_the_factor_it_applied() {
-        let label = mint_label(&drifted(100.0, 1.25), "t");
+        let label = mint_label(&drifted(100.0, 1.25), 0, "t");
         assert!(
             (label.normalization - 0.8).abs() < 1e-9,
             "a 1.25x slowdown is corrected by 0.8, got {}",
@@ -1928,7 +2037,7 @@ mod tests {
         // a normalized set on a different clock.
         let mut bench = drifted(100.0, 1.0);
         bench.sentinel = None;
-        let _ = mint_label(&bench, "unit test");
+        let _ = mint_label(&bench, 0, "unit test");
     }
 
     // ── Population sizes (item 5) ───────────────────────────────────────────

--- a/pixelflow-pipeline/src/bin/gen_bench_corpus.rs
+++ b/pixelflow-pipeline/src/bin/gen_bench_corpus.rs
@@ -59,8 +59,8 @@ use clap::Parser;
 use pixelflow_ir::{ExprArena, ExprId, OpKind};
 use pixelflow_pipeline::training::corpus::write_corpus;
 use pixelflow_pipeline::training::quarantine::Quarantine;
-use pixelflow_pipeline::training::split::{SplitManifest, Tier};
-use pixelflow_pipeline::training::structural::{SigNode, arena_structural_key};
+use pixelflow_pipeline::training::split::{Family, SplitManifest, Tier};
+use pixelflow_pipeline::training::structural::FenceKey;
 use pixelflow_search::egraph::collect_rule_templates;
 use pixelflow_search::nnue::{BwdGenConfig, BwdGenerator};
 
@@ -301,9 +301,10 @@ const BANDS: &[Band] = &[
     },
 ];
 
-// Structural hashing lives in `pixelflow_pipeline::training::structural` —
-// shared with bootstrap_extraction_head's live-stream holdout fence so both
-// stages agree on what "same structure" means.
+// The feature-quotient key lives in `pixelflow_pipeline::training::structural`
+// — shared with bootstrap_extraction_head's live-stream holdout fence and its
+// loaded-TRAIN revalidation, so all three stages agree on what "the model has
+// already seen this" means (P1(d)).
 
 // ============================================================================
 // Tier-aware structural dedup (plan 0.2)
@@ -500,13 +501,12 @@ const MIN_FAMILY_ADMISSIONS: usize = 8;
 /// the global rate alarm cannot see (it averages over ~300 families).
 const MAX_FAMILY_QUARANTINE_RATE: f64 = 0.20;
 
-/// Everything one `(tier, band, seed)` family did with its attempts. Every
-/// candidate is accounted for: `attempts == admitted + too_large +
-/// duplicate_within + cross_tier_drop + quarantined`.
+/// Everything one `(tier, family)` did with its attempts. Every candidate is
+/// accounted for: `attempts == admitted + too_large + duplicate_within +
+/// cross_tier_drop + quarantined`.
 struct FamilyOutcome {
     tier: Tier,
-    band: usize,
-    seed: u64,
+    family: Family,
     /// Expressions this family was asked for.
     quota: usize,
     attempts: usize,
@@ -519,11 +519,10 @@ struct FamilyOutcome {
 }
 
 impl FamilyOutcome {
-    fn new(tier: Tier, band: usize, seed: u64, quota: usize) -> Self {
+    fn new(tier: Tier, family: Family, quota: usize) -> Self {
         Self {
             tier,
-            band,
-            seed,
+            family,
             quota,
             attempts: 0,
             admitted: 0,
@@ -537,7 +536,7 @@ impl FamilyOutcome {
     fn label(&self) -> String {
         format!(
             "{} band {:>2} family {:>2}",
-            self.tier, self.band, self.seed
+            self.tier, self.family.band, self.family.seed
         )
     }
 
@@ -642,10 +641,10 @@ fn assert_family_integrity(families: &[FamilyOutcome]) {
 /// Decorrelated per-family RNG seed (SplitMix64 finalizer over a unique
 /// (band, family) encoding), so adjacent family indices do not produce
 /// correlated generator streams.
-fn family_rng_seed(global_seed: u64, band: usize, family_seed: u64) -> u64 {
+fn family_rng_seed(global_seed: u64, family: Family) -> u64 {
     let mut z = global_seed
-        .wrapping_add((band as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15))
-        .wrapping_add(family_seed.wrapping_mul(0xBF58_476D_1CE4_E5B9))
+        .wrapping_add((family.band as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15))
+        .wrapping_add(family.seed.wrapping_mul(0xBF58_476D_1CE4_E5B9))
         .wrapping_add(0x94D0_49BB_1331_11EB);
     z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
     z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
@@ -768,7 +767,7 @@ fn main() {
         .unwrap_or_else(|| format!("{}/corpus_quarantine.jsonl", args.output));
     let mut quarantine = Quarantine::new(&quarantine_log_path);
 
-    let mut ledger: DedupLedger<Vec<SigNode>> = DedupLedger::new();
+    let mut ledger: DedupLedger<FenceKey> = DedupLedger::new();
     let mut tier_entries: [Vec<(String, ExprArena, ExprId)>; 3] =
         [Vec::new(), Vec::new(), Vec::new()];
 
@@ -781,7 +780,7 @@ fn main() {
                  (known: swirl, circle_sdf, poly, redundant, normalize)"
             )
         });
-        let key = arena_structural_key(&arena, root);
+        let key = FenceKey::of(&arena, root);
         assert_eq!(
             ledger.probe(&key, Tier::Final),
             Admission::New,
@@ -816,8 +815,8 @@ fn main() {
     for tier in [Tier::Final, Tier::Dev, Tier::Train] {
         let spec = manifest.spec(tier);
         let mut tier_generated = 0usize;
-        for (band_idx, fseed) in spec.families() {
-            let band = &BANDS[band_idx];
+        for family in spec.families() {
+            let band = &BANDS[family.band];
             let config = BwdGenConfig {
                 max_depth: band.max_depth,
                 leaf_prob: band.leaf_prob,
@@ -826,12 +825,12 @@ fn main() {
                 ..BwdGenConfig::default()
             };
             let mut rng = BwdGenerator::new(
-                family_rng_seed(args.seed, band_idx, fseed),
+                family_rng_seed(args.seed, family),
                 config,
                 collect_rule_templates(),
             );
 
-            let mut outcome = FamilyOutcome::new(tier, band_idx, fseed, per_family);
+            let mut outcome = FamilyOutcome::new(tier, family, per_family);
             let max_attempts = per_family * 10;
 
             while outcome.admitted < per_family && outcome.attempts < max_attempts {
@@ -845,7 +844,7 @@ fn main() {
                     continue;
                 }
 
-                let key = arena_structural_key(&arena, root);
+                let key = FenceKey::of(&arena, root);
                 match ledger.probe(&key, tier) {
                     Admission::New => {}
                     Admission::DuplicateWithin => {
@@ -861,8 +860,8 @@ fn main() {
                 let name = format!(
                     "{}_b{:02}_f{:02}_{:05}",
                     tier.name(),
-                    band_idx,
-                    fseed,
+                    family.band,
+                    family.seed,
                     tier_generated + outcome.admitted
                 );
                 let (exclusion, _conditioning) = quarantine.verdict(&name, &arena, root);
@@ -1012,7 +1011,7 @@ mod tests {
         for band in 0..BANDS.len() {
             for fseed in 0..8u64 {
                 assert!(
-                    seen.insert(family_rng_seed(42, band, fseed)),
+                    seen.insert(family_rng_seed(42, Family::new(band, fseed))),
                     "seed collision at band {band}, family {fseed}"
                 );
             }
@@ -1023,7 +1022,7 @@ mod tests {
 
     /// A family that admitted everything it was asked for.
     fn healthy_family() -> FamilyOutcome {
-        let mut f = FamilyOutcome::new(Tier::Dev, 3, 7, 40);
+        let mut f = FamilyOutcome::new(Tier::Dev, Family::new(3, 7), 40);
         f.attempts = 40;
         f.admitted = 40;
         f
@@ -1045,7 +1044,7 @@ mod tests {
         // note and continued, and the five named kernels kept corpus_final.bin
         // nonempty — so the "tier is nonempty" check saw nothing wrong while
         // the manifest's held-out family had vanished.
-        let mut f = FamilyOutcome::new(Tier::Final, 5, 2, 40);
+        let mut f = FamilyOutcome::new(Tier::Final, Family::new(5, 2), 40);
         f.attempts = 400;
         f.too_large = 300;
         f.duplicate_within = 100;
@@ -1054,7 +1053,7 @@ mod tests {
 
     #[test]
     fn zero_admission_failure_names_the_family_and_its_attrition() {
-        let mut f = FamilyOutcome::new(Tier::Final, 5, 2, 40);
+        let mut f = FamilyOutcome::new(Tier::Final, Family::new(5, 2), 40);
         f.attempts = 400;
         f.too_large = 300;
         f.duplicate_within = 100;
@@ -1067,7 +1066,7 @@ mod tests {
 
     #[test]
     fn family_short_of_the_admission_floor_fails() {
-        let mut f = FamilyOutcome::new(Tier::Train, 0, 1, 40);
+        let mut f = FamilyOutcome::new(Tier::Train, Family::new(0, 1), 40);
         f.attempts = 400;
         f.admitted = MIN_FAMILY_ADMISSIONS - 1;
         f.too_large = 400 - f.admitted;
@@ -1082,7 +1081,7 @@ mod tests {
         // A run with more families than target expressions asks each family for
         // less than MIN_FAMILY_ADMISSIONS; judging it against the floor would
         // fail every family on an arithmetic impossibility.
-        let mut f = FamilyOutcome::new(Tier::Dev, 1, 1, 3);
+        let mut f = FamilyOutcome::new(Tier::Dev, Family::new(1, 1), 3);
         f.attempts = 3;
         f.admitted = 3;
         assert_eq!(f.required(), 3);
@@ -1095,7 +1094,7 @@ mod tests {
         // reached the numeric gate was refused: the survivors are selected by
         // whatever the quarantine happens to reject. The GLOBAL rate alarm
         // averages over hundreds of families and cannot see this.
-        let mut f = FamilyOutcome::new(Tier::Train, 2, 4, 40);
+        let mut f = FamilyOutcome::new(Tier::Train, Family::new(2, 4), 40);
         f.attempts = 40;
         f.admitted = 20;
         f.quarantined.insert("numeric_mismatch", 20);
@@ -1108,7 +1107,7 @@ mod tests {
     #[test]
     fn quarantine_rate_ignores_candidates_that_never_reached_the_gate() {
         // Too-large and duplicate candidates are not evidence about numerics.
-        let mut f = FamilyOutcome::new(Tier::Train, 2, 4, 40);
+        let mut f = FamilyOutcome::new(Tier::Train, Family::new(2, 4), 40);
         f.attempts = 400;
         f.admitted = 40;
         f.too_large = 300;
@@ -1128,7 +1127,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "failed the per-family integrity check")]
     fn one_bad_family_fails_a_run_of_healthy_ones() {
-        let mut bad = FamilyOutcome::new(Tier::Final, 9, 9, 40);
+        let mut bad = FamilyOutcome::new(Tier::Final, Family::new(9, 9), 40);
         bad.attempts = 400;
         bad.too_large = 400;
         assert_family_integrity(&[healthy_family(), bad, healthy_family()]);

--- a/pixelflow-pipeline/src/jit_bench.rs
+++ b/pixelflow-pipeline/src/jit_bench.rs
@@ -429,6 +429,116 @@ pub struct BenchResult {
     pub sentinel: Option<SentinelContext>,
 }
 
+// =============================================================================
+// Clock newtypes (docs/plans/2026-08-17-cost-model-domain.md, J4)
+// =============================================================================
+//
+// A nanosecond reading is meaningless without saying WHICH clock it is
+// denominated in: the local clock running when a particular sample was
+// taken (drifts over a session — thermal, contention, scheduler placement),
+// or the session's OPENING clock, the one canonical unit every label and
+// every call-overhead figure is compared in. Before these types, both were
+// the same `f64`, and the only thing stopping "subtract overhead, then
+// normalize" (WRONG — leaves a drift-dependent residue, see
+// `training::mint::normalized_label_ns`) from replacing "normalize, then
+// subtract overhead" (RIGHT) was a doc comment. Review caught the swap
+// twice. `LocalNs` has no `Sub` impl at all, so the raw reading cannot have
+// overhead taken off it before [`LocalNs::normalize`] — the sole conversion
+// to [`SessionNs`] — runs. The wrong order is now a compile error, not a
+// convention.
+
+/// A duration on the LOCAL clock: the clock that was actually running when
+/// this particular sample was taken. Not comparable to another `LocalNs`
+/// from a different point in the same session without normalizing — that is
+/// the whole reason [`SentinelContext`] exists.
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
+pub struct LocalNs(f64);
+
+impl LocalNs {
+    /// # Panics
+    /// Panics on a non-finite reading — a raw timer sample is never NaN or
+    /// infinite short of a harness bug, and propagating one silently would
+    /// poison every downstream label.
+    #[must_use]
+    pub fn new(ns: f64) -> Self {
+        assert!(ns.is_finite(), "LocalNs::new: non-finite reading {ns}");
+        Self(ns)
+    }
+
+    #[must_use]
+    pub fn get(self) -> f64 {
+        self.0
+    }
+
+    /// The ONLY way to leave the local clock: re-express this reading in the
+    /// session's opening clock via the drift factor the sentinel measured.
+    /// Nothing else produces a [`SessionNs`] from a raw reading, so "apply
+    /// drift" cannot be skipped or reordered by a future caller.
+    #[must_use]
+    pub fn normalize(self, drift: DriftFactor) -> SessionNs {
+        SessionNs(self.0 * drift.0)
+    }
+}
+
+/// A duration in the SESSION's opening clock — the canonical, comparable
+/// unit. Every [`CostLabel::value`] and every call-overhead figure lives
+/// here. Produced either by [`LocalNs::normalize`] (a drift-corrected
+/// reading) or [`SessionNs::new`] (a value already known to be on this
+/// clock — e.g. the identity-kernel call overhead, itself measured once at
+/// session open where the local and opening clocks coincide by
+/// construction).
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
+pub struct SessionNs(f64);
+
+impl SessionNs {
+    /// # Panics
+    /// Panics on a non-finite value, for the same reason as [`LocalNs::new`].
+    #[must_use]
+    pub fn new(ns: f64) -> Self {
+        assert!(ns.is_finite(), "SessionNs::new: non-finite value {ns}");
+        Self(ns)
+    }
+
+    #[must_use]
+    pub fn get(self) -> f64 {
+        self.0
+    }
+}
+
+impl std::ops::Sub for SessionNs {
+    type Output = SessionNs;
+    /// Call overhead is a `SessionNs`, so it can only be subtracted from a
+    /// `SessionNs` — `LocalNs` has no `Sub` impl at all. That asymmetry is
+    /// what makes "normalize, then subtract overhead" the only expression
+    /// that type-checks (J4).
+    fn sub(self, overhead: SessionNs) -> SessionNs {
+        SessionNs(self.0 - overhead.0)
+    }
+}
+
+/// The clock-speed correction factor `calibration_ns / local_sentinel_ns`
+/// (see [`SentinelContext::normalization`]) — the only producer.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct DriftFactor(f64);
+
+impl DriftFactor {
+    #[must_use]
+    pub fn get(self) -> f64 {
+        self.0
+    }
+}
+
+/// How many expressions a run had already produced labels for when this one
+/// was minted — collection order, the axis timing drift correlates with
+/// (generation emits size/family bands sequentially, so an uncorrected label
+/// set turns residual drift into learnable spurious signal; see
+/// `training::mint`). Persisted alongside [`CostLabel`] so a downstream
+/// consumer can verify residual drift isn't confounded with structure,
+/// rather than assuming the benchmark-order shuffle removed the
+/// correlation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct BenchPosition(pub usize);
+
 /// The sentinel state a [`BenchResult`] was measured under: the most recent
 /// sentinel reading (`local_sentinel_ns`) and the session's opening
 /// calibration (`calibration_ns`).
@@ -467,7 +577,7 @@ impl SentinelContext {
     /// nothing cannot correct anything, and silently returning `inf`/`NaN`
     /// would poison every corrected label downstream.
     #[must_use]
-    pub fn normalization(&self) -> f64 {
+    pub fn normalization(&self) -> DriftFactor {
         assert!(
             self.calibration_ns > 0.0 && self.local_sentinel_ns > 0.0,
             "SentinelContext::normalization: non-positive sentinel reading \
@@ -475,7 +585,7 @@ impl SentinelContext {
             self.calibration_ns,
             self.local_sentinel_ns
         );
-        self.calibration_ns / self.local_sentinel_ns
+        DriftFactor(self.calibration_ns / self.local_sentinel_ns)
     }
 }
 
@@ -515,6 +625,113 @@ impl BenchResult {
         } else {
             Ok(())
         }
+    }
+
+    /// The measurement's value in the session's opening clock: the sentinel's
+    /// drift applied to the raw reading, THEN call overhead subtracted — the
+    /// only order [`LocalNs`]/[`SessionNs`] type-check (J4). Also returns the
+    /// drift factor that was applied, for callers that persist it.
+    ///
+    /// This is the one place that arithmetic happens; [`CostLabel::mint`] and
+    /// `training::mint::normalized_label_ns`/`label_normalization` both call
+    /// it rather than restating the formula.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `self.sentinel` is `None` — a sessionless measurement (no
+    /// `BenchSession`) carries no drift information, so it cannot be
+    /// corrected into a value comparable with session-minted ones. `context`
+    /// names the call site in the panic message.
+    pub fn corrected_session_ns(&self, context: &str) -> (SessionNs, DriftFactor) {
+        let calibration = self.sentinel.unwrap_or_else(|| {
+            panic!(
+                "{context}: label minted from a BenchResult with no sentinel context — the \
+                 measurement came from a sessionless wrapper (no QoS pin, no drift sentinel, no \
+                 overhead subtraction), so its drift is neither measured nor correctable. Mint \
+                 labels through a BenchSession"
+            )
+        });
+        let drift = calibration.normalization();
+        let overhead = SessionNs::new(self.call_overhead_ns);
+        let value = LocalNs::new(self.ns).normalize(drift) - overhead;
+        (value, drift)
+    }
+}
+
+/// A measurement that has left the clock it was taken on
+/// (docs/plans/2026-08-17-cost-model-domain.md, J3): a value in
+/// [`SessionNs`], plus the context that makes the value meaningful — which
+/// [`BenchMode`] it was measured under, how much drift correction it took,
+/// where in the run it was minted, and the sentinel calibration it was
+/// corrected against.
+///
+/// These five pieces used to travel separately — `ns`/`adjusted_ns`/
+/// `call_overhead_ns` as bare fields on [`BenchResult`], `mode` beside them,
+/// [`SentinelContext`] behind an `Option` — and nothing stopped a raw,
+/// unnormalized `f64` from reaching a training target. [`CostLabel::mint`] is
+/// now the only way to produce one, and [`CostLabel::target_log_ns`] is the
+/// only bridge from a label to the `f32` a model is trained on.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct CostLabel {
+    value: SessionNs,
+    mode: BenchMode,
+    drift: DriftFactor,
+    position: BenchPosition,
+    calibration: SentinelContext,
+}
+
+impl CostLabel {
+    /// Mint a label from a session-produced [`BenchResult`] at collection
+    /// `position`. `context` names the call site for the panic message.
+    ///
+    /// # Panics
+    ///
+    /// See [`BenchResult::corrected_session_ns`].
+    #[must_use]
+    pub fn mint(bench: &BenchResult, position: BenchPosition, context: &str) -> Self {
+        let (value, drift) = bench.corrected_session_ns(context);
+        let calibration = bench
+            .sentinel
+            .expect("corrected_session_ns already panicked above on None");
+        Self {
+            value,
+            mode: bench.mode,
+            drift,
+            position,
+            calibration,
+        }
+    }
+
+    #[must_use]
+    pub fn value(&self) -> SessionNs {
+        self.value
+    }
+
+    #[must_use]
+    pub fn mode(&self) -> BenchMode {
+        self.mode
+    }
+
+    #[must_use]
+    pub fn drift(&self) -> DriftFactor {
+        self.drift
+    }
+
+    #[must_use]
+    pub fn position(&self) -> BenchPosition {
+        self.position
+    }
+
+    #[must_use]
+    pub fn calibration(&self) -> SentinelContext {
+        self.calibration
+    }
+
+    /// The training target: `log_ns` of the normalized value. The only way
+    /// to turn a `CostLabel` into the `f32` a model is trained on.
+    #[must_use]
+    pub fn target_log_ns(&self) -> f32 {
+        log_ns(self.value)
     }
 }
 
@@ -1262,22 +1479,27 @@ pub fn benchmark_compile_fresh(
     validate_median(median).map(|ns| CompileCostResult { ns, code_bytes })
 }
 
-/// Convert nanoseconds to log-nanoseconds (floored at 1e-3ns, capped at 1s).
+/// Convert a session-clock nanosecond value to log-nanoseconds (floored at
+/// 1e-3ns, capped at 1s).
 ///
-/// Relocated from the deleted `training::gen_es` (the ES-guided corpus-growth
-/// optimizer it lived in was RL-adjacent scaffolding removed per
-/// docs/plans/2026-07-07-guided-saturation-redesign.md); this conversion
-/// itself is just a unit change on a [`BenchResult::ns`] measurement, used by
-/// the surviving supervised extraction-head training path.
+/// Takes [`SessionNs`], not a bare `f64` (J3/J4): a raw, un-drift-corrected
+/// reading must go through [`LocalNs::normalize`] (directly, or via
+/// [`CostLabel::mint`] / [`BenchResult::corrected_session_ns`]) before it can
+/// become a training target — that ordering is exactly the bug class this
+/// module's clock newtypes exist to make a type error. Relocated from the
+/// deleted `training::gen_es` (the ES-guided corpus-growth optimizer it lived
+/// in was RL-adjacent scaffolding removed per
+/// docs/plans/2026-07-07-guided-saturation-redesign.md).
 ///
 /// # Panics
 ///
 /// Panics if `ns` is NaN.
 #[must_use]
-pub fn log_ns(ns: f64) -> f32 {
-    assert!(!ns.is_nan(), "log_ns called with NaN");
+pub fn log_ns(ns: SessionNs) -> f32 {
+    let raw = ns.get();
+    assert!(!raw.is_nan(), "log_ns called with NaN");
     // NaN already rejected above, so clamp's total order is well-defined here.
-    let clamped = ns.clamp(1e-3, 1e9);
+    let clamped = raw.clamp(1e-3, 1e9);
     libm::logf(clamped as f32)
 }
 
@@ -1289,7 +1511,7 @@ mod tests {
     #[test]
     fn verify_log_ns() {
         // log(1.0) = 0.0
-        let v = log_ns(1.0);
+        let v = log_ns(SessionNs::new(1.0));
         assert!(
             libm::fabsf(v) < 0.001,
             "log_ns(1.0) should be ~0.0, got {}",
@@ -1297,8 +1519,8 @@ mod tests {
         );
 
         // Values below 1e-3 should be floored to 1e-3.
-        let v_low = log_ns(0.0001);
-        let v_floor = log_ns(1e-3);
+        let v_low = log_ns(SessionNs::new(0.0001));
+        let v_floor = log_ns(SessionNs::new(1e-3));
         assert!(
             libm::fabsf(v_low - v_floor) < 0.001,
             "log_ns(0.0001) should equal log_ns(1e-3), got {} vs {}",
@@ -1307,7 +1529,7 @@ mod tests {
         );
 
         // log(e) ≈ 1.0
-        let v_e = log_ns(core::f64::consts::E);
+        let v_e = log_ns(SessionNs::new(core::f64::consts::E));
         assert!(
             libm::fabsf(v_e - 1.0) < 0.01,
             "log_ns(e) should be ~1.0, got {}",
@@ -1562,24 +1784,24 @@ mod tests {
             local_sentinel_ns: 125.0,
             calibration_ns: 100.0,
         };
-        assert!((slowed.normalization() - 0.8).abs() < 1e-12);
+        assert!((slowed.normalization().get() - 0.8).abs() < 1e-12);
         // An 80ns label minted under that sentinel corrects to 64ns in the
         // run's opening clock.
-        assert!((80.0 * slowed.normalization() - 64.0).abs() < 1e-12);
+        assert!((80.0 * slowed.normalization().get() - 64.0).abs() < 1e-12);
 
         // Machine sped up: factor > 1 scales deflated labels back up.
         let sped_up = SentinelContext {
             local_sentinel_ns: 80.0,
             calibration_ns: 100.0,
         };
-        assert!((sped_up.normalization() - 1.25).abs() < 1e-12);
+        assert!((sped_up.normalization().get() - 1.25).abs() < 1e-12);
 
         // No drift: identity.
         let steady = SentinelContext {
             local_sentinel_ns: 100.0,
             calibration_ns: 100.0,
         };
-        assert!((steady.normalization() - 1.0).abs() < 1e-12);
+        assert!((steady.normalization().get() - 1.0).abs() < 1e-12);
     }
 
     #[test]
@@ -1590,6 +1812,83 @@ mod tests {
             calibration_ns: 100.0,
         }
         .normalization();
+    }
+
+    // ── Clock newtypes + CostLabel (J3/J4) ──────────────────────────────────
+
+    #[test]
+    fn local_ns_normalize_is_the_only_path_to_session_ns() {
+        // 1.25x slowdown: a 125ns local reading is a 100ns session-clock
+        // value, matching SentinelContext::normalization's own worked
+        // example.
+        let drift = SentinelContext {
+            local_sentinel_ns: 125.0,
+            calibration_ns: 100.0,
+        }
+        .normalization();
+        let value = LocalNs::new(125.0).normalize(drift);
+        assert!((value.get() - 100.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn session_ns_sub_is_the_only_way_to_remove_overhead() {
+        let a = SessionNs::new(10.0);
+        let b = SessionNs::new(3.0);
+        assert!(((a - b).get() - 7.0).abs() < 1e-12);
+        // LocalNs deliberately has no `Sub` impl — there is no expression
+        // `LocalNs::new(10.0) - SessionNs::new(3.0)` that compiles, which is
+        // the point: overhead cannot be subtracted before the reading is
+        // normalized onto the session clock.
+    }
+
+    #[test]
+    fn cost_label_mint_matches_the_hand_derived_ordering() {
+        // Same drifted-measurement shape as `training::mint`'s tests: a
+        // nonzero overhead so the two possible orderings of
+        // normalize-then-subtract disagree, and CostLabel::mint must land on
+        // the correct one.
+        const OVERHEAD_NS: f64 = 4.0;
+        const KERNEL_NS: f64 = 3.0;
+        const DRIFT: f64 = 1.45;
+        const CALIBRATION_NS: f64 = 8.0;
+        let bench = BenchResult {
+            ns: (KERNEL_NS + OVERHEAD_NS) * DRIFT,
+            adjusted_ns: (KERNEL_NS + OVERHEAD_NS) * DRIFT - OVERHEAD_NS,
+            call_overhead_ns: OVERHEAD_NS,
+            iqr_ns: 0.0,
+            mode: BenchMode::Latency,
+            repeat_batches: 1,
+            output: [0.0; 4],
+            outputs: Vec::new(),
+            sentinel: Some(SentinelContext {
+                calibration_ns: CALIBRATION_NS,
+                local_sentinel_ns: CALIBRATION_NS * DRIFT,
+            }),
+        };
+        let label = CostLabel::mint(&bench, BenchPosition(7), "test");
+        assert!((label.value().get() - KERNEL_NS).abs() < 1e-9);
+        assert_eq!(label.mode(), BenchMode::Latency);
+        assert_eq!(label.position(), BenchPosition(7));
+        assert_eq!(label.calibration(), bench.sentinel.unwrap());
+        assert!((label.drift().get() - 1.0 / DRIFT).abs() < 1e-9);
+        assert_eq!(label.target_log_ns(), log_ns(SessionNs::new(KERNEL_NS)));
+    }
+
+    #[test]
+    #[should_panic(expected = "no sentinel context")]
+    fn cost_label_mint_refuses_an_unprotected_measurement() {
+        let bench = BenchResult {
+            ns: 42.0,
+            adjusted_ns: 42.0,
+            call_overhead_ns: 0.0,
+            iqr_ns: 0.0,
+            mode: BenchMode::Throughput,
+            repeat_batches: 1,
+            output: [0.0; 4],
+            outputs: Vec::new(),
+            sentinel: None,
+        };
+        let _ = CostLabel::mint(&bench, BenchPosition(0), "unit test");
     }
 
     #[test]
@@ -1679,7 +1978,7 @@ mod tests {
                 .expect("session-minted results carry a SentinelContext");
             assert_eq!(ctx.calibration_ns, session.calibration_ns());
             assert_eq!(ctx.local_sentinel_ns, session.calibration_ns());
-            assert!((ctx.normalization() - 1.0).abs() < 1e-12);
+            assert!((ctx.normalization().get() - 1.0).abs() < 1e-12);
         }
         // Outputs are mode-independent pure function values.
         throughput

--- a/pixelflow-pipeline/src/journal.rs
+++ b/pixelflow-pipeline/src/journal.rs
@@ -11,11 +11,30 @@
 //! (docs/plans/2026-08-17-cost-model-domain.md, J15) — a fix to one could
 //! silently fail to reach the other, the same NO-SILENT-FAILURES class as
 //! J14's `run_scalar`.
+//!
+//! The mechanics above are the writer's easy half. Its other job — owning the
+//! *shape* every journal line takes, not just how the bytes land — used to be
+//! absent: `bench_extraction_3way` hand-rolled a `config_hash` from source
+//! revision, corpus bytes, weights bytes, protocol params, and the build
+//! environment, entirely inside that one binary; `bootstrap_extraction_head`
+//! wrote a journal line with none of that provenance at all — two runs of it
+//! against different corpora or different commits were indistinguishable.
+//! [`ConfigHash`], [`ArtifactId`], and [`JournalEntry`] below are that shared
+//! shape (docs/plans/2026-08-17-cost-model-domain.md, J15): every
+//! journal-writing binary composes a `ConfigHash` the same way, names its
+//! weights the same way, and wraps its own metrics in the same envelope, so
+//! two binaries can no longer diverge on what "this run's provenance" means.
 use std::fs;
 use std::io::Write as _;
 use std::path::Path;
+use std::process::Command;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+
+/// Re-exported so journal-writing binaries need one `use` for both the
+/// writer mechanics and the content-hash primitive their `ConfigHash` inputs
+/// (corpus identity, weights identity, diff hash) are built from.
+pub use crate::schema::fnv1a64_hex;
 
 /// Refuse to append to a journal that is still a Git LFS pointer.
 ///
@@ -69,6 +88,278 @@ pub fn append_record<T: Serialize>(path: &Path, record: &T) {
     writeln!(journal, "{line}")
         .unwrap_or_else(|e| panic!("failed to append to {}: {e}", path.display()));
     eprintln!("Journal appended: {}", path.display());
+}
+
+// ── Provenance: ConfigHash, ArtifactId, JournalEntry (J15) ─────────────────
+
+/// Paths a config hash must not vary with: a run WRITES into these
+/// (`pixelflow-pipeline/data/` holds this run's own JSONL output;
+/// `docs/results/` holds the journal this line is about to join), so
+/// including them in a dirty-tree diff would make the hash depend on the
+/// run's own prior output — a second invocation of an otherwise-unchanged
+/// tree would then hash differently from the first, the opposite of an
+/// identity.
+pub const DIFF_HASH_EXCLUDES: [&str; 2] = [
+    ":(exclude)pixelflow-pipeline/data",
+    ":(exclude)docs/results",
+];
+
+fn git(args: &[&str]) -> Result<String, String> {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    match Command::new("git")
+        .args(args)
+        .current_dir(manifest_dir)
+        .output()
+    {
+        Ok(out) if out.status.success() => {
+            Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+        }
+        Ok(out) => Err(format!(
+            "`git {}` exited {}: {}",
+            args.join(" "),
+            out.status,
+            String::from_utf8_lossy(&out.stderr).trim()
+        )),
+        Err(e) => Err(format!("failed to spawn git: {e}")),
+    }
+}
+
+/// What source revision a run's numbers came off.
+///
+/// `rev` alone is not enough: every uncommitted variant of the same HEAD
+/// collapses onto one `"<sha>-dirty"` string, so two working trees measuring
+/// different code would hash identically and produce indistinguishable
+/// journal lines. `diff_hash` restores the distinction by hashing the actual
+/// uncommitted diff over tracked source (excluding [`DIFF_HASH_EXCLUDES`]).
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct SourceVersion {
+    /// `git rev-parse HEAD`, suffixed `-dirty` on an unclean tree, or
+    /// `"unversioned"` when git itself cannot answer.
+    pub rev: String,
+    /// FNV-1a hex of `git diff HEAD` over tracked source (excluding
+    /// [`DIFF_HASH_EXCLUDES`]). `None` on a clean tree. FNV rather than a
+    /// cryptographic hash because the job is *distinguishing* local working
+    /// trees, not resisting an adversary.
+    pub diff_hash: Option<String>,
+}
+
+impl SourceVersion {
+    /// Resolve the working tree's current version. Runs git in this crate's
+    /// manifest directory so the answer names this repo regardless of cwd.
+    ///
+    /// On any git failure the revision is `"unversioned"`, printed loudly to
+    /// stderr rather than silently swallowed — a run whose code cannot be
+    /// attributed to a commit is still worth having, but a caller must be
+    /// able to see why cross-run comparisons against it cannot be trusted.
+    #[must_use]
+    pub fn current(excludes: &[&str]) -> Self {
+        let unversioned = |why: &str| -> SourceVersion {
+            eprintln!(
+                "WARNING: could not resolve the source revision ({why}) — this run's \
+                 config hash will record source_rev=\"unversioned\", making it \
+                 UNATTRIBUTABLE to a commit."
+            );
+            SourceVersion {
+                rev: "unversioned".to_string(),
+                diff_hash: None,
+            }
+        };
+        let head = match git(&["rev-parse", "HEAD"]) {
+            Ok(s) if !s.is_empty() => s,
+            Ok(_) => return unversioned("`git rev-parse HEAD` produced no output"),
+            Err(why) => return unversioned(&why),
+        };
+        let status = match git(&["status", "--porcelain"]) {
+            Ok(s) => s,
+            Err(why) => return unversioned(&why),
+        };
+        if status.trim().is_empty() {
+            return SourceVersion {
+                rev: head,
+                diff_hash: None,
+            };
+        }
+        let mut diff_args = vec!["diff", "HEAD", "--"];
+        diff_args.extend(excludes.iter().copied());
+        match git(&diff_args) {
+            Ok(diff) => SourceVersion {
+                rev: format!("{head}-dirty"),
+                diff_hash: Some(fnv1a64_hex(diff.as_bytes())),
+            },
+            Err(why) => {
+                eprintln!(
+                    "WARNING: the working tree is dirty but the diff could not be hashed \
+                     ({why}) — this run's config hash cannot distinguish it from other \
+                     uncommitted variants of {head}."
+                );
+                SourceVersion {
+                    rev: format!("{head}-dirty"),
+                    diff_hash: None,
+                }
+            }
+        }
+    }
+
+    fn hash_input(&self) -> String {
+        match &self.diff_hash {
+            Some(h) => format!("{};diff={h}", self.rev),
+            None => self.rev.clone(),
+        }
+    }
+}
+
+/// The build and machine facts that select the emitted instructions — same
+/// source, different machine or build, different timings, so these belong in
+/// every config hash beside the source revision.
+///
+/// Compile-time facts only: `target_arch`/`target_feature` are what actually
+/// select the emitter, and the profile decides whether the timings are
+/// meaningful at all. The specific CPU model is deliberately not read here —
+/// it needs a syscall or `/proc`, varies across otherwise-identical cloud
+/// instances, and a run's sentinel calibration already records per-run clock
+/// behavior.
+#[must_use]
+pub fn environment_fingerprint() -> String {
+    let isa = if cfg!(target_feature = "avx512f") {
+        "avx512f"
+    } else if cfg!(target_feature = "avx2") {
+        "avx2"
+    } else if cfg!(target_feature = "fma") {
+        "fma"
+    } else {
+        "baseline"
+    };
+    format!(
+        "arch={};os={};ptr={};isa={};profile={}",
+        std::env::consts::ARCH,
+        std::env::consts::OS,
+        usize::BITS,
+        isa,
+        if cfg!(debug_assertions) {
+            "debug"
+        } else {
+            "release"
+        },
+    )
+}
+
+/// Where an artifact lives and the content hash binding this record to those
+/// exact bytes — the [`crate::training::mint::weights_identity`] pattern,
+/// generalized to any file a journal line needs to name.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ArtifactId {
+    pub path: String,
+    pub identity: String,
+}
+
+impl ArtifactId {
+    /// Name `path`, content-hashing `bytes` as its identity.
+    #[must_use]
+    pub fn of(path: impl Into<String>, bytes: &[u8]) -> Self {
+        Self {
+            path: path.into(),
+            identity: fnv1a64_hex(bytes),
+        }
+    }
+
+    /// Name `path` with an identity already computed elsewhere (e.g.
+    /// [`crate::training::mint::MintMetadata::weights_fnv64`], so a caller
+    /// that already loaded the mint sidecar need not re-hash the weights
+    /// bytes just to fill this in).
+    #[must_use]
+    pub fn with_identity(path: impl Into<String>, identity: impl Into<String>) -> Self {
+        Self {
+            path: path.into(),
+            identity: identity.into(),
+        }
+    }
+}
+
+/// Everything that shapes a measurement, content-hashed into one value: the
+/// source revision (+ diff), which corpus was measured, which weights
+/// produced the run, and the machine it ran on. Two runs with the same
+/// `value` are the same experiment; the individual fields stay alongside it
+/// so a journal reader does not have to decompose the hash to find out WHY
+/// two runs differ.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ConfigHash {
+    pub source_rev: String,
+    pub source_diff_hash: Option<String>,
+    pub corpus_identity: String,
+    pub weights_identity: String,
+    pub environment: String,
+    /// Caller-supplied protocol parameters (seeds, sample sizes, tier,
+    /// benchmark mode, epoch count, ...) that are not artifacts but still
+    /// define the experiment. Free text, since the two binaries' protocols
+    /// differ and forcing one shape onto both would be artificial
+    /// commonality (docs/plans/2026-08-17-cost-model-domain.md, journal.rs
+    /// module doc: "each with its own record schema... that stays").
+    pub protocol: String,
+    /// FNV-1a 64 hex over every field above, concatenated in declaration
+    /// order — the single value two runs compare to ask "same setup?".
+    pub value: String,
+}
+
+impl ConfigHash {
+    #[must_use]
+    pub fn compose(
+        source: &SourceVersion,
+        corpus_identity: &str,
+        weights_identity: &str,
+        protocol: &str,
+    ) -> Self {
+        let environment = environment_fingerprint();
+        let composed = format!(
+            "rev={};corpus={corpus_identity};weights={weights_identity};env={environment};\
+             protocol={protocol}",
+            source.hash_input(),
+        );
+        Self {
+            source_rev: source.rev.clone(),
+            source_diff_hash: source.diff_hash.clone(),
+            corpus_identity: corpus_identity.to_string(),
+            weights_identity: weights_identity.to_string(),
+            environment,
+            protocol: protocol.to_string(),
+            value: fnv1a64_hex(composed.as_bytes()),
+        }
+    }
+}
+
+/// One line of `docs/results/journal.jsonl`: the envelope every
+/// journal-writing binary shares — which record type, when, under what
+/// configuration, and which weights produced it — wrapping the caller's own
+/// metrics. Two binaries hand-rolling this envelope independently, so a fix
+/// or a new provenance field in one could silently fail to reach the other,
+/// is exactly the structurally-divergent-journal-line risk this type exists
+/// to close (docs/plans/2026-08-17-cost-model-domain.md, J15): the shape a
+/// caller can even attempt to serialize is fixed here, once.
+#[derive(Serialize)]
+pub struct JournalEntry<T: Serialize> {
+    pub record: &'static str,
+    pub ts_unix: u64,
+    pub config: ConfigHash,
+    pub weights: ArtifactId,
+    #[serde(flatten)]
+    pub metrics: T,
+}
+
+impl<T: Serialize> JournalEntry<T> {
+    #[must_use]
+    pub fn new(record: &'static str, config: ConfigHash, weights: ArtifactId, metrics: T) -> Self {
+        Self {
+            record,
+            ts_unix: crate::schema::unix_now_s(),
+            config,
+            weights,
+            metrics,
+        }
+    }
+
+    /// Append this entry to `path` via [`append_record`].
+    pub fn append(&self, path: &Path) {
+        append_record(path, self);
+    }
 }
 
 #[cfg(test)]

--- a/pixelflow-pipeline/src/journal.rs
+++ b/pixelflow-pipeline/src/journal.rs
@@ -99,9 +99,18 @@ pub fn append_record<T: Serialize>(path: &Path, record: &T) {
 /// run's own prior output — a second invocation of an otherwise-unchanged
 /// tree would then hash differently from the first, the opposite of an
 /// identity.
+///
+/// The `top,` magic is load-bearing, not decoration: [`git`] runs with
+/// `current_dir` set to this crate's own manifest directory
+/// (`.../pixelflow-pipeline`), so a bare `:(exclude)pixelflow-pipeline/data`
+/// is resolved relative to THAT directory — i.e. as
+/// `pixelflow-pipeline/pixelflow-pipeline/data`, which never exists — and
+/// silently excludes nothing. `:(top,exclude)` anchors the pathspec to the
+/// repository root regardless of the process's cwd, which is what a
+/// repo-root-relative path here was always meant to mean.
 pub const DIFF_HASH_EXCLUDES: [&str; 2] = [
-    ":(exclude)pixelflow-pipeline/data",
-    ":(exclude)docs/results",
+    ":(top,exclude)pixelflow-pipeline/data",
+    ":(top,exclude)docs/results",
 ];
 
 /// Raw, untrimmed stdout on success. Deliberately not trimmed here: `diff
@@ -424,6 +433,99 @@ mod tests {
                 // fallback covers this case at the call site.
             }
         }
+    }
+
+    #[test]
+    fn diff_hash_exclusions_survive_running_from_a_subdirectory() {
+        // Reproduces the real defect (P2 finding on the fix commit for PR
+        // #1019): `git()` runs with `current_dir` set to THIS crate's own
+        // manifest directory, not the repository root, so a bare
+        // `:(exclude)pixelflow-pipeline/data` pathspec is resolved relative
+        // to that directory — i.e. as
+        // `pixelflow-pipeline/pixelflow-pipeline/data`, which never exists —
+        // and silently excludes nothing. `:(top,exclude)` anchors to the
+        // repo root regardless of cwd.
+        //
+        // Builds an isolated scratch repo shaped like this one (a
+        // `pixelflow-pipeline/` subdirectory below the repo root) so the
+        // pathspec-vs-cwd mismatch is exercised exactly as `git()` triggers
+        // it, without touching this session's actual working tree.
+        fn run_git(cwd: &Path, args: &[&str]) -> String {
+            let out = Command::new("git")
+                .args(args)
+                .current_dir(cwd)
+                .env("GIT_AUTHOR_NAME", "test")
+                .env("GIT_AUTHOR_EMAIL", "test@example.com")
+                .env("GIT_COMMITTER_NAME", "test")
+                .env("GIT_COMMITTER_EMAIL", "test@example.com")
+                .output()
+                .unwrap_or_else(|e| panic!("failed to spawn git {args:?}: {e}"));
+            assert!(
+                out.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+            String::from_utf8_lossy(&out.stdout).into_owned()
+        }
+
+        let root = std::env::temp_dir().join(format!(
+            "pf_journal_pathspec_test_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system clock is before the unix epoch")
+                .as_nanos()
+        ));
+        let crate_dir = root.join("pixelflow-pipeline");
+        let data_dir = crate_dir.join("data");
+        let src_dir = crate_dir.join("src");
+        fs::create_dir_all(&data_dir).expect("create data dir");
+        fs::create_dir_all(&src_dir).expect("create src dir");
+
+        run_git(&root, &["init", "-q"]);
+        fs::write(data_dir.join("out.jsonl"), "before\n").expect("write data file");
+        fs::write(src_dir.join("lib.rs"), "// before\n").expect("write source file");
+        run_git(&root, &["add", "-A"]);
+        run_git(&root, &["commit", "-q", "-m", "initial"]);
+
+        // Dirty the tree: change BOTH the run-output file (should be
+        // excluded) and a real source file (should NOT be excluded).
+        fs::write(data_dir.join("out.jsonl"), "after\n").expect("rewrite data file");
+        fs::write(src_dir.join("lib.rs"), "// after\n").expect("rewrite source file");
+
+        // `git()` runs from the crate directory, exactly like the real
+        // helper — this is what makes the bare pathspec resolve wrong.
+        let bare_diff = run_git(
+            &crate_dir,
+            &[
+                "diff",
+                "HEAD",
+                "--",
+                ":(exclude)pixelflow-pipeline/data",
+                ":(exclude)docs/results",
+            ],
+        );
+        assert!(
+            bare_diff.contains("out.jsonl"),
+            "test assumption: the bare pathspec must reproduce the bug (fail to \
+             exclude the data file) when run from the crate subdirectory, or this \
+             test is no longer exercising it:\n{bare_diff}"
+        );
+
+        let mut anchored_args: Vec<&str> = vec!["diff", "HEAD", "--"];
+        anchored_args.extend(DIFF_HASH_EXCLUDES);
+        let anchored_diff = run_git(&crate_dir, &anchored_args);
+        assert!(
+            !anchored_diff.contains("out.jsonl"),
+            "the top-anchored exclude must drop the run's own output file even when \
+             git runs from the crate subdirectory:\n{anchored_diff}"
+        );
+        assert!(
+            anchored_diff.contains("lib.rs"),
+            "the top-anchored exclude must NOT drop a real source change:\n{anchored_diff}"
+        );
+
+        fs::remove_dir_all(&root).ok();
     }
 
     #[test]

--- a/pixelflow-pipeline/src/journal.rs
+++ b/pixelflow-pipeline/src/journal.rs
@@ -104,6 +104,14 @@ pub const DIFF_HASH_EXCLUDES: [&str; 2] = [
     ":(exclude)docs/results",
 ];
 
+/// Raw, untrimmed stdout on success. Deliberately not trimmed here: `diff
+/// HEAD` output is hashed byte-for-byte by [`SourceVersion::current`] (see
+/// [`SourceVersion::diff_hash`]), and a `.trim()` in this shared helper would
+/// have silently dropped trailing-whitespace-only differences from every
+/// caller's diff hash, aliasing two distinct working trees onto one
+/// `diff_hash` — defeating the provenance guarantee the journal exists for.
+/// Callers that want a trimmed single-line answer (`rev-parse HEAD`,
+/// `status --porcelain`) trim at their own call site instead.
 fn git(args: &[&str]) -> Result<String, String> {
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     match Command::new("git")
@@ -111,9 +119,7 @@ fn git(args: &[&str]) -> Result<String, String> {
         .current_dir(manifest_dir)
         .output()
     {
-        Ok(out) if out.status.success() => {
-            Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
-        }
+        Ok(out) if out.status.success() => Ok(String::from_utf8_lossy(&out.stdout).into_owned()),
         Ok(out) => Err(format!(
             "`git {}` exited {}: {}",
             args.join(" "),
@@ -164,8 +170,11 @@ impl SourceVersion {
                 diff_hash: None,
             }
         };
+        // `git()` hands back raw stdout now (see its doc comment) — `rev-parse`
+        // and `status` are trimmed here, at their own call sites, since only
+        // the `diff` branch below needs the untrimmed bytes.
         let head = match git(&["rev-parse", "HEAD"]) {
-            Ok(s) if !s.is_empty() => s,
+            Ok(s) if !s.trim().is_empty() => s.trim().to_string(),
             Ok(_) => return unversioned("`git rev-parse HEAD` produced no output"),
             Err(why) => return unversioned(&why),
         };
@@ -184,6 +193,11 @@ impl SourceVersion {
         match git(&diff_args) {
             Ok(diff) => SourceVersion {
                 rev: format!("{head}-dirty"),
+                // Raw bytes, untrimmed: a dirty diff whose only difference
+                // from another is trailing whitespace on the last changed
+                // line must not hash the same as that other diff (P2 finding
+                // on PR #1019) — trimming here would silently alias two
+                // distinct working trees onto one `diff_hash`.
                 diff_hash: Some(fnv1a64_hex(diff.as_bytes())),
             },
             Err(why) => {
@@ -386,6 +400,42 @@ mod tests {
         assert_eq!(lines, vec!["{\"n\":1}", "{\"n\":2}"]);
 
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn git_returns_raw_untrimmed_stdout() {
+        // `git rev-parse HEAD` always terminates its answer with a trailing
+        // newline. If `git()` still trimmed internally (the defect this
+        // guards against — a trimmed `diff HEAD` silently loses
+        // trailing-whitespace-only differences before `SourceVersion` hashes
+        // it, aliasing two distinct working trees onto one `diff_hash`), that
+        // newline would never survive to a caller. Black-box probe of the
+        // shared helper's contract, not of this repo's source-control state.
+        match git(&["rev-parse", "HEAD"]) {
+            Ok(raw) => assert!(
+                raw.ends_with('\n'),
+                "git() must hand back raw untrimmed stdout, including the trailing \
+                 newline every git subcommand emits, or a hashed diff could silently \
+                 lose trailing whitespace: got {raw:?}"
+            ),
+            Err(_) => {
+                // No git binary, or not a repo, in this environment — nothing
+                // to assert here; SourceVersion::current's "unversioned"
+                // fallback covers this case at the call site.
+            }
+        }
+    }
+
+    #[test]
+    fn diff_hash_distinguishes_trailing_whitespace_only_changes() {
+        // The defect this guards: hashing a TRIMMED diff would collapse two
+        // working trees whose only difference is trailing whitespace on the
+        // last changed line onto the same `diff_hash` (P2 finding on PR
+        // #1019) — defeating the journal's provenance guarantee that two
+        // distinct trees never share an identity.
+        let a = "diff --git a/x b/x\n+some line\n";
+        let b = "diff --git a/x b/x\n+some line \n"; // trailing space added
+        assert_ne!(fnv1a64_hex(a.as_bytes()), fnv1a64_hex(b.as_bytes()));
     }
 
     #[test]

--- a/pixelflow-pipeline/src/journal.rs
+++ b/pixelflow-pipeline/src/journal.rs
@@ -187,7 +187,16 @@ impl SourceVersion {
             Ok(_) => return unversioned("`git rev-parse HEAD` produced no output"),
             Err(why) => return unversioned(&why),
         };
-        let status = match git(&["status", "--porcelain"]) {
+        // Filtered by the SAME `excludes` the diff below uses: a tree whose
+        // only changes are under an excluded path (typically this run's own
+        // prior output, `docs/results/journal.jsonl`) must not read as dirty
+        // when the diff that follows would be empty anyway — otherwise a
+        // clean run and an excluded-paths-only rerun disagree on `rev`
+        // ("<sha>" vs "<sha>-dirty") despite hashing the identical (empty)
+        // diff (P2 finding on the fix commit for PR #1019).
+        let mut status_args = vec!["status", "--porcelain", "--"];
+        status_args.extend(excludes.iter().copied());
+        let status = match git(&status_args) {
             Ok(s) => s,
             Err(why) => return unversioned(&why),
         };
@@ -247,17 +256,25 @@ pub fn environment_fingerprint() -> String {
         "avx512f"
     } else if cfg!(target_feature = "avx2") {
         "avx2"
-    } else if cfg!(target_feature = "fma") {
-        "fma"
     } else {
         "baseline"
     };
+    // Independent of `isa`, not a rung in its fallback chain: an
+    // `avx2,+fma` build and an `avx2,-fma` build previously both read
+    // isa=avx2 (the `else if target_feature = "fma"` arm was unreachable
+    // whenever avx2 was also set), so two runs executing materially
+    // different kernels — `pixelflow-codegen`'s `emit_fmadd_c_in_dst` emits
+    // a hardware `vfmadd231ps` under `fma` and a separate multiply-then-add
+    // otherwise, with different timing and rounding — received the same
+    // environment fingerprint (P2 finding on the fix commit for PR #1019).
+    let fma = cfg!(target_feature = "fma");
     format!(
-        "arch={};os={};ptr={};isa={};profile={}",
+        "arch={};os={};ptr={};isa={};fma={};profile={}",
         std::env::consts::ARCH,
         std::env::consts::OS,
         usize::BITS,
         isa,
+        fma,
         if cfg!(debug_assertions) {
             "debug"
         } else {
@@ -388,6 +405,7 @@ impl<T: Serialize> JournalEntry<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
 
     #[derive(Serialize)]
     struct Rec {
@@ -435,41 +453,37 @@ mod tests {
         }
     }
 
-    #[test]
-    fn diff_hash_exclusions_survive_running_from_a_subdirectory() {
-        // Reproduces the real defect (P2 finding on the fix commit for PR
-        // #1019): `git()` runs with `current_dir` set to THIS crate's own
-        // manifest directory, not the repository root, so a bare
-        // `:(exclude)pixelflow-pipeline/data` pathspec is resolved relative
-        // to that directory — i.e. as
-        // `pixelflow-pipeline/pixelflow-pipeline/data`, which never exists —
-        // and silently excludes nothing. `:(top,exclude)` anchors to the
-        // repo root regardless of cwd.
-        //
-        // Builds an isolated scratch repo shaped like this one (a
-        // `pixelflow-pipeline/` subdirectory below the repo root) so the
-        // pathspec-vs-cwd mismatch is exercised exactly as `git()` triggers
-        // it, without touching this session's actual working tree.
-        fn run_git(cwd: &Path, args: &[&str]) -> String {
-            let out = Command::new("git")
-                .args(args)
-                .current_dir(cwd)
-                .env("GIT_AUTHOR_NAME", "test")
-                .env("GIT_AUTHOR_EMAIL", "test@example.com")
-                .env("GIT_COMMITTER_NAME", "test")
-                .env("GIT_COMMITTER_EMAIL", "test@example.com")
-                .output()
-                .unwrap_or_else(|e| panic!("failed to spawn git {args:?}: {e}"));
-            assert!(
-                out.status.success(),
-                "git {args:?} failed: {}",
-                String::from_utf8_lossy(&out.stderr)
-            );
-            String::from_utf8_lossy(&out.stdout).into_owned()
-        }
+    /// Run `git` in `cwd`, panicking on spawn failure or nonzero exit, and
+    /// return raw stdout. Shared by the scratch-repo tests below, which
+    /// exercise `git()`'s cwd/pathspec contract against an isolated repo
+    /// rather than this session's actual working tree.
+    fn run_git(cwd: &Path, args: &[&str]) -> String {
+        let out = Command::new("git")
+            .args(args)
+            .current_dir(cwd)
+            .env("GIT_AUTHOR_NAME", "test")
+            .env("GIT_AUTHOR_EMAIL", "test@example.com")
+            .env("GIT_COMMITTER_NAME", "test")
+            .env("GIT_COMMITTER_EMAIL", "test@example.com")
+            .output()
+            .unwrap_or_else(|e| panic!("failed to spawn git {args:?}: {e}"));
+        assert!(
+            out.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8_lossy(&out.stdout).into_owned()
+    }
 
+    /// A scratch repo shaped like this one (a `pixelflow-pipeline/`
+    /// subdirectory below the repo root, with a `data/` output dir and a
+    /// `src/` source dir inside it), committed with one file in each. Returns
+    /// `(repo_root, crate_dir)`. Callers dirty the tree and run `git` from
+    /// `crate_dir` — exactly where the real `git()` helper runs from — to
+    /// exercise the cwd/pathspec mismatch these tests guard against.
+    fn scratch_repo(tag: &str) -> (PathBuf, PathBuf) {
         let root = std::env::temp_dir().join(format!(
-            "pf_journal_pathspec_test_{}_{}",
+            "pf_journal_{tag}_{}_{}",
             std::process::id(),
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
@@ -488,10 +502,25 @@ mod tests {
         run_git(&root, &["add", "-A"]);
         run_git(&root, &["commit", "-q", "-m", "initial"]);
 
+        (root, crate_dir)
+    }
+
+    #[test]
+    fn diff_hash_exclusions_survive_running_from_a_subdirectory() {
+        // Reproduces the real defect (P2 finding on the fix commit for PR
+        // #1019): `git()` runs with `current_dir` set to THIS crate's own
+        // manifest directory, not the repository root, so a bare
+        // `:(exclude)pixelflow-pipeline/data` pathspec is resolved relative
+        // to that directory — i.e. as
+        // `pixelflow-pipeline/pixelflow-pipeline/data`, which never exists —
+        // and silently excludes nothing. `:(top,exclude)` anchors to the
+        // repo root regardless of cwd.
+        let (root, crate_dir) = scratch_repo("pathspec_test");
+
         // Dirty the tree: change BOTH the run-output file (should be
         // excluded) and a real source file (should NOT be excluded).
-        fs::write(data_dir.join("out.jsonl"), "after\n").expect("rewrite data file");
-        fs::write(src_dir.join("lib.rs"), "// after\n").expect("rewrite source file");
+        fs::write(crate_dir.join("data/out.jsonl"), "after\n").expect("rewrite data file");
+        fs::write(crate_dir.join("src/lib.rs"), "// after\n").expect("rewrite source file");
 
         // `git()` runs from the crate directory, exactly like the real
         // helper — this is what makes the bare pathspec resolve wrong.
@@ -526,6 +555,58 @@ mod tests {
         );
 
         fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn status_filtering_ignores_excluded_paths_only_changes() {
+        // Reproduces the real defect (P2 finding on the fix commit for PR
+        // #1019): `git status --porcelain` without the same `excludes` the
+        // diff uses reports the tree dirty even when the ONLY changes are
+        // under an excluded path (typically this run's own prior output),
+        // so `SourceVersion::current` would record rev="<sha>-dirty" while
+        // hashing an empty diff — disagreeing with a genuinely clean run on
+        // `rev` despite both having nothing to say about tracked source.
+        let (root, crate_dir) = scratch_repo("status_filter_test");
+
+        // Dirty ONLY the excluded output file — no source change at all.
+        fs::write(crate_dir.join("data/out.jsonl"), "after\n").expect("rewrite data file");
+
+        let unfiltered = run_git(&crate_dir, &["status", "--porcelain"]);
+        assert!(
+            !unfiltered.trim().is_empty(),
+            "test assumption: unfiltered status must see the excluded-only change, or \
+             this test is no longer exercising the bug"
+        );
+
+        let mut filtered_args: Vec<&str> = vec!["status", "--porcelain", "--"];
+        filtered_args.extend(DIFF_HASH_EXCLUDES);
+        let filtered = run_git(&crate_dir, &filtered_args);
+        assert!(
+            filtered.trim().is_empty(),
+            "status filtered by DIFF_HASH_EXCLUDES must report clean when the only \
+             changes are under an excluded path: {filtered:?}"
+        );
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn environment_fingerprint_records_fma_independently_of_isa() {
+        // The defect this guards: `fma` used to be the last rung of the
+        // `isa` if/else chain, so it was unreachable whenever `avx2` (or
+        // `avx512f`) was also set — an avx2+fma build and an avx2-only build
+        // read the same `isa=avx2`, hiding a real codegen difference
+        // (`emit_fmadd_c_in_dst`). `fma=` must appear as its own field,
+        // independent of whatever `isa` says.
+        let fp = environment_fingerprint();
+        assert!(
+            fp.contains(";isa=") && fp.contains(";fma="),
+            "isa and fma must both be present as independent fields: {fp}"
+        );
+        assert!(
+            fp.contains(";fma=true") || fp.contains(";fma=false"),
+            "fma must be a plain boolean, not folded into isa's value: {fp}"
+        );
     }
 
     #[test]

--- a/pixelflow-pipeline/src/lib.rs
+++ b/pixelflow-pipeline/src/lib.rs
@@ -11,6 +11,7 @@ pub mod jit_bench;
 pub mod journal;
 pub mod oracle_compare;
 pub mod oracle_lowering;
+pub mod schema;
 
 // Training infrastructure (requires std feature)
 #[cfg(feature = "training")]

--- a/pixelflow-pipeline/src/schema.rs
+++ b/pixelflow-pipeline/src/schema.rs
@@ -1,0 +1,156 @@
+//! Content-hash identity for persisted formats — the single mechanism that
+//! replaces hand-bumped magic/version integers as the thing that gates
+//! loading (docs/plans/2026-08-17-cost-model-domain.md, J9 — kills P1(b)).
+//!
+//! A hand-bumped integer is a promise a human has to remember to keep every
+//! time a serialized field's MEANING changes, not just whenever the byte
+//! layout does. The corpus format's `VERSION` comment documents exactly this
+//! failure mode by naming it three times over (op renumbering, subtree
+//! compaction, dedup-key change) — three bumps a human had to remember to
+//! make, on top of getting the diagnosis right. `SchemaIdentity` removes the
+//! separate step: the identity IS the content hash of a written description
+//! of the format (`SCHEMA`), so there is no version integer to forget to
+//! move. Changing what a field means without updating `SCHEMA` leaves the
+//! description wrong — a review-time smell — but the identity can never
+//! silently drift from the text that produced it, and a stale file can never
+//! load unnoticed: the whole point is to turn "forgot to bump" into
+//! "impossible to forget", per this repo's NO-SILENT-FAILURES rule.
+
+use std::io;
+
+/// FNV-1a 64, as a `const fn` so [`SchemaIdentity::SCHEMA_IDENTITY`] can be
+/// derived at compile time from `SCHEMA`'s bytes.
+///
+/// The one hash implementation every content identity in `pixelflow-pipeline`
+/// is built from — schema identities here, the mint sidecar's
+/// `weights_identity`, and the journal's corpus/diff/config identities. Three
+/// independent copies of this exact algorithm existed before this
+/// consolidation, which is precisely the "one definition, imported, not
+/// restated" violation the domain-model plan calls out.
+#[must_use]
+pub const fn fnv1a64_const(bytes: &[u8]) -> u64 {
+    const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+    let mut hash = FNV_OFFSET;
+    let mut i = 0;
+    while i < bytes.len() {
+        hash ^= bytes[i] as u64;
+        hash = hash.wrapping_mul(FNV_PRIME);
+        i += 1;
+    }
+    hash
+}
+
+/// [`fnv1a64_const`], hex-formatted, for runtime content hashes (weight
+/// bytes, corpus bytes, diff text) that are not compile-time constants.
+#[must_use]
+pub fn fnv1a64_hex(bytes: &[u8]) -> String {
+    format!("{:016x}", fnv1a64_const(bytes))
+}
+
+/// A persisted artifact whose on-disk identity is *derived* from a written
+/// description of its layout and field semantics, not hand-maintained beside
+/// it.
+///
+/// # Contract
+/// - `SCHEMA` enumerates this format's fields, dimensions, and what each one
+///   MEANS — the description that would otherwise live only in a doc comment
+///   a version bump could silently outrun.
+/// - `SCHEMA_IDENTITY` is `SCHEMA`'s content hash (the default is correct for
+///   every implementer; it exists as an associated const only so it can be
+///   used in a `const` context such as a fixed-size header field).
+/// - `MAGIC` is a short human-readable prefix, kept for `file`(1)-style
+///   inspection. It is a courtesy — `SCHEMA_IDENTITY` is the gate.
+///
+/// Every loader must assert `stored == Self::SCHEMA_IDENTITY` and refuse
+/// loudly on mismatch, via [`identity_mismatch`] or an equivalent panic that
+/// names the regeneration command.
+///
+/// Deliberately no format-evolution ceremony: an artifact that mismatches is
+/// regenerated, not migrated — these are scratch/derived files, cheaper to
+/// remint than to version (docs/plans/2026-08-17-cost-model-domain.md §2).
+pub trait SchemaIdentity {
+    /// Short human-readable prefix. Courtesy only; never the gate.
+    const MAGIC: &'static str;
+    /// The written description of this format's fields and their meaning.
+    /// The sole input to `SCHEMA_IDENTITY` — edit this when a field's
+    /// meaning changes, and the identity changes with it, by construction.
+    const SCHEMA: &'static str;
+    /// Content hash of `SCHEMA`. Do not override.
+    const SCHEMA_IDENTITY: u64 = fnv1a64_const(Self::SCHEMA.as_bytes());
+}
+
+/// Unix seconds now — shared by every persisted-artifact timestamp
+/// ([`crate::journal::JournalEntry::ts_unix`],
+/// [`crate::training::mint::MintMetadata::written_at_unix_s`]) so the two
+/// don't drift into different clocks. Lives here (unconditionally compiled)
+/// rather than in the `training`-gated `mint` module, so `journal` — used
+/// regardless of the `training` feature — can share it too.
+///
+/// # Panics
+///
+/// Panics if the system clock is before the Unix epoch.
+#[must_use]
+pub fn unix_now_s() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock is before the unix epoch")
+        .as_secs()
+}
+
+/// The standard loud-refusal error for a [`SchemaIdentity`] mismatch: names
+/// what was stored, what was expected, and the command that regenerates the
+/// artifact. Every `SchemaIdentity` loader should return this (or panic with
+/// an equivalent message) rather than composing its own wording.
+#[must_use]
+pub fn identity_mismatch(kind: &str, stored: u64, expected: u64, regen_cmd: &str) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!(
+            "{kind} schema identity mismatch: stored {stored:016x}, expected {expected:016x}. \
+             The format's meaning changed since this file was written, so reading it further \
+             would silently misinterpret its bytes. Regenerate it with:\n  {regen_cmd}"
+        ),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Fixture;
+    impl SchemaIdentity for Fixture {
+        const MAGIC: &'static str = "FIXT";
+        const SCHEMA: &'static str = "field a: f32 kernel cost in ns; field b: u32 sample count";
+    }
+
+    #[test]
+    fn identity_is_deterministic_and_nonzero() {
+        assert_eq!(Fixture::SCHEMA_IDENTITY, Fixture::SCHEMA_IDENTITY);
+        assert_ne!(Fixture::SCHEMA_IDENTITY, 0);
+    }
+
+    #[test]
+    fn different_schema_text_yields_different_identity() {
+        // Same field, different meaning: exactly the case a hand-bumped
+        // integer can silently fail to reflect (P1(b)).
+        const A: &str = "field a means kernel cost";
+        const B: &str = "field a means kernel latency";
+        assert_ne!(fnv1a64_const(A.as_bytes()), fnv1a64_const(B.as_bytes()));
+    }
+
+    #[test]
+    fn hex_and_const_agree() {
+        let bytes = b"some artifact bytes";
+        assert_eq!(fnv1a64_hex(bytes), format!("{:016x}", fnv1a64_const(bytes)));
+    }
+
+    #[test]
+    fn mismatch_error_names_the_regen_command_and_both_identities() {
+        let e = identity_mismatch("corpus", 1, 2, "cargo run --bin gen_bench_corpus");
+        let msg = e.to_string();
+        assert!(msg.contains("gen_bench_corpus"), "{msg}");
+        assert!(msg.contains("0000000000000001"), "{msg}");
+        assert!(msg.contains("0000000000000002"), "{msg}");
+    }
+}

--- a/pixelflow-pipeline/src/training/corpus.rs
+++ b/pixelflow-pipeline/src/training/corpus.rs
@@ -3,14 +3,13 @@
 //! Replaces JSONL text corpus with a binary format that loads in microseconds
 //! via sequential read (no parsing, no allocation beyond the arena vecs).
 //!
-//! ## Format (v4; byte layout unchanged since v3 — v4 bumps because the
-//! ## cross-tier dedup key a stored TRAIN tier was built against changed,
-//! ## not because any byte here did; see "Version is coupled to the
+//! ## Format (the header's second field is a derived identity, not a
+//! ## hand-bumped version — see "The schema identity is coupled to the
 //! ## payload's meaning" below)
 //!
 //! ```text
 //! magic: [u8; 4] = b"PXCR"
-//! version: u32 (little-endian) = 4
+//! schema_identity: u64 (little-endian) = corpus_identity()
 //! count: u32 (little-endian)
 //!
 //! For each expression:
@@ -52,12 +51,15 @@
 //! instead of the feature-quotient [`FenceKey`](super::structural::FenceKey)
 //! parses fine but can hold a DEV/FINAL leak in TRAIN — P1(d)). A hand-bumped
 //! `VERSION` integer needs a human to remember to move it every time any of
-//! the three changes; this format instead carries a
-//! [`crate::schema::SchemaIdentity`] (`CorpusFormat`) whose identity is a
-//! content hash of `CorpusFormat::SCHEMA` — editing that description IS the
-//! version bump, so there is no separate step to forget
-//! (docs/plans/2026-08-17-cost-model-domain.md, J9, kills P1(b)). Any stored
-//! identity other than the current one is a hard load error.
+//! the three changes; this format instead carries [`corpus_identity`], which
+//! folds [`crate::schema::SchemaIdentity`]'s content hash of
+//! `CorpusFormat::SCHEMA` (editing that description IS the version bump, so
+//! there is no separate step to forget) together with a hash of the LIVE
+//! `OpKind` encoding table — the op-renumbering case that prose alone cannot
+//! see, since "dense 0..COUNT discriminants" reads the same before and after
+//! a renumbering (docs/plans/2026-08-17-cost-model-domain.md, J9, kills
+//! P1(b)). Any stored identity other than the current one is a hard load
+//! error.
 
 use std::io::{self, Write};
 use std::path::Path;

--- a/pixelflow-pipeline/src/training/corpus.rs
+++ b/pixelflow-pipeline/src/training/corpus.rs
@@ -3,11 +3,14 @@
 //! Replaces JSONL text corpus with a binary format that loads in microseconds
 //! via sequential read (no parsing, no allocation beyond the arena vecs).
 //!
-//! ## Format (v3)
+//! ## Format (v4; byte layout unchanged since v3 — v4 bumps because the
+//! ## cross-tier dedup key a stored TRAIN tier was built against changed,
+//! ## not because any byte here did; see "Version is coupled to the
+//! ## payload's meaning" below)
 //!
 //! ```text
 //! magic: [u8; 4] = b"PXCR"
-//! version: u32 (little-endian) = 3
+//! version: u32 (little-endian) = 4
 //! count: u32 (little-endian)
 //!
 //! For each expression:
@@ -37,25 +40,24 @@
 //! B3 holdout-integrity bug: 110 of 380 DEV entries dropped by a filter
 //! measuring dead nodes). After compaction, stored size *is* expression size.
 //!
-//! ## Version is coupled to the payload's meaning
+//! ## The schema identity is coupled to the payload's meaning
 //!
-//! Two independent things invalidate a stored corpus, and neither announces
-//! itself as a parse error. `VERSION` is what stands between both of them and
-//! a silent misread, so any version other than the current one is a hard load
-//! error.
-//!
-//! **The op encoding can change under us.** Ops are stored in `pixelflow-ir`'s
-//! own encoding (`OpKind::marshal`), whose bytes that crate is free to change
-//! without telling anyone. A corpus written under a different encoding parses
-//! perfectly and decodes into different operations, so changing the encoding
-//! means bumping the version here. That is what v2 marked — the dense 0..COUNT
-//! opcode renumbering.
-//!
-//! **The payload's meaning can change while its bytes stay well-formed.** v3
-//! marks reachable-subtree compaction: a v2 file parses perfectly, but its node
-//! counts include the generator's dead nodes and so mean something else
-//! entirely. Both bumps guard the same silently-wrong-data shape from opposite
-//! directions.
+//! Three independent things can invalidate a stored corpus, and none of them
+//! announce themselves as a parse error: the op encoding (`pixelflow-ir`'s
+//! `OpKind::marshal` is free to renumber without telling anyone, so a stale
+//! corpus decodes to different operations rather than failing to parse); the
+//! reachable-subtree compaction (an uncompacted file parses fine, but its
+//! node counts are arena history, not expression size — bug B3); and which
+//! tier a file was deduplicated against (a corpus keyed on raw structure
+//! instead of the feature-quotient [`FenceKey`](super::structural::FenceKey)
+//! parses fine but can hold a DEV/FINAL leak in TRAIN — P1(d)). A hand-bumped
+//! `VERSION` integer needs a human to remember to move it every time any of
+//! the three changes; this format instead carries a
+//! [`crate::schema::SchemaIdentity`] (`CorpusFormat`) whose identity is a
+//! content hash of `CorpusFormat::SCHEMA` — editing that description IS the
+//! version bump, so there is no separate step to forget
+//! (docs/plans/2026-08-17-cost-model-domain.md, J9, kills P1(b)). Any stored
+//! identity other than the current one is a hard load error.
 
 use std::io::{self, Write};
 use std::path::Path;
@@ -63,26 +65,53 @@ use std::path::Path;
 use pixelflow_ir::kind::OpCode;
 use pixelflow_ir::{ExprArena, ExprId, ExprNode, OpKind};
 
-const MAGIC: &[u8; 4] = b"PXCR";
-// Bump this whenever anything about the bytes below changes meaning — the
-// header's shape, a node tag, the encoding `OpKind::marshal` writes ops in, or
-// which nodes the payload carries.
-// See `docs/designs/opkind-numbering-is-private.md` §4.4.
-// The encoding one is easy to forget precisely because it changes nothing
-// here: the file still parses, and every op byte quietly names a different
-// operation. A stale corpus is cheap to replace and expensive to misread, so
-// when in doubt, bump.
-//
-// 1 → 2: OpKind discriminants were renumbered dense (0..COUNT); ops serialize
-//        through `OpKind::marshal`, so a v1 corpus decodes its op bytes as
-//        different ops under the new numbering.
-// 2 → 3: entries now store only the subtree reachable from the root. A v2
-//        file still *parses*, which is worse than a parse error — its node
-//        counts include the generator's dead nodes, so every size filter
-//        reading a v2 corpus measures arena history instead of expression
-//        size (bug B3).
-// Both bumps turn silent corruption into a load-time error.
-const VERSION: u32 = 3;
+use crate::schema::{SchemaIdentity, identity_mismatch};
+
+/// Marker type naming the corpus binary format for [`SchemaIdentity`]. The
+/// format has no single Rust value of its own — it serializes a
+/// `Vec<(String, ExprArena, ExprId)>` — so this type exists purely to carry
+/// `SCHEMA` and derive `SCHEMA_IDENTITY` from it.
+struct CorpusFormat;
+
+impl SchemaIdentity for CorpusFormat {
+    const MAGIC: &'static str = "PXCR";
+    // Every field this format's bytes carry, and what each one means. This
+    // text IS the version: change what a field means here and
+    // `SCHEMA_IDENTITY` (its content hash) changes with it, so a corpus
+    // written under the old meaning cannot silently be read under the new
+    // one. History, for readers orienting themselves: the op encoding went
+    // dense (0..COUNT) under `OpKind::marshal`; entries were narrowed to only
+    // the subtree reachable from `root` (arena.len() is generator history,
+    // not expression size — bug B3); and the cross-tier dedup key moved from
+    // raw structure to the feature-quotient `FenceKey`, because the
+    // extraction head's features collapse literals and a literal-keyed dedup
+    // could seat a DEV/FINAL-equivalent expression in TRAIN (P1(d)).
+    const SCHEMA: &'static str = "\
+        header: magic[4]=PXCR, schema_identity: u64 le, count: u32 le entries follow; \
+        entry: name_len u16 le, name utf8 bytes, node_count u32 le, nary_count u32 le, \
+        root_index u32 le (ExprId.0 into this entry's own node list), \
+        nodes: node_count encoded ExprNodes in child-before-parent order, \
+        nary_children: [u32 le; nary_count] (ExprId.0 values); \
+        ExprNode tag byte: 0=Var(index u8), 1=Const(f32 le), 2=Param(index u8), \
+        3=Unary(OpKind::marshal, ExprId le), \
+        4=Binary(OpKind::marshal, ExprId le, ExprId le), \
+        5=Ternary(OpKind::marshal, ExprId le, ExprId le, ExprId le), \
+        6=Nary(OpKind::marshal, nary_children start u32 le, len u16 le), \
+        7=Buffer(BufferId u16 le) refused at write time, its declaration is never \
+        serialized; \
+        op byte encoding: pixelflow_ir::OpKind::marshal, dense 0..COUNT discriminants \
+        private to pixelflow-ir; \
+        entries store ONLY the subtree reachable from root (reachable_subtree \
+        compaction) so stored node_count is expression size, not generator-arena \
+        size; \
+        cross-tier dedup key an on-disk TRAIN tier was built against: the \
+        feature-quotient FenceKey (structural_key composed with the extraction \
+        head's literal-collapsing feature map), not raw structural equality";
+}
+
+fn regen_command() -> &'static str {
+    "cargo run --release -p pixelflow-pipeline --features training --bin gen_bench_corpus"
+}
 
 // ── ExprNode serialization tags ──────────────────────────────────────────────
 
@@ -203,8 +232,8 @@ pub fn write_corpus(path: &Path, entries: &[(String, ExprArena, ExprId)]) -> io:
     let mut w = io::BufWriter::new(file);
 
     // Header
-    w.write_all(MAGIC)?;
-    w.write_all(&VERSION.to_le_bytes())?;
+    w.write_all(CorpusFormat::MAGIC.as_bytes())?;
+    w.write_all(&CorpusFormat::SCHEMA_IDENTITY.to_le_bytes())?;
     w.write_all(&(entries.len() as u32).to_le_bytes())?;
 
     for (name, arena, root) in entries {
@@ -308,32 +337,32 @@ fn read_corpus_bytes(data: &[u8]) -> io::Result<Vec<(String, ExprArena, ExprId)>
     // Header
     let mut magic = [0u8; 4];
     r.read_exact(&mut magic)?;
-    if &magic != MAGIC {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("bad corpus magic: expected {:?}, got {:?}", MAGIC, magic),
-        ));
-    }
-
-    // Exact-version check, no tolerance. Op bytes mean whatever the IR's
-    // encoding said when the file was written, and that encoding may change
-    // without notice — so a "best effort" read of an old file would decode
-    // valid-looking bytes into the wrong ops rather than fail. Both prior
-    // changes are silent-corruption shaped rather than parse-error shaped:
-    // v1's op bytes decode as different ops under the dense OpKind numbering,
-    // and v2's node counts include generator dead nodes, so v2 size filters
-    // measure the wrong thing. Neither would fail to parse.
-    let version = r.read_u32()?;
-    if version != VERSION {
+    if magic != *CorpusFormat::MAGIC.as_bytes() {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             format!(
-                "unsupported corpus version: {version} (expected {VERSION}); the OpKind \
-                 opcode numbering changed (v1→v2) and entries are now stored as the \
-                 reachable subtree only (v2→v3), so older corpora decode to the wrong ops \
-                 or the wrong node counts — regenerate the corpus with `cargo run --release \
-                 -p pixelflow-pipeline --features training --bin gen_bench_corpus`"
+                "bad corpus magic: expected {:?}, got {:?}",
+                CorpusFormat::MAGIC.as_bytes(),
+                magic
             ),
+        ));
+    }
+
+    // Exact-identity check, no tolerance. Op bytes mean whatever the IR's
+    // encoding said when the file was written, and that encoding may change
+    // without notice — so a "best effort" read of a stale file would decode
+    // valid-looking bytes into the wrong ops rather than fail. A hand-bumped
+    // integer needs a human to remember to move it every time the format's
+    // meaning changes; this identity is derived from `CorpusFormat::SCHEMA`
+    // (docs/plans/2026-08-17-cost-model-domain.md, J9), so any change to what
+    // the bytes below mean changes the identity by construction.
+    let stored_identity = r.read_u64()?;
+    if stored_identity != CorpusFormat::SCHEMA_IDENTITY {
+        return Err(identity_mismatch(
+            "corpus",
+            stored_identity,
+            CorpusFormat::SCHEMA_IDENTITY,
+            regen_command(),
         ));
     }
 
@@ -514,6 +543,12 @@ impl<'a> Cursor<'a> {
         self.read_exact(&mut buf)?;
         Ok(u32::from_le_bytes(buf))
     }
+
+    fn read_u64(&mut self) -> io::Result<u64> {
+        let mut buf = [0u8; 8];
+        self.read_exact(&mut buf)?;
+        Ok(u64::from_le_bytes(buf))
+    }
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -672,40 +707,28 @@ mod tests {
     }
 
     #[test]
-    fn bad_version_fails() {
+    fn stale_schema_identity_is_refused_with_regeneration_hint() {
+        // Any identity other than the current one must be a hard error — this
+        // is what replaced three separate hand-bumped-version tests (op
+        // renumbering, subtree compaction, FenceKey dedup): all three are now
+        // exactly one case, "the stored identity doesn't match", because the
+        // identity is derived from the format description rather than
+        // hand-maintained beside it (J9).
         let mut data = Vec::new();
-        data.extend_from_slice(MAGIC);
-        data.extend_from_slice(&99u32.to_le_bytes()); // bad version
+        data.extend_from_slice(CorpusFormat::MAGIC.as_bytes());
+        data.extend_from_slice(&0xdead_beef_dead_beefu64.to_le_bytes()); // stale identity
         data.extend_from_slice(&0u32.to_le_bytes()); // count=0
-        match read_corpus_from_bytes("bad_version", &data) {
-            Ok(_) => panic!("expected error for bad version"),
-            Err(e) => assert!(
-                e.to_string().contains("unsupported corpus version"),
-                "unexpected error: {e}"
-            ),
-        }
-    }
-
-    #[test]
-    fn v1_corpus_is_refused_with_regeneration_hint() {
-        // A v1 header must be a hard error: it was written under a different
-        // op encoding, so its op bytes decode as different ops — the reader
-        // must refuse it, not fall back to decoding garbage.
-        let mut data = Vec::new();
-        data.extend_from_slice(MAGIC);
-        data.extend_from_slice(&1u32.to_le_bytes()); // written under an older encoding
-        data.extend_from_slice(&0u32.to_le_bytes()); // count=0
-        match read_corpus_from_bytes("v1_refused", &data) {
-            Ok(_) => panic!("v1 corpus must be refused: its op bytes decode as wrong OpKinds"),
+        match read_corpus_from_bytes("stale_identity", &data) {
+            Ok(_) => panic!("a stale schema identity must be refused, not decoded"),
             Err(e) => {
                 let msg = e.to_string();
                 assert!(
-                    msg.contains("unsupported corpus version: 1"),
-                    "error must name the rejected version: {msg}"
+                    msg.contains("schema identity mismatch"),
+                    "error must name the failure class: {msg}"
                 );
                 assert!(
-                    msg.contains("opcode numbering changed"),
-                    "error must explain WHY v1 is rejected: {msg}"
+                    msg.contains("deadbeefdeadbeef"),
+                    "error must name the rejected identity: {msg}"
                 );
                 assert!(
                     msg.contains("gen_bench_corpus"),
@@ -716,33 +739,16 @@ mod tests {
     }
 
     #[test]
-    fn v2_corpus_is_refused_with_regeneration_hint() {
-        // v2 parses byte-for-byte, which is precisely why it must be refused:
-        // its entries carry the generator's dead nodes, so a v2 file read by
-        // v3 code reports arena history as expression size and every
-        // node-count filter silently drops the wrong expressions (bug B3).
-        let mut data = Vec::new();
-        data.extend_from_slice(MAGIC);
-        data.extend_from_slice(&2u32.to_le_bytes()); // pre-compaction version
-        data.extend_from_slice(&0u32.to_le_bytes()); // count=0
-        match read_corpus_from_bytes("v2_refused", &data) {
-            Ok(_) => panic!("v2 corpus must be refused: its node counts include dead nodes"),
-            Err(e) => {
-                let msg = e.to_string();
-                assert!(
-                    msg.contains("unsupported corpus version: 2"),
-                    "error must name the rejected version: {msg}"
-                );
-                assert!(
-                    msg.contains("reachable subtree"),
-                    "error must explain WHY v2 is rejected: {msg}"
-                );
-                assert!(
-                    msg.contains("gen_bench_corpus"),
-                    "error must name the regeneration binary: {msg}"
-                );
-            }
-        }
+    fn schema_identity_changes_when_the_schema_text_does() {
+        // The mechanism this format now relies on, pinned directly: editing
+        // what a field means (here, simulated by comparing two schema
+        // strings) changes the derived identity without a separate bump step
+        // to forget.
+        use crate::schema::fnv1a64_const;
+        let old_meaning = fnv1a64_const(b"root_index means an index into the WRITER's arena");
+        let new_meaning = fnv1a64_const(b"root_index means an index into THIS ENTRY's nodes");
+        assert_ne!(old_meaning, new_meaning);
+        assert_eq!(CorpusFormat::SCHEMA_IDENTITY, CorpusFormat::SCHEMA_IDENTITY);
     }
 
     // ── Reachable-subtree compaction (bug B3) ───────────────────────────────

--- a/pixelflow-pipeline/src/training/corpus.rs
+++ b/pixelflow-pipeline/src/training/corpus.rs
@@ -65,7 +65,7 @@ use std::path::Path;
 use pixelflow_ir::kind::OpCode;
 use pixelflow_ir::{ExprArena, ExprId, ExprNode, OpKind};
 
-use crate::schema::{SchemaIdentity, identity_mismatch};
+use crate::schema::{SchemaIdentity, fnv1a64_const, identity_mismatch};
 
 /// Marker type naming the corpus binary format for [`SchemaIdentity`]. The
 /// format has no single Rust value of its own — it serializes a
@@ -111,6 +111,63 @@ impl SchemaIdentity for CorpusFormat {
 
 fn regen_command() -> &'static str {
     "cargo run --release -p pixelflow-pipeline --features training --bin gen_bench_corpus"
+}
+
+// ── Identity: SCHEMA text folded with the LIVE op encoding table ───────────
+//
+// `CorpusFormat::SCHEMA_IDENTITY` alone has a hole: it hashes the prose in
+// `SCHEMA` above, and that prose only *describes* the encoding as "dense
+// 0..COUNT discriminants private to pixelflow-ir" — a sentence that stays
+// true, and therefore stays byte-identical, no matter which op ends up at
+// which byte. `OpKind::marshal` is free to renumber (`docs/designs/
+// opkind-numbering-is-private.md`), and a renumbering changes nothing this
+// text says, so `SCHEMA_IDENTITY` alone cannot see it: an old corpus would
+// pass the new identity check and silently decode every affected opcode as
+// the wrong operation — exactly the failure J9 exists to make impossible.
+//
+// This is the derived-encoding-fingerprint design that opkind-numbering-is-
+// private.md §4.3 named `OpKind::ENCODING_ID` and rejected as disproportion-
+// ate — at the time, a hand-bumped `VERSION` integer was still the actual
+// gate, so the fingerprint would have been a second, redundant guard over
+// the same format. That premise is gone: this corpus format's gate is now
+// `SchemaIdentity`'s derived hash and nothing else, so a renumbering that
+// outruns the prose has no other guard left to catch it. `pixelflow-ir` is
+// out of scope for this change (its numbering stays private, per that same
+// doc), so the fingerprint is computed here, from `OpKind`'s public
+// `all()`/`marshal()`/`name()` surface, rather than as an `OpKind` const.
+//
+// Folds `(name, marshal() byte)` for every live op, in `OpKind::all()`
+// order, plus the op count — not just the byte sequence, which is always
+// `0..COUNT` by construction and so is invariant under a renumbering that
+// only swaps which op sits at which position.
+fn opcode_encoding_identity() -> u64 {
+    let mut buf: Vec<u8> = Vec::new();
+    let mut count: u32 = 0;
+    for op in OpKind::all() {
+        let name = op.name().as_bytes();
+        assert!(
+            name.len() <= u8::MAX as usize,
+            "opcode_encoding_identity: op name '{}' exceeds u8::MAX bytes",
+            op.name()
+        );
+        buf.push(name.len() as u8);
+        buf.extend_from_slice(name);
+        buf.extend_from_slice(&op.marshal().to_bytes());
+        count += 1;
+    }
+    buf.extend_from_slice(&count.to_le_bytes());
+    fnv1a64_const(&buf)
+}
+
+/// The identity actually written to disk and checked on load: the schema
+/// prose's hash, folded with the live `(op name, encoded byte)` table so a
+/// renumbering in `pixelflow-ir` changes the identity by construction, not
+/// by someone remembering to edit `CorpusFormat::SCHEMA` to match.
+fn corpus_identity() -> u64 {
+    let mut buf = Vec::with_capacity(16);
+    buf.extend_from_slice(&CorpusFormat::SCHEMA_IDENTITY.to_le_bytes());
+    buf.extend_from_slice(&opcode_encoding_identity().to_le_bytes());
+    fnv1a64_const(&buf)
 }
 
 // ── ExprNode serialization tags ──────────────────────────────────────────────
@@ -233,7 +290,7 @@ pub fn write_corpus(path: &Path, entries: &[(String, ExprArena, ExprId)]) -> io:
 
     // Header
     w.write_all(CorpusFormat::MAGIC.as_bytes())?;
-    w.write_all(&CorpusFormat::SCHEMA_IDENTITY.to_le_bytes())?;
+    w.write_all(&corpus_identity().to_le_bytes())?;
     w.write_all(&(entries.len() as u32).to_le_bytes())?;
 
     for (name, arena, root) in entries {
@@ -354,14 +411,18 @@ fn read_corpus_bytes(data: &[u8]) -> io::Result<Vec<(String, ExprArena, ExprId)>
     // valid-looking bytes into the wrong ops rather than fail. A hand-bumped
     // integer needs a human to remember to move it every time the format's
     // meaning changes; this identity is derived from `CorpusFormat::SCHEMA`
-    // (docs/plans/2026-08-17-cost-model-domain.md, J9), so any change to what
-    // the bytes below mean changes the identity by construction.
+    // folded with the live op encoding table (`corpus_identity`, docs/plans/
+    // 2026-08-17-cost-model-domain.md, J9), so any change to what the bytes
+    // below mean — INCLUDING a silent `OpKind::marshal` renumbering the
+    // prose doesn't happen to mention — changes the identity by
+    // construction, not by someone remembering to update `SCHEMA`'s text.
     let stored_identity = r.read_u64()?;
-    if stored_identity != CorpusFormat::SCHEMA_IDENTITY {
+    let expected_identity = corpus_identity();
+    if stored_identity != expected_identity {
         return Err(identity_mismatch(
             "corpus",
             stored_identity,
-            CorpusFormat::SCHEMA_IDENTITY,
+            expected_identity,
             regen_command(),
         ));
     }
@@ -744,11 +805,72 @@ mod tests {
         // what a field means (here, simulated by comparing two schema
         // strings) changes the derived identity without a separate bump step
         // to forget.
-        use crate::schema::fnv1a64_const;
         let old_meaning = fnv1a64_const(b"root_index means an index into the WRITER's arena");
         let new_meaning = fnv1a64_const(b"root_index means an index into THIS ENTRY's nodes");
         assert_ne!(old_meaning, new_meaning);
         assert_eq!(CorpusFormat::SCHEMA_IDENTITY, CorpusFormat::SCHEMA_IDENTITY);
+    }
+
+    // ── corpus_identity folds in the live opcode encoding (P1 finding on
+    // PR #1019: SCHEMA_IDENTITY alone hashes only prose) ───────────────────
+
+    #[test]
+    fn corpus_identity_is_deterministic() {
+        assert_eq!(corpus_identity(), corpus_identity());
+        assert_eq!(opcode_encoding_identity(), opcode_encoding_identity());
+    }
+
+    #[test]
+    fn corpus_identity_depends_on_more_than_the_schema_text() {
+        // The defect this guards: `CorpusFormat::SCHEMA` describes the op
+        // encoding only as "dense 0..COUNT discriminants" — a sentence a
+        // renumbering never has to touch. If `corpus_identity` reduced to
+        // `SCHEMA_IDENTITY` alone, that renumbering would leave the on-disk
+        // gate unchanged and a stale corpus would decode every affected op
+        // as whatever now sits at its old byte. Folding the live encoding
+        // table in means the composite identity cannot equal the bare
+        // schema-text hash.
+        assert_ne!(
+            corpus_identity(),
+            CorpusFormat::SCHEMA_IDENTITY,
+            "corpus_identity must depend on the live opcode encoding, not just the \
+             schema prose describing it"
+        );
+    }
+
+    #[test]
+    fn encoding_identity_changes_if_an_op_is_reassigned_a_different_byte() {
+        // Pins the sensitivity a renumbering needs caught: hashing the byte
+        // sequence ALONE would be invariant under a swap (marshal's bytes
+        // are always the dense sequence 0..COUNT no matter which op holds
+        // which position), so the identity has to be computed over
+        // (name, byte) pairs — this reimplements that computation generically
+        // over a synthetic table, standing in for a renumbering of the real
+        // (private) `OpKind` table, which nothing outside `pixelflow-ir` can
+        // fabricate directly.
+        fn identity_of(table: &[(&str, u8)]) -> u64 {
+            let mut buf: Vec<u8> = Vec::new();
+            for (name, byte) in table {
+                buf.push(name.len() as u8);
+                buf.extend_from_slice(name.as_bytes());
+                buf.push(*byte);
+            }
+            buf.extend_from_slice(&(table.len() as u32).to_le_bytes());
+            fnv1a64_const(&buf)
+        }
+
+        let before = [("add", 0u8), ("sub", 1u8), ("mul", 2u8)];
+        // A renumbering: `add` and `sub` swap encoded bytes. The byte
+        // sequence itself (0,1,2) is unchanged; only the mapping is.
+        let after = [("add", 1u8), ("sub", 0u8), ("mul", 2u8)];
+
+        assert_ne!(
+            identity_of(&before),
+            identity_of(&after),
+            "swapping which op maps to a byte must change the identity — this is \
+             exactly what OpKind::marshal renumbering does, and a hash that can't \
+             see it defeats the corpus identity check (P1 on PR #1019)"
+        );
     }
 
     // ── Reachable-subtree compaction (bug B3) ───────────────────────────────

--- a/pixelflow-pipeline/src/training/episodes.rs
+++ b/pixelflow-pipeline/src/training/episodes.rs
@@ -21,7 +21,7 @@ use std::path::Path;
 use pixelflow_ir::{ExprArena, ExprId};
 use pixelflow_search::egraph::saturate::saturate_with_full_budget;
 use pixelflow_search::egraph::{
-    EGraph, IncrementalExtractor, Rewrite, all_rules, compute_ref_counts, extract_neural_to_arena,
+    EGraph, IncrementalExtractor, Rewrite, all_rules, extract_neural_to_arena,
 };
 use pixelflow_search::nnue::ExprNnue;
 use pixelflow_search::nnue::RuleTemplates;
@@ -268,9 +268,8 @@ pub fn run_episode(
     }
     let extractor = IncrementalExtractor::new(model, 8);
     let (_final_cost, final_choices) = extractor.extract_choices_only(&egraph, root);
-    let _final_ref_counts = compute_ref_counts(&egraph, root, &final_choices);
     let (final_arena, final_arena_root) =
-        pixelflow_search::egraph::choices_to_arena(&egraph, root, &final_choices);
+        pixelflow_search::egraph::choices_to_arena(&final_choices);
 
     if final_arena.has_degenerate(final_arena_root) {
         log_exclusion(

--- a/pixelflow-pipeline/src/training/mint.rs
+++ b/pixelflow-pipeline/src/training/mint.rs
@@ -27,6 +27,16 @@
 //!    never trained to predict, and those two modes rank expression shapes
 //!    differently. The sidecar exists so the gate can *assert* the match
 //!    instead of assuming it.
+//!
+//! Both functions below are thin `f64` wrappers around
+//! [`BenchResult::corrected_session_ns`] / [`crate::jit_bench::CostLabel`]
+//! (docs/plans/2026-08-17-cost-model-domain.md, J3/J4): the ordering they
+//! document is enforced there by the [`crate::jit_bench::LocalNs`] /
+//! [`crate::jit_bench::SessionNs`] newtypes, not merely described here in
+//! prose. Callers that track collection order should mint a
+//! [`crate::jit_bench::CostLabel`] directly instead of going through these —
+//! they exist for callers (e.g. `training::episodes`) that only need the
+//! scalar value.
 
 use std::io;
 use std::path::{Path, PathBuf};
@@ -34,6 +44,7 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 use crate::jit_bench::{BenchMode, BenchResult};
+use crate::schema::{SchemaIdentity, identity_mismatch};
 
 // ── Sentinel normalization ──────────────────────────────────────────────────
 
@@ -68,7 +79,11 @@ use crate::jit_bench::{BenchMode, BenchResult};
 /// benchmarked. That is precisely the order-dependent contamination the
 /// sentinel exists to remove, and at the accepted sub-50% drift band with a
 /// ~4ns call overhead it is >1ns, which is a large fraction of the smallest
-/// kernels — the bulk of the corpus.
+/// kernels — the bulk of the corpus. This function no longer has an
+/// opportunity to get that order wrong: it delegates to
+/// [`BenchResult::corrected_session_ns`], where the raw reading is a
+/// [`crate::jit_bench::LocalNs`] with no `Sub` impl, so overhead cannot be
+/// taken off before normalization runs.
 ///
 /// The alternative, remeasuring the identity kernel next to every label and
 /// normalizing that too, is rejected: it buys the same number at the price of
@@ -89,15 +104,7 @@ use crate::jit_bench::{BenchMode, BenchResult};
 /// unnecessary. `context` names the call site in the panic.
 #[must_use]
 pub fn normalized_label_ns(bench: &BenchResult, context: &str) -> f64 {
-    let sentinel = bench.sentinel.unwrap_or_else(|| {
-        panic!(
-            "{context}: label minted from a BenchResult with no sentinel context — the \
-             measurement came from a sessionless wrapper (no QoS pin, no drift sentinel, no \
-             overhead subtraction), so its drift is neither measured nor correctable. Mint \
-             labels through a BenchSession"
-        )
-    });
-    bench.ns * sentinel.normalization() - bench.call_overhead_ns
+    bench.corrected_session_ns(context).0.get()
 }
 
 /// The sentinel normalization factor a measurement carries, for persisting
@@ -109,13 +116,7 @@ pub fn normalized_label_ns(bench: &BenchResult, context: &str) -> f64 {
 /// error in label-minting paths.
 #[must_use]
 pub fn label_normalization(bench: &BenchResult, context: &str) -> f64 {
-    let sentinel = bench.sentinel.unwrap_or_else(|| {
-        panic!(
-            "{context}: label normalization requested for a BenchResult with no sentinel \
-             context — mint labels through a BenchSession"
-        )
-    });
-    sentinel.normalization()
+    bench.corrected_session_ns(context).1.get()
 }
 
 /// Summary statistics of the per-label normalization factors a run applied.
@@ -186,6 +187,17 @@ pub fn mint_metadata_path(weights: &Path) -> PathBuf {
 /// What a weights file's training targets mean.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct MintMetadata {
+    /// Content hash of [`MintMetadata::SCHEMA`] — this sidecar's own format
+    /// identity, checked by [`MintMetadata::read_for`]
+    /// (docs/plans/2026-08-17-cost-model-domain.md, J9, kills P1(b)). A
+    /// sidecar with a JSON shape `serde` can still parse but whose FIELDS now
+    /// mean something else (not merely a byte-shape change, which `serde`
+    /// already refuses) would otherwise load silently; this field turns that
+    /// into a loud, named refusal the same way [`weights_fnv64`] turns a
+    /// swapped weights file into one.
+    ///
+    /// [`weights_fnv64`]: MintMetadata::weights_fnv64
+    pub schema_identity: String,
     /// [`bench_mode_slug`] of the mode every target was measured in.
     pub bench_mode: String,
     /// Which binary wrote these weights.
@@ -214,21 +226,49 @@ pub struct MintMetadata {
 /// FNV-1a 64 over the weights bytes — the identity [`MintMetadata`] records.
 ///
 /// The job is binding two local files to each other, not resisting an
-/// adversary, so the same non-cryptographic hash the journal uses for corpus
-/// and diff identities is enough here too.
+/// adversary, so the same non-cryptographic hash [`crate::journal`] uses for
+/// corpus and diff identities is enough here too — this is the
+/// `SchemaIdentity`-style content-hash-as-gate pattern's original instance,
+/// generalized by [`crate::schema`]
+/// (docs/plans/2026-08-17-cost-model-domain.md, J9 §2).
 #[must_use]
 pub fn weights_identity(bytes: &[u8]) -> String {
-    const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
-    const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
-    let mut hash = FNV_OFFSET;
-    for &b in bytes {
-        hash ^= u64::from(b);
-        hash = hash.wrapping_mul(FNV_PRIME);
-    }
-    format!("{hash:016x}")
+    crate::schema::fnv1a64_hex(bytes)
+}
+
+impl SchemaIdentity for MintMetadata {
+    const MAGIC: &'static str = "PXMM";
+    // Every field this sidecar carries, and what it means. Edit this when a
+    // field's meaning changes (not merely its name/type — serde already
+    // refuses those); the derived `SCHEMA_IDENTITY` changes with it, so a
+    // sidecar written under the old meaning cannot silently be read under a
+    // consumer that expects the new one.
+    const SCHEMA: &'static str = "\
+        bench_mode: bench_mode_slug of the BenchMode every training target was \
+        measured in; \
+        trainer: which binary wrote these weights; \
+        samples: training sample count the weights were fit on, post-exclusion; \
+        order_shuffle_seed: seed of the shuffle that decided BENCHMARK order (not \
+        storage order) during minting; \
+        sentinel_calibration_ns: the minting session's opening sentinel calibration; \
+        normalization: NormalizationStats{count,min,median,max} of the per-label \
+        drift-correction factors actually applied across the minting run; \
+        weights_fnv64: FNV-1a 64 hex content hash binding this sidecar to the exact \
+        weight bytes it describes; \
+        written_at_unix_s: unix seconds at sidecar write time";
 }
 
 impl MintMetadata {
+    /// Hex [`SchemaIdentity::SCHEMA_IDENTITY`] for the current build — what a
+    /// freshly-written sidecar's [`Self::schema_identity`] field must equal,
+    /// and what [`Self::read_for`] checks a loaded sidecar against.
+    ///
+    /// [`Self::schema_identity`]: MintMetadata::schema_identity
+    #[must_use]
+    pub fn current_schema_identity() -> String {
+        format!("{:016x}", <Self as SchemaIdentity>::SCHEMA_IDENTITY)
+    }
+
     /// Write the sidecar for `weights`.
     ///
     /// # Errors
@@ -264,12 +304,27 @@ impl MintMetadata {
                 ),
             )
         })?;
-        serde_json::from_str(&text).map_err(|e| {
+        let meta: Self = serde_json::from_str(&text).map_err(|e| {
             io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!("mint metadata sidecar {} is malformed: {e}", path.display()),
             )
-        })
+        })?;
+        // A field can keep its JSON name and type while its MEANING changes
+        // (serde's parse succeeding says nothing about that); this is the
+        // check `serde_json::from_str` above cannot make (J9, kills P1(b)).
+        let expected = Self::current_schema_identity();
+        if meta.schema_identity != expected {
+            let stored = u64::from_str_radix(&meta.schema_identity, 16).unwrap_or(0);
+            return Err(identity_mismatch(
+                "mint sidecar",
+                stored,
+                <Self as SchemaIdentity>::SCHEMA_IDENTITY,
+                "cargo run --release -p pixelflow-pipeline --features training --bin \
+                 bootstrap_extraction_head",
+            ));
+        }
+        Ok(meta)
     }
 
     /// Assert these weights were minted in `expected`.
@@ -315,16 +370,16 @@ impl MintMetadata {
 
 /// Unix seconds now.
 ///
+/// Lives in [`crate::schema`] (unconditionally compiled) rather than here, so
+/// [`crate::journal`] — which every journal-writing binary uses regardless of
+/// the `training` feature — can share it without depending on this
+/// `training`-gated module. Re-exported here so existing callers keep
+/// importing it from `training::mint`.
+///
 /// # Panics
 ///
 /// Panics if the system clock is before the Unix epoch.
-#[must_use]
-pub fn unix_now_s() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .expect("system clock is before the unix epoch")
-        .as_secs()
-}
+pub use crate::schema::unix_now_s;
 
 /// Human-readable modification time of `path`, as an age in seconds plus the
 /// raw unix timestamp — enough for a log line to say *which* file a warm
@@ -432,7 +487,7 @@ mod tests {
         const KERNEL_NS: f64 = 3.0;
         let drift = 1.45f64;
         let b = drifted(KERNEL_NS, OVERHEAD_NS, drift);
-        let factor = b.sentinel.expect("sentinel").normalization();
+        let factor = b.sentinel.expect("sentinel").normalization().get();
 
         let wrong = b.adjusted_ns * factor;
         let residue = wrong - KERNEL_NS;
@@ -577,6 +632,7 @@ mod tests {
 
         let weights_bytes = b"not real weights, but identity-checked all the same";
         let meta = MintMetadata {
+            schema_identity: MintMetadata::current_schema_identity(),
             bench_mode: bench_mode_slug(BenchMode::Latency).to_string(),
             trainer: "bootstrap_extraction_head".to_string(),
             samples: 7,
@@ -607,6 +663,7 @@ mod tests {
         // Codex 3758853787: new weights beside an old sidecar — the aborted
         // half-written training run. Mode checks alone would accept it.
         let meta = MintMetadata {
+            schema_identity: MintMetadata::current_schema_identity(),
             bench_mode: bench_mode_slug(BenchMode::Latency).to_string(),
             trainer: "bootstrap_extraction_head".to_string(),
             samples: 7,
@@ -623,6 +680,7 @@ mod tests {
     #[should_panic(expected = "objective mismatch")]
     fn require_mode_rejects_the_other_objective() {
         let meta = MintMetadata {
+            schema_identity: MintMetadata::current_schema_identity(),
             bench_mode: bench_mode_slug(BenchMode::Latency).to_string(),
             trainer: "bootstrap_extraction_head".to_string(),
             samples: 1,
@@ -633,6 +691,37 @@ mod tests {
             written_at_unix_s: 0,
         };
         meta.require_mode(BenchMode::Throughput);
+    }
+
+    #[test]
+    fn stale_schema_identity_is_rejected_even_though_json_parses() {
+        // The case `serde_json::from_str` alone cannot catch (J9): the JSON
+        // shape is perfectly well-formed, every field name and type matches,
+        // but `schema_identity` names an older format meaning.
+        let dir = std::env::temp_dir().join(format!("mint_meta_stale_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("scratch dir");
+        let weights = dir.join("extraction_head.bin");
+        let weights_bytes = b"stale-schema fixture weights";
+
+        let meta = MintMetadata {
+            schema_identity: "0000000000000000".to_string(), // not the current identity
+            bench_mode: bench_mode_slug(BenchMode::Latency).to_string(),
+            trainer: "bootstrap_extraction_head".to_string(),
+            samples: 3,
+            order_shuffle_seed: 1,
+            sentinel_calibration_ns: 1.0,
+            normalization: NormalizationStats::summarize(&[1.0]),
+            weights_fnv64: weights_identity(weights_bytes),
+            written_at_unix_s: 0,
+        };
+        meta.write_for(&weights).expect("write sidecar");
+
+        let err = MintMetadata::read_for(&weights).expect_err("stale schema must be refused");
+        let msg = err.to_string();
+        assert!(msg.contains("schema identity mismatch"), "{msg}");
+        assert!(msg.contains("bootstrap_extraction_head"), "{msg}");
+
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]

--- a/pixelflow-pipeline/src/training/split.rs
+++ b/pixelflow-pipeline/src/training/split.rs
@@ -719,6 +719,19 @@ impl<T: HoldoutSide> Fence<T> {
         );
         let entries = super::corpus::read_corpus(&path)
             .unwrap_or_else(|e| panic!("failed to read {tier} corpus {}: {e}", path.display()));
+        // A zero-entry file parses fine (the writer permits an empty corpus)
+        // but is not a fence: `blocked_by_either` would silently admit every
+        // candidate on this side, and training could proceed as if the
+        // promised {tier} holdout existed when it does not — existence and a
+        // successful parse alone do not establish the fence invariant.
+        assert!(
+            !entries.is_empty(),
+            "{tier} tier corpus at {} is empty (zero entries) — a holdout fence built from it \
+             would block nothing, silently admitting every candidate on this side. Regenerate \
+             the tiered corpus with gen_bench_corpus (--output {})",
+            path.display(),
+            corpus_dir.display()
+        );
 
         let mut keys = HashSet::with_capacity(entries.len());
         let mut node_counts = Vec::with_capacity(entries.len());
@@ -867,6 +880,18 @@ mod tests {
     #[should_panic(expected = "holdout fence cannot be built")]
     fn fence_refuses_to_build_from_a_missing_tier_file() {
         let dir = scratch_dir("missing");
+        let _ = Fence::<DevSide>::build(&dir);
+    }
+
+    #[test]
+    #[should_panic(expected = "is empty (zero entries)")]
+    fn fence_refuses_to_build_from_an_empty_tier_file() {
+        // A zero-entry corpus is a valid PXCR file (the writer permits an
+        // empty corpus), but a fence built from it would block nothing —
+        // existence and a successful parse are not enough (P2 finding on the
+        // fix commit for PR #1019).
+        let dir = scratch_dir("empty_tier");
+        write_tier(&dir, Tier::Dev, &[]);
         let _ = Fence::<DevSide>::build(&dir);
     }
 

--- a/pixelflow-pipeline/src/training/split.rs
+++ b/pixelflow-pipeline/src/training/split.rs
@@ -18,7 +18,12 @@
 
 use std::collections::HashSet;
 use std::fmt;
+use std::marker::PhantomData;
 use std::path::Path;
+
+use pixelflow_ir::{ExprArena, ExprId};
+
+use super::structural::FenceKey;
 
 /// Corpus tier. Ordered by holdout sacredness: `Train < Dev < Final`, so the
 /// corpus build can assert it admits more-sacred tiers first and cross-tier
@@ -116,6 +121,31 @@ impl SeedRange {
     }
 }
 
+/// One generator family: a `(band, seed)` draw stream — the split unit
+/// (docs/plans/2026-08-17-cost-model-domain.md, J7). A newtype instead of a
+/// bare tuple so a swapped argument order (`(seed, band)`) is a type error
+/// at the call site instead of a silently wrong RNG seed or tier lookup.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Family {
+    /// Index into the generator's band table.
+    pub band: usize,
+    /// The family's draw-stream seed.
+    pub seed: u64,
+}
+
+impl Family {
+    #[must_use]
+    pub fn new(band: usize, seed: u64) -> Self {
+        Self { band, seed }
+    }
+}
+
+impl fmt::Display for Family {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "band {} family {}", self.band, self.seed)
+    }
+}
+
 /// One tier's family set: the cartesian product of `bands` and the seeds in
 /// `seed_ranges`.
 #[derive(Clone, Debug, Default)]
@@ -127,13 +157,14 @@ pub struct TierSpec {
 }
 
 impl TierSpec {
-    /// Whether the family `(band, seed)` belongs to this tier.
+    /// Whether `family` belongs to this tier.
     #[must_use]
-    pub fn contains(&self, band: usize, seed: u64) -> bool {
-        self.bands.contains(&band) && self.seed_ranges.iter().any(|r| r.contains(seed))
+    pub fn contains(&self, family: Family) -> bool {
+        self.bands.contains(&family.band)
+            && self.seed_ranges.iter().any(|r| r.contains(family.seed))
     }
 
-    /// Total number of `(band, seed)` families in this tier.
+    /// Total number of families in this tier.
     ///
     /// # Panics
     ///
@@ -147,13 +178,13 @@ impl TierSpec {
             .unwrap_or_else(|_| panic!("TierSpec::family_count overflows usize: {total} families"))
     }
 
-    /// All `(band, seed)` families of this tier, band-major, in manifest
-    /// order — the deterministic generation order for the corpus build.
-    pub fn families(&self) -> impl Iterator<Item = (usize, u64)> + '_ {
+    /// All families of this tier, band-major, in manifest order — the
+    /// deterministic generation order for the corpus build.
+    pub fn families(&self) -> impl Iterator<Item = Family> + '_ {
         self.bands.iter().flat_map(move |&band| {
             self.seed_ranges
                 .iter()
-                .flat_map(move |r| (r.start..=r.end).map(move |seed| (band, seed)))
+                .flat_map(move |r| (r.start..=r.end).map(move |seed| Family::new(band, seed)))
         })
     }
 }
@@ -201,13 +232,13 @@ impl SplitManifest {
         }
     }
 
-    /// Which tier the family `(band, seed)` belongs to, if any. Validation
-    /// guarantees at most one tier matches.
+    /// Which tier `family` belongs to, if any. Validation guarantees at
+    /// most one tier matches.
     #[must_use]
-    pub fn tier_of(&self, band: usize, seed: u64) -> Option<Tier> {
+    pub fn tier_of(&self, family: Family) -> Option<Tier> {
         Tier::ALL
             .into_iter()
-            .find(|&tier| self.spec(tier).contains(band, seed))
+            .find(|&tier| self.spec(tier).contains(family))
     }
 
     /// Largest band index referenced anywhere in the manifest, so the corpus
@@ -591,11 +622,274 @@ fn parse_string_list(value: &str) -> Result<Vec<String>, String> {
         .collect()
 }
 
+// ── Holdout fence (plan 0.2, J7/J8) ─────────────────────────────────────────
+
+mod private {
+    /// Seals [`super::HoldoutSide`] to this module's two markers.
+    pub trait Sealed {}
+}
+
+/// Which tier a [`Fence`] is allowed to be built from: always a held-out
+/// tier, never the tier a fence exists to protect.
+///
+/// Sealed to [`DevSide`] and [`FinalSide`] — there is no impl (and cannot
+/// be, from outside this module) for `Tier::Train`. "Build the fence from
+/// the tier it exists to hold out of" is not a misuse a caller could make
+/// and get away with; it is not an API a caller can *reach*, because
+/// [`Fence::build`] takes no data from its caller at all — it derives its
+/// own source file from `Self::TIER`. See the direction note on [`Fence`].
+pub trait HoldoutSide: private::Sealed {
+    /// The corpus tier this side is fenced from.
+    const TIER: Tier;
+}
+
+/// Marker: the DEV tier.
+pub struct DevSide;
+/// Marker: the FINAL tier.
+pub struct FinalSide;
+
+impl private::Sealed for DevSide {}
+impl private::Sealed for FinalSide {}
+impl HoldoutSide for DevSide {
+    const TIER: Tier = Tier::Dev;
+}
+impl HoldoutSide for FinalSide {
+    const TIER: Tier = Tier::Final;
+}
+
+/// A holdout fence: every [`FenceKey`] belonging to tier `T`'s corpus file,
+/// so a candidate expression from anywhere else can be checked for
+/// "structure (in feature-quotient space) the model has already seen"
+/// (docs/plans/2026-08-17-cost-model-domain.md, J7/J8/P1(d)).
+///
+/// # Direction
+///
+/// `T` is phantom, but not decorative: [`Fence::build`] is the only
+/// constructor, and it does not accept entries from its caller — it reads
+/// `corpus_dir/corpus_{T::TIER}.bin` itself. So a `Fence<DevSide>` is
+/// *always* built from `corpus_dev.bin`, never from whatever the caller
+/// happened to have on hand, and a `Fence<Train>` cannot be spelled at all
+/// (`HoldoutSide` has no impl for `Tier::Train` — see the sealed trait
+/// above). Both together are what "the backwards misuse must not compile"
+/// means here: there is no code path that produces a fence built from the
+/// tier it is meant to hold out of. This is not a convention a caller could
+/// violate by passing the wrong argument — `HoldoutSide` being sealed means
+/// no crate, including this one, can name a third implementor:
+///
+/// ```compile_fail
+/// use pixelflow_pipeline::training::split::{Fence, HoldoutSide, Tier};
+///
+/// struct TrainSide;
+/// // `private::Sealed` is not reachable outside this module, so this impl
+/// // does not compile — and without it, `Fence<TrainSide>` below is not a
+/// // well-formed type at all.
+/// impl HoldoutSide for TrainSide {
+///     const TIER: Tier = Tier::Train;
+/// }
+///
+/// let _bad: Fence<TrainSide> = todo!();
+/// ```
+pub struct Fence<T: HoldoutSide> {
+    keys: HashSet<FenceKey>,
+    entries: usize,
+    node_counts: Vec<usize>,
+    _side: PhantomData<T>,
+}
+
+impl<T: HoldoutSide> Fence<T> {
+    /// Build from every entry of `corpus_dir/corpus_{T::TIER}.bin`.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the tier file is missing or fails to parse. A fence that
+    /// silently held zero structures because its source file did not exist
+    /// would validate nothing while looking like it validated everything.
+    #[must_use]
+    pub fn build(corpus_dir: &Path) -> Self {
+        let tier = T::TIER;
+        let path = corpus_dir.join(format!("corpus_{}.bin", tier.name()));
+        assert!(
+            path.exists(),
+            "{tier} tier corpus not found at {} — a holdout fence cannot be built without it, \
+             and training an unfenced stream would put {tier} structures into the training set \
+             (the held-out metrics would stop measuring a holdout). Run gen_bench_corpus \
+             (--output {}), which writes all three tiers together",
+            path.display(),
+            corpus_dir.display()
+        );
+        let entries = super::corpus::read_corpus(&path)
+            .unwrap_or_else(|e| panic!("failed to read {tier} corpus {}: {e}", path.display()));
+
+        let mut keys = HashSet::with_capacity(entries.len());
+        let mut node_counts = Vec::with_capacity(entries.len());
+        for (_name, arena, root) in &entries {
+            keys.insert(FenceKey::of(arena, *root));
+            node_counts.push(arena.node_count_subtree(*root));
+        }
+        Self {
+            keys,
+            entries: entries.len(),
+            node_counts,
+            _side: PhantomData,
+        }
+    }
+
+    /// Whether `key` is already owned by this side of the fence.
+    #[must_use]
+    pub fn contains(&self, key: &FenceKey) -> bool {
+        self.keys.contains(key)
+    }
+
+    /// Number of distinct feature-quotient structures fenced.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.keys.len()
+    }
+
+    /// Whether this side holds no structures at all.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.keys.is_empty()
+    }
+
+    /// Raw entry count of the source corpus file (`>= len()`: two entries
+    /// may collapse to one feature-quotient key).
+    #[must_use]
+    pub fn entries(&self) -> usize {
+        self.entries
+    }
+
+    /// Node count of every fenced structure's *entry* (one per corpus
+    /// entry, not deduplicated), for size-distribution reporting.
+    #[must_use]
+    pub fn node_counts(&self) -> &[usize] {
+        &self.node_counts
+    }
+}
+
+/// Check `(arena, root)` against every held-out side (DEV and FINAL): a
+/// candidate expression whose feature-quotient structure already belongs to
+/// either is holdout, whichever side owns it.
+#[must_use]
+pub fn blocked_by_either(
+    dev: &Fence<DevSide>,
+    final_fence: &Fence<FinalSide>,
+    arena: &ExprArena,
+    root: ExprId,
+) -> bool {
+    let key = FenceKey::of(arena, root);
+    dev.contains(&key) || final_fence.contains(&key)
+}
+
 // ── Tests ───────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pixelflow_ir::OpKind;
+
+    fn scratch_dir(tag: &str) -> std::path::PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock is before the unix epoch")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("split_fence_{tag}_{nanos}"));
+        std::fs::create_dir_all(&dir)
+            .unwrap_or_else(|e| panic!("failed to create {}: {e}", dir.display()));
+        dir
+    }
+
+    fn scaled_var(k: f32) -> (ExprArena, ExprId) {
+        let mut arena = ExprArena::new();
+        let x = arena.push_var(0);
+        let c = arena.push_const(k);
+        let root = arena.push_binary(OpKind::Mul, x, c);
+        (arena, root)
+    }
+
+    fn write_tier(dir: &Path, tier: Tier, exprs: &[(ExprArena, ExprId)]) {
+        let entries: Vec<(String, ExprArena, ExprId)> = exprs
+            .iter()
+            .enumerate()
+            .map(|(i, (a, r))| (format!("{}_{i}", tier.name()), a.clone(), *r))
+            .collect();
+        super::super::corpus::write_corpus(
+            &dir.join(format!("corpus_{}.bin", tier.name())),
+            &entries,
+        )
+        .unwrap_or_else(|e| panic!("failed to write {} corpus: {e}", tier.name()));
+    }
+
+    #[test]
+    fn fence_of_x_times_2_blocks_x_times_3_the_review_case() {
+        // The exact review case: a DEV entry `X * 2.0` must fence out a
+        // TRAIN candidate `X * 3.0` — same feature-quotient structure,
+        // different literal.
+        let dir = scratch_dir("review_case");
+        write_tier(&dir, Tier::Dev, &[scaled_var(2.0)]);
+        write_tier(&dir, Tier::Final, &[scaled_var(99.0)]);
+
+        let dev = Fence::<DevSide>::build(&dir);
+        let final_fence = Fence::<FinalSide>::build(&dir);
+
+        let (candidate, root) = scaled_var(3.0);
+        assert!(
+            blocked_by_either(&dev, &final_fence, &candidate, root),
+            "X * 3.0 must be fenced out by a DEV entry of X * 2.0 — both are the identical \
+             input to the extraction head"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn genuinely_different_topology_is_not_fenced() {
+        let dir = scratch_dir("different_topology");
+        write_tier(&dir, Tier::Dev, &[scaled_var(2.0)]);
+        write_tier(&dir, Tier::Final, &[scaled_var(99.0)]);
+
+        let dev = Fence::<DevSide>::build(&dir);
+        let final_fence = Fence::<FinalSide>::build(&dir);
+
+        let mut arena = ExprArena::new();
+        let x = arena.push_var(0);
+        let c = arena.push_const(2.0);
+        let add = arena.push_binary(OpKind::Add, x, c);
+        assert!(
+            !blocked_by_either(&dev, &final_fence, &arena, add),
+            "X + 2.0 is a different op from the fenced X * 2.0 and must survive"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    #[should_panic(expected = "holdout fence cannot be built")]
+    fn fence_refuses_to_build_from_a_missing_tier_file() {
+        let dir = scratch_dir("missing");
+        let _ = Fence::<DevSide>::build(&dir);
+    }
+
+    #[test]
+    fn fence_reports_entries_and_distinct_keys_separately() {
+        let dir = scratch_dir("entries_vs_keys");
+        // Two entries, same feature-quotient structure: entries() counts
+        // both, len() counts the one distinct key.
+        write_tier(&dir, Tier::Dev, &[scaled_var(2.0), scaled_var(3.0)]);
+        write_tier(&dir, Tier::Final, &[scaled_var(99.0)]);
+
+        let dev = Fence::<DevSide>::build(&dir);
+        assert_eq!(dev.entries(), 2);
+        assert_eq!(dev.len(), 1);
+        assert!(!dev.is_empty());
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    // Direction (J7 "backwards misuse must not compile") is exercised by the
+    // `compile_fail` doc-test on [`Fence`]'s "# Direction" section, not a
+    // `#[test]` here — `HoldoutSide` being sealed means the misuse has no
+    // runtime form to assert against, only a type that fails to resolve.
 
     const VALID: &str = r#"
 # leading comment
@@ -616,23 +910,33 @@ kernels = ["swirl", "poly"]
     #[test]
     fn parses_valid_manifest_and_assigns_tiers() {
         let m = SplitManifest::parse(VALID).expect("valid manifest must parse");
-        assert_eq!(m.tier_of(0, 0), Some(Tier::Train));
-        assert_eq!(m.tier_of(2, 7), Some(Tier::Train));
-        assert_eq!(m.tier_of(1, 3), Some(Tier::Dev));
-        assert_eq!(m.tier_of(3, 2), Some(Tier::Final));
-        assert_eq!(m.tier_of(3, 5), Some(Tier::Final));
+        assert_eq!(m.tier_of(Family::new(0, 0)), Some(Tier::Train));
+        assert_eq!(m.tier_of(Family::new(2, 7)), Some(Tier::Train));
+        assert_eq!(m.tier_of(Family::new(1, 3)), Some(Tier::Dev));
+        assert_eq!(m.tier_of(Family::new(3, 2)), Some(Tier::Final));
+        assert_eq!(m.tier_of(Family::new(3, 5)), Some(Tier::Final));
         // Seed 4 falls in the gap between final's ranges.
-        assert_eq!(m.tier_of(3, 4), None);
+        assert_eq!(m.tier_of(Family::new(3, 4)), None);
         // Band 9 is in no tier; seed 8 is outside every range.
-        assert_eq!(m.tier_of(9, 0), None);
-        assert_eq!(m.tier_of(0, 8), None);
+        assert_eq!(m.tier_of(Family::new(9, 0)), None);
+        assert_eq!(m.tier_of(Family::new(0, 8)), None);
         assert_eq!(m.final_kernels, vec!["swirl", "poly"]);
         assert_eq!(m.max_band_index(), 3);
         // train: 2 bands x 8 seeds; final: 1 band x (4 + 2) seeds.
         assert_eq!(m.train.family_count(), 16);
         assert_eq!(m.final_tier.family_count(), 6);
-        let fams: Vec<(usize, u64)> = m.final_tier.families().collect();
-        assert_eq!(fams, vec![(3, 0), (3, 1), (3, 2), (3, 3), (3, 5), (3, 6)]);
+        let fams: Vec<Family> = m.final_tier.families().collect();
+        assert_eq!(
+            fams,
+            vec![
+                Family::new(3, 0),
+                Family::new(3, 1),
+                Family::new(3, 2),
+                Family::new(3, 3),
+                Family::new(3, 5),
+                Family::new(3, 6),
+            ]
+        );
     }
 
     #[test]
@@ -647,10 +951,10 @@ kernels = ["swirl", "poly"]
         assert_eq!(m.max_band_index(), 37, "band table has 38 bands (0..=37)");
         // Spot-check the by-family holdout: dev band 22 is dev at every seed,
         // and no train band collides with it.
-        assert_eq!(m.tier_of(22, 0), Some(Tier::Dev));
-        assert_eq!(m.tier_of(22, 7), Some(Tier::Dev));
-        assert_eq!(m.tier_of(12, 3), Some(Tier::Final));
-        assert_eq!(m.tier_of(0, 3), Some(Tier::Train));
+        assert_eq!(m.tier_of(Family::new(22, 0)), Some(Tier::Dev));
+        assert_eq!(m.tier_of(Family::new(22, 7)), Some(Tier::Dev));
+        assert_eq!(m.tier_of(Family::new(12, 3)), Some(Tier::Final));
+        assert_eq!(m.tier_of(Family::new(0, 3)), Some(Tier::Train));
     }
 
     #[test]
@@ -668,8 +972,8 @@ seeds = [[0, 0]]
 kernels = ["swirl"]
 "#;
         let m = SplitManifest::parse(text).expect("disjoint seed ranges on a shared band are fine");
-        assert_eq!(m.tier_of(0, 7), Some(Tier::Train));
-        assert_eq!(m.tier_of(0, 8), Some(Tier::Dev));
+        assert_eq!(m.tier_of(Family::new(0, 7)), Some(Tier::Train));
+        assert_eq!(m.tier_of(Family::new(0, 8)), Some(Tier::Dev));
     }
 
     #[test]

--- a/pixelflow-pipeline/src/training/structural.rs
+++ b/pixelflow-pipeline/src/training/structural.rs
@@ -1,140 +1,102 @@
-//! Structural hashing of arena expressions.
+//! The feature-quotient structural key of an arena expression.
 //!
-//! One structural key per expression DAG, shared by every stage that must
-//! agree on "same structure": `gen_bench_corpus`'s cross-tier dedup ledger
-//! (plan 0.2) and `bootstrap_extraction_head`'s live-stream holdout fence
-//! (a live-generated training expression whose structure already lives in
-//! the DEV or FINAL tier would be trained on and then evaluated, so DEV
-//! metrics would no longer measure a holdout). Keeping the hash in one place
-//! is the point: two divergent notions of "duplicate" would re-open exactly
-//! that leak.
+//! One key per expression DAG, shared by every stage that must agree on
+//! "the model has already seen this" (docs/plans/2026-08-17-cost-model-domain.md,
+//! J8 / P1(d)): `gen_bench_corpus`'s cross-tier dedup ledger,
+//! `bootstrap_extraction_head`'s live-stream holdout fence, and its
+//! loaded-TRAIN revalidation. Keeping the key in one place is the point: two
+//! divergent notions of "the same expression" would re-open exactly the leak
+//! this module exists to close.
+//!
+//! # Why "feature-quotient" and not "structural"
+//!
+//! `pixelflow_search`'s extraction head never sees a literal. Every feature
+//! path funnels through [`OpKind`] identity —
+//! `ArenaCostDag::resolve`/`child_kind` compute it via
+//! [`ExprArena::kind`], which maps `Var(_)` to `OpKind::Var` and
+//! `Const(_)`/`Param(_)` to `OpKind::Const` regardless of the index or
+//! value carried — so `X * 2.0` and `X * 3.0` are the *identical* input
+//! vector to the model. A holdout fence keyed on the literal-carrying
+//! structural hash (`Const` compared by bit pattern) would let `X * 3.0`
+//! train while `X * 2.0` sits in DEV: two points the model cannot tell
+//! apart, one on each side of the holdout. That is leakage by the plan's
+//! own definition — "structure the model has effectively seen appearing on
+//! the certifying side" — even though the literal bytes never repeat.
+//!
+//! [`FenceKey::of`] is the ONE constructor, and it computes op identity by
+//! calling [`ExprArena::kind`] — the exact function the featurizer calls —
+//! rather than re-deriving a parallel notion of "same op". Collapsing
+//! *more* than the featurizer distinguishes (this key also drops which
+//! coordinate a `Var` names, whereas the model's variance-fraction feature
+//! can sometimes tell `X` from `Z`) is safe: a coarser fence only ever
+//! drops an extra TRAIN candidate that was not actually a leak
+//! (over-fencing), never misses one that was (under-fencing) — see the
+//! plan's "at least as coarse as the feature equivalence" requirement.
 
 use std::collections::{HashMap, HashSet};
 
-use pixelflow_ir::{ExprArena, ExprId, ExprNode, OpKind};
+use pixelflow_ir::{ExprArena, ExprId, OpKind};
 
-/// One node of a structural key: the node's operation plus the key-local ids
-/// of its children, in deterministic post-order. `Const` compares by bit
-/// pattern (`-0.0` and `+0.0` are structurally distinct, as are NaN
-/// payloads).
+/// One node of a [`FenceKey`]: the node's [`OpKind`] identity plus the
+/// key-local ids of its children, in deterministic post-order. No literal
+/// payload — see the module docs for why.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub enum SigNode {
-    /// Coordinate variable.
-    Var(u8),
-    /// Constant, by exact bit pattern.
-    Const(u32),
-    /// Kernel parameter.
-    Param(u8),
-    /// Buffer reference.
-    Buffer(u16),
-    /// Unary op over a key-local child id.
-    Unary(OpKind, u32),
-    /// Binary op over key-local child ids.
-    Binary(OpKind, u32, u32),
-    /// Ternary op over key-local child ids.
-    Ternary(OpKind, u32, u32, u32),
-    /// N-ary op over key-local child ids.
-    Nary(OpKind, Box<[u32]>),
+struct QuotientNode {
+    op: OpKind,
+    children: Box<[u32]>,
 }
 
-/// The structural key of the DAG reachable from `root`: a deterministic
-/// post-order listing of [`SigNode`]s with arena ids rewritten to key-local
-/// ids, so two arenas holding the same structure produce equal keys
-/// regardless of node numbering or dead nodes.
-#[must_use]
-pub fn arena_structural_key(arena: &ExprArena, root: ExprId) -> Vec<SigNode> {
-    enum Task {
-        Visit(ExprId),
-        Emit(ExprId),
-    }
+/// The feature-quotient key of the DAG reachable from `root`: what the
+/// expression looks like to the extraction head, not what it literally is.
+/// Two arenas holding the same op-identity/topology produce equal keys
+/// regardless of node numbering, dead nodes, or literal values (`Const`
+/// bit pattern, `Var`/`Param` index).
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct FenceKey(Vec<QuotientNode>);
 
-    let mut work = vec![Task::Visit(root)];
-    let mut visited = HashSet::new();
-    let mut signatures = Vec::new();
-    let mut ids = HashMap::<ExprId, u32>::new();
+impl FenceKey {
+    /// The ONE constructor. Walks the DAG reachable from `root`, calling
+    /// [`ExprArena::kind`] for op identity — the same call the
+    /// extraction-head featurizer makes — so this key is a canonicalization
+    /// of the featurizer's own view, not a re-implementation of it.
+    #[must_use]
+    pub fn of(arena: &ExprArena, root: ExprId) -> Self {
+        enum Task {
+            Visit(ExprId),
+            Emit(ExprId),
+        }
 
-    while let Some(task) = work.pop() {
-        match task {
-            Task::Visit(id) => {
-                if !visited.insert(id) {
-                    continue;
-                }
-                work.push(Task::Emit(id));
-                let children: Vec<ExprId> = arena.children(id).collect();
-                for child in children.into_iter().rev() {
-                    work.push(Task::Visit(child));
-                }
-            }
-            Task::Emit(id) => {
-                let sig = match arena.node(id) {
-                    ExprNode::Var(i) => SigNode::Var(*i),
-                    ExprNode::Const(v) => SigNode::Const(v.to_bits()),
-                    ExprNode::Param(i) => SigNode::Param(*i),
-                    ExprNode::Buffer(b) => SigNode::Buffer(b.0),
-                    ExprNode::Unary(op, a) => SigNode::Unary(*op, ids[a]),
-                    ExprNode::Binary(op, a, b) => SigNode::Binary(*op, ids[a], ids[b]),
-                    ExprNode::Ternary(op, a, b, c) => SigNode::Ternary(*op, ids[a], ids[b], ids[c]),
-                    ExprNode::Nary(op, start, len) => {
-                        let children = arena.nary_children_slice(*start, *len);
-                        let child_ids: Vec<u32> = children.iter().map(|child| ids[child]).collect();
-                        SigNode::Nary(*op, child_ids.into_boxed_slice())
+        let mut work = vec![Task::Visit(root)];
+        let mut visited = HashSet::new();
+        let mut nodes = Vec::new();
+        let mut ids = HashMap::<ExprId, u32>::new();
+
+        while let Some(task) = work.pop() {
+            match task {
+                Task::Visit(id) => {
+                    if !visited.insert(id) {
+                        continue;
                     }
-                };
-                let sig_id = signatures.len() as u32;
-                signatures.push(sig);
-                ids.insert(id, sig_id);
+                    work.push(Task::Emit(id));
+                    let children: Vec<ExprId> = arena.children(id).collect();
+                    for child in children.into_iter().rev() {
+                        work.push(Task::Visit(child));
+                    }
+                }
+                Task::Emit(id) => {
+                    let children: Box<[u32]> = arena.children(id).map(|c| ids[&c]).collect();
+                    let node = QuotientNode {
+                        op: arena.kind(id),
+                        children,
+                    };
+                    let key_id = nodes.len() as u32;
+                    nodes.push(node);
+                    ids.insert(id, key_id);
+                }
             }
         }
-    }
 
-    signatures
-}
-
-/// A set of structural keys — the holdout fence used by
-/// `bootstrap_extraction_head`: every DEV and FINAL expression is inserted,
-/// then each live-generated TRAIN expression is probed and dropped on a hit.
-///
-/// Deliberately the same [`arena_structural_key`] the corpus builder's
-/// cross-tier ledger uses. Two notions of "same structure" would let a shallow
-/// motif slip the fence here while the ledger considered it a duplicate, which
-/// is exactly the leak (train on it, then evaluate on it, and call the result
-/// held-out).
-#[derive(Default)]
-pub struct StructuralKeySet {
-    keys: HashSet<Vec<SigNode>>,
-}
-
-impl StructuralKeySet {
-    /// An empty fence.
-    #[must_use]
-    pub fn new() -> Self {
-        Self {
-            keys: HashSet::new(),
-        }
-    }
-
-    /// Insert the structure of `root`. Returns `true` when it was not already
-    /// present (mirroring [`HashSet::insert`]).
-    pub fn insert(&mut self, arena: &ExprArena, root: ExprId) -> bool {
-        self.keys.insert(arena_structural_key(arena, root))
-    }
-
-    /// Whether this structure is already fenced.
-    #[must_use]
-    pub fn contains(&self, arena: &ExprArena, root: ExprId) -> bool {
-        self.keys.contains(&arena_structural_key(arena, root))
-    }
-
-    /// Number of distinct structures fenced.
-    #[must_use]
-    pub fn len(&self) -> usize {
-        self.keys.len()
-    }
-
-    /// Whether the fence holds no structures at all.
-    #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.keys.is_empty()
+        FenceKey(nodes)
     }
 }
 
@@ -142,46 +104,47 @@ impl StructuralKeySet {
 mod tests {
     use super::*;
 
-    #[test]
-    fn key_set_fences_by_structure_not_identity() {
-        // The fence is populated from one arena and probed with another that
-        // merely holds the same shape — the holdout-leak case.
-        let mut holdout = ExprArena::new();
-        let hx = holdout.push_var(0);
-        let hc = holdout.push_const(2.0);
-        let hroot = holdout.push_binary(OpKind::Mul, hx, hc);
-
-        let mut fence = StructuralKeySet::new();
-        assert!(fence.insert(&holdout, hroot));
-        assert!(!fence.insert(&holdout, hroot), "second insert is a no-op");
-        assert_eq!(fence.len(), 1);
-
-        let mut live = ExprArena::new();
-        let _dead = live.push_const(99.0);
-        let lx = live.push_var(0);
-        let lc = live.push_const(2.0);
-        let lhit = live.push_binary(OpKind::Mul, lx, lc);
-        assert!(fence.contains(&live, lhit), "same structure must be fenced");
-
-        let lmiss = live.push_binary(OpKind::Add, lx, lc);
-        assert!(
-            !fence.contains(&live, lmiss),
-            "a different structure must pass the fence"
-        );
+    fn scaled_var(k: f32) -> (ExprArena, ExprId) {
+        let mut arena = ExprArena::new();
+        let x = arena.push_var(0);
+        let c = arena.push_const(k);
+        let root = arena.push_binary(OpKind::Mul, x, c);
+        (arena, root)
     }
 
     #[test]
-    fn empty_key_set_fences_nothing() {
-        let fence = StructuralKeySet::new();
-        assert!(fence.is_empty());
-        let mut arena = ExprArena::new();
-        let x = arena.push_var(0);
-        assert!(!fence.contains(&arena, x));
+    fn feature_quotient_collapses_literals() {
+        // The exact review case: X * 2.0 and X * 3.0 are the same input to
+        // the extraction head (OpKind::Const carries no value), so they must
+        // be the same FenceKey.
+        let (a, ra) = scaled_var(2.0);
+        let (b, rb) = scaled_var(3.0);
+        assert_eq!(FenceKey::of(&a, ra), FenceKey::of(&b, rb));
+    }
+
+    #[test]
+    fn feature_quotient_distinguishes_different_topology() {
+        let mut a = ExprArena::new();
+        let ax = a.push_var(0);
+        let ac = a.push_const(2.0);
+        let mul = a.push_binary(OpKind::Mul, ax, ac);
+        let add = a.push_binary(OpKind::Add, ax, ac);
+        assert_ne!(FenceKey::of(&a, mul), FenceKey::of(&a, add));
+    }
+
+    #[test]
+    fn feature_quotient_collapses_var_index() {
+        // Var(0) and Var(1) both featurize as plain `OpKind::Var` — the
+        // model's embedding table has no per-coordinate row.
+        let mut a = ExprArena::new();
+        let x = a.push_var(0);
+        let mut b = ExprArena::new();
+        let y = b.push_var(1);
+        assert_eq!(FenceKey::of(&a, x), FenceKey::of(&b, y));
     }
 
     #[test]
     fn identical_structures_in_different_arenas_share_a_key() {
-        // Same structure, different arena layouts (dead node in the second).
         let mut a = ExprArena::new();
         let ax = a.push_var(0);
         let ac = a.push_const(2.0);
@@ -193,26 +156,23 @@ mod tests {
         let bc = b.push_const(2.0);
         let broot = b.push_binary(OpKind::Mul, bx, bc);
 
-        assert_eq!(
-            arena_structural_key(&a, aroot),
-            arena_structural_key(&b, broot)
-        );
+        assert_eq!(FenceKey::of(&a, aroot), FenceKey::of(&b, broot));
     }
 
     #[test]
-    fn different_structures_get_different_keys() {
+    fn key_is_stable_under_dag_sharing() {
+        // `s + s` where `s = sqrt(X)`: the shared child must contribute one
+        // key-local id, not two — mirroring the featurizer's reload-edge
+        // policy for shared subexpressions.
         let mut a = ExprArena::new();
-        let ax = a.push_var(0);
-        let ac = a.push_const(2.0);
-        let mul = a.push_binary(OpKind::Mul, ax, ac);
-        let add = a.push_binary(OpKind::Add, ax, ac);
-        assert_ne!(arena_structural_key(&a, mul), arena_structural_key(&a, add));
-
-        // Constants compare by bit pattern: 0.0 vs -0.0 are distinct.
-        let mut p = ExprArena::new();
-        let pz = p.push_const(0.0);
-        let mut n = ExprArena::new();
-        let nz = n.push_const(-0.0);
-        assert_ne!(arena_structural_key(&p, pz), arena_structural_key(&n, nz));
+        let x = a.push_var(0);
+        let s = a.push_unary(OpKind::Sqrt, x);
+        let root = a.push_binary(OpKind::Add, s, s);
+        let key = FenceKey::of(&a, root);
+        // Root has two children referencing the same key-local id.
+        assert_eq!(
+            key.0.last().unwrap().children[0],
+            key.0.last().unwrap().children[1]
+        );
     }
 }

--- a/pixelflow-pipeline/src/training/unified_backward.rs
+++ b/pixelflow-pipeline/src/training/unified_backward.rs
@@ -28,6 +28,17 @@
 //! What remains is the value loss: MSE against ground-truth JIT cost,
 //! chain-ruled through `value_mlp` → `expr_proj` → trunk → `w1` (edge tower).
 //! This is what `bootstrap_extraction_head` trains with.
+//!
+//! ## Op embeddings are frozen (P1(a))
+//!
+//! The chain above stops at `w1` — [`backward_value`] never reaches
+//! [`backward_through_accumulator`], which is the only function that turns a
+//! `d_acc_input` gradient into a `d_embeddings` one, and it has no live
+//! caller (grep it). So `grads.d_embeddings` is always exactly zero on the
+//! live path. [`apply_unified_sgd`] does not update `net.embeddings` from it
+//! — see that function's doc for why running weight decay and unit-sphere
+//! projection against an always-zero gradient was the confirmed defect
+//! (docs/plans/2026-08-17-cost-model-domain.md, P1(a)) this freeze closes.
 
 #![expect(
     clippy::needless_range_loop,
@@ -748,10 +759,11 @@ pub fn apply_unified_sgd(
     } = config;
     // Per-group L2 norm clipping.  Each semantic pathway is clipped
     // independently so an explosion in one group cannot suppress others.
+    // (Embeddings are not among these groups — see the frozen-embeddings
+    // block below.)
     let clip_stats = grads.clip_stats(grad_clip);
     let scale_backbone = clip_stats.backbone_scale;
     let scale_value = clip_stats.value_scale;
-    let scale_embeddings = clip_stats.embeddings_scale;
     let scale_trunk = clip_stats.trunk_scale;
 
     // Macro to apply SGD update to a single scalar parameter.
@@ -852,19 +864,32 @@ pub fn apply_unified_sgd(
         scale_value
     );
 
-    // ── Embeddings (scale_embeddings) ─────────────────────────────────────────
-
-    // embeddings: one K-vector per op
-    for op in OpKind::all() {
-        for i in 0..K {
-            sgd_scalar!(
-                net.embeddings.e[op][i],
-                grads.d_embeddings[op][i],
-                momentum_buf.d_embeddings[op][i],
-                scale_embeddings
-            );
-        }
-    }
+    // ── Embeddings: FROZEN (P1(a)) ───────────────────────────────────────────
+    //
+    // `net.embeddings` is deliberately left untouched here — no SGD update,
+    // no weight decay, no momentum accumulation — because nothing in this
+    // trainer's live call graph computes a gradient for it: `backward_value`
+    // never calls `backward_through_accumulator` (the only function that
+    // turns a `d_acc_input` gradient into `d_embeddings`), so
+    // `grads.d_embeddings` is always exactly zero. Running weight decay
+    // against an always-zero gradient is not "no update", it is a slow decay
+    // toward zero with no opposing signal — pure drift, not training.
+    //
+    // That drift was P1(a): `ValueSample::acc` is cached ONCE (from
+    // `model.embeddings` before any SGD step), but this function used to
+    // mutate `net.embeddings` every batch regardless, so the cached
+    // accumulator's baked-in embeddings silently diverged from the live
+    // `model.embeddings` used to build DEV-time features
+    // (`bootstrap_extraction_head`'s Phase 3) — a train/deploy skew with no
+    // training benefit behind it. Freezing embeddings makes both paths read
+    // the same (constant) embeddings by construction; see
+    // `embeddings_are_frozen_without_a_gradient_producer` and
+    // `dev_and_train_path_features_match_after_training_with_frozen_embeddings`
+    // below.
+    //
+    // Unfreeze this block only once a real gradient producer exists (wiring
+    // `backward_through_accumulator` into `backward_value`) — mutation
+    // without a gradient is the defect, not the freeze.
 
     // ── Shared trunk (scale_trunk) ───────────────────────────────────────────
 
@@ -890,27 +915,13 @@ pub fn apply_unified_sgd(
         );
     }
 
-    // ── Post-SGD embedding normalization ────────────────────────────────────
-    // Op embeddings drift in L2 norm over training rounds (can reach 100+).
-    // This makes stale replay trajectories inconsistent: old trajectories
-    // stored small-norm embeddings, new ones store large-norm. Re-normalizing
-    // at replay load time (embed_from_replay) is a band-aid — it destroys
-    // the relative geometry between rule embeddings from the same round.
-    //
-    // Instead, keep embeddings on the unit sphere after every update.
-    // This is equivalent to projected gradient descent on S^{K-1}.
-    for op in OpKind::all() {
-        let l2 = net.embeddings.e[op]
-            .iter()
-            .map(|x| x * x)
-            .sum::<f32>()
-            .sqrt();
-        if l2 > 1e-8 {
-            for i in 0..K {
-                net.embeddings.e[op][i] /= l2;
-            }
-        }
-    }
+    // No post-SGD embedding normalization: the unit-sphere projection that
+    // used to run here unconditionally is itself a mutation, and P1(a)
+    // applies to it exactly as it does to the SGD update above — projecting
+    // a parameter every batch with no gradient behind it is drift, not
+    // training. Re-introduce it (as projected gradient descent on the
+    // embeddings' own update, not a blanket post-pass) only alongside a real
+    // gradient producer.
 }
 
 // ============================================================================
@@ -1427,6 +1438,103 @@ mod tests {
         assert!(
             (delta + 1.0).abs() < 1e-6,
             "trunk update should be clipped to -1.0, got {delta}"
+        );
+    }
+
+    // ========================================================================
+    // Test 8b: P1(a) — embeddings are frozen without a gradient producer
+    // ========================================================================
+
+    #[test]
+    fn embeddings_are_frozen_without_a_gradient_producer() {
+        // `backward_value` never populates `d_embeddings` on the live path
+        // (only `backward_through_accumulator` would, and it has no live
+        // caller — see this module's doc). `apply_unified_sgd` must
+        // therefore never decay, project, or otherwise move
+        // `net.embeddings`: with no opposing gradient, doing so anyway is
+        // pure drift, not training (P1(a)).
+        let mut net = make_test_net();
+        let init = net.embeddings.clone();
+
+        let mut momentum_buf = UnifiedGradients::zero();
+        let config = SgdConfig {
+            lr: 0.05,
+            momentum: 0.9,
+            weight_decay: 1e-2,
+            grad_clip: 5.0,
+        };
+
+        for step in 0..50u32 {
+            let mut grads = UnifiedGradients::zero();
+            // Nonzero everywhere else, so this exercises the same
+            // multi-group clipping/momentum path a real batch does.
+            grads.d_w1[0][0] = 1.0;
+            grads.d_trunk_w[3][4] = -2.0;
+            grads.d_value_mlp_b2 = 0.7;
+            // Deliberately nonzero (unlike reality) to prove the freeze is
+            // unconditional — a decay-of-an-always-zero-gradient coincidence
+            // would not catch a regression that starts reading this field.
+            for op in OpKind::all() {
+                grads.d_embeddings[op][0] = 3.0 + step as f32;
+            }
+            apply_unified_sgd(&mut net, &grads, &mut momentum_buf, config);
+        }
+
+        assert_eq!(
+            net.embeddings.e.as_slice(),
+            init.e.as_slice(),
+            "embeddings must be bit-identical to init after training batches: \
+             apply_unified_sgd must not decay, project, or otherwise update embeddings while \
+             nothing computes a gradient for them"
+        );
+    }
+
+    #[test]
+    fn dev_and_train_path_features_match_after_training_with_frozen_embeddings() {
+        // P1(a)'s DEV-path/train-path skew: `ValueSample::acc` is built once
+        // (train-path snapshot), embeddings decayed/projected every batch
+        // with no gradient behind it, and `EdgeAccumulator::from_arena_dag`
+        // was rebuilt for DEV against the now-drifted `model.embeddings` —
+        // two different embeddings for the same expression. With embeddings
+        // frozen, the two paths must read identical features.
+        use pixelflow_ir::ExprArena;
+
+        let mut arena = ExprArena::new();
+        let x = arena.push_var(0);
+        let one = arena.push_const(1.0);
+        let sum = arena.push_binary(OpKind::Add, x, one);
+        let two = arena.push_const(2.0);
+        let root = arena.push_binary(OpKind::Mul, sum, two);
+
+        let mut net = make_test_net();
+        // TRAIN-path snapshot: built once, as `bootstrap_extraction_head`'s
+        // Phase 1d does, before any SGD step.
+        let train_acc = EdgeAccumulator::from_arena_dag(&arena, root, &net.embeddings);
+
+        let mut momentum_buf = UnifiedGradients::zero();
+        let config = SgdConfig {
+            lr: 0.05,
+            momentum: 0.9,
+            weight_decay: 1e-2,
+            grad_clip: 5.0,
+        };
+        for _ in 0..20 {
+            let cache = forward_cached(&net, &train_acc);
+            let mut grads = UnifiedGradients::zero();
+            backward_value(&net, &cache, 4.0, 1.0, &mut grads);
+            apply_unified_sgd(&mut net, &grads, &mut momentum_buf, config);
+        }
+
+        // DEV-path: rebuilt from the SAME arena, AFTER training, against
+        // whatever `net.embeddings` training left behind — the deployed
+        // prediction path (`bootstrap_extraction_head`'s Phase 3).
+        let dev_acc = EdgeAccumulator::from_arena_dag(&arena, root, &net.embeddings);
+
+        assert_eq!(
+            train_acc.extraction_input(),
+            dev_acc.extraction_input(),
+            "train-path and DEV-path features diverged for the same expression — embeddings \
+             drifted between accumulator construction and DEV evaluation (P1(a))"
         );
     }
 

--- a/pixelflow-search/src/egraph/extract.rs
+++ b/pixelflow-search/src/egraph/extract.rs
@@ -140,6 +140,26 @@ impl<'g> Extraction<'g> {
         &self.choices
     }
 
+    /// The choice vector [`choices_to_arena`] will actually materialise:
+    /// every `Shl`/`Shr` count child re-pinned to a `Const` representative of
+    /// its class ([`pin_shift_counts`]), because the emitter's shift lowering
+    /// requires an immediate and a count class can legitimately hold
+    /// arithmetic that is value-equal to a constant without being one
+    /// (e.g. `Y - Y` merged with `Const(0)`).
+    ///
+    /// Any consumer that computes *features* from an `Extraction` — not just
+    /// [`choices_to_arena`] itself — must walk this view, not [`Self::choices`]
+    /// directly: featurizing the raw (possibly non-`Const`) choice for a
+    /// count class would describe a DAG that is not the one actually
+    /// compiled, reintroducing the same train/deploy skew `Self::chosen_variance`
+    /// exists to remove for the class-wide-meet case (P1(c)). See
+    /// [`Self::chosen_variance`] and `ChoicesCostDag` in `crate::nnue::factored`,
+    /// both of which take this view rather than re-deriving it (one
+    /// definition, imported, not restated).
+    pub(crate) fn pinned_choices(&self) -> Vec<Option<usize>> {
+        pin_shift_counts(self.egraph, &self.choices)
+    }
+
     /// Unwrap into the raw choice vector.
     ///
     /// Kept for legacy raw-vector consumers (`ExtractionPolicy::choices`,
@@ -169,13 +189,29 @@ impl<'g> Extraction<'g> {
     /// Returned as a dense `Vec<Option<Variance>>` indexed by canonical
     /// e-class id; `None` for classes with no recorded choice (unreachable
     /// from root).
-    pub(crate) fn chosen_variance(&self) -> Vec<Option<Variance>> {
+    ///
+    /// Takes `pinned` — [`Self::pinned_choices`] — rather than deriving it
+    /// internally, so the caller's structural walk of the same `Extraction`
+    /// (`ChoicesCostDag` in `crate::nnue::factored`) is forced to use the
+    /// identical pinned view: a shift count e-class that legitimately holds
+    /// both a `Const` and a value-equal varying-shaped alternative (the same
+    /// merged-class situation as the `Sub(X, X)`/`Const(0)` example above,
+    /// but for a `Shl`/`Shr` count child) must be walked here as whatever
+    /// [`choices_to_arena`] will actually emit, or this variance disagrees
+    /// with the arena [`EdgeAccumulator::from_arena_dag`] featurizes for
+    /// exactly the reason unpinned [`Self::choice`] alone caused P1(c).
+    pub(crate) fn chosen_variance(&self, pinned: &[Option<usize>]) -> Vec<Option<Variance>> {
         enum Task {
             Visit(EClassId),
             /// All children of this e-class's chosen node have been
             /// resolved; combine them. `(canonical_id, node_idx)`.
             Complete(u32, usize),
         }
+
+        let choice_of = |class: EClassId| -> Option<usize> {
+            let idx = self.egraph.find(class).0 as usize;
+            pinned.get(idx).copied().flatten()
+        };
 
         let mut variance: Vec<Option<Variance>> = alloc::vec![None; self.egraph.num_classes()];
         let mut stack: Vec<Task> = alloc::vec![Task::Visit(self.root)];
@@ -188,7 +224,7 @@ impl<'g> Extraction<'g> {
                     if variance[idx].is_some() {
                         continue; // Diamond sharing: already resolved.
                     }
-                    let Some(node_idx) = self.choice(canonical) else {
+                    let Some(node_idx) = choice_of(canonical) else {
                         continue; // Not reachable via a recorded choice.
                     };
                     let nodes = self.egraph.nodes(canonical);
@@ -1099,8 +1135,9 @@ pub fn choices_to_arena(
     let egraph = extraction.egraph();
     let root = extraction.root();
 
-    // Shifts must reach codegen with a constant count — see `pin_shift_counts`.
-    let pinned = pin_shift_counts(egraph, extraction.choices());
+    // Shifts must reach codegen with a constant count — see
+    // `Extraction::pinned_choices` / `pin_shift_counts`.
+    let pinned = extraction.pinned_choices();
     let choices: &[Option<usize>] = &pinned;
 
     enum Task {
@@ -2209,6 +2246,103 @@ mod tests {
             "deploy path must classify the chosen Sub(X, X) as pixel-varying, not fold \
              it into CONST via the class-wide meet"
         );
+
+        // ---------------------------------------------------------------
+        // Shift-count pinning (review thread on PR #1019, factored.rs:984):
+        // a Shl/Shr count e-class can legitimately hold both a Const and a
+        // value-equal varying-shaped alternative (same situation as the
+        // Sub(X, X)/Const(0) merge above, but for the count child of a
+        // shift). `choices_to_arena` always pins that child to the Const
+        // representative (`pin_shift_counts` — the emitter's shift lowering
+        // requires an immediate), so if the extraction chose the varying
+        // node, the deploy-path features must reflect the PINNED arena, not
+        // the raw choice — otherwise this walker both double-counts nodes
+        // `choices_to_arena` never emits and disagrees with the arena's
+        // variance histogram.
+        // ---------------------------------------------------------------
+        struct ShlOp;
+        impl crate::egraph::ops::Op for ShlOp {
+            fn kind(&self) -> OpKind {
+                OpKind::Shl
+            }
+        }
+
+        // The arena `choices_to_arena` will actually materialise: pinning
+        // always wins, so the compiled form is `Shl(X, Const(0))` no matter
+        // which node the count class's extraction chose.
+        let mut arena3 = ExprArena::new();
+        let x3 = arena3.push_var(0);
+        let zero3 = arena3.push_const(0.0);
+        let shl3 = arena3.push_binary(OpKind::Shl, x3, zero3);
+        let train3 = EdgeAccumulator::from_arena_dag(&arena3, shl3, &nnue.embeddings);
+
+        let mut eg3 = EGraph::new();
+        let ex3 = eg3.add(ENode::Var(0));
+        let ey3 = eg3.add(ENode::Var(1));
+        let esub3 = eg3.add(ENode::Op {
+            op: &ops::Sub,
+            children: alloc::vec![ey3, ey3],
+        });
+        let econst3 = eg3.add(ENode::constant(0.0));
+        let count3 = eg3.union(esub3, econst3); // Sub(Y, Y) = 0, same class as Const(0)
+        eg3.rebuild();
+        let eshl3 = eg3.add(ENode::Op {
+            op: &ShlOp,
+            children: alloc::vec![ex3, count3],
+        });
+
+        // Choose the varying Sub(Y, Y) node for the count class, not the
+        // Const — exactly the scenario `pin_shift_counts` exists to correct
+        // at emission time.
+        let canonical_count3 = eg3.find(count3);
+        let sub_idx3 = eg3
+            .nodes(canonical_count3)
+            .iter()
+            .position(|n| matches!(n, ENode::Op { .. }))
+            .expect("merged count class holds the Sub node");
+        let mut choices3: Vec<Option<usize>> = alloc::vec![None; eg3.num_classes()];
+        choices3[eg3.find(eshl3).0 as usize] = Some(0);
+        choices3[canonical_count3.0 as usize] = Some(sub_idx3);
+        choices3[eg3.find(ex3).0 as usize] = Some(0);
+        choices3[eg3.find(ey3).0 as usize] = Some(0);
+        let extraction3 = Extraction::from_backfill(&eg3, eshl3, choices3);
+
+        let deploy3 =
+            EdgeAccumulator::from_dag_choices_with_variance(&extraction3, &nnue.embeddings, true);
+
+        assert_eq!(
+            train3.node_count, deploy3.node_count,
+            "node_count (shift-count pinning case): the deploy path must not walk into \
+             Sub(Y, Y) once the count is pinned to Const(0), or its node count will \
+             disagree with the arena choices_to_arena actually emits"
+        );
+        assert_eq!(
+            train3.edge_count, deploy3.edge_count,
+            "edge_count (shift-count pinning case)"
+        );
+        assert_eq!(
+            train3.variance_frac_pixel, deploy3.variance_frac_pixel,
+            "variance_frac_pixel (shift-count pinning case)"
+        );
+        assert_eq!(
+            train3.variance_frac_scanline, deploy3.variance_frac_scanline,
+            "deploy path must not count Y's scanline variance from the un-pinned \
+             Sub(Y, Y) count child"
+        );
+        assert_eq!(
+            train3.variance_frac_const, deploy3.variance_frac_const,
+            "variance_frac_const (shift-count pinning case)"
+        );
+        assert_eq!(
+            train3.variance_frac_frame, deploy3.variance_frac_frame,
+            "variance_frac_frame (shift-count pinning case)"
+        );
+        for i in 0..train3.values.len() {
+            assert_eq!(
+                train3.values[i], deploy3.values[i],
+                "accumulator values[{i}] diverge on the shift-count pinning case"
+            );
+        }
     }
 
     // =========================================================================

--- a/pixelflow-search/src/egraph/extract.rs
+++ b/pixelflow-search/src/egraph/extract.rs
@@ -5,10 +5,232 @@
 //! [`pixelflow_ir::ExprArena`].
 
 use super::cost::{CostFunction, CostModel};
+use super::deps::var_variance;
 use super::graph::EGraph;
 use super::node::{EClassId, ENode};
 use crate::nnue::{EdgeAccumulator, ExprNnue};
 use alloc::vec::Vec;
+use pixelflow_ir::Variance;
+
+/// A witnessed selection: an e-graph, a root e-class, and a well-founded
+/// choice function from every e-class reachable from `root` to the node
+/// index selected for it.
+///
+/// "Well-founded" means: every reachable e-class has a recorded choice, and
+/// the choice graph is acyclic (bottom-up realizable). Those two properties
+/// are exactly what let a choice function be materialised at all — an
+/// unvalidated `Vec<Option<usize>>` can loop forever when walked (a real
+/// 2.7GB OOM, see `choices_to_arena`'s doc comment), and a call site that
+/// forgets to repair or backfill it produces that bug silently.
+///
+/// `Extraction` makes the bug class unrepresentable: the only ways to
+/// obtain a value of this type are [`Extraction::from_dp`] (wraps
+/// [`repair_choices_well_founded`]) and [`Extraction::from_backfill`]
+/// (wraps [`backfill_well_founded`]) — both establish well-foundedness as
+/// part of construction, so a bare unvalidated vector can never cross into
+/// [`choices_to_arena`] or the extraction-head accumulator builders
+/// ([`EdgeAccumulator::from_dag_choices`],
+/// [`EdgeAccumulator::from_dag_choices_with_variance`]), which accept only
+/// `&Extraction`. See docs/plans/2026-08-17-cost-model-domain.md §1
+/// "Extraction (J2)".
+pub struct Extraction<'g> {
+    egraph: &'g EGraph,
+    root: EClassId,
+    choices: Vec<Option<usize>>,
+}
+
+impl<'g> Extraction<'g> {
+    /// The DP path's smart constructor: makes `choices` well-founded via
+    /// [`repair_choices_well_founded`] (resolving any mutual cycles the
+    /// bottom-up DP recorded — `CYCLE_COST` penalizes only
+    /// self-references, so two merged classes can each cheapest-pick a
+    /// node through the other), then seals the result.
+    pub(crate) fn from_dp(
+        egraph: &'g EGraph,
+        root: EClassId,
+        mut choices: Vec<Option<usize>>,
+    ) -> Self {
+        let root = egraph.find(root);
+        repair_choices_well_founded(egraph, root, &mut choices);
+        Self {
+            egraph,
+            root,
+            choices,
+        }
+    }
+
+    /// The NNUE refinement path's smart constructor: fills any e-class
+    /// reachable from `root` still lacking a choice via
+    /// [`backfill_well_founded`], then seals the result.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the result is cyclic. A well-founded backfill cannot
+    /// itself introduce a cycle — reaching this means the caller sealed a
+    /// choice state that was never cycle-checked, which is a bug at the
+    /// call site, not a recoverable outcome (NO SILENT FAILURES).
+    pub(crate) fn from_backfill(
+        egraph: &'g EGraph,
+        root: EClassId,
+        mut choices: Vec<Option<usize>>,
+    ) -> Self {
+        let root = egraph.find(root);
+        backfill_well_founded(egraph, root, &mut choices);
+        assert!(
+            !choices_have_cycle_from(egraph, root, &choices),
+            "Extraction::from_backfill: choice graph is cyclic after backfill for root {} — \
+             a well-founded backfill cannot itself introduce a cycle; the caller sealed a \
+             state that was never cycle-checked",
+            root.0
+        );
+        Self {
+            egraph,
+            root,
+            choices,
+        }
+    }
+
+    /// Attempt to build a candidate extraction that swaps `class`'s choice
+    /// to `node_idx`, backfilling any newly-introduced children and
+    /// rejecting (returning `None`) if the swap closes a cycle through
+    /// already-chosen classes.
+    ///
+    /// This is the NNUE refinement search's per-candidate constructor —
+    /// unlike [`Extraction::from_backfill`], a cycle here is a normal
+    /// search outcome (reject this candidate, try another), not a bug.
+    pub(crate) fn try_swap(&self, class: EClassId, node_idx: usize) -> Option<Self> {
+        let canonical = self.egraph.find(class);
+        let mut choices = self.choices.clone();
+        choices[canonical.0 as usize] = Some(node_idx);
+        if let Some(ENode::Op { children, .. }) = self.egraph.nodes(canonical).get(node_idx) {
+            for &child in children {
+                backfill_well_founded(self.egraph, child, &mut choices);
+            }
+        }
+        if choices_have_cycle_from(self.egraph, self.root, &choices) {
+            return None;
+        }
+        Some(Self {
+            egraph: self.egraph,
+            root: self.root,
+            choices,
+        })
+    }
+
+    /// The e-graph this extraction selects nodes from.
+    pub fn egraph(&self) -> &'g EGraph {
+        self.egraph
+    }
+
+    /// The extraction's (canonical) root e-class.
+    pub fn root(&self) -> EClassId {
+        self.root
+    }
+
+    /// The chosen node index for `class`, if `class` is reachable from
+    /// [`Self::root`]. `None` for classes outside the extraction.
+    pub fn choice(&self, class: EClassId) -> Option<usize> {
+        let idx = self.egraph.find(class).0 as usize;
+        self.choices.get(idx).copied().flatten()
+    }
+
+    /// Read-only view of the raw choice vector, indexed by canonical
+    /// e-class id. Still only reachable through a sealed `Extraction`.
+    pub(crate) fn choices(&self) -> &[Option<usize>] {
+        &self.choices
+    }
+
+    /// Unwrap into the raw choice vector.
+    ///
+    /// Kept for legacy raw-vector consumers (`ExtractionPolicy::choices`,
+    /// `compute_ref_counts`, `build_extracted_dag_from_choices`) that
+    /// predate this type; new code should consume `&Extraction` instead.
+    pub(crate) fn into_choices(self) -> Vec<Option<usize>> {
+        self.choices
+    }
+
+    /// Variance (coordinate dependency) of the node this extraction
+    /// actually selected for each reachable e-class — computed
+    /// recursively over the CHOSEN nodes, not the class-wide meet
+    /// [`super::deps::DepsAnalysis`] computes.
+    ///
+    /// `DepsAnalysis::get` answers "what's the best variance ANY node in
+    /// this class could give" (a meet across every e-node in the class).
+    /// Once a rewrite merges a pixel-varying node into a class alongside a
+    /// constant one (e.g. `Sub(X, X)` unioned with `Const(0)`), that meet
+    /// reports CONST even when the extraction actually chose the varying
+    /// node — so deploy-path features would silently disagree with what
+    /// [`EdgeAccumulator::from_arena_dag`] computes on the exact arena the
+    /// extraction emits (P1(c)). This walk instead evaluates variance of
+    /// exactly the node [`Self::choice`] selected, recursing into its
+    /// children's chosen variance — the deploy-side counterpart of
+    /// `pixelflow_ir::variance::compute_arena_variance`.
+    ///
+    /// Returned as a dense `Vec<Option<Variance>>` indexed by canonical
+    /// e-class id; `None` for classes with no recorded choice (unreachable
+    /// from root).
+    pub(crate) fn chosen_variance(&self) -> Vec<Option<Variance>> {
+        enum Task {
+            Visit(EClassId),
+            /// All children of this e-class's chosen node have been
+            /// resolved; combine them. `(canonical_id, node_idx)`.
+            Complete(u32, usize),
+        }
+
+        let mut variance: Vec<Option<Variance>> = alloc::vec![None; self.egraph.num_classes()];
+        let mut stack: Vec<Task> = alloc::vec![Task::Visit(self.root)];
+
+        while let Some(task) = stack.pop() {
+            match task {
+                Task::Visit(class) => {
+                    let canonical = self.egraph.find(class);
+                    let idx = canonical.0 as usize;
+                    if variance[idx].is_some() {
+                        continue; // Diamond sharing: already resolved.
+                    }
+                    let Some(node_idx) = self.choice(canonical) else {
+                        continue; // Not reachable via a recorded choice.
+                    };
+                    let nodes = self.egraph.nodes(canonical);
+                    match &nodes[node_idx] {
+                        ENode::Var(v) => variance[idx] = Some(var_variance(*v)),
+                        ENode::Const(_) | ENode::Buffer(_) => {
+                            variance[idx] = Some(Variance::CONST);
+                        }
+                        ENode::Op { children, .. } => {
+                            stack.push(Task::Complete(canonical.0, node_idx));
+                            for &child in children {
+                                stack.push(Task::Visit(child));
+                            }
+                        }
+                    }
+                }
+                Task::Complete(canonical_id, node_idx) => {
+                    let idx = canonical_id as usize;
+                    if variance[idx].is_some() {
+                        continue; // Diamond sharing: already resolved.
+                    }
+                    let canonical = EClassId(canonical_id);
+                    let nodes = self.egraph.nodes(canonical);
+                    let ENode::Op { children, .. } = &nodes[node_idx] else {
+                        panic!(
+                            "Extraction::chosen_variance: Complete task for non-Op node \
+                             (e-class {canonical_id})"
+                        );
+                    };
+                    let mut v = Variance::CONST;
+                    for &child in children {
+                        let cidx = self.egraph.find(child).0 as usize;
+                        v = v.union(variance[cidx].unwrap_or(Variance::ALL));
+                    }
+                    variance[idx] = Some(v);
+                }
+            }
+        }
+
+        variance
+    }
+}
 
 /// Incremental 3-pass neural extractor.
 ///
@@ -37,15 +259,15 @@ impl<'a> IncrementalExtractor<'a> {
         Self { nnue, top_k }
     }
 
-    /// Run the extraction refinement loop and return only `(cost, choices)`.
+    /// Run the extraction refinement loop and return `(cost, extraction)`.
     ///
-    /// The `choices` vector maps canonical e-class ID to the chosen node index.
-    /// Call [`choices_to_arena`] to materialise the extracted DAG.
-    pub fn extract_choices_only(
+    /// Call [`choices_to_arena`] on the returned [`Extraction`] to
+    /// materialise the extracted DAG.
+    pub fn extract_choices_only<'g>(
         &self,
-        egraph: &EGraph,
+        egraph: &'g EGraph,
         root_class: EClassId,
-    ) -> (f32, Vec<Option<usize>>) {
+    ) -> (f32, Extraction<'g>) {
         const MAX_PASSES: usize = 10;
 
         // Pass 1: Bootstrap with a well-founded choice per reachable e-class.
@@ -55,22 +277,18 @@ impl<'a> IncrementalExtractor<'a> {
         // `backfill_well_founded`), and refinement below then improves
         // whatever valid start this provides.
         let num_classes = egraph.num_classes();
-        let mut choices: Vec<Option<usize>> = alloc::vec![None; num_classes];
-        backfill_well_founded(egraph, root_class, &mut choices);
-
-        // Run variance analysis once — O(n) over e-graph, provides
-        // per-e-class coordinate dependency info to the extraction head.
-        let variance_analysis = super::deps::DepsAnalysis::analyze(egraph);
+        let choices: Vec<Option<usize>> = alloc::vec![None; num_classes];
+        let mut current_extraction = Extraction::from_backfill(egraph, root_class, choices);
 
         // Build initial DAG-aware accumulator. Sharing-aware by construction:
         // shared subexpressions are counted once (computation) plus one
-        // var_ref edge (register load) per later reference.
+        // var_ref edge (register load) per later reference. Variance is
+        // computed from the CHOSEN nodes (P1(c)) — see
+        // `Extraction::chosen_variance`.
         let current_acc = EdgeAccumulator::from_dag_choices_with_variance(
-            egraph,
-            root_class,
-            &choices,
+            &current_extraction,
             &self.nnue.embeddings,
-            Some(&variance_analysis),
+            true,
         );
         let mut current_cost = self.nnue.predict_log_cost_with_features(&current_acc);
 
@@ -82,7 +300,7 @@ impl<'a> IncrementalExtractor<'a> {
         // This is O(reachable_classes) per candidate, same as the old tree-based path,
         // but now sharing-aware. True incremental updates can be added later.
         for _pass in 0..MAX_PASSES {
-            let active = self.get_active_classes(egraph, root_class, &choices);
+            let active = self.get_active_classes(&current_extraction);
             let mut improved = false;
 
             for &class in &active {
@@ -92,7 +310,7 @@ impl<'a> IncrementalExtractor<'a> {
                     continue;
                 }
 
-                let current_node_idx = choices[canonical.0 as usize].unwrap_or_else(|| {
+                let current_node_idx = current_extraction.choice(canonical).unwrap_or_else(|| {
                     panic!(
                         "extract_choices_only: e-class {} is active (reachable from root) \
                          but has no recorded choice — backfill_well_founded should have \
@@ -106,14 +324,15 @@ impl<'a> IncrementalExtractor<'a> {
                 //
                 // Each candidate is evaluated on a COMPLETE choice state: the
                 // swap applied AND the newly reachable subtree backfilled,
-                // then cycle-checked. The previous shape checked the swap
-                // with unfilled classes modeled as node 0 and only backfilled
-                // after acceptance — so the state it verified was not the
-                // state it adopted. Cloning is O(classes), the same order as
-                // the accumulator rebuild below, so this costs nothing
-                // asymptotically and removes the drift.
+                // then cycle-checked via `Extraction::try_swap`. The previous
+                // shape checked the swap with unfilled classes modeled as
+                // node 0 and only backfilled after acceptance — so the state
+                // it verified was not the state it adopted. Cloning is
+                // O(classes), the same order as the accumulator rebuild
+                // below, so this costs nothing asymptotically and removes
+                // the drift.
                 let mut best_swap_cost = current_cost;
-                let mut best_swap: Option<Vec<Option<usize>>> = None;
+                let mut best_swap: Option<Extraction<'g>> = None;
 
                 for node_idx in 0..candidates_to_try {
                     if node_idx == current_node_idx {
@@ -127,40 +346,29 @@ impl<'a> IncrementalExtractor<'a> {
                         }
                     }
 
-                    let mut test_choices = choices.clone();
-                    test_choices[canonical.0 as usize] = Some(node_idx);
-                    if let Some(ENode::Op { children, .. }) = egraph.nodes(canonical).get(node_idx)
-                    {
-                        for &child in children {
-                            backfill_well_founded(egraph, child, &mut test_choices);
-                        }
-                    }
-                    // The backfilled subtrees are well-founded internally,
-                    // but the swapped node can still close a loop through
-                    // classes that already held choices — reject those.
-                    if choices_have_cycle_from(egraph, root_class, &test_choices) {
+                    // Rejects candidates that close a cycle through classes
+                    // that already held choices.
+                    let Some(candidate) = current_extraction.try_swap(canonical, node_idx) else {
                         continue;
-                    }
+                    };
 
                     let test_acc = EdgeAccumulator::from_dag_choices_with_variance(
-                        egraph,
-                        root_class,
-                        &test_choices,
+                        &candidate,
                         &self.nnue.embeddings,
-                        Some(&variance_analysis),
+                        true,
                     );
                     let test_cost = self.nnue.predict_log_cost_with_features(&test_acc);
 
                     if test_cost < best_swap_cost {
                         best_swap_cost = test_cost;
-                        best_swap = Some(test_choices);
+                        best_swap = Some(candidate);
                     }
                 }
 
                 if let Some(swapped) = best_swap {
                     // Adopt EXACTLY the state that was cycle-checked and
                     // scored — no post-acceptance re-derivation.
-                    choices = swapped;
+                    current_extraction = swapped;
                     current_cost = best_swap_cost;
                     improved = true;
                 }
@@ -171,16 +379,13 @@ impl<'a> IncrementalExtractor<'a> {
             }
         }
 
-        (current_cost, choices)
+        (current_cost, current_extraction)
     }
 
     /// Walk the current best tree and collect active (reachable) e-class IDs.
-    fn get_active_classes(
-        &self,
-        egraph: &EGraph,
-        root: EClassId,
-        choices: &[Option<usize>],
-    ) -> Vec<EClassId> {
+    fn get_active_classes(&self, extraction: &Extraction<'_>) -> Vec<EClassId> {
+        let egraph = extraction.egraph();
+        let root = extraction.root();
         use alloc::collections::BTreeSet;
 
         let mut active = Vec::new();
@@ -195,7 +400,7 @@ impl<'a> IncrementalExtractor<'a> {
 
             active.push(canonical);
 
-            let node_idx = choices[canonical.0 as usize].unwrap_or_else(|| {
+            let node_idx = extraction.choice(canonical).unwrap_or_else(|| {
                 panic!(
                     "get_active_classes: e-class {} reachable from root has no recorded \
                      choice — extract_choices_only must call backfill_well_founded \
@@ -354,8 +559,8 @@ pub fn extract_neural_to_arena(
     nnue: &ExprNnue,
 ) -> (pixelflow_ir::ExprArena, pixelflow_ir::ExprId, f32) {
     let extractor = IncrementalExtractor::new(nnue, 8);
-    let (cost, choices) = extractor.extract_choices_only(egraph, root);
-    let (arena, root_id) = choices_to_arena(egraph, root, &choices);
+    let (cost, extraction) = extractor.extract_choices_only(egraph, root);
+    let (arena, root_id) = choices_to_arena(&extraction);
     (arena, root_id, cost)
 }
 
@@ -679,10 +884,10 @@ pub fn extract<C: CostFunction>(
 
     let total_cost = best_cost[egraph.find(root).0 as usize].unwrap_or(usize::MAX);
 
-    // Repair any mutual cycles in the choice graph before building the tree.
-    repair_choices_well_founded(egraph, root, &mut best_node);
-
-    let (arena, root_id) = choices_to_arena(egraph, root, &best_node);
+    // Seals `best_node` into an `Extraction`, repairing any mutual cycles
+    // the DP recorded before the tree is built.
+    let extraction = Extraction::from_dp(egraph, root, best_node);
+    let (arena, root_id) = choices_to_arena(&extraction);
     (arena, root_id, total_cost)
 }
 
@@ -887,14 +1092,15 @@ fn pin_shift_counts(egraph: &EGraph, choices: &[Option<usize>]) -> alloc::vec::V
 }
 
 pub fn choices_to_arena(
-    egraph: &EGraph,
-    root: EClassId,
-    choices: &[Option<usize>],
+    extraction: &Extraction<'_>,
 ) -> (pixelflow_ir::ExprArena, pixelflow_ir::ExprId) {
     use pixelflow_ir::{ExprArena, ExprId};
 
+    let egraph = extraction.egraph();
+    let root = extraction.root();
+
     // Shifts must reach codegen with a constant count — see `pin_shift_counts`.
-    let pinned = pin_shift_counts(egraph, choices);
+    let pinned = pin_shift_counts(egraph, extraction.choices());
     let choices: &[Option<usize>] = &pinned;
 
     enum Task {
@@ -1482,14 +1688,40 @@ mod tests {
         // Before the gray-marking assert, this walk re-scheduled the cycle
         // forever: a full-DEV bench run grew to 2.7GB and died by SIGKILL
         // with zero diagnostics. The cycle must be a loud extractor
-        // accusation instead.
+        // accusation instead. `Extraction`'s own constructors now refuse a
+        // cyclic choice set before this point is ever reached (see
+        // `extraction_constructors_refuse_a_cyclic_choice_set`) — this test
+        // exercises `choices_to_arena`'s own belt-and-suspenders check by
+        // constructing the `Extraction` directly (private-field literal,
+        // valid from within this module), bypassing the smart constructors
+        // on purpose.
         let (egraph, merged, n1) = cyclic_capable_egraph();
         let mut choices: Vec<Option<usize>> = alloc::vec![None; egraph.num_classes()];
         let m = egraph.find(merged).0 as usize;
         let i = egraph.find(n1).0 as usize;
         choices[m] = Some(neg_index(&egraph, merged).expect("merged class holds Neg(n1)"));
         choices[i] = Some(neg_index(&egraph, n1).expect("n1 holds Neg(x)"));
-        let _ = choices_to_arena(&egraph, merged, &choices);
+        let extraction = Extraction {
+            egraph: &egraph,
+            root: egraph.find(merged),
+            choices,
+        };
+        let _ = choices_to_arena(&extraction);
+    }
+
+    #[test]
+    #[should_panic(expected = "cyclic")]
+    fn extraction_constructors_refuse_a_cyclic_choice_set() {
+        // The type-level guarantee J2 adds: a cyclic choice vector can no
+        // longer become an `Extraction` at all, so the 2.7GB-OOM class of
+        // bug can't reach `choices_to_arena` in the first place.
+        let (egraph, merged, n1) = cyclic_capable_egraph();
+        let mut choices: Vec<Option<usize>> = alloc::vec![None; egraph.num_classes()];
+        let m = egraph.find(merged).0 as usize;
+        let i = egraph.find(n1).0 as usize;
+        choices[m] = Some(neg_index(&egraph, merged).expect("merged class holds Neg(n1)"));
+        choices[i] = Some(neg_index(&egraph, n1).expect("n1 holds Neg(x)"));
+        let _ = Extraction::from_backfill(&egraph, merged, choices);
     }
 
     #[test]
@@ -1505,8 +1737,8 @@ mod tests {
         let (egraph, merged, _n1) = cyclic_capable_egraph();
         let nnue = ExprNnue::new_with_latency_prior(42);
         let extractor = IncrementalExtractor::new(&nnue, 8);
-        let (_cost, choices) = extractor.extract_choices_only(&egraph, merged);
-        let (arena, root) = choices_to_arena(&egraph, merged, &choices);
+        let (_cost, extraction) = extractor.extract_choices_only(&egraph, merged);
+        let (arena, root) = choices_to_arena(&extraction);
         // The merged class IS x, so whatever form was chosen must evaluate
         // like x — and with cycles broken toward leaves, the only consistent
         // forms are Var(0) or neg-chains over it inside one arena.
@@ -1534,7 +1766,12 @@ mod tests {
             "repair must leave a well-founded choice set"
         );
         // Materialization is the proof of well-foundedness.
-        let (arena, root) = choices_to_arena(&egraph, merged, &choices);
+        let extraction = Extraction {
+            egraph: &egraph,
+            root: egraph.find(merged),
+            choices,
+        };
+        let (arena, root) = choices_to_arena(&extraction);
         assert!(root.0 < arena.len() as u32);
 
         // And a set that is ALREADY acyclic passes through untouched.
@@ -1776,8 +2013,12 @@ mod tests {
         let nnue = ExprNnue::new_with_latency_prior(42);
 
         // DAG accumulator
-        let dag_acc =
-            EdgeAccumulator::from_dag_choices(&egraph, product, &choices, &nnue.embeddings);
+        let extraction = Extraction {
+            egraph: &egraph,
+            root: egraph.find(product),
+            choices,
+        };
+        let dag_acc = EdgeAccumulator::from_dag_choices(&extraction, &nnue.embeddings);
 
         assert_eq!(dag_acc.node_count, 3, "DAG acc should count 3 unique nodes");
         assert_eq!(
@@ -1857,18 +2098,12 @@ mod tests {
             children: alloc::vec![ea, eyc],
         });
 
-        let mut choices: Vec<Option<usize>> = alloc::vec![None; eg.num_classes()];
-        backfill_well_founded(&eg, eroot, &mut choices);
+        let choices: Vec<Option<usize>> = alloc::vec![None; eg.num_classes()];
+        let extraction = Extraction::from_backfill(&eg, eroot, choices);
 
         let nnue = ExprNnue::new_with_latency_prior(7);
-        let variance = crate::egraph::deps::DepsAnalysis::analyze(&eg);
-        let deploy = EdgeAccumulator::from_dag_choices_with_variance(
-            &eg,
-            eroot,
-            &choices,
-            &nnue.embeddings,
-            Some(&variance),
-        );
+        let deploy =
+            EdgeAccumulator::from_dag_choices_with_variance(&extraction, &nnue.embeddings, true);
         let train = EdgeAccumulator::from_arena_dag(&arena, root, &nnue.embeddings);
 
         assert_eq!(train.node_count, deploy.node_count, "node_count");
@@ -1902,6 +2137,78 @@ mod tests {
             "identical features must produce identical predicted log-cost"
         );
         assert!(p_train.is_finite());
+
+        // ---------------------------------------------------------------
+        // P1(c) extension: a merged e-class holding BOTH a pixel-varying
+        // node (Sub(X, X)) and a constant (Const(0)) — the class-wide meet
+        // `DepsAnalysis` computes collapses this to CONST (see
+        // `deps::meet_across_enodes_x_minus_x_is_const`), but if the
+        // extraction actually CHOSE the varying node, the emitted arena is
+        // pixel-varying and the deploy features must say so too. This is
+        // exactly the scenario that fails under the old meet-based lookup.
+        // ---------------------------------------------------------------
+        let mut arena2 = ExprArena::new();
+        let x2 = arena2.push_var(0);
+        let sub2 = arena2.push_binary(OpKind::Sub, x2, x2);
+        let train2 = EdgeAccumulator::from_arena_dag(&arena2, sub2, &nnue.embeddings);
+
+        let mut eg2 = EGraph::new();
+        let ex2 = eg2.add(ENode::Var(0));
+        let esub2 = eg2.add(ENode::Op {
+            op: &ops::Sub,
+            children: alloc::vec![ex2, ex2],
+        });
+        let econst2 = eg2.add(ENode::constant(0.0));
+        let merged2 = eg2.union(esub2, econst2); // Sub(X, X) = 0
+        eg2.rebuild();
+
+        // Sanity: the class-wide meet DOES collapse to CONST — the exact
+        // data source P1(c) replaces. If this assumption ever stops
+        // holding, the regression below is no longer exercising the bug.
+        let canonical2 = eg2.find(merged2);
+        let meet = crate::egraph::deps::DepsAnalysis::analyze(&eg2);
+        assert_eq!(
+            meet.get(&eg2, canonical2),
+            pixelflow_ir::Variance::CONST,
+            "test assumes the class-wide meet collapses to CONST after the merge"
+        );
+
+        // Choose the Sub(X, X) node explicitly — not the Const — the
+        // extraction scenario the bug requires.
+        let sub_idx = eg2
+            .nodes(canonical2)
+            .iter()
+            .position(|n| matches!(n, ENode::Op { .. }))
+            .expect("merged class holds the Sub node");
+        // `backfill_well_founded` (and thus `Extraction::from_backfill`)
+        // short-circuits the moment `root`'s own entry is already `Some` —
+        // it never descends to fill still-missing descendants in that case
+        // (that's what makes `Extraction::try_swap`'s per-child calls
+        // necessary during refinement). So the merged class's leaf, `X`,
+        // needs its own choice set explicitly too.
+        let mut choices2: Vec<Option<usize>> = alloc::vec![None; eg2.num_classes()];
+        choices2[canonical2.0 as usize] = Some(sub_idx);
+        choices2[eg2.find(ex2).0 as usize] = Some(0);
+        let extraction2 = Extraction::from_backfill(&eg2, merged2, choices2);
+
+        let deploy2 =
+            EdgeAccumulator::from_dag_choices_with_variance(&extraction2, &nnue.embeddings, true);
+
+        assert_eq!(
+            train2.node_count, deploy2.node_count,
+            "node_count (merged-class case)"
+        );
+        assert_eq!(
+            train2.variance_frac_pixel, deploy2.variance_frac_pixel,
+            "variance_frac_pixel must reflect the CHOSEN Sub(X, X) node, not the \
+             class-wide meet"
+        );
+        assert_eq!(train2.variance_frac_const, deploy2.variance_frac_const);
+        assert!(
+            deploy2.variance_frac_pixel > 0.0,
+            "deploy path must classify the chosen Sub(X, X) as pixel-varying, not fold \
+             it into CONST via the class-wide meet"
+        );
     }
 
     // =========================================================================
@@ -1925,7 +2232,12 @@ mod tests {
         choices[egraph.find(x).0 as usize] = Some(0);
         choices[egraph.find(y).0 as usize] = Some(0);
 
-        let (arena, root_id) = choices_to_arena(&egraph, add, &choices);
+        let extraction = Extraction {
+            egraph: &egraph,
+            root: egraph.find(add),
+            choices,
+        };
+        let (arena, root_id) = choices_to_arena(&extraction);
 
         assert_eq!(arena.len(), 3, "X + Y should have exactly 3 arena nodes");
         // Root should be the last node (post-order: X, Y, Add)
@@ -1948,7 +2260,12 @@ mod tests {
         choices[egraph.find(mul).0 as usize] = Some(0);
         choices[egraph.find(x).0 as usize] = Some(0);
 
-        let (arena, root_id) = choices_to_arena(&egraph, mul, &choices);
+        let extraction = Extraction {
+            egraph: &egraph,
+            root: egraph.find(mul),
+            choices,
+        };
+        let (arena, root_id) = choices_to_arena(&extraction);
 
         assert_eq!(
             arena.len(),
@@ -1975,7 +2292,12 @@ mod tests {
         choices[egraph.find(x).0 as usize] = Some(0);
         choices[egraph.find(y).0 as usize] = Some(0);
 
-        let (arena, root_id) = choices_to_arena(&egraph, add, &choices);
+        let extraction = Extraction {
+            egraph: &egraph,
+            root: egraph.find(add),
+            choices,
+        };
+        let (arena, root_id) = choices_to_arena(&extraction);
         let (extracted_arena, extracted_root, _cost) = extract(&egraph, add, &CostModel::default());
         assert_eq!(arena.len(), extracted_arena.len());
         assert_eq!(root_id, extracted_root);

--- a/pixelflow-search/src/egraph/extraction.rs
+++ b/pixelflow-search/src/egraph/extraction.rs
@@ -16,7 +16,7 @@
 // `std`-off as aspirational until the `std-off-status` job in
 // `.github/workflows/rust.yaml` is green.
 use super::cost::CostModel;
-use super::extract::extract_dag;
+use super::extract::{Extraction, extract_dag};
 use super::graph::EGraph;
 use super::node::EClassId;
 use crate::nnue::ExprNnue;
@@ -45,15 +45,32 @@ pub enum ExtractionPolicy<'a> {
 }
 
 impl ExtractionPolicy<'_> {
-    /// Per-e-class extraction choices under this policy.
-    pub fn choices(&self, egraph: &EGraph, root: EClassId) -> Vec<Option<usize>> {
+    /// Per-e-class extraction choices under this policy, as a validated
+    /// [`Extraction`] — the well-founded (egraph, root, choices) triple
+    /// [`super::extract::choices_to_arena`] and the NNUE accumulator
+    /// builders require.
+    pub fn extraction<'g>(&self, egraph: &'g EGraph, root: EClassId) -> Extraction<'g> {
         match self {
             ExtractionPolicy::Nnue(model) => {
                 let extractor = super::extract::IncrementalExtractor::new(model, 8);
                 extractor.extract_choices_only(egraph, root).1
             }
-            ExtractionPolicy::Static(costs) => extract_dag(egraph, root, costs.as_ref()).choices,
+            ExtractionPolicy::Static(costs) => {
+                let dag = extract_dag(egraph, root, costs.as_ref());
+                // `extract_dag` already repairs `dag.choices` into a
+                // well-founded set internally; `from_dp`'s repair pass is
+                // then a verified no-op (drain phase only).
+                Extraction::from_dp(egraph, root, dag.choices)
+            }
         }
+    }
+
+    /// Per-e-class extraction choices under this policy, as a raw vector —
+    /// kept for `pixelflow-compiler`'s ref-counting / DAG-codegen consumers
+    /// (`compute_ref_counts`, `build_extracted_dag_from_choices`) that
+    /// predate the [`Extraction`] type.
+    pub fn choices(&self, egraph: &EGraph, root: EClassId) -> Vec<Option<usize>> {
+        self.extraction(egraph, root).into_choices()
     }
 }
 

--- a/pixelflow-search/src/egraph/mod.rs
+++ b/pixelflow-search/src/egraph/mod.rs
@@ -43,8 +43,8 @@ pub use cost::{CostFunction, CostModel};
 pub use deps::{Deps, DepsAnalysis};
 pub use derivative::{ChainRule, derivative_rules};
 pub use extract::{
-    ExtractedDAG, IncrementalExtractor, build_extracted_dag_from_choices, choices_to_arena,
-    compute_ref_counts, extract, extract_dag, extract_neural_to_arena,
+    ExtractedDAG, Extraction, IncrementalExtractor, build_extracted_dag_from_choices,
+    choices_to_arena, compute_ref_counts, extract, extract_dag, extract_neural_to_arena,
 };
 pub use extraction::{ExtractionPolicy, env_extraction_policy};
 pub use graph::{ApplyResult, EGraph, EGraphBatch, RewriteTarget, SaturationStats};

--- a/pixelflow-search/src/nnue/factored.rs
+++ b/pixelflow-search/src/nnue/factored.rs
@@ -952,37 +952,40 @@ impl EdgeAccumulator {
         )
     }
 
-    /// Build accumulator from e-graph extraction choices with DAG-aware
-    /// sharing (no variance histogram — prefer
+    /// Build accumulator from an [`Extraction`](crate::egraph::extract::Extraction)
+    /// with DAG-aware sharing (no variance histogram — prefer
     /// [`Self::from_dag_choices_with_variance`]).
     pub fn from_dag_choices(
-        egraph: &crate::egraph::EGraph,
-        root: crate::egraph::EClassId,
-        choices: &[Option<usize>],
+        extraction: &crate::egraph::extract::Extraction<'_>,
         emb: &OpEmbeddings,
     ) -> Self {
-        Self::from_dag_choices_with_variance(egraph, root, choices, emb, None)
+        Self::from_dag_choices_with_variance(extraction, emb, false)
     }
 
-    /// Build accumulator from DAG choices, optionally incorporating variance
-    /// analysis — the DEPLOYMENT-side adapter over [`Self::from_cost_dag`].
+    /// Build accumulator from an [`Extraction`](crate::egraph::extract::Extraction),
+    /// optionally populating the variance histogram — the DEPLOYMENT-side
+    /// adapter over [`Self::from_cost_dag`].
     ///
-    /// If `variance_analysis` is provided, the accumulator's variance
-    /// histogram features are populated (fraction of nodes at each variance
-    /// level).
+    /// When `with_variance` is set, variance is computed recursively over
+    /// the extraction's CHOSEN nodes
+    /// ([`Extraction::chosen_variance`](crate::egraph::extract::Extraction::chosen_variance)),
+    /// not the class-wide meet `DepsAnalysis` computes — see P1(c) in
+    /// docs/plans/2026-08-17-cost-model-domain.md. Once a rewrite merges a
+    /// pixel-varying node into a class alongside a constant one, the
+    /// class-wide meet reports CONST regardless of which node the
+    /// extraction actually chose; recursing over the chosen nodes instead
+    /// keeps this identical to what [`Self::from_arena_dag`] computes on
+    /// the exact arena the extraction emits.
     pub fn from_dag_choices_with_variance(
-        egraph: &crate::egraph::EGraph,
-        root: crate::egraph::EClassId,
-        choices: &[Option<usize>],
+        extraction: &crate::egraph::extract::Extraction<'_>,
         emb: &OpEmbeddings,
-        variance_analysis: Option<&crate::egraph::deps::DepsAnalysis>,
+        with_variance: bool,
     ) -> Self {
+        let variance = with_variance.then(|| extraction.chosen_variance());
         Self::from_cost_dag(
             &ChoicesCostDag {
-                egraph,
-                root,
-                choices,
-                variance_analysis,
+                extraction,
+                variance,
             },
             emb,
         )
@@ -1099,13 +1102,15 @@ impl CostDag for ArenaCostDag<'_> {
     }
 }
 
-/// Deployment-side [`CostDag`]: an e-graph plus per-e-class extraction
-/// choices, as walked by `IncrementalExtractor::extract_choices_only`.
+/// Deployment-side [`CostDag`]: an [`Extraction`](crate::egraph::extract::Extraction)
+/// (an e-graph plus a validated, well-founded choice function), as produced
+/// by `IncrementalExtractor::extract_choices_only`.
 struct ChoicesCostDag<'a> {
-    egraph: &'a crate::egraph::EGraph,
-    root: crate::egraph::EClassId,
-    choices: &'a [Option<usize>],
-    variance_analysis: Option<&'a crate::egraph::deps::DepsAnalysis>,
+    extraction: &'a crate::egraph::extract::Extraction<'a>,
+    /// Chosen-node variance, indexed by canonical e-class id — see
+    /// [`Extraction::chosen_variance`](crate::egraph::extract::Extraction::chosen_variance).
+    /// `None` when the caller didn't ask for variance features.
+    variance: Option<Vec<Option<pixelflow_ir::Variance>>>,
 }
 
 impl ChoicesCostDag<'_> {
@@ -1122,18 +1127,19 @@ impl ChoicesCostDag<'_> {
 
 impl CostDag for ChoicesCostDag<'_> {
     fn id_bound(&self) -> usize {
-        self.egraph.num_classes()
+        self.extraction.egraph().num_classes()
     }
 
     fn root(&self) -> u32 {
-        self.egraph.find(self.root).0
+        self.extraction.root().0
     }
 
     fn resolve(&self, id: u32, out: &mut Vec<u32>) -> Option<OpKind> {
         use crate::egraph::{EClassId, ENode};
-        let canonical = self.egraph.find(EClassId(id));
-        let node_idx = self.choices[canonical.0 as usize]?;
-        let nodes = self.egraph.nodes(canonical);
+        let egraph = self.extraction.egraph();
+        let canonical = egraph.find(EClassId(id));
+        let node_idx = self.extraction.choice(canonical)?;
+        let nodes = egraph.nodes(canonical);
         let node = nodes.get(node_idx).unwrap_or_else(|| {
             panic!(
                 "from_dag_choices: node_idx {} out of bounds for e-class {} (has {} nodes)",
@@ -1144,7 +1150,7 @@ impl CostDag for ChoicesCostDag<'_> {
         });
         if let ENode::Op { children, .. } = node {
             for &child in children {
-                out.push(self.egraph.find(child).0);
+                out.push(egraph.find(child).0);
             }
         }
         Some(Self::kind_of(node))
@@ -1152,18 +1158,18 @@ impl CostDag for ChoicesCostDag<'_> {
 
     fn child_kind(&self, id: u32) -> Option<OpKind> {
         use crate::egraph::EClassId;
-        let canonical = self.egraph.find(EClassId(id));
-        let node_idx = self.choices[canonical.0 as usize]?;
-        self.egraph
-            .nodes(canonical)
-            .get(node_idx)
-            .map(Self::kind_of)
+        let egraph = self.extraction.egraph();
+        let canonical = egraph.find(EClassId(id));
+        let node_idx = self.extraction.choice(canonical)?;
+        egraph.nodes(canonical).get(node_idx).map(Self::kind_of)
     }
 
     fn variance(&self, id: u32) -> Option<pixelflow_ir::Variance> {
         use crate::egraph::EClassId;
-        self.variance_analysis
-            .map(|va| va.get(self.egraph, EClassId(id)))
+        let canonical = self.extraction.egraph().find(EClassId(id));
+        self.variance
+            .as_ref()
+            .and_then(|v| v.get(canonical.0 as usize).copied().flatten())
     }
 }
 

--- a/pixelflow-search/src/nnue/factored.rs
+++ b/pixelflow-search/src/nnue/factored.rs
@@ -981,10 +981,18 @@ impl EdgeAccumulator {
         emb: &OpEmbeddings,
         with_variance: bool,
     ) -> Self {
-        let variance = with_variance.then(|| extraction.chosen_variance());
+        // Computed once and shared by `resolve`/`child_kind` (structure) and
+        // `chosen_variance` (variance) below, so both walk the identical
+        // Shl/Shr-pinned view `choices_to_arena` will materialise — see
+        // `ChoicesCostDag::pinned`'s doc comment for why splitting these
+        // across two different choice views is a train/deploy skew, not
+        // just a redundant computation.
+        let pinned = extraction.pinned_choices();
+        let variance = with_variance.then(|| extraction.chosen_variance(&pinned));
         Self::from_cost_dag(
             &ChoicesCostDag {
                 extraction,
+                pinned,
                 variance,
             },
             emb,
@@ -1107,7 +1115,19 @@ impl CostDag for ArenaCostDag<'_> {
 /// by `IncrementalExtractor::extract_choices_only`.
 struct ChoicesCostDag<'a> {
     extraction: &'a crate::egraph::extract::Extraction<'a>,
-    /// Chosen-node variance, indexed by canonical e-class id — see
+    /// [`Extraction::pinned_choices`] — the same `Shl`/`Shr` count
+    /// substitution `choices_to_arena` applies, computed once so `resolve`
+    /// and `child_kind` walk the DAG `choices_to_arena` will actually
+    /// materialise rather than whatever node the extraction chose for a
+    /// count class. Using the raw (unpinned) `extraction.choice` here would
+    /// let this walker descend into a count class's non-`Const` alternative
+    /// — inflating `node_count`/`edge_count` with nodes `choices_to_arena`
+    /// never emits, and (with `variance` below keyed by the pinned view)
+    /// tripping `from_cost_dag`'s "half-populated histogram" assertion the
+    /// moment a shift's count class holds a value-equal varying form.
+    pinned: Vec<Option<usize>>,
+    /// Chosen-node variance, indexed by canonical e-class id — computed over
+    /// the SAME `pinned` view via
     /// [`Extraction::chosen_variance`](crate::egraph::extract::Extraction::chosen_variance).
     /// `None` when the caller didn't ask for variance features.
     variance: Option<Vec<Option<pixelflow_ir::Variance>>>,
@@ -1122,6 +1142,11 @@ impl ChoicesCostDag<'_> {
             ENode::Buffer(_) => OpKind::Buffer,
             ENode::Op { op, .. } => op.kind(),
         }
+    }
+
+    /// The pinned choice recorded for `class`'s canonical id, if any.
+    fn pinned_choice(&self, class: crate::egraph::EClassId) -> Option<usize> {
+        self.pinned.get(class.0 as usize).copied().flatten()
     }
 }
 
@@ -1138,7 +1163,7 @@ impl CostDag for ChoicesCostDag<'_> {
         use crate::egraph::{EClassId, ENode};
         let egraph = self.extraction.egraph();
         let canonical = egraph.find(EClassId(id));
-        let node_idx = self.extraction.choice(canonical)?;
+        let node_idx = self.pinned_choice(canonical)?;
         let nodes = egraph.nodes(canonical);
         let node = nodes.get(node_idx).unwrap_or_else(|| {
             panic!(
@@ -1160,7 +1185,7 @@ impl CostDag for ChoicesCostDag<'_> {
         use crate::egraph::EClassId;
         let egraph = self.extraction.egraph();
         let canonical = egraph.find(EClassId(id));
-        let node_idx = self.extraction.choice(canonical)?;
+        let node_idx = self.pinned_choice(canonical)?;
         egraph.nodes(canonical).get(node_idx).map(Self::kind_of)
     }
 

--- a/pixelflow-search/src/runtime.rs
+++ b/pixelflow-search/src/runtime.rs
@@ -133,8 +133,8 @@ fn optimize_runtime_arena_uncached(arena: &ExprArena, root: ExprId) -> Option<(E
     );
 
     let policy = env_extraction_policy();
-    let choices = policy.choices(&egraph, root_class);
-    let (extracted, extracted_root) = choices_to_arena(&egraph, root_class, &choices);
+    let extraction = policy.extraction(&egraph, root_class);
+    let (extracted, extracted_root) = choices_to_arena(&extraction);
 
     // The extracted arena declares buffers in extraction-traversal order,
     // which need not match the input's — and slot order is ABI: the JIT


### PR DESCRIPTION
## Summary

Follow-up integration round on top of #1015 (the guide-encapsulation cleanup), implementing docs/plans/2026-08-17-cost-model-domain.md's join rows J2, J3, J4, J7, J8, J9, J14, J15 and closing all four P1 defect classes that round named:

| P1 | Defect | Type that now makes it unrepresentable |
|---|---|---|
| **(a)** | Cached `ValueSample` accumulators go stale while SGD mutates embeddings every batch, with no gradient behind the mutation | `apply_unified_sgd` no longer touches `net.embeddings` at all — `backward_value` never populates `grads.d_embeddings` (no live caller of `backward_through_accumulator`), so decaying/projecting it was pure drift with no training signal. Two regression tests pin the freeze and the train/DEV feature match it restores. |
| **(b)** | The corpus/weights checkpoint's hand-bumped version integer (`VERSION: u32`, `TRIE` magic) can silently fail to move when a field's *meaning* changes | `SchemaIdentity` trait (`pixelflow_pipeline::schema`): identity is a content hash of a written field-by-field `SCHEMA` description, so editing the description **is** the version bump — there's no separate integer to forget. Every loader (`corpus::read_corpus`, `MintMetadata::read_for`) asserts it and refuses loudly, naming the exact regen command. |
| **(c)** | Variance features come from the e-class's class-wide meet (`DepsAnalysis::get`), not the node the extraction actually chose | `Extraction::chosen_variance()` walks only the CHOSEN nodes. Once a rewrite merges a pixel-varying node into a class alongside a constant (`Sub(X,X) = Const(0)`), the meet collapses to CONST regardless of which node was picked; `Extraction` is now the only thing variance can be computed from, so the meet is structurally unreachable from the deploy feature path. |
| **(d)** | The holdout fence is keyed on raw structure while the extraction head's features collapse literals, so `X * 2.0` (DEV) doesn't fence `X * 3.0` (TRAIN) even though they're the identical input to the model | `FenceKey::of` computes op identity via the exact call (`ExprArena::kind`) the featurizer uses. `Fence<T: HoldoutSide>` is phantom-tagged on a sealed `DevSide`/`FinalSide` marker trait, so a fence built from the tier it's meant to protect (`Fence<Train>`) cannot be named from any crate — not a convention, a type that doesn't exist. |

## What's in each commit

1. **`pixelflow-search`: validated `Extraction` type; variance from chosen nodes** (J2, kills P1(c)) — `Extraction<'g>` wraps a witnessed, well-founded `(egraph, root, choices)` selection; the only constructors (`from_dp`, `from_backfill`, `try_swap`) establish well-foundedness as part of construction, so a bare `Vec<Option<usize>>` can no longer reach `choices_to_arena` or the NNUE accumulator builders.
2. **`pixelflow-pipeline`: freeze untrainable embeddings** (kills P1(a)) — independent of everything else in this PR; touches only `unified_backward.rs`.
3. **`pixelflow-pipeline`: derived schema identity; provenance-composing journal (infra)** (J9, J15 infra) — purely additive: `schema.rs` (new) + `journal.rs`'s `ConfigHash`/`ArtifactId`/`JournalEntry`/`SourceVersion` additions, nothing wired in yet.
4. **`pixelflow-pipeline`: `CostLabel`/clock newtypes; feature-quotient holdout fence; wire schema identity + journal everywhere** (J3, J4, J7, J8, J14, kills P1(b), P1(d)) — the consumer wiring: `LocalNs`/`SessionNs`/`DriftFactor`/`CostLabel` (J3/J4 — `LocalNs` has no `Sub` impl, so "subtract overhead before normalizing" no longer type-checks), `Family`/`Fence<T>`/`FenceKey` (J7/J8), the corpus/mint-sidecar `SchemaIdentity` wiring (P1(b)), and every journal-writing binary switched to the shared `ConfigHash::compose`/`JournalEntry` (J15).

## Artifact-regeneration consequence

The corpus format's cross-tier dedup key changed from raw structural equality to the feature-quotient `FenceKey` — this is a **meaning** change, not just a byte-layout one, so `CorpusFormat`'s derived `SCHEMA_IDENTITY` changed and any corpus written before this PR is refused loudly at load (not silently misread) with the exact `gen_bench_corpus` command to regenerate it. Likewise any `extraction_head.bin.mint.json` sidecar written before this PR is refused at load with the `bootstrap_extraction_head` regen command. `pixelflow-pipeline/data/` is scratch (gitignored) — no tracked artifacts needed migrating.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — 102 test suites, 0 failed
- [x] `cargo test -p pixelflow-pipeline --features training` — 128+49+27+20+1, 0 failed
- [x] `cargo test -p pixelflow-search` — 122 passed, 1 ignored (unit) + 4+2 integration + 9 ignored doctests
- [x] `cargo test -p pixelflow-ir`
- [x] `cargo check -p pixelflow-ir --no-default-features`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] End-to-end pipeline smoke: `gen_bench_corpus` → `bootstrap_extraction_head` → `bench_extraction_3way` against a scratch corpus, all three run and journal successfully; cross-tier `FenceKey` dedup and the live-stream holdout fence both fire.
- [x] A corrupted `SchemaIdentity` in both a corpus file and a mint sidecar is refused loudly (exit 134, message names stored vs. expected identity and the regen command) — verified against real generated artifacts, not just the unit tests.
- [x] Embedding freeze holds in a live run: a 0-epoch and a 5-epoch checkpoint from the same seed compare byte-for-byte identical on the embeddings segment.
- [x] Re-verified all gates after splitting into 4 commits (each commit builds standalone in sequence).

Full plan: `docs/plans/2026-08-17-cost-model-domain.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)