### PR TITLE
test(core-term): descriptive test names + mutation-testing gap fixes (round 2)

### DIFF
--- a/core-term/src/ansi/pict_sgr_tests.rs
+++ b/core-term/src/ansi/pict_sgr_tests.rs
@@ -137,7 +137,7 @@ fn parsed_attrs(seq: &[u8]) -> Option<Vec<Attribute>> {
 }
 
 #[test]
-fn pict_sgr_pairwise_matches_oracle() {
+fn it_should_match_the_oracle_for_every_pairwise_generated_sgr_sequence() {
     let factors = sgr_factors();
     let level_counts: Vec<usize> = factors.iter().map(Vec::len).collect();
     let rows = pairwise(&level_counts);
@@ -173,7 +173,7 @@ fn pict_sgr_pairwise_matches_oracle() {
 /// sequence whose codes are all *unrecognized* must be ignored, not turned into
 /// a full attribute reset.
 #[test]
-fn unknown_only_sgr_is_ignored_not_reset() {
+fn it_should_ignore_an_sgr_sequence_containing_only_unknown_codes_instead_of_resetting() {
     // `ESC[73m` — a single unimplemented code. Correct behavior: no-op.
     assert_eq!(
         parsed_attrs(b"\x1b[73m"),
@@ -186,7 +186,7 @@ fn unknown_only_sgr_is_ignored_not_reset() {
 /// is silently dropped when it shares the sequence with a recognized attribute,
 /// so `ESC[73m` and `ESC[1;73m` disagree on how `73` is handled.
 #[test]
-fn unknown_sgr_is_dropped_when_mixed_with_known() {
+fn it_should_drop_unknown_sgr_codes_while_keeping_known_attributes_when_mixed() {
     assert_eq!(
         parsed_attrs(b"\x1b[1;73m"),
         Some(vec![Attribute::Bold]),

--- a/core-term/src/ansi/tests.rs
+++ b/core-term/src/ansi/tests.rs
@@ -2134,6 +2134,31 @@ mod mutation_tests {
     }
 
     // -----------------------------------------------------------------------
+    // OSC MAX_OSC_LEN boundary enforcement
+    // Mutation: `<` to `<=` in add_string_byte would allow the buffer to grow
+    //           one byte past MAX_OSC_LEN before dropping further bytes.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn it_should_truncate_an_osc_string_to_the_max_osc_len_limit() {
+        let payload = vec![b'x'; 2000];
+        let mut input = b"\x1b]0;".to_vec();
+        input.extend_from_slice(&payload);
+        input.push(0x07); // BEL
+
+        let cmds = process_bytes(&input);
+        let Some(AnsiCommand::Osc(data)) = cmds.first() else {
+            panic!("expected Osc command, got {:?}", cmds);
+        };
+        assert_eq!(
+            data.len(),
+            1024,
+            "OSC string must be truncated at MAX_OSC_LEN, got {} bytes",
+            data.len()
+        );
+    }
+
+    // -----------------------------------------------------------------------
     // UTF-8 boundary: exact invalid/valid byte transitions
     // Mutations: off-by-one on UTF8_2_BYTE_MIN (0xC2), UTF8_4_BYTE_MAX (0xF4),
     //            continuation range (0x80..=0xBF)
@@ -2263,6 +2288,24 @@ mod mutation_tests {
             !cmds.iter().any(|c| matches!(c, AnsiCommand::Dcs(_))),
             "CAN must cancel DCS; got {:?}",
             cmds
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // A CAN-cancelled string sequence must not leak its bytes into the next
+    // OSC/DCS/PM/APC string.
+    // Mutation: replacing AnsiParser::clear_string_buffer with a no-op leaves
+    // the cancelled sequence's bytes in the buffer, so the next dispatched
+    // string command's payload would be prefixed with the stale bytes.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn it_should_not_leak_a_can_cancelled_osc_strings_bytes_into_the_next_osc() {
+        let cmds = process_bytes(b"\x1b]0;oldjunk\x18\x1b]1;newdata\x07");
+        assert_eq!(
+            cmds,
+            vec![AnsiCommand::Osc(b"1;newdata".to_vec())],
+            "the cancelled sequence's bytes must not appear in the next OSC's payload"
         );
     }
 

--- a/core-term/src/ansi/tests.rs
+++ b/core-term/src/ansi/tests.rs
@@ -49,7 +49,7 @@ fn it_should_process_c0_bel() {
 }
 
 #[test]
-fn c0control_from_byte_accepts_only_the_documented_control_range() {
+fn it_should_accept_only_documented_control_bytes_in_c0control_from_byte() {
     // Valid C0 range (0x00..=0x1F) except ESC, which is handled separately,
     // plus DEL (0x7F). `from_byte` transmutes the byte into `C0Control`, so
     // any byte outside this exact set must return `None` rather than
@@ -78,7 +78,7 @@ fn c0control_from_byte_accepts_only_the_documented_control_range() {
 }
 
 #[test]
-fn c0control_display_prints_the_mnemonic_for_every_variant() {
+fn it_should_display_the_correct_mnemonic_for_every_c0control_variant() {
     let expected: &[(C0Control, &str)] = &[
         (C0Control::NUL, "NUL"),
         (C0Control::SOH, "SOH"),
@@ -1431,7 +1431,7 @@ mod mutation_tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn sgr_bold_is_1() {
+    fn it_should_set_bold_attribute_for_sgr_code_1() {
         let cmds = process_bytes(b"\x1b[1m");
         assert_eq!(
             cmds,
@@ -1442,7 +1442,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn sgr_faint_is_2() {
+    fn it_should_set_faint_attribute_for_sgr_code_2() {
         let cmds = process_bytes(b"\x1b[2m");
         assert_eq!(
             cmds,
@@ -1453,7 +1453,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn sgr_italic_is_3() {
+    fn it_should_set_italic_attribute_for_sgr_code_3() {
         let cmds = process_bytes(b"\x1b[3m");
         assert_eq!(
             cmds,
@@ -1464,7 +1464,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn sgr_underline_is_4() {
+    fn it_should_set_underline_attribute_for_sgr_code_4() {
         let cmds = process_bytes(b"\x1b[4m");
         assert_eq!(
             cmds,
@@ -1475,7 +1475,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn sgr_blink_slow_is_5() {
+    fn it_should_set_slow_blink_attribute_for_sgr_code_5() {
         let cmds = process_bytes(b"\x1b[5m");
         assert_eq!(
             cmds,
@@ -1486,7 +1486,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn sgr_blink_rapid_is_6() {
+    fn it_should_set_rapid_blink_attribute_for_sgr_code_6() {
         let cmds = process_bytes(b"\x1b[6m");
         assert_eq!(
             cmds,
@@ -1497,7 +1497,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn sgr_reverse_is_7() {
+    fn it_should_set_reverse_attribute_for_sgr_code_7() {
         let cmds = process_bytes(b"\x1b[7m");
         assert_eq!(
             cmds,
@@ -1508,7 +1508,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn sgr_conceal_is_8() {
+    fn it_should_set_conceal_attribute_for_sgr_code_8() {
         let cmds = process_bytes(b"\x1b[8m");
         assert_eq!(
             cmds,
@@ -1519,7 +1519,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn sgr_strikethrough_is_9() {
+    fn it_should_set_strikethrough_attribute_for_sgr_code_9() {
         let cmds = process_bytes(b"\x1b[9m");
         assert_eq!(
             cmds,
@@ -1530,7 +1530,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn sgr_underline_double_is_21() {
+    fn it_should_set_double_underline_attribute_for_sgr_code_21() {
         let cmds = process_bytes(b"\x1b[21m");
         assert_eq!(
             cmds,
@@ -1541,7 +1541,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn sgr_normal_intensity_is_22() {
+    fn it_should_set_no_bold_attribute_for_sgr_code_22() {
         let cmds = process_bytes(b"\x1b[22m");
         assert_eq!(
             cmds,
@@ -1552,7 +1552,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn sgr_no_italic_is_23() {
+    fn it_should_set_no_italic_attribute_for_sgr_code_23() {
         let cmds = process_bytes(b"\x1b[23m");
         assert_eq!(
             cmds,
@@ -1563,7 +1563,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn sgr_no_underline_is_24() {
+    fn it_should_set_no_underline_attribute_for_sgr_code_24() {
         let cmds = process_bytes(b"\x1b[24m");
         assert_eq!(
             cmds,
@@ -1574,7 +1574,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn sgr_no_blink_is_25() {
+    fn it_should_set_no_blink_attribute_for_sgr_code_25() {
         let cmds = process_bytes(b"\x1b[25m");
         assert_eq!(
             cmds,
@@ -1585,7 +1585,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn sgr_no_reverse_is_27() {
+    fn it_should_set_no_reverse_attribute_for_sgr_code_27() {
         let cmds = process_bytes(b"\x1b[27m");
         assert_eq!(
             cmds,
@@ -1596,7 +1596,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn sgr_no_conceal_is_28() {
+    fn it_should_set_no_conceal_attribute_for_sgr_code_28() {
         let cmds = process_bytes(b"\x1b[28m");
         assert_eq!(
             cmds,
@@ -1607,7 +1607,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn sgr_no_strikethrough_is_29() {
+    fn it_should_set_no_strikethrough_attribute_for_sgr_code_29() {
         let cmds = process_bytes(b"\x1b[29m");
         assert_eq!(
             cmds,
@@ -1618,7 +1618,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn sgr_overlined_is_53() {
+    fn it_should_set_overlined_attribute_for_sgr_code_53() {
         let cmds = process_bytes(b"\x1b[53m");
         assert_eq!(
             cmds,
@@ -1629,7 +1629,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn sgr_no_overlined_is_55() {
+    fn it_should_set_no_overlined_attribute_for_sgr_code_55() {
         let cmds = process_bytes(b"\x1b[55m");
         assert_eq!(
             cmds,
@@ -1640,7 +1640,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn sgr_underline_color_set_is_58() {
+    fn it_should_parse_indexed_and_rgb_underline_color_for_sgr_code_58() {
         // 58;5;42 -> UnderlineColor(Indexed(42))
         let cmds = process_bytes(b"\x1b[58;5;42m");
         assert_eq!(
@@ -1661,7 +1661,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn sgr_underline_color_default_is_59() {
+    fn it_should_set_default_underline_color_for_sgr_code_59() {
         let cmds = process_bytes(b"\x1b[59m");
         assert_eq!(
             cmds,
@@ -1677,7 +1677,7 @@ mod mutation_tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn sgr_fg_all_eight_normal_colors() {
+    fn it_should_map_sgr_codes_30_to_37_to_the_eight_normal_foreground_colors() {
         // Tests every entry in map_basic_code_to_color for Normal intensity.
         // A mutation that shifts the base constant by ±1 would fail on Black or White.
         let cases: &[(u8, NamedColor)] = &[
@@ -1706,7 +1706,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn sgr_fg_default_is_39() {
+    fn it_should_set_default_foreground_color_for_sgr_code_39() {
         // Mutation: wrong constant (38 vs 39 would change to extended-color path)
         let cmds = process_bytes(b"\x1b[39m");
         assert_eq!(
@@ -1723,7 +1723,7 @@ mod mutation_tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn sgr_bg_all_eight_normal_colors() {
+    fn it_should_map_sgr_codes_40_to_47_to_the_eight_normal_background_colors() {
         let cases: &[(u8, NamedColor)] = &[
             (40, NamedColor::Black),
             (41, NamedColor::Red),
@@ -1750,7 +1750,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn sgr_bg_default_is_49() {
+    fn it_should_set_default_background_color_for_sgr_code_49() {
         let cmds = process_bytes(b"\x1b[49m");
         assert_eq!(
             cmds,
@@ -1766,7 +1766,7 @@ mod mutation_tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn sgr_fg_all_eight_bright_colors() {
+    fn it_should_map_sgr_codes_90_to_97_to_the_eight_bright_foreground_colors() {
         let cases: &[(u8, NamedColor)] = &[
             (90, NamedColor::BrightBlack),
             (91, NamedColor::BrightRed),
@@ -1797,7 +1797,7 @@ mod mutation_tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn sgr_bg_all_eight_bright_colors() {
+    fn it_should_map_sgr_codes_100_to_107_to_the_eight_bright_background_colors() {
         let cases: &[(u8, NamedColor)] = &[
             (100, NamedColor::BrightBlack),
             (101, NamedColor::BrightRed),
@@ -1829,7 +1829,7 @@ mod mutation_tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn sgr_fg_256_color_index_min() {
+    fn it_should_parse_256_color_foreground_index_0() {
         // 38;5;0 -> Foreground(Indexed(0))
         let cmds = process_bytes(b"\x1b[38;5;0m");
         assert_eq!(
@@ -1841,7 +1841,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn sgr_fg_256_color_index_max() {
+    fn it_should_parse_256_color_foreground_index_255() {
         // 38;5;255 -> Foreground(Indexed(255))
         let cmds = process_bytes(b"\x1b[38;5;255m");
         assert_eq!(
@@ -1853,7 +1853,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn sgr_bg_256_color() {
+    fn it_should_parse_256_color_background_index() {
         // 48;5;100 -> Background(Indexed(100))
         // Mutation: mixing up 38 and 48 would swap Fg/Bg
         let cmds = process_bytes(b"\x1b[48;5;100m");
@@ -1866,7 +1866,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn sgr_fg_rgb_truecolor() {
+    fn it_should_parse_truecolor_rgb_foreground() {
         // 38;2;255;128;0 -> Foreground(Rgb(255, 128, 0))
         let cmds = process_bytes(b"\x1b[38;2;255;128;0m");
         assert_eq!(
@@ -1878,7 +1878,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn sgr_bg_rgb_truecolor() {
+    fn it_should_parse_truecolor_rgb_background() {
         // 48;2;10;20;30 -> Background(Rgb(10, 20, 30))
         let cmds = process_bytes(b"\x1b[48;2;10;20;30m");
         assert_eq!(
@@ -1890,7 +1890,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn sgr_rgb_channel_order_is_r_g_b_not_b_g_r() {
+    fn it_should_preserve_r_g_b_channel_order_for_truecolor_foreground() {
         // Explicitly verify R,G,B order - a mutation swapping two channel reads would survive
         // a test using equal values. Using distinct non-symmetric values.
         let cmds = process_bytes(b"\x1b[38;2;1;2;3m");
@@ -1908,56 +1908,56 @@ mod mutation_tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn csi_cursor_up_no_param_defaults_to_1() {
+    fn it_should_default_cursor_up_count_to_1_when_no_param_is_given() {
         let cmds = process_bytes(b"\x1b[A");
         assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::CursorUp(1))]);
     }
 
     #[test]
-    fn csi_cursor_up_param_zero_is_coerced_to_1() {
+    fn it_should_coerce_cursor_up_param_zero_to_1() {
         // param_or_1 applies max(1), so 0 -> 1
         let cmds = process_bytes(b"\x1b[0A");
         assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::CursorUp(1))]);
     }
 
     #[test]
-    fn csi_cursor_up_explicit_5() {
+    fn it_should_move_cursor_up_by_explicit_count_5() {
         let cmds = process_bytes(b"\x1b[5A");
         assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::CursorUp(5))]);
     }
 
     #[test]
-    fn csi_cursor_down_defaults_to_1() {
+    fn it_should_default_cursor_down_count_to_1_when_no_param_is_given() {
         let cmds = process_bytes(b"\x1b[B");
         assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::CursorDown(1))]);
     }
 
     #[test]
-    fn csi_cursor_forward_defaults_to_1() {
+    fn it_should_default_cursor_forward_count_to_1_when_no_param_is_given() {
         let cmds = process_bytes(b"\x1b[C");
         assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::CursorForward(1))]);
     }
 
     #[test]
-    fn csi_cursor_backward_defaults_to_1() {
+    fn it_should_default_cursor_backward_count_to_1_when_no_param_is_given() {
         let cmds = process_bytes(b"\x1b[D");
         assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::CursorBackward(1))]);
     }
 
     #[test]
-    fn csi_cursor_next_line_defaults_to_1() {
+    fn it_should_default_cursor_next_line_count_to_1_when_no_param_is_given() {
         let cmds = process_bytes(b"\x1b[E");
         assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::CursorNextLine(1))]);
     }
 
     #[test]
-    fn csi_cursor_prev_line_defaults_to_1() {
+    fn it_should_default_cursor_prev_line_count_to_1_when_no_param_is_given() {
         let cmds = process_bytes(b"\x1b[F");
         assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::CursorPrevLine(1))]);
     }
 
     #[test]
-    fn csi_cursor_char_absolute_defaults_to_1() {
+    fn it_should_default_cursor_character_absolute_column_to_1_when_no_param_is_given() {
         let cmds = process_bytes(b"\x1b[G");
         assert_eq!(
             cmds,
@@ -1970,7 +1970,7 @@ mod mutation_tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn csi_cup_both_params_present() {
+    fn it_should_set_cursor_position_from_explicit_row_and_column_params() {
         let cmds = process_bytes(b"\x1b[5;10H");
         assert_eq!(
             cmds,
@@ -1979,7 +1979,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn csi_cup_row_only_col_defaults_to_1() {
+    fn it_should_default_cursor_position_column_to_1_when_only_row_is_given() {
         let cmds = process_bytes(b"\x1b[3H");
         assert_eq!(
             cmds,
@@ -1988,7 +1988,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn csi_cup_no_params_both_default_to_1() {
+    fn it_should_default_cursor_position_row_and_column_to_1_when_no_params_are_given() {
         // ESC [ H with no params = home (1,1); tested above but repeat here for clarity
         let cmds = process_bytes(b"\x1b[H");
         assert_eq!(
@@ -2003,25 +2003,25 @@ mod mutation_tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn csi_erase_in_display_no_param_defaults_to_0() {
+    fn it_should_default_erase_in_display_mode_to_0_when_no_param_is_given() {
         let cmds = process_bytes(b"\x1b[J");
         assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::EraseInDisplay(0))]);
     }
 
     #[test]
-    fn csi_erase_in_display_explicit_2() {
+    fn it_should_erase_entire_display_for_explicit_mode_2() {
         let cmds = process_bytes(b"\x1b[2J");
         assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::EraseInDisplay(2))]);
     }
 
     #[test]
-    fn csi_erase_in_line_no_param_defaults_to_0() {
+    fn it_should_default_erase_in_line_mode_to_0_when_no_param_is_given() {
         let cmds = process_bytes(b"\x1b[K");
         assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::EraseInLine(0))]);
     }
 
     #[test]
-    fn csi_erase_in_line_explicit_1() {
+    fn it_should_erase_line_for_explicit_mode_1() {
         let cmds = process_bytes(b"\x1b[1K");
         assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::EraseInLine(1))]);
     }
@@ -2032,43 +2032,43 @@ mod mutation_tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn esc_d_is_index() {
+    fn it_should_map_esc_d_to_index_command() {
         let cmds = process_bytes(b"\x1bD");
         assert_eq!(cmds, vec![AnsiCommand::Esc(EscCommand::Index)]);
     }
 
     #[test]
-    fn esc_e_is_next_line() {
+    fn it_should_map_esc_e_to_next_line_command() {
         let cmds = process_bytes(b"\x1bE");
         assert_eq!(cmds, vec![AnsiCommand::Esc(EscCommand::NextLine)]);
     }
 
     #[test]
-    fn esc_h_is_set_tab_stop() {
+    fn it_should_map_esc_h_to_set_tab_stop_command() {
         let cmds = process_bytes(b"\x1bH");
         assert_eq!(cmds, vec![AnsiCommand::Esc(EscCommand::SetTabStop)]);
     }
 
     #[test]
-    fn esc_m_is_reverse_index() {
+    fn it_should_map_esc_m_to_reverse_index_command() {
         let cmds = process_bytes(b"\x1bM");
         assert_eq!(cmds, vec![AnsiCommand::Esc(EscCommand::ReverseIndex)]);
     }
 
     #[test]
-    fn esc_7_is_save_cursor() {
+    fn it_should_map_esc_7_to_save_cursor_command() {
         let cmds = process_bytes(b"\x1b7");
         assert_eq!(cmds, vec![AnsiCommand::Esc(EscCommand::SaveCursor)]);
     }
 
     #[test]
-    fn esc_8_is_restore_cursor() {
+    fn it_should_map_esc_8_to_restore_cursor_command() {
         let cmds = process_bytes(b"\x1b8");
         assert_eq!(cmds, vec![AnsiCommand::Esc(EscCommand::RestoreCursor)]);
     }
 
     #[test]
-    fn esc_c_is_reset_to_initial_state() {
+    fn it_should_map_esc_c_to_reset_to_initial_state_command() {
         let cmds = process_bytes(b"\x1bc");
         assert_eq!(
             cmds,
@@ -2077,13 +2077,13 @@ mod mutation_tests {
     }
 
     #[test]
-    fn esc_n_is_single_shift_2() {
+    fn it_should_map_esc_n_to_single_shift_2_command() {
         let cmds = process_bytes(b"\x1bN");
         assert_eq!(cmds, vec![AnsiCommand::Esc(EscCommand::SingleShift2)]);
     }
 
     #[test]
-    fn esc_o_is_single_shift_3() {
+    fn it_should_map_esc_o_to_single_shift_3_command() {
         let cmds = process_bytes(b"\x1bO");
         assert_eq!(cmds, vec![AnsiCommand::Esc(EscCommand::SingleShift3)]);
     }
@@ -2095,7 +2095,7 @@ mod mutation_tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn csi_accepts_exactly_16_params() {
+    fn it_should_retain_all_16_params_at_the_max_params_limit() {
         // SGR with 16 parameters: 1;2;0;0;... (14 zeros)
         // All 16 must be collected and processed.
         let cmds = process_bytes(b"\x1b[1;2;0;0;0;0;0;0;0;0;0;0;0;0;0;0m");
@@ -2117,7 +2117,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn csi_silently_drops_17th_param() {
+    fn it_should_drop_the_17th_csi_param_beyond_the_max_params_limit() {
         // 16 zeros then ;7 (Reverse). The 17th param (7) must be ignored.
         // We send: ESC [ 0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;7m
         //          that's 16 zeros + 1 extra -> the 7 (Reverse) is the 17th and dropped.
@@ -2140,7 +2140,7 @@ mod mutation_tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn utf8_0xc1_is_invalid_start_produces_replacement() {
+    fn it_should_treat_0xc1_as_an_invalid_utf8_start_byte() {
         // 0xC1 is just below the valid 2-byte start range (0xC2)
         let cmds = process_bytes(&[0xC1, 0x80]);
         // Both bytes should produce replacement characters, not a valid char
@@ -2153,7 +2153,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn utf8_0xc2_is_valid_2_byte_start() {
+    fn it_should_decode_0xc2_as_a_valid_2_byte_utf8_start() {
         // 0xC2 0x80 = U+0080 (PAD) - lowest valid 2-byte sequence
         let cmds = process_bytes(&[0xC2, 0x80]);
         assert_eq!(
@@ -2164,7 +2164,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn utf8_0xf4_0x8f_0xbf_0xbf_is_valid() {
+    fn it_should_decode_the_highest_valid_utf8_code_point_u10ffff() {
         // 0xF4 0x8F 0xBF 0xBF = U+10FFFF (highest valid code point)
         let cmds = process_bytes(&[0xF4, 0x8F, 0xBF, 0xBF]);
         assert_eq!(
@@ -2175,7 +2175,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn utf8_0xf5_is_invalid_start_produces_replacement() {
+    fn it_should_treat_0xf5_as_an_invalid_utf8_start_byte() {
         // 0xF5 is just above the valid 4-byte start range (0xF4)
         let cmds = process_bytes(&[0xF5, 0x80, 0x80, 0x80]);
         assert!(
@@ -2187,7 +2187,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn utf8_continuation_0x7f_is_not_valid_continuation() {
+    fn it_should_reject_0x7f_as_a_utf8_continuation_byte() {
         // 0xE2 starts a 3-byte sequence; 0x7F is DEL (not a continuation byte 0x80..=0xBF)
         // Should abort the UTF-8 sequence and emit replacement + DEL control
         let cmds = process_bytes(&[0xE2, 0x7F]);
@@ -2200,7 +2200,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn utf8_continuation_0xc0_is_not_valid_continuation() {
+    fn it_should_reject_0xc0_as_a_utf8_continuation_byte() {
         // 0xC0 is above the continuation range (0x80..=0xBF)
         // Should abort the UTF-8 sequence
         let cmds = process_bytes(&[0xE2, 0xC0]);
@@ -2213,7 +2213,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn utf8_continuation_0xbf_is_valid_continuation() {
+    fn it_should_accept_0xbf_as_the_highest_valid_utf8_continuation_byte() {
         // 0xDF 0xBF = U+07FF - uses 0xBF which is the highest continuation byte
         let cmds = process_bytes(&[0xDF, 0xBF]);
         assert_eq!(
@@ -2229,7 +2229,7 @@ mod mutation_tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn osc_cancelled_by_can() {
+    fn it_should_cancel_osc_string_on_can_and_resume_printing() {
         // CAN (0x18) inside an OSC should discard the string and return to ground
         let cmds = process_bytes(b"\x1b]0;title\x18rest");
         // No Osc command should appear; "rest" prints normally
@@ -2246,7 +2246,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn osc_cancelled_by_sub() {
+    fn it_should_cancel_osc_string_on_sub() {
         // SUB (0x1A) inside an OSC should also discard it
         let cmds = process_bytes(b"\x1b]0;title\x1Arest");
         assert!(
@@ -2257,7 +2257,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn dcs_cancelled_by_can() {
+    fn it_should_cancel_dcs_string_on_can() {
         let cmds = process_bytes(b"\x1bPdata\x18rest");
         assert!(
             !cmds.iter().any(|c| matches!(c, AnsiCommand::Dcs(_))),
@@ -2272,7 +2272,7 @@ mod mutation_tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn csi_param_overflow_saturates_not_panics() {
+    fn it_should_saturate_csi_param_overflow_to_u16_max_instead_of_panicking() {
         // A number larger than u16::MAX (65535) should saturate to u16::MAX, not panic
         let cmds = process_bytes(b"\x1b[99999A");
         // Should produce CursorUp with some value (saturated), not panic
@@ -2290,19 +2290,19 @@ mod mutation_tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn csi_ctc_0_is_set_tab_stop() {
+    fn it_should_map_ctc_param_0_to_set_tab_stop() {
         let cmds = process_bytes(b"\x1b[0W");
         assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::SetTabStop)]);
     }
 
     #[test]
-    fn csi_ctc_2_clears_current_tab_stop() {
+    fn it_should_map_ctc_param_2_to_clear_current_tab_stop() {
         let cmds = process_bytes(b"\x1b[2W");
         assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::ClearTabStops(0))]);
     }
 
     #[test]
-    fn csi_ctc_5_clears_all_tab_stops() {
+    fn it_should_map_ctc_param_5_to_clear_all_tab_stops() {
         let cmds = process_bytes(b"\x1b[5W");
         assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::ClearTabStops(3))]);
     }
@@ -2313,13 +2313,13 @@ mod mutation_tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn csi_s_uppercase_is_scroll_up() {
+    fn it_should_map_uppercase_csi_s_to_scroll_up() {
         let cmds = process_bytes(b"\x1b[3S");
         assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::ScrollUp(3))]);
     }
 
     #[test]
-    fn csi_t_uppercase_is_scroll_down() {
+    fn it_should_map_uppercase_csi_t_to_scroll_down() {
         let cmds = process_bytes(b"\x1b[3T");
         assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::ScrollDown(3))]);
     }
@@ -2330,19 +2330,19 @@ mod mutation_tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn csi_at_is_insert_character() {
+    fn it_should_map_csi_at_to_insert_character() {
         let cmds = process_bytes(b"\x1b[2@");
         assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::InsertCharacter(2))]);
     }
 
     #[test]
-    fn csi_p_uppercase_is_delete_character() {
+    fn it_should_map_uppercase_csi_p_to_delete_character() {
         let cmds = process_bytes(b"\x1b[2P");
         assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::DeleteCharacter(2))]);
     }
 
     #[test]
-    fn csi_x_uppercase_is_erase_character() {
+    fn it_should_map_uppercase_csi_x_to_erase_character() {
         let cmds = process_bytes(b"\x1b[2X");
         assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::EraseCharacter(2))]);
     }
@@ -2352,13 +2352,13 @@ mod mutation_tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn csi_l_uppercase_is_insert_line() {
+    fn it_should_map_uppercase_csi_l_to_insert_line() {
         let cmds = process_bytes(b"\x1b[4L");
         assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::InsertLine(4))]);
     }
 
     #[test]
-    fn csi_m_uppercase_is_delete_line() {
+    fn it_should_map_uppercase_csi_m_to_delete_line() {
         let cmds = process_bytes(b"\x1b[4M");
         assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::DeleteLine(4))]);
     }
@@ -2369,7 +2369,7 @@ mod mutation_tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn csi_decstbm_explicit_top_and_bottom() {
+    fn it_should_set_scrolling_region_from_explicit_top_and_bottom_params() {
         let cmds = process_bytes(b"\x1b[5;24r");
         assert_eq!(
             cmds,
@@ -2381,7 +2381,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn csi_decstbm_top_defaults_to_1() {
+    fn it_should_default_scrolling_region_top_to_1_and_bottom_to_0_when_no_params_are_given() {
         // No params: top=1, bottom=0 (convention for "last line")
         let cmds = process_bytes(b"\x1b[r");
         assert_eq!(
@@ -2399,7 +2399,7 @@ mod mutation_tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn csi_f_is_cup_alias_for_h() {
+    fn it_should_treat_csi_f_as_an_alias_for_cursor_position() {
         // 'f' is an alias for 'H' (CursorPosition / HVP).
         // A mutation removing the `| (false, b"", b'f')` arm would produce Error.
         let cmds = process_bytes(b"\x1b[5;10f");
@@ -2410,7 +2410,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn csi_d_is_vpa_column_always_1() {
+    fn it_should_hardcode_vpa_column_to_1_for_csi_d() {
         // 'd' = VPA (Vertical Position Absolute). Column is hardcoded to 1.
         // Mutation: changing the hardcoded 1 to 0, or wiring column to param.
         let cmds = process_bytes(b"\x1b[7d");
@@ -2421,7 +2421,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn csi_d_default_row_is_1() {
+    fn it_should_default_vpa_row_to_1_when_no_param_is_given() {
         // No param: row defaults to 1 (param_or_1), column always 1.
         let cmds = process_bytes(b"\x1b[d");
         assert_eq!(
@@ -2431,7 +2431,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn csi_c_is_primary_device_attributes() {
+    fn it_should_map_csi_c_to_primary_device_attributes() {
         // 'c' with no params triggers PrimaryDeviceAttributes.
         // Mutation: confusing 'c' with other single-char finals.
         let cmds = process_bytes(b"\x1b[c");
@@ -2442,7 +2442,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn csi_n_is_device_status_report() {
+    fn it_should_map_csi_6n_to_device_status_report() {
         // 'n' with param 6 = DSR cursor position request.
         // Mutation: confusing 'n' with 'm' (SGR) or wrong default.
         let cmds = process_bytes(b"\x1b[6n");
@@ -2453,7 +2453,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn csi_n_default_param_is_0() {
+    fn it_should_default_device_status_report_param_to_0() {
         // No param: DSR(0).
         let cmds = process_bytes(b"\x1b[n");
         assert_eq!(
@@ -2463,14 +2463,14 @@ mod mutation_tests {
     }
 
     #[test]
-    fn csi_s_is_save_cursor() {
+    fn it_should_map_lowercase_csi_s_to_save_cursor() {
         // 's' = save cursor (ANSI). Mutation: confusing 's' with 'S' (ScrollUp).
         let cmds = process_bytes(b"\x1b[s");
         assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::SaveCursor)]);
     }
 
     #[test]
-    fn csi_u_is_restore_cursor() {
+    fn it_should_map_csi_u_to_restore_cursor() {
         // 'u' = restore cursor (ANSI). Mutation: confusing 'u' with 'U'.
         let cmds = process_bytes(b"\x1b[u");
         assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::RestoreCursor)]);

--- a/core-term/src/io/event_monitor_actor/mod.rs
+++ b/core-term/src/io/event_monitor_actor/mod.rs
@@ -363,7 +363,7 @@ mod tests {
     }
 
     #[test]
-    fn troupe_delivers_output_and_child_exit() {
+    fn it_should_deliver_child_output_and_report_exit_after_eof() {
         let (sink, writer, handle) = spawn_troupe("/bin/sh", &["-c", "printf 'hello-troupe'"]);
 
         assert!(
@@ -385,7 +385,7 @@ mod tests {
     }
 
     #[test]
-    fn troupe_round_trips_writes_through_child() {
+    fn it_should_round_trip_written_data_through_the_child_process() {
         let (sink, writer, handle) = spawn_troupe("/bin/cat", &[]);
 
         writer
@@ -405,7 +405,7 @@ mod tests {
     }
 
     #[test]
-    fn shutdown_interrupts_blocked_reader() {
+    fn it_should_not_hang_when_dropping_writer_and_handle_while_reader_is_blocked() {
         let (_sink, writer, handle) = spawn_troupe("/bin/cat", &[]);
 
         // Give the reader time to enter its epoll/kqueue wait.
@@ -455,7 +455,7 @@ mod tests {
     }
 
     #[test]
-    fn resize_before_bind_is_applied() {
+    fn it_should_survive_a_resize_sent_before_the_writer_is_bound() {
         // A resize sent on the writer handle immediately (likely before the
         // Bind lands, since Control outranks Management) must not be lost or
         // panic — the writer coalesces it and applies it at Bind.

--- a/core-term/src/io/pty_tests.rs
+++ b/core-term/src/io/pty_tests.rs
@@ -116,7 +116,7 @@ fn read_from_pty_with_timeout(pty: &mut NixPty, expected_str: &str) -> Result<St
 }
 
 #[test]
-fn pty_spawn_successful() {
+fn it_should_run_a_command_and_read_its_output_after_spawning_a_pty() {
     // Use sh -c to be more robust across platforms and ensure output flushing
     let config = PtyConfig {
         command_executable: "/bin/sh",
@@ -154,7 +154,7 @@ fn pty_spawn_successful() {
 }
 
 #[test]
-fn pty_read_write_interaction() {
+fn it_should_deliver_written_input_to_the_child_and_read_back_its_response() {
     let shell_command = "read r_line; echo \"input was: $r_line\"";
     let config = PtyConfig {
         command_executable: "/bin/sh",
@@ -195,7 +195,7 @@ fn pty_read_write_interaction() {
 }
 
 #[test]
-fn pty_child_acquires_controlling_terminal() {
+fn it_should_give_the_child_a_controlling_terminal_that_dev_tty_resolves_to() {
     // /dev/tty resolves only through the controlling terminal. The spawn
     // path acquires the ctty via setsid + first-tty-open (posix_spawn has no
     // TIOCSCTTY); if that dance broke, the redirect below would fail and
@@ -214,7 +214,7 @@ fn pty_child_acquires_controlling_terminal() {
 }
 
 #[test]
-fn pty_child_gets_default_sigpipe() {
+fn it_should_reset_sigpipe_disposition_so_pipelines_terminate_normally() {
     // Rust ignores SIGPIPE and ignored dispositions survive exec; the spawn
     // path must reset it or `foo | head`-style pipelines never terminate.
     // `yes` only exits here by dying of SIGPIPE when `head` closes the pipe.
@@ -232,7 +232,7 @@ fn pty_child_gets_default_sigpipe() {
 }
 
 #[test]
-fn pty_resize_successful() {
+fn it_should_return_ok_when_resizing_the_pty() {
     // Use `sleep` from PATH to be cross-platform (macOS has /bin/sleep, Linux /usr/bin/sleep)
     let config = PtyConfig {
         command_executable: "sleep",
@@ -270,7 +270,7 @@ fn pty_resize_successful() {
 }
 
 #[test]
-fn pty_child_termination_on_drop() {
+fn it_should_terminate_the_child_process_when_the_pty_is_dropped() {
     let config = PtyConfig {
         command_executable: "sleep",
         args: &["2"], // Arg for sleep is just the duration
@@ -333,7 +333,7 @@ fn pty_child_termination_on_drop() {
 }
 
 #[test]
-fn pty_spawn_invalid_command() {
+fn it_should_return_a_not_found_error_when_spawning_a_nonexistent_command() {
     let non_existent_cmd = "/path/to/absolutely/nonexistent/command_39291az";
     let config = PtyConfig {
         command_executable: non_existent_cmd,

--- a/core-term/src/io/waker.rs
+++ b/core-term/src/io/waker.rs
@@ -172,7 +172,7 @@ mod tests {
     }
 
     #[test]
-    fn wake_unblocks_armed_event_monitor() {
+    fn it_should_unblock_an_armed_event_monitor_when_woken() {
         let waker = Arc::new(FdWaker::new().expect("waker"));
         let monitor = EventMonitor::new().expect("monitor");
         monitor
@@ -204,7 +204,7 @@ mod tests {
     }
 
     #[test]
-    fn wake_while_disarmed_writes_no_byte_and_fails_next_arm() {
+    fn it_should_write_no_byte_when_disarmed_and_surface_the_missed_wake_on_next_arm() {
         let waker = FdWaker::new().expect("waker");
 
         waker.wake();
@@ -222,7 +222,7 @@ mod tests {
     }
 
     #[test]
-    fn wake_is_idempotent_when_pipe_fills() {
+    fn it_should_not_block_or_panic_when_woken_far_more_than_the_pipe_buffer_holds() {
         let waker = FdWaker::new().expect("waker");
         assert!(waker.arm());
         // Far more wakes than the pipe buffer holds; must not block or panic.

--- a/core-term/src/keys.rs
+++ b/core-term/src/keys.rs
@@ -42,7 +42,7 @@ mod tests {
     }
 
     #[test]
-    fn map_key_found() {
+    fn it_should_return_the_bound_action_when_key_and_modifiers_match() {
         let bindings = vec![
             Keybinding {
                 key: KeySymbol::Char('C'),
@@ -70,7 +70,7 @@ mod tests {
     }
 
     #[test]
-    fn map_key_not_found_symbol_mismatch() {
+    fn it_should_return_none_when_the_key_symbol_does_not_match_any_binding() {
         let bindings = vec![Keybinding {
             key: KeySymbol::Char('C'),
             mods: Modifiers::CONTROL | Modifiers::SHIFT,
@@ -87,7 +87,7 @@ mod tests {
     }
 
     #[test]
-    fn map_key_not_found_modifier_mismatch() {
+    fn it_should_return_none_when_the_modifiers_do_not_match_any_binding() {
         let bindings = vec![Keybinding {
             key: KeySymbol::Char('C'),
             mods: Modifiers::CONTROL | Modifiers::SHIFT,
@@ -100,7 +100,7 @@ mod tests {
     }
 
     #[test]
-    fn map_key_not_found_empty_bindings() {
+    fn it_should_return_none_when_no_keybindings_are_configured() {
         let config = config_with_bindings(vec![]);
         let result = map_key_event_to_action(
             KeySymbol::Char('C'),
@@ -111,7 +111,7 @@ mod tests {
     }
 
     #[test]
-    fn map_key_multiple_bindings_first_match() {
+    fn it_should_keep_the_first_bindings_action_when_duplicate_bindings_exist() {
         let bindings = vec![
             Keybinding {
                 key: KeySymbol::Char('A'),

--- a/core-term/src/term/emulator/input_handler.rs
+++ b/core-term/src/term/emulator/input_handler.rs
@@ -206,7 +206,7 @@ mod tests {
     }
 
     #[test]
-    fn paste_text_action_bracketed_on() {
+    fn it_should_wrap_pasted_text_in_bracketed_paste_escapes_when_bracketed_paste_is_enabled() {
         let mut emu = create_test_emu_for_input();
         // Enable bracketed paste mode via the public message-passing surface (CSI ? 2004 h).
         use crate::ansi::commands::CsiCommand;
@@ -225,7 +225,7 @@ mod tests {
     }
 
     #[test]
-    fn paste_text_action_bracketed_off() {
+    fn it_should_write_pasted_text_directly_to_the_screen_when_bracketed_paste_is_disabled() {
         let mut emu = create_test_emu_for_input();
         assert!(!emu.dec_modes.bracketed_paste_mode);
 
@@ -294,7 +294,7 @@ mod tests {
     }
 
     #[test]
-    fn control_event_resize_returns_resize_pty_action() {
+    fn it_should_return_resize_pty_action_with_cell_dimensions_on_resize_control_event() {
         let mut emu = create_test_emu_for_input();
 
         // Default cell size is 10x16 (from config)
@@ -326,7 +326,7 @@ mod tests {
     }
 
     #[test]
-    fn control_event_resize_minimum_dimensions() {
+    fn it_should_clamp_resize_dimensions_to_the_minimum_grid_size() {
         let mut emu = create_test_emu_for_input();
 
         // Very small resize (should clamp to MIN_GRID_DIMENSION)
@@ -358,7 +358,7 @@ mod tests {
     }
 
     #[test]
-    fn control_event_request_snapshot_returns_none() {
+    fn it_should_return_none_for_request_snapshot_control_event() {
         let mut emu = create_test_emu_for_input();
 
         let result = emu.interpret_input(EmulatorInput::Control(ControlEvent::RequestSnapshot));
@@ -367,7 +367,7 @@ mod tests {
     }
 
     #[test]
-    fn control_event_pty_data_ready_returns_none() {
+    fn it_should_return_none_for_pty_data_ready_control_event() {
         let mut emu = create_test_emu_for_input();
 
         let result = emu.interpret_input(EmulatorInput::Control(ControlEvent::PtyDataReady));

--- a/core-term/src/term/emulator/key_translator.rs
+++ b/core-term/src/term/emulator/key_translator.rs
@@ -301,7 +301,7 @@ mod tests {
     }
 
     #[test]
-    fn arrow_keys_normal_mode() {
+    fn it_should_translate_arrow_keys_to_csi_sequences_in_normal_cursor_key_mode() {
         let modes = DecPrivateModes {
             cursor_keys_app_mode: false,
             ..Default::default()
@@ -325,7 +325,7 @@ mod tests {
     }
 
     #[test]
-    fn arrow_keys_app_mode() {
+    fn it_should_translate_arrow_keys_to_ss3_sequences_in_application_cursor_key_mode() {
         let modes = DecPrivateModes {
             cursor_keys_app_mode: true,
             ..Default::default()
@@ -358,7 +358,7 @@ mod tests {
     }
 
     #[test]
-    fn macos_private_use_area_characters_ignored_for_arrow_keys() {
+    fn it_should_ignore_macos_private_use_area_characters_and_translate_arrow_keys_by_symbol() {
         // macOS sends U+F700-F703 for arrow keys in the `characters` field
         // These should be ignored and the KeySymbol should be used instead
         let modes = DecPrivateModes::default();

--- a/core-term/src/term/emulator/mouse.rs
+++ b/core-term/src/term/emulator/mouse.rs
@@ -200,7 +200,7 @@ mod tests {
     }
 
     #[test]
-    fn no_mode_returns_none() {
+    fn it_should_return_none_when_no_mouse_reporting_mode_is_enabled() {
         let modes = DecPrivateModes::default();
         let result = encode_mouse_event(
             &modes,
@@ -215,7 +215,7 @@ mod tests {
     }
 
     #[test]
-    fn sgr_left_press() {
+    fn it_should_encode_a_left_button_press_in_sgr_mode() {
         let modes = modes_with_sgr();
         let result = encode_mouse_event(
             &modes,
@@ -232,7 +232,7 @@ mod tests {
     }
 
     #[test]
-    fn sgr_left_release() {
+    fn it_should_encode_a_left_button_release_using_lowercase_m_in_sgr_mode() {
         let modes = modes_with_sgr();
         let result = encode_mouse_event(
             &modes,
@@ -249,7 +249,7 @@ mod tests {
     }
 
     #[test]
-    fn sgr_right_press() {
+    fn it_should_encode_a_right_button_press_in_sgr_mode() {
         let modes = modes_with_sgr();
         let result = encode_mouse_event(
             &modes,
@@ -265,7 +265,7 @@ mod tests {
     }
 
     #[test]
-    fn sgr_right_release() {
+    fn it_should_preserve_button_identity_when_encoding_a_right_button_release_in_sgr_mode() {
         let modes = modes_with_sgr();
         let result = encode_mouse_event(
             &modes,
@@ -282,7 +282,7 @@ mod tests {
     }
 
     #[test]
-    fn sgr_middle_press() {
+    fn it_should_encode_a_middle_button_press_in_sgr_mode() {
         let modes = modes_with_sgr();
         let result = encode_mouse_event(
             &modes,
@@ -298,7 +298,7 @@ mod tests {
     }
 
     #[test]
-    fn sgr_motion_left() {
+    fn it_should_add_32_to_the_button_code_when_encoding_left_button_motion_in_sgr_mode() {
         let modes = modes_with_any_event_sgr();
         let result = encode_mouse_event(
             &modes,
@@ -315,7 +315,7 @@ mod tests {
     }
 
     #[test]
-    fn sgr_motion_right() {
+    fn it_should_add_32_to_the_button_code_when_encoding_right_button_motion_in_sgr_mode() {
         let modes = modes_with_button_event_sgr();
         let result = encode_mouse_event(
             &modes,
@@ -332,7 +332,7 @@ mod tests {
     }
 
     #[test]
-    fn sgr_scroll_up() {
+    fn it_should_encode_scroll_up_as_button_code_64_in_sgr_mode() {
         let modes = modes_with_sgr();
         let result = encode_mouse_event(
             &modes,
@@ -348,7 +348,7 @@ mod tests {
     }
 
     #[test]
-    fn sgr_scroll_down() {
+    fn it_should_encode_scroll_down_as_button_code_65_in_sgr_mode() {
         let modes = modes_with_sgr();
         let result = encode_mouse_event(
             &modes,
@@ -364,7 +364,7 @@ mod tests {
     }
 
     #[test]
-    fn legacy_left_press() {
+    fn it_should_encode_a_left_button_press_in_legacy_mode() {
         let modes = modes_with_vt200();
         let result = encode_mouse_event(
             &modes,
@@ -381,7 +381,7 @@ mod tests {
     }
 
     #[test]
-    fn legacy_left_release_uses_code_3() {
+    fn it_should_encode_a_left_button_release_using_button_code_3_in_legacy_mode() {
         let modes = modes_with_vt200();
         let result = encode_mouse_event(
             &modes,
@@ -398,7 +398,7 @@ mod tests {
     }
 
     #[test]
-    fn legacy_right_release_uses_code_3() {
+    fn it_should_encode_a_right_button_release_using_button_code_3_in_legacy_mode() {
         let modes = modes_with_vt200();
         let result = encode_mouse_event(
             &modes,
@@ -415,7 +415,7 @@ mod tests {
     }
 
     #[test]
-    fn legacy_coords_overflow_returns_none() {
+    fn it_should_return_none_when_legacy_mode_coordinates_exceed_the_222_cell_limit() {
         let modes = modes_with_vt200();
         let result = encode_mouse_event(
             &modes,
@@ -500,7 +500,7 @@ mod tests {
     }
 
     #[test]
-    fn sgr_large_coordinates() {
+    fn it_should_encode_coordinates_beyond_the_legacy_mode_limit_in_sgr_mode() {
         let modes = modes_with_sgr();
         // SGR has no coordinate limit
         let result = encode_mouse_event(

--- a/core-term/src/term/layout.rs
+++ b/core-term/src/term/layout.rs
@@ -129,7 +129,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn pixels_to_cells_basic() {
+    fn it_should_convert_pixel_coordinates_to_cell_coordinates_with_no_padding() {
         let layout = Layout {
             cols: 80,
             rows: 24,
@@ -154,7 +154,7 @@ mod tests {
     }
 
     #[test]
-    fn pixels_to_cells_with_padding() {
+    fn it_should_treat_coordinates_inside_padding_on_either_axis_as_a_miss() {
         let layout = Layout {
             cols: 80,
             rows: 24,
@@ -164,9 +164,15 @@ mod tests {
             padding_y: 10,
         };
 
-        // Click in padding
+        // Click in padding on both axes
         assert_eq!(layout.pixels_to_cells(0, 0), None);
         assert_eq!(layout.pixels_to_cells(4, 9), None);
+
+        // Click inside x-padding only (y is past its padding boundary)
+        assert_eq!(layout.pixels_to_cells(4, 10), None);
+
+        // Click inside y-padding only (x is past its padding boundary)
+        assert_eq!(layout.pixels_to_cells(5, 9), None);
 
         // Top-left cell (accounting for padding)
         assert_eq!(layout.pixels_to_cells(5, 10), Some((0, 0)));
@@ -176,7 +182,7 @@ mod tests {
     }
 
     #[test]
-    fn pixels_to_cells_out_of_bounds() {
+    fn it_should_return_none_when_pixel_coordinates_fall_outside_the_grid() {
         let layout = Layout {
             cols: 80,
             rows: 24,

--- a/core-term/src/term/screen.rs
+++ b/core-term/src/term/screen.rs
@@ -1208,7 +1208,7 @@ mod tests {
     }
 
     #[test]
-    fn selection_default_state() {
+    fn it_should_default_to_no_selection() {
         let screen = create_test_screen(10, 5);
         assert_eq!(screen.selection, Selection::default());
     }
@@ -1245,7 +1245,7 @@ mod tests {
     }
 
     #[test]
-    fn update_selection_marks_old_and_new_lines_dirty() {
+    fn it_should_mark_both_old_and_new_lines_dirty_when_selection_updates() {
         let mut screen = create_test_screen(10, 5);
         screen.start_selection(Point { x: 1, y: 1 }, SelectionMode::Cell); // Replaced Normal with Cell
         screen.update_selection(Point { x: 3, y: 1 });
@@ -1256,7 +1256,7 @@ mod tests {
     }
 
     #[test]
-    fn update_selection_when_not_active() {
+    fn it_should_leave_selection_state_unchanged_when_updated_while_inactive() {
         let mut screen = create_test_screen(10, 5);
         screen.start_selection(Point { x: 1, y: 1 }, SelectionMode::Cell); // Replaced Normal with Cell
         screen.selection.is_active = false;
@@ -1286,13 +1286,13 @@ mod tests {
     }
 
     #[test]
-    fn is_selected_normal_no_selection() {
+    fn it_should_report_no_point_selected_when_there_is_no_selection() {
         let screen = create_test_screen(10, 5);
         assert!(!screen.is_selected(Point { x: 1, y: 1 }));
     }
 
     #[test]
-    fn is_selected_normal_single_line() {
+    fn it_should_report_points_within_a_single_line_cell_selection_as_selected() {
         let mut screen = create_test_screen(10, 5);
         screen.start_selection(Point { x: 2, y: 1 }, SelectionMode::Cell); // Replaced Normal with Cell
         screen.update_selection(Point { x: 5, y: 1 });
@@ -1303,7 +1303,7 @@ mod tests {
     }
 
     #[test]
-    fn is_selected_normal_multi_line() {
+    fn it_should_report_points_within_a_multi_line_cell_selection_as_selected() {
         let mut screen = create_test_screen(10, 5);
         screen.start_selection(Point { x: 3, y: 1 }, SelectionMode::Cell); // Replaced Normal with Cell
         screen.update_selection(Point { x: 2, y: 3 });
@@ -1315,7 +1315,7 @@ mod tests {
     }
 
     #[test]
-    fn is_selected_normal_multi_line_selection_ends_at_width_minus_1() {
+    fn it_should_include_full_width_rows_in_a_multi_line_selection_spanning_whole_lines() {
         let mut screen = create_test_screen(10, 5);
         screen.start_selection(Point { x: 8, y: 0 }, SelectionMode::Cell); // Replaced Normal with Cell
         screen.update_selection(Point { x: 2, y: 2 });
@@ -1327,7 +1327,7 @@ mod tests {
     }
 
     #[test]
-    fn is_selected_normal_reverse_selection_points() {
+    fn it_should_report_points_selected_when_cell_selection_start_is_after_end() {
         let mut screen = create_test_screen(10, 5);
         screen.start_selection(Point { x: 5, y: 2 }, SelectionMode::Cell); // Replaced Normal with Cell
         screen.update_selection(Point { x: 1, y: 1 });
@@ -1340,7 +1340,7 @@ mod tests {
     }
 
     #[test]
-    fn is_selected_point_equals_start_or_end() {
+    fn it_should_report_selection_endpoints_themselves_as_selected() {
         let mut screen = create_test_screen(10, 5);
         screen.start_selection(Point { x: 2, y: 2 }, SelectionMode::Cell); // Replaced Normal with Cell
         assert!(screen.is_selected(Point { x: 2, y: 2 }));
@@ -1350,7 +1350,7 @@ mod tests {
     }
 
     #[test]
-    fn is_selected_out_of_bounds_point() {
+    fn it_should_report_out_of_bounds_points_as_not_selected() {
         let mut screen = create_test_screen(10, 5);
         screen.start_selection(Point { x: 0, y: 0 }, SelectionMode::Cell); // Replaced Normal with Cell
         screen.update_selection(Point {
@@ -1368,13 +1368,13 @@ mod tests {
     }
 
     #[test]
-    fn is_selected_block_no_selection() {
+    fn it_should_report_no_point_selected_when_there_is_no_block_selection() {
         let screen = create_test_screen(10, 5);
         assert!(!screen.is_selected(Point { x: 1, y: 1 }));
     }
 
     #[test]
-    fn is_selected_block_simple() {
+    fn it_should_report_points_within_a_block_selection_rectangle_as_selected() {
         let mut screen = create_test_screen(10, 5);
         screen.start_selection(Point { x: 1, y: 1 }, SelectionMode::Block);
         screen.update_selection(Point { x: 3, y: 3 });
@@ -1383,7 +1383,7 @@ mod tests {
     }
 
     #[test]
-    fn is_selected_block_reverse_points() {
+    fn it_should_report_points_selected_when_block_selection_start_is_after_end() {
         let mut screen = create_test_screen(10, 5);
         screen.start_selection(Point { x: 3, y: 3 }, SelectionMode::Block);
         screen.update_selection(Point { x: 1, y: 1 });
@@ -1391,13 +1391,13 @@ mod tests {
     }
 
     #[test]
-    fn get_selected_text_normal_no_selection() {
+    fn it_should_return_none_from_get_selected_text_when_there_is_no_selection() {
         let screen = create_test_screen(10, 5);
         assert_eq!(screen.get_selected_text(), None);
     }
 
     #[test]
-    fn get_selected_text_normal_single_char() {
+    fn it_should_return_a_single_character_for_a_single_point_cell_selection() {
         let mut screen = create_test_screen(5, 3);
         fill_screen_with_pattern(&mut screen);
         screen.start_selection(Point { x: 1, y: 1 }, SelectionMode::Cell); // Replaced Normal with Cell
@@ -1405,7 +1405,7 @@ mod tests {
     }
 
     #[test]
-    fn get_selected_text_normal_single_line_partial() {
+    fn it_should_return_partial_line_text_for_a_cell_selection_within_one_line() {
         let mut screen = create_test_screen(5, 3);
         fill_screen_with_pattern(&mut screen);
         screen.start_selection(Point { x: 1, y: 0 }, SelectionMode::Cell); // Replaced Normal with Cell
@@ -1414,7 +1414,7 @@ mod tests {
     }
 
     #[test]
-    fn get_selected_text_normal_single_line_full() {
+    fn it_should_return_the_whole_line_text_for_a_cell_selection_spanning_the_full_width() {
         let mut screen = create_test_screen(5, 3);
         fill_screen_with_pattern(&mut screen);
         screen.start_selection(Point { x: 0, y: 0 }, SelectionMode::Cell); // Replaced Normal with Cell
@@ -1426,7 +1426,7 @@ mod tests {
     }
 
     #[test]
-    fn get_selected_text_normal_multi_line() {
+    fn it_should_join_multiple_selected_lines_with_newlines_in_cell_mode() {
         let mut screen = create_test_screen(3, 3);
         fill_screen_with_pattern(&mut screen);
         screen.start_selection(Point { x: 1, y: 0 }, SelectionMode::Cell); // Replaced Normal with Cell
@@ -1435,7 +1435,7 @@ mod tests {
     }
 
     #[test]
-    fn get_selected_text_normal_multi_line_reversed_points() {
+    fn it_should_join_selected_lines_with_newlines_when_cell_selection_start_is_after_end() {
         let mut screen = create_test_screen(3, 3);
         fill_screen_with_pattern(&mut screen);
         screen.start_selection(Point { x: 1, y: 2 }, SelectionMode::Cell); // Replaced Normal with Cell
@@ -1444,7 +1444,7 @@ mod tests {
     }
 
     #[test]
-    fn get_selected_text_normal_trailing_spaces_behavior() {
+    fn it_should_include_trailing_spaces_only_when_the_selection_spans_them() {
         let mut screen = create_test_screen(5, 2);
         {
             let row0 = Arc::make_mut(&mut screen.grid[0]);
@@ -1513,14 +1513,14 @@ mod tests {
     }
 
     #[test]
-    fn get_selected_text_block_no_selection() {
+    fn it_should_return_none_from_get_selected_text_when_there_is_no_block_selection() {
         let mut screen = create_test_screen(10, 5);
         screen.selection.mode = SelectionMode::Block;
         assert_eq!(screen.get_selected_text(), None);
     }
 
     #[test]
-    fn get_selected_text_block_simple() {
+    fn it_should_return_rectangular_text_for_a_block_selection() {
         let mut screen = create_test_screen(5, 4);
         fill_screen_with_pattern(&mut screen);
         screen.start_selection(Point { x: 1, y: 0 }, SelectionMode::Block);
@@ -1532,7 +1532,7 @@ mod tests {
     }
 
     #[test]
-    fn get_selected_text_block_reversed_points() {
+    fn it_should_return_the_same_rectangular_text_when_block_selection_start_is_after_end() {
         let mut screen = create_test_screen(5, 4);
         fill_screen_with_pattern(&mut screen);
         screen.start_selection(Point { x: 3, y: 2 }, SelectionMode::Block);
@@ -1544,7 +1544,7 @@ mod tests {
     }
 
     #[test]
-    fn get_selected_text_block_one_column() {
+    fn it_should_return_a_single_column_of_text_for_a_one_column_block_selection() {
         let mut screen = create_test_screen(5, 4);
         fill_screen_with_pattern(&mut screen);
         screen.start_selection(Point { x: 1, y: 0 }, SelectionMode::Block);
@@ -1553,7 +1553,7 @@ mod tests {
     }
 
     #[test]
-    fn get_selected_text_block_one_row() {
+    fn it_should_return_a_single_row_of_text_for_a_one_row_block_selection() {
         let mut screen = create_test_screen(5, 4);
         fill_screen_with_pattern(&mut screen);
         screen.start_selection(Point { x: 1, y: 1 }, SelectionMode::Block);
@@ -1562,7 +1562,7 @@ mod tests {
     }
 
     #[test]
-    fn get_selected_text_block_beyond_line_length() {
+    fn it_should_include_blank_columns_when_block_selection_extends_beyond_line_content() {
         let mut screen = create_test_screen(3, 2);
         {
             let row0 = Arc::make_mut(&mut screen.grid[0]);
@@ -1609,7 +1609,7 @@ mod tests {
     }
 
     #[test]
-    fn selection_cleared_on_resize() {
+    fn it_should_clear_selection_when_screen_is_resized() {
         let mut screen = create_test_screen(10, 5);
         screen.start_selection(Point { x: 1, y: 1 }, SelectionMode::Cell); // Replaced Normal with Cell
         screen.update_selection(Point { x: 5, y: 2 });
@@ -1619,7 +1619,7 @@ mod tests {
     }
 
     #[test]
-    fn scroll_up_populates_scrollback() {
+    fn it_should_push_scrolled_off_line_into_scrollback_on_scroll_up() {
         let mut screen = create_test_screen_with_scrollback(10, 5, 10);
         fill_screen_with_pattern(&mut screen);
         // scroll up 1 line. Top line should go to scrollback.
@@ -1662,7 +1662,7 @@ mod tests {
     }
 
     #[test]
-    fn block_selection_wide_char_full() {
+    fn it_should_include_full_wide_character_when_block_selection_covers_both_its_cells() {
         let mut screen = create_screen_with_wide_char();
         // Select "b" "你" "c" (columns 1 to 4)
         screen.start_selection(Point { x: 1, y: 0 }, SelectionMode::Block);
@@ -1673,7 +1673,7 @@ mod tests {
     }
 
     #[test]
-    fn block_selection_wide_char_partial_left() {
+    fn it_should_include_wide_character_when_block_selection_covers_only_its_primary_cell() {
         let mut screen = create_screen_with_wide_char();
         // Select "b" "你" (primary only) (columns 1 to 2)
         screen.start_selection(Point { x: 1, y: 0 }, SelectionMode::Block);
@@ -1685,7 +1685,7 @@ mod tests {
     }
 
     #[test]
-    fn block_selection_wide_char_partial_right() {
+    fn it_should_omit_wide_spacer_cell_from_selected_text_when_selection_starts_at_the_spacer() {
         let mut screen = create_screen_with_wide_char();
         // Select spacer of "你" and "c" (columns 3 to 4)
         screen.start_selection(Point { x: 3, y: 0 }, SelectionMode::Block);

--- a/core-term/src/term/tests.rs
+++ b/core-term/src/term/tests.rs
@@ -256,7 +256,7 @@ fn it_should_move_to_column_zero_of_the_next_line_when_lnm_is_set_and_lf_is_rece
 }
 
 #[test]
-fn carriage_return_input() {
+fn it_should_move_cursor_to_column_zero_and_overwrite_on_carriage_return() {
     let mut term = create_test_emulator(10, 1);
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('A')));
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('B')));
@@ -269,7 +269,7 @@ fn carriage_return_input() {
 }
 
 #[test]
-fn csi_cursor_forward_cuf() {
+fn it_should_move_cursor_forward_by_n_columns_on_csi_cuf() {
     let mut term = create_test_emulator(10, 1); // Cursor at (0,0)
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Csi(
         CsiCommand::CursorForward(1),
@@ -285,7 +285,7 @@ fn csi_cursor_forward_cuf() {
 }
 
 #[test]
-fn csi_ed_clear_below_csi_j() {
+fn it_should_clear_from_cursor_to_end_of_screen_on_csi_ed_erase_below() {
     let mut term = create_test_emulator(3, 2);
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('A')));
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('B')));
@@ -313,7 +313,7 @@ fn csi_ed_clear_below_csi_j() {
 }
 
 #[test]
-fn csi_sgr_fg_color() {
+fn it_should_apply_and_reset_sgr_foreground_color() {
     let mut term = create_test_emulator(5, 1);
     let red_attr = vec![Attribute::Foreground(Color::Named(NamedColor::Red))];
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Csi(
@@ -391,7 +391,7 @@ fn fill_emulator_screen(emu: &mut TerminalEmulator, text_lines: Vec<String>) {
 
 // --- Basic Selection Flow Tests ---
 #[test]
-fn mouse_press_starts_selection() {
+fn it_should_start_a_selection_on_mouse_press() {
     let mut emu = create_test_emulator(10, 5);
     let action = send_mouse_input(&mut emu, start_selection_at(1, 1), MouseButton::Left);
 
@@ -423,7 +423,7 @@ fn mouse_press_starts_selection() {
 }
 
 #[test]
-fn mouse_drag_updates_selection() {
+fn it_should_update_selection_end_point_on_mouse_drag() {
     let mut emu = create_test_emulator(10, 5);
     send_mouse_input(&mut emu, start_selection_at(1, 1), MouseButton::Left);
     let action = send_mouse_input(&mut emu, extend_selection_to(5, 2), MouseButton::Left);
@@ -451,7 +451,7 @@ fn mouse_drag_updates_selection() {
 }
 
 #[test]
-fn mouse_release_ends_selection_activity() {
+fn it_should_deactivate_selection_on_mouse_release() {
     let mut emu = create_test_emulator(10, 5);
     send_mouse_input(&mut emu, start_selection_at(1, 1), MouseButton::Left);
     send_mouse_input(&mut emu, extend_selection_to(5, 2), MouseButton::Left);
@@ -491,14 +491,14 @@ fn mouse_release_ends_selection_activity() {
 
 // --- Copy Action Tests ---
 #[test]
-fn initiate_copy_no_selection() {
+fn it_should_return_none_when_initiating_copy_with_no_selection() {
     let mut emu = create_test_emulator(10, 5);
     let action = emu.interpret_input(EmulatorInput::User(UserInputAction::InitiateCopy));
     assert_eq!(action, None, "Should return None if no selection exists.");
 }
 
 #[test]
-fn initiate_copy_with_selection() {
+fn it_should_copy_selected_text_to_clipboard_on_initiate_copy() {
     let mut emu = create_test_emulator(10, 2);
     fill_emulator_screen(&mut emu, vec!["Hello".to_string(), "World".to_string()]);
 
@@ -519,7 +519,7 @@ fn initiate_copy_with_selection() {
 }
 
 #[test]
-fn initiate_copy_block_selection() {
+fn it_should_copy_block_selected_text_to_clipboard_on_initiate_copy() {
     let mut emu = create_test_emulator(3, 3);
     fill_emulator_screen(
         &mut emu,
@@ -546,7 +546,7 @@ fn initiate_copy_block_selection() {
 
 // --- Selection Clearing Tests ---
 #[test]
-fn new_mouse_press_clears_old_selection() {
+fn it_should_replace_old_selection_when_a_new_mouse_press_starts() {
     let mut emu = create_test_emulator(10, 5);
 
     send_mouse_input(&mut emu, start_selection_at(0, 0), MouseButton::Left);
@@ -594,7 +594,7 @@ fn new_mouse_press_clears_old_selection() {
 
 // --- Selection Interaction with Scrolling Test ---
 #[test]
-fn selection_coordinates_adjust_on_scroll() {
+fn it_should_keep_selection_anchored_to_screen_row_rather_than_content_when_screen_scrolls() {
     let mut emu = create_test_emulator(10, 3);
     fill_emulator_screen(
         &mut emu,
@@ -652,7 +652,7 @@ fn selection_coordinates_adjust_on_scroll() {
 
 // --- Selection with Alternate Screen Test ---
 #[test]
-fn selection_on_alt_screen_then_exit() {
+fn it_should_clear_selection_and_restore_primary_screen_when_exiting_alt_screen() {
     let mut emu = create_test_emulator(10, 3);
     fill_emulator_screen(
         &mut emu,
@@ -705,7 +705,7 @@ fn selection_on_alt_screen_then_exit() {
 // --- End of Selection with Alternate Screen Test ---
 
 #[test]
-fn resize_larger() {
+fn it_should_preserve_content_and_add_blank_rows_when_resized_larger() {
     let mut term = create_test_emulator(5, 2);
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('1')));
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('2')));
@@ -730,7 +730,7 @@ fn resize_larger() {
 }
 
 #[test]
-fn resize_smaller_content_truncation() {
+fn it_should_truncate_content_when_resized_smaller() {
     let mut term = create_test_emulator(5, 2);
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('H')));
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('e')));
@@ -747,7 +747,7 @@ fn resize_smaller_content_truncation() {
 }
 
 #[test]
-fn osc_set_window_title() {
+fn it_should_set_window_title_from_osc_sequence() {
     let mut term = create_test_emulator(10, 1);
 
     let action = term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Osc(
@@ -768,7 +768,7 @@ fn osc_set_window_title() {
 }
 
 #[test]
-fn key_event_printable_char() {
+fn it_should_write_printable_char_to_pty_on_key_input() {
     let mut term = create_test_emulator(5, 1);
     let key_input = UserInputAction::KeyInput {
         symbol: KeySymbol::Char('x'),
@@ -787,7 +787,7 @@ fn key_event_printable_char() {
 }
 
 #[test]
-fn key_event_arrow_up() {
+fn it_should_write_cursor_up_escape_sequence_on_arrow_up_key() {
     let mut term = create_test_emulator(5, 1);
     let key_input = UserInputAction::KeyInput {
         symbol: KeySymbol::Up,
@@ -863,7 +863,7 @@ fn it_should_preserve_selection_range_and_mode_in_a_constructed_snapshot() {
 }
 
 #[test]
-fn mode_show_cursor_dectcem() {
+fn it_should_hide_and_show_cursor_on_dectcem_reset_and_set() {
     let mut term = create_test_emulator(5, 1);
 
     let snap_default = term.get_render_snapshot().expect("Snapshot was None");
@@ -900,7 +900,7 @@ fn mode_show_cursor_dectcem() {
 // --- PS1 Multi-line Prompt Tests ---
 
 #[test]
-fn ps1_multiline_prompt_at_bottom_causes_scroll() {
+fn it_should_scroll_when_multiline_prompt_reaches_bottom_of_screen() {
     let mut term = create_test_emulator(5, 3);
 
     for _ in 0..5 {
@@ -930,7 +930,7 @@ fn ps1_multiline_prompt_at_bottom_causes_scroll() {
 }
 
 #[test]
-fn ps1_multiline_prompt_ends_on_last_line_no_scroll_by_prompt() {
+fn it_should_not_scroll_when_multiline_prompt_ends_exactly_on_last_line() {
     let mut term = create_test_emulator(5, 3);
 
     for _ in 0..5 {
@@ -953,7 +953,7 @@ fn ps1_multiline_prompt_ends_on_last_line_no_scroll_by_prompt() {
 }
 
 #[test]
-fn ps1_multiline_prompt_last_line_fills_screen_then_input() {
+fn it_should_wrap_and_scroll_when_input_follows_a_prompt_that_fills_the_last_line() {
     let mut term = create_test_emulator(3, 2);
 
     for _ in 0..3 {
@@ -983,7 +983,7 @@ fn ps1_multiline_prompt_last_line_fills_screen_then_input() {
 }
 
 #[test]
-fn ps1_prompt_causes_multiple_scrolls() {
+fn it_should_scroll_multiple_times_for_a_multiline_prompt_taller_than_the_screen() {
     let mut term = create_test_emulator(3, 2);
 
     for _ in 0..3 {
@@ -1012,7 +1012,7 @@ fn ps1_prompt_causes_multiple_scrolls() {
 }
 
 #[test]
-fn ps1_prompt_with_internal_wrapping_and_scrolling() {
+fn it_should_wrap_within_a_prompt_line_and_scroll_on_subsequent_newline() {
     let mut term = create_test_emulator(3, 2);
     for _ in 0..3 {
         term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('A')));
@@ -1047,7 +1047,7 @@ fn ps1_prompt_with_internal_wrapping_and_scrolling() {
 }
 
 #[test]
-fn ps1_multiline_exact_fill_then_scroll_on_final_lf() {
+fn it_should_scroll_on_final_linefeed_when_prompt_exactly_fills_the_screen() {
     let mut term = create_test_emulator(3, 2);
 
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('P')));
@@ -1067,7 +1067,7 @@ fn ps1_multiline_exact_fill_then_scroll_on_final_lf() {
 }
 
 #[test]
-fn ps1_multiline_with_sgr_at_bottom_scrolls() {
+fn it_should_preserve_sgr_colors_across_scroll_in_a_multiline_prompt() {
     let mut term = create_test_emulator(5, 2);
 
     for _ in 0..5 {
@@ -1151,7 +1151,7 @@ fn ps1_multiline_with_sgr_at_bottom_scrolls() {
 }
 
 #[test]
-fn lf_at_bottom_of_partial_scrolling_region_no_origin_mode() {
+fn it_should_scroll_only_the_partial_scrolling_region_on_lf_at_its_bottom_without_origin_mode() {
     let cols = 10;
     let rows = 5;
     let mut emu = create_test_emulator(cols, rows);
@@ -1235,7 +1235,7 @@ fn lf_at_bottom_of_partial_scrolling_region_no_origin_mode() {
     );
 }
 #[test]
-fn primary_device_attributes_response() {
+fn it_should_respond_to_primary_device_attributes_query_with_da1_response() {
     let mut term = create_test_emulator(80, 24);
 
     let input_da = EmulatorInput::Ansi(AnsiCommand::Csi(CsiCommand::PrimaryDeviceAttributes));
@@ -1277,7 +1277,7 @@ mod selection_logic_tests {
     }
 
     #[test]
-    fn extend_selection_active_and_inactive() {
+    fn it_should_ignore_extend_selection_when_none_is_active_and_extend_it_once_started() {
         let mut emu = create_test_emulator(10, 5);
         let start_point = Point { x: 2, y: 1 };
         let extend_point = Point { x: 5, y: 2 };
@@ -1303,7 +1303,7 @@ mod selection_logic_tests {
     }
 
     #[test]
-    fn apply_selection_clear_click_and_drag() {
+    fn it_should_clear_selection_on_click_but_retain_range_after_drag_on_apply_selection_clear() {
         let mut emu = create_test_emulator(10, 5);
         let point1 = Point { x: 2, y: 1 };
         let point2 = Point { x: 5, y: 1 };
@@ -1347,7 +1347,7 @@ mod selection_logic_tests {
     }
 
     #[test]
-    fn verify_clear_selection() {
+    fn it_should_clear_selection_range_when_clear_selection_is_called() {
         let mut emu = create_test_emulator(10, 5);
 
         // Create and deactivate a selection
@@ -1372,13 +1372,13 @@ mod get_selected_text_tests {
     use super::*;
 
     #[test]
-    fn get_selected_text_no_selection() {
+    fn it_should_return_none_for_get_selected_text_with_no_selection() {
         let emu = create_test_emulator(10, 5);
         assert_eq!(emu.get_selected_text(), None);
     }
 
     #[test]
-    fn get_selected_text_single_line() {
+    fn it_should_return_selected_text_for_a_single_line_selection() {
         let mut emu = create_test_emulator(10, 5);
         fill_emulator_screen(&mut emu, vec!["Hello World".to_string()]);
 
@@ -1395,7 +1395,7 @@ mod get_selected_text_tests {
     }
 
     #[test]
-    fn get_selected_text_single_line_trailing_spaces_in_selection() {
+    fn it_should_include_trailing_spaces_in_a_single_line_selection() {
         let mut emu = create_test_emulator(10, 1);
         fill_emulator_screen(&mut emu, vec!["Hi   ".to_string()]);
 
@@ -1411,7 +1411,7 @@ mod get_selected_text_tests {
     }
 
     #[test]
-    fn get_selected_text_multi_line() {
+    fn it_should_return_selected_text_spanning_multiple_lines_joined_by_newline() {
         let mut emu = create_test_emulator(10, 5);
         fill_emulator_screen(
             &mut emu,
@@ -1434,7 +1434,7 @@ mod get_selected_text_tests {
     }
 
     #[test]
-    fn get_selected_text_multi_line_full_lines() {
+    fn it_should_return_full_line_text_for_single_and_multi_line_selections() {
         let mut emu = create_test_emulator(10, 3);
         fill_emulator_screen(
             &mut emu,
@@ -1470,7 +1470,7 @@ mod get_selected_text_tests {
     }
 
     #[test]
-    fn get_selected_text_line_boundaries() {
+    fn it_should_return_selected_text_across_a_line_boundary() {
         let mut emu = create_test_emulator(10, 2);
         fill_emulator_screen(
             &mut emu,
@@ -1489,7 +1489,7 @@ mod get_selected_text_tests {
     }
 
     #[test]
-    fn get_selected_text_empty_cells_within_grid() {
+    fn it_should_preserve_empty_cells_as_spaces_within_selected_text() {
         let mut emu = create_test_emulator(5, 1);
         // Create sparse content: "A   E" by printing A, moving cursor to col 4, then printing E
         emu.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('A')));
@@ -1510,7 +1510,7 @@ mod get_selected_text_tests {
     }
 
     #[test]
-    fn get_selected_text_selection_beyond_line_length() {
+    fn it_should_pad_selected_text_with_spaces_when_selection_extends_beyond_line_content() {
         let mut emu = create_test_emulator(10, 1);
         fill_emulator_screen(&mut emu, vec!["Test".to_string()]);
 
@@ -1526,7 +1526,7 @@ mod get_selected_text_tests {
     }
 
     #[test]
-    fn get_selected_text_reversed_points() {
+    fn it_should_normalize_selection_order_when_end_point_precedes_start_point() {
         let mut emu = create_test_emulator(10, 5);
         fill_emulator_screen(&mut emu, vec!["Hello World".to_string()]);
 
@@ -1548,7 +1548,7 @@ mod paste_text_tests {
     use super::*;
 
     #[test]
-    fn paste_text_bracketed_off_simple() {
+    fn it_should_insert_pasted_text_at_cursor_when_bracketed_paste_is_off() {
         let mut emu = create_test_emulator(20, 1);
         // Bracketed paste mode is off by default - just verify behavior
 
@@ -1565,7 +1565,7 @@ mod paste_text_tests {
     }
 
     #[test]
-    fn paste_text_bracketed_off_with_newline() {
+    fn it_should_move_to_next_line_on_newline_in_pasted_text() {
         let mut emu = create_test_emulator(20, 2);
         // Bracketed paste mode is off by default - just verify behavior
 
@@ -1579,7 +1579,7 @@ mod paste_text_tests {
     }
 
     #[test]
-    fn paste_text_bracketed_off_causes_wrap() {
+    fn it_should_wrap_pasted_text_that_exceeds_line_width() {
         let mut emu = create_test_emulator(5, 2);
         // Bracketed paste mode is off by default - just verify wrapping behavior
 
@@ -1595,7 +1595,7 @@ mod paste_text_tests {
     }
 
     #[test]
-    fn paste_text_bracketed_on_logs_warning_processes_chars() {
+    fn it_should_process_pasted_chars_even_when_bracketed_paste_mode_is_on() {
         let mut emu = create_test_emulator(20, 1);
         // Enable bracketed paste mode
         emu.interpret_input(EmulatorInput::Ansi(AnsiCommand::Csi(
@@ -1615,7 +1615,7 @@ mod paste_text_tests {
     }
 
     #[test]
-    fn ansi_resize_sets_terminal_dimensions() {
+    fn it_should_resize_terminal_dimensions_on_window_manipulation_resize_request() {
         let mut emu = create_test_emulator(80, 24);
         assert_eq!(
             emu.get_render_snapshot()
@@ -1641,7 +1641,7 @@ mod paste_text_tests {
     }
 
     #[test]
-    fn ansi_resize_updates_snapshot_dimensions() {
+    fn it_should_reflect_resized_dimensions_in_the_next_snapshot() {
         let mut emu = create_test_emulator(80, 24);
 
         let resize_command = AnsiCommand::Csi(CsiCommand::WindowManipulation {
@@ -1660,7 +1660,7 @@ mod paste_text_tests {
     }
 
     #[test]
-    fn ansi_resize_with_zero_rows_ignored() {
+    fn it_should_ignore_window_manipulation_resize_with_zero_rows() {
         let mut emu = create_test_emulator(80, 24);
 
         let resize_command = AnsiCommand::Csi(CsiCommand::WindowManipulation {
@@ -1680,7 +1680,7 @@ mod paste_text_tests {
     }
 
     #[test]
-    fn ansi_resize_with_zero_cols_ignored() {
+    fn it_should_ignore_window_manipulation_resize_with_zero_cols() {
         let mut emu = create_test_emulator(80, 24);
 
         let resize_command = AnsiCommand::Csi(CsiCommand::WindowManipulation {
@@ -1700,7 +1700,7 @@ mod paste_text_tests {
     }
 
     #[test]
-    fn ansi_resize_with_missing_params_ignored() {
+    fn it_should_ignore_window_manipulation_resize_with_missing_rows_or_cols_parameter() {
         let mut emu = create_test_emulator(80, 24);
 
         let resize_command = AnsiCommand::Csi(CsiCommand::WindowManipulation {
@@ -1762,7 +1762,7 @@ mod paste_text_tests {
 /// clean, or the app's damage gate re-renders on every timer tick for as
 /// long as the user stays scrolled back.
 #[test]
-fn scrolled_back_idle_snapshot_is_clean() {
+fn it_should_produce_a_clean_snapshot_when_idle_at_an_unchanged_scrolled_back_view() {
     let mut term = create_test_emulator(4, 2);
     for ch in "a\r\nb\r\nc\r\nd\r\ne".chars() {
         match ch {
@@ -1795,7 +1795,7 @@ fn scrolled_back_idle_snapshot_is_clean() {
 /// scrollback-sourced line remains to carry the signal — every line's screen
 /// position changed, so the snapshot must be dirty.
 #[test]
-fn returning_to_live_screen_marks_dirty() {
+fn it_should_mark_snapshot_dirty_when_returning_to_the_live_screen_from_scrollback() {
     let mut term = create_test_emulator(4, 2);
     for _ in 0..4 {
         term.interpret_input(EmulatorInput::Ansi(AnsiCommand::C0Control(
@@ -1817,7 +1817,7 @@ fn returning_to_live_screen_marks_dirty() {
 /// (the offset anchors to the scrollback's END), so new output must dirty
 /// the scrolled-back view.
 #[test]
-fn scrollback_growth_under_held_offset_marks_dirty() {
+fn it_should_mark_snapshot_dirty_when_new_output_grows_scrollback_under_a_held_offset() {
     let mut term = create_test_emulator(4, 2);
     for _ in 0..4 {
         term.interpret_input(EmulatorInput::Ansi(AnsiCommand::C0Control(
@@ -1843,7 +1843,7 @@ fn scrollback_growth_under_held_offset_marks_dirty() {
 /// CUF/CUB/CUP and style changes move the cursor without touching a line,
 /// and a skipped frame would freeze the visible cursor at its old cell.
 #[test]
-fn cursor_only_movement_marks_its_rows_dirty() {
+fn it_should_dirty_the_snapshot_for_cursor_only_movement_and_settle_clean_at_rest() {
     let mut term = create_test_emulator(4, 2);
     let _ = term.get_render_snapshot().expect("snapshot");
     let clean = term.get_render_snapshot().expect("snapshot");
@@ -1886,7 +1886,7 @@ fn cursor_only_movement_marks_its_rows_dirty() {
 // outside it (with no other dirty reason) isolate `view_changed`'s own
 // contribution to the OR.
 #[test]
-fn scroll_region_push_dirties_rows_outside_the_region() {
+fn it_should_dirty_rows_outside_the_scrolling_region_when_a_scroll_changes_the_view() {
     let mut term = create_test_emulator(4, 6);
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Csi(
         CsiCommand::SetScrollingRegion { top: 1, bottom: 3 },

--- a/core-term/src/term/unicode.rs
+++ b/core-term/src/term/unicode.rs
@@ -77,14 +77,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn ascii_char_width() {
+    fn it_should_report_a_display_width_of_one_for_ascii_characters() {
         assert_eq!(get_char_display_width('A'), 1, "Width of 'A' should be 1");
         assert_eq!(get_char_display_width(' '), 1, "Width of space should be 1");
         assert_eq!(get_char_display_width('~'), 1, "Width of '~' should be 1");
     }
 
     #[test]
-    fn box_drawing_char_widths() {
+    fn it_should_report_a_display_width_of_one_for_box_drawing_characters() {
         assert_eq!(
             get_char_display_width('─'),
             1,
@@ -144,7 +144,7 @@ mod tests {
     }
 
     #[test]
-    fn cjk_wide_char_widths() {
+    fn it_should_report_a_display_width_of_two_for_cjk_characters() {
         assert_eq!(
             get_char_display_width('世'),
             2,
@@ -168,7 +168,7 @@ mod tests {
     }
 
     #[test]
-    fn control_char_widths() {
+    fn it_should_report_zero_display_width_for_control_characters() {
         assert_eq!(
             get_char_display_width('\u{0000}'),
             0,
@@ -208,7 +208,7 @@ mod tests {
     }
 
     #[test]
-    fn locale_initializer_called() {
+    fn it_should_initialize_the_locale_lazily_on_first_call() {
         // Ensure OnceLock mechanism is engaged
         let _ = get_char_display_width(' ');
         assert!(

--- a/core-term/src/terminal_app.rs
+++ b/core-term/src/terminal_app.rs
@@ -931,7 +931,7 @@ mod tests {
     }
 
     #[test]
-    fn handle_control_resize() {
+    fn it_should_resize_emulator_and_send_pty_resize_on_control_resize_event() {
         let (mut app, mut writer_rx, _, _scheduler) = match create_test_app() {
             Some(v) => v,
             None => return,
@@ -1013,7 +1013,7 @@ mod tests {
     /// injects the exact KeyDown the X11 mapper produces for Ctrl+C and
     /// asserts the child dies (i.e. 0x03 reached the PTY line discipline).
     #[test]
-    fn ctrl_c_interrupts_yes_flood() {
+    fn it_should_interrupt_a_flooding_child_process_when_ctrl_c_is_pressed_during_frame_pressure() {
         use crate::io::event_monitor_actor::PtyTroupe;
         use crate::io::pty::{NixPty, PtyChannel, PtyConfig};
         use std::time::{Duration, Instant};
@@ -1155,7 +1155,7 @@ mod tests {
     }
 
     #[test]
-    fn handle_management_keydown() {
+    fn it_should_write_key_input_to_pty_on_management_keydown() {
         let (mut app, mut writer_rx, _, _scheduler) = match create_test_app() {
             Some(v) => v,
             None => return,
@@ -1235,7 +1235,7 @@ mod tests {
     }
 
     #[test]
-    fn scene_paints_default_background_and_recompiles_on_resize() {
+    fn it_should_render_default_background_and_recompile_kernel_after_resize() {
         // The app compiles its kernel for the PLATFORM's pixel format, so
         // the frame must be that format too — a hardcoded one was correct
         // only while rendering converted per pixel.


### PR DESCRIPTION
## Summary

Continuation of the test-quality pass started in #997, which was scoped to `cursor.rs`, `key_translator.rs`, and `mouse.rs`. This PR finishes the naming sweep for the rest of `core-term` and runs mutation testing over the ANSI parsing layer (the largest remaining block of self-contained protocol logic).

**Naming**: every `#[test]` in `core-term` now starts with `it_should_` and reads as a sentence when you put "it should" in front of it, per the style guide ("reading the name should tell you what's broken"). Renamed ~230 tests across:
- `keys.rs`, `term/layout.rs`, `term/unicode.rs`, `term/emulator/{mouse,key_translator,input_handler}.rs`
- `ansi/tests.rs` (93) and `ansi/pict_sgr_tests.rs` (3) — read each test body before renaming, not just prefixing the old name (e.g. `sgr_underline_color_set_is_58`, which actually covers both indexed *and* RGB underline-color parsing, became `it_should_parse_indexed_and_rgb_underline_color_for_sgr_code_58`)
- `term/tests.rs` (54), `term/screen.rs` (30), `terminal_app.rs` (4), `io/pty_tests.rs` (7), `io/waker.rs` (3), `io/event_monitor_actor/mod.rs` (4)

All renames are pure `fn`-identifier changes — no test bodies, assertions, or behavior touched. `grep -rn "#\[test\]" -A1 | grep -viE it_should` now returns nothing in `core-term/src`.

**Public-interface check**: spot-checked the newly-touched files; all tests still go through public constructors/methods (`TerminalEmulator::interpret_input`, `AnsiProcessor::process_bytes`, etc.) or are ordinary same-module unit tests against `pub(crate)`/private state within the defining module — consistent with the pattern #997 already audited and found normal for this codebase.

**Mutation testing** (`cargo-mutants`), picking up where #997 left off (`cursor.rs`/`key_translator.rs`/`mouse.rs` at 97.5%):

| File(s) | Mutants | Caught | Real gaps found & fixed |
|---|---|---|---|
| `term/layout.rs` | 54 | 52 → 54 | 1: `pixels_to_cells`'s `x_px < padding_x \|\| y_px < padding_y` had no test isolating one axis in padding — flipping to `&&` survived |
| `term/unicode.rs`, `ansi/pict.rs` | 11 | 9 | 0 (2 misses are equivalent mutants, see below) |
| `ansi/mod.rs` | 2 | 1 (+1 unviable) | 0 |
| `ansi/lexer.rs`, `ansi/parser.rs` | 104 | 85 → 87 | 2: `AnsiParser::clear_string_buffer` (a CAN-cancelled OSC could leak its bytes into the next string sequence) and `add_string_byte`'s `<` bound against `MAX_OSC_LEN` had no boundary test |

Added tests for all 3 real gaps; re-ran mutants to confirm each newly-added test kills its mutant.

**Investigated and ruled out** (documented in the commit message, not chased with fake tests, per "don't spend effort on unfalsifiable distinctions"):
- `unicode.rs`'s C0/ZWJ special-casing and `decode_continuation_byte`'s surrogate/max-codepoint check are unreachable/redundant given `wcwidth`'s actual output on this platform and `str::from_utf8`'s own guarantees, respectively.
- `lexer.rs`'s `is_unambiguous_interrupting_control` is provably a no-op: every byte it special-cases is `< 0x80`, so it always also fails the UTF-8 continuation-byte check the fallback path would have applied anyway — same output tokens either way.
- `parser.rs`'s `clear_esc_state` and `to_byte_lossy` are only reachable from a parser state the state machine's single entry point never produces with the preconditions that would make them observable.
- `parser.rs`'s `dispatch_osc/dcs/pm/apc` take a `ConsumeSt` parameter whose branch body is empty in all four — it currently has zero observable effect (ST consumption is handled entirely by the calling state-machine arms). Flagged as a production-code simplification opportunity but left alone — out of scope for a test-quality pass.
- Dropped an attempted `MAX_INTERMEDIATES` boundary test after confirming empirically that `dispatch_csi` remaps *any* `CsiCommand::Unsupported` (2+ intermediates) to a bare `AnsiCommand::Error(final_byte)`, discarding the intermediates vec entirely — the exact count beyond 1 is provably unobservable through any output.

## Test plan

- [x] `cargo test -p core-term` (unit + integration + doctests) — all green, 461 lib tests + 18 integration tests passing
- [x] `cargo clippy -p core-term --tests` — clean
- [x] `cargo mutants` re-run on every touched file to confirm added tests kill their target mutants and no new gaps were introduced

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6zWGAiNWkT482UF6XtVNB)_