### PR TITLE
fix(ci): unbreak main's postsubmit — budget the trig periodicity checks for their own argument error

### DIFF
--- a/pixelflow-core/src/ops/trig.rs
+++ b/pixelflow-core/src/ops/trig.rs
@@ -242,6 +242,35 @@ mod tests {
         buf[0]
     }
 
+    /// The approximation's own error budget, per the module's documented
+    /// accuracy. Every comparison against an external reference allows this.
+    const APPROX_TOL: f32 = 1e-5;
+
+    /// `TWO_PI - 2π`: the phase one winding of the f32 constant loses against
+    /// the real period.
+    const WINDING_PHASE_ERROR: f32 = 1.748_455_5e-7;
+
+    /// The distance from `x` to the next representable f32 above it.
+    fn ulp(x: f32) -> f32 {
+        let bits = x.abs().to_bits();
+        f32::from_bits(bits + 1) - f32::from_bits(bits)
+    }
+
+    /// How far apart `sin`/`cos` of `x` and of `x + windings*TWO_PI` may land
+    /// without the range reduction being at fault.
+    ///
+    /// The shifted angle is not `windings` exact periods from `x`: `TWO_PI` is
+    /// an f32, so each winding sheds `WINDING_PHASE_ERROR` of phase, and the
+    /// sum then rounds to f32. Both are errors in the *test's* construction of
+    /// the argument rather than in the reduction under test, and `|d/dx| ≤ 1`
+    /// passes them straight into the value — so the budget carries them
+    /// alongside the approximation error each of the two evaluations has.
+    fn periodicity_tolerance(shifted: f32, windings: i32) -> f32 {
+        let accumulated_phase = (windings.unsigned_abs() as f32) * WINDING_PHASE_ERROR;
+        let rounding = ulp(shifted) * 0.5;
+        2.0 * APPROX_TOL + accumulated_phase + rounding
+    }
+
     const PRINCIPAL_RANGE_ANGLES: &[f32] = &[
         0.0,
         PI / 6.0,
@@ -260,7 +289,10 @@ mod tests {
         for &x in PRINCIPAL_RANGE_ANGLES {
             let got = eval_scalar(Field::from(x).sin());
             let want = x.sin();
-            assert!((got - want).abs() < 1e-5, "sin({x}) = {got}, want {want}");
+            assert!(
+                (got - want).abs() < APPROX_TOL,
+                "sin({x}) = {got}, want {want}"
+            );
         }
     }
 
@@ -269,7 +301,10 @@ mod tests {
         for &x in PRINCIPAL_RANGE_ANGLES {
             let got = eval_scalar(Field::from(x).cos());
             let want = x.cos();
-            assert!((got - want).abs() < 1e-5, "cos({x}) = {got}, want {want}");
+            assert!(
+                (got - want).abs() < APPROX_TOL,
+                "cos({x}) = {got}, want {want}"
+            );
         }
     }
 
@@ -285,9 +320,10 @@ mod tests {
             for &k in &[-37i32, -5, -2, -1, 1, 2, 5, 37] {
                 let shifted = x + (k as f32) * TWO_PI;
                 let got = eval_scalar(Field::from(shifted).sin());
+                let tol = periodicity_tolerance(shifted, k);
                 assert!(
-                    (got - base).abs() < 1e-5,
-                    "sin({x} + {k}*2π) = {got}, want {base} (periodicity)"
+                    (got - base).abs() < tol,
+                    "sin({x} + {k}*2π) = {got}, want {base} +/- {tol} (periodicity)"
                 );
             }
         }
@@ -300,9 +336,10 @@ mod tests {
             for &k in &[-37i32, -5, -2, -1, 1, 2, 5, 37] {
                 let shifted = x + (k as f32) * TWO_PI;
                 let got = eval_scalar(Field::from(shifted).cos());
+                let tol = periodicity_tolerance(shifted, k);
                 assert!(
-                    (got - base).abs() < 1e-5,
-                    "cos({x} + {k}*2π) = {got}, want {base} (periodicity)"
+                    (got - base).abs() < tol,
+                    "cos({x} + {k}*2π) = {got}, want {base} +/- {tol} (periodicity)"
                 );
             }
         }
@@ -314,12 +351,12 @@ mod tests {
             let got_sin = eval_scalar(Field::from(x).sin());
             let got_cos = eval_scalar(Field::from(x).cos());
             assert!(
-                (got_sin - x.sin()).abs() < 1e-5,
+                (got_sin - x.sin()).abs() < APPROX_TOL,
                 "sin({x}) = {got_sin}, want {}",
                 x.sin()
             );
             assert!(
-                (got_cos - x.cos()).abs() < 1e-5,
+                (got_cos - x.cos()).abs() < APPROX_TOL,
                 "cos({x}) = {got_cos}, want {}",
                 x.cos()
             );
@@ -411,7 +448,7 @@ mod tests {
             assert!(s.abs() <= 1.0, "sin({x:e}) = {s} outside [-1, 1]");
             assert!(c.abs() <= 1.0, "cos({x:e}) = {c} outside [-1, 1]");
             assert!(
-                (s - x.sin()).abs() < 1e-5,
+                (s - x.sin()).abs() < APPROX_TOL,
                 "sin({x:e}) = {s}, want {}",
                 x.sin()
             );


### PR DESCRIPTION
## Summary

`main`'s postsubmit has failed on **every commit since `084d3ef` (#992)** — runs #273 through #280, eight in a row, the last green run being #272 on 14 August. Each failure filed an automatic revert PR (#1001, #1006, #1008, #1010, #1012, #1014, #1018, #1021), none of which can merge. One test is responsible:

```
=== ISA matrix summary ===
  sse2 (baseline)      PASS
  avx2 (no fma)        PASS
  avx2+fma             FAIL (test)
  avx512f+dq           BUILT+LINT (not run: host lacks avx512f)

---- ops::trig::tests::cos_is_periodic_across_many_windings ----
cos(-2.1 + 37*2π) = -0.50483537, want -0.5048459 (periodicity)
```

## The implementation is not at fault

Measured against an f64 oracle at exactly the angles these tests use, `sin`/`cos` are accurate to **6.5e-7** — comfortably inside the module's documented ≈1.5e-6. Nothing regressed in the range reduction #992 added.

## The tolerance is

The periodicity tests compare `f(x)` against `f(x + k·TWO_PI)` under a flat `1e-5` budget. That budget covers the approximation's error but not the error in the argument **the test itself constructs**:

| Source | Size at `k = 37`, \|x\| ≈ 230 |
|---|---|
| `TWO_PI` is an f32 — 1.75e-7 short of a real period, times `k` windings | 6.5e-6 |
| the sum `x + k·TWO_PI` then rounds to f32 — half an ulp | 9.3e-6 |
| the approximation itself, at each of the two evaluated points | ≤ 2 × 1e-5 |

`|d/dx| ≤ 1` for both functions, so the first two pass straight into the value. Together they already exceed the old flat budget before the approximation gets a say.

`-fp-contract=fast` is what exposed it rather than caused it: with `+fma`, the test's own `x + (k as f32) * TWO_PI` contracts to a **single-rounding FMA**, landing on a different argument than the two-rounding form and stopping the two error terms from partly cancelling. That is why exactly one of the four ISA levels failed.

## The fix

`periodicity_tolerance(shifted, windings)` derives the budget from those three terms instead of asserting a flat constant. A broken range reduction diverges by O(1) — that is the failure mode #992 was written to catch — so the check keeps all the teeth it had. The repeated `1e-5` literals become a named `APPROX_TOL`.

## Why the presubmit missed it

`ci(isa-matrix)` splits build+lint into presubmit and defers **tests** to postsubmit. #992's presubmit was green because presubmit never ran this test at `avx2+fma`; the first execution was postsubmit on `main`, after the merge.

## Test plan

- [x] `pixelflow-core` lib suite under each ISA level's RUSTFLAGS:

  | level | before | after |
  |---|---|---|
  | `sse2` | 123 passed / 0 failed | 123 passed / 0 failed |
  | `+avx2` | 123 passed / 0 failed | 123 passed / 0 failed |
  | `+avx2,+fma` | 122 passed / **1 failed** | **123 passed / 0 failed** |
  | `+avx512f,+avx512dq` | 124 passed / 0 failed | 124 passed / 0 failed |

- [x] `cargo fmt -p pixelflow-core -- --check` — clean
- [x] `cargo clippy -p pixelflow-core --lib --tests` — clean
- [x] Accuracy re-measured against an f64 oracle at the tests' own angles: worst 6.48e-7

Only a `#[cfg(test)]` module in `pixelflow-core` changed; no production code is touched.

## Follow-up worth considering (not in this PR)

The eight-commit run of red postsubmits is a detection-latency problem as much as a test bug: because the ISA matrix runs tests only after merge, a break lands on `main` and then every subsequent innocent commit inherits the failure and gets its own auto-revert PR. Running the matrix's tests at one representative ISA level presubmit would have caught this on #992.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaPJaPfDAXHHhn9TycD7Kg)_