### PR TITLE
test(pixelflow-search): close nnue::guide mutation gaps (2026-08-25 audit)

### DIFF
--- a/pixelflow-search/src/nnue/factored.rs
+++ b/pixelflow-search/src/nnue/factored.rs
@@ -1757,7 +1757,7 @@ mod tests {
     // ========================================================================
 
     #[test]
-    fn param_count_exceeds_10k_and_memory_stays_under_200kb() {
+    fn param_count_should_exceed_10k_and_memory_should_stay_under_200kb() {
         // Param count should include the whole backbone + value head.
         let count = ExprNnue::param_count();
         // Backbone (embeddings + w1 + b1 + trunk) ~13,808, plus expr_proj +
@@ -1777,7 +1777,7 @@ mod tests {
     // ========================================================================
 
     #[test]
-    fn edge_accumulator_add_then_remove_returns_to_zero() {
+    fn edge_accumulator_add_then_remove_should_return_to_zero() {
         let emb = OpEmbeddings::new_random(42);
         let mut acc = EdgeAccumulator::new();
 

--- a/pixelflow-search/src/nnue/factored.rs
+++ b/pixelflow-search/src/nnue/factored.rs
@@ -1752,24 +1752,12 @@ mod tests {
     use alloc::boxed::Box;
     use alloc::sync::Arc;
 
-    #[test]
-    fn verify_param_count() {
-        // Verify parameter count is reasonable and finite
-        let count = ExprNnue::param_count();
-        assert!(count > 0, "Should have parameters");
-        assert!(
-            ExprNnue::memory_bytes() < 200_000,
-            "NNUE should use < 200KB, got {} bytes",
-            ExprNnue::memory_bytes()
-        );
-    }
-
     // ========================================================================
     // ExprNnue Tests
     // ========================================================================
 
     #[test]
-    fn consolidated_param_count() {
+    fn param_count_exceeds_10k_and_memory_stays_under_200kb() {
         // Param count should include the whole backbone + value head.
         let count = ExprNnue::param_count();
         // Backbone (embeddings + w1 + b1 + trunk) ~13,808, plus expr_proj +
@@ -1789,8 +1777,7 @@ mod tests {
     // ========================================================================
 
     #[test]
-    fn complex_pe_roundtrip() {
-        // add_edge + remove_edge should return the accumulator to zero.
+    fn edge_accumulator_add_then_remove_returns_to_zero() {
         let emb = OpEmbeddings::new_random(42);
         let mut acc = EdgeAccumulator::new();
 

--- a/pixelflow-search/src/nnue/guide/accumulator.rs
+++ b/pixelflow-search/src/nnue/guide/accumulator.rs
@@ -533,7 +533,7 @@ mod tests {
     // ========================================================================
 
     #[test]
-    fn reset_zeroes_values_and_counts_but_preserves_budgets() {
+    fn reset_should_zero_values_and_counts_but_preserve_budgets() {
         let emb = OpEmbeddings::new_random(3);
         let mut gacc = GraphAccumulator::new();
         gacc.add_edge(&emb, OpKind::Add, OpKind::Mul);
@@ -866,10 +866,47 @@ mod tests {
         );
     }
 
-    // Note on the `norm < 1e-12` guard in `l2_normalize_section` (the `<` vs
-    // `<=` mutant at that line): the boundary is only observable when a
-    // section's L2 norm lands on *exactly* 1e-12, which no combination of
-    // `OpEmbeddings::new_random` seeds and edge counts here can be made to
-    // hit deterministically — it is not exercised by any test in this file,
-    // by design rather than oversight.
+    #[test]
+    fn normalize_in_place_normalizes_a_section_whose_norm_is_exactly_the_guard_threshold() {
+        // `l2_normalize_section` skips a section when `norm < 1e-12`, so the
+        // threshold itself must still normalize. A single populated lane makes
+        // the section norm `sqrtf(x*x)`, which is exactly `x` for this value —
+        // asserted below so the fixture cannot drift off the boundary — and
+        // that pins `<` against a `<=` mutant: `<=` would return early and
+        // leave the lane at 1e-12 instead of scaling it to 1.0.
+        const GUARD_THRESHOLD: f32 = 1e-12;
+
+        let mut gacc = GraphAccumulator::new();
+        gacc.values[0] = GUARD_THRESHOLD;
+        let section_norm = sqrtf(gacc.values[0] * gacc.values[0]);
+        assert_eq!(
+            section_norm, GUARD_THRESHOLD,
+            "fixture must sit exactly on the guard boundary, not below it"
+        );
+
+        gacc.normalize_in_place();
+
+        assert!(
+            (gacc.values[0] - 1.0).abs() < 1e-5,
+            "a section at exactly the guard threshold must normalize; got {}",
+            gacc.values[0]
+        );
+    }
+
+    #[test]
+    fn normalize_in_place_leaves_a_section_whose_norm_is_below_the_guard_threshold_untouched() {
+        // The other side of the same boundary: strictly below 1e-12 the
+        // section is left alone rather than amplified toward 1.0.
+        const BELOW_THRESHOLD: f32 = 1e-13;
+
+        let mut gacc = GraphAccumulator::new();
+        gacc.values[0] = BELOW_THRESHOLD;
+
+        gacc.normalize_in_place();
+
+        assert_eq!(
+            gacc.values[0], BELOW_THRESHOLD,
+            "a section below the guard threshold must be left untouched"
+        );
+    }
 }

--- a/pixelflow-search/src/nnue/guide/accumulator.rs
+++ b/pixelflow-search/src/nnue/guide/accumulator.rs
@@ -515,4 +515,361 @@ mod tests {
         acc.remove_leaf();
         assert_eq!(acc.node_count, 0, "node_count must not underflow");
     }
+
+    /// An arbitrary, all-distinct baseline for [`GraphAccumulator::values`]
+    /// (never all-zero, never uniform), so that a subtraction mutated into
+    /// an addition, a multiply, or a mis-indexed write is visible at every
+    /// lane rather than only at ones that happen to coincide with zero.
+    fn distinct_baseline() -> [f32; GRAPH_ACC_DIM] {
+        let mut v = [0.0f32; GRAPH_ACC_DIM];
+        for (i, x) in v.iter_mut().enumerate() {
+            *x = 10.0 + i as f32;
+        }
+        v
+    }
+
+    // ========================================================================
+    // reset
+    // ========================================================================
+
+    #[test]
+    fn reset_zeroes_values_and_counts_but_preserves_budgets() {
+        let emb = OpEmbeddings::new_random(3);
+        let mut gacc = GraphAccumulator::new();
+        gacc.add_edge(&emb, OpKind::Add, OpKind::Mul);
+        gacc.add_leaf();
+        gacc.node_budget = 77;
+        gacc.epoch_budget = 42;
+
+        gacc.reset();
+
+        assert_eq!(gacc.values, [0.0f32; GRAPH_ACC_DIM]);
+        assert_eq!(gacc.edge_count, 0);
+        assert_eq!(gacc.node_count, 0);
+        assert_eq!(gacc.node_budget, 77, "node_budget must survive reset");
+        assert_eq!(gacc.epoch_budget, 42, "epoch_budget must survive reset");
+    }
+
+    // ========================================================================
+    // add_edge_at_depth / remove_edge_at_depth (exact values)
+    // ========================================================================
+
+    #[test]
+    fn add_edge_at_depth_writes_the_exact_marginal_and_binding_values() {
+        let emb = OpEmbeddings::new_random(7);
+        let p = *emb.get(OpKind::Add);
+        let c = *emb.get(OpKind::Mul);
+        let depth = 3;
+        let c_shifted = shift_by(&c, depth);
+
+        let mut expected = [0.0f32; GRAPH_ACC_DIM];
+        for i in 0..K {
+            expected[i] = p[i]; // marginal parent
+            expected[K + i] = c[i]; // marginal child
+            expected[2 * K + i] = p[i] * c_shifted[i]; // 1-hop VSA binding
+            // expected[3*K+i] stays 0.0: add_edge_at_depth must not touch the 2-hop section.
+        }
+
+        let mut gacc = GraphAccumulator::new();
+        gacc.add_edge_at_depth(&emb, OpKind::Add, OpKind::Mul, depth);
+
+        assert_eq!(gacc.values, expected);
+        assert_eq!(
+            gacc.edge_count, 1,
+            "edge_count must increment by exactly one"
+        );
+        assert_eq!(
+            gacc.node_count, 0,
+            "add_edge_at_depth must not touch node_count"
+        );
+    }
+
+    #[test]
+    fn remove_edge_at_depth_subtracts_the_exact_marginal_and_binding_values() {
+        let emb = OpEmbeddings::new_random(11);
+        let p = *emb.get(OpKind::Sub);
+        let c = *emb.get(OpKind::Sqrt);
+        let depth = 2;
+        let c_shifted = shift_by(&c, depth);
+
+        let mut gacc = GraphAccumulator::new();
+        gacc.values = distinct_baseline();
+        gacc.edge_count = 5;
+
+        gacc.remove_edge_at_depth(&emb, OpKind::Sub, OpKind::Sqrt, depth);
+
+        let mut expected = distinct_baseline();
+        for i in 0..K {
+            expected[i] -= p[i];
+            expected[K + i] -= c[i];
+            expected[2 * K + i] -= p[i] * c_shifted[i];
+        }
+
+        assert_eq!(gacc.values, expected);
+        assert_eq!(
+            gacc.edge_count, 4,
+            "edge_count must decrement by exactly one"
+        );
+    }
+
+    #[test]
+    fn add_edge_at_depth_then_remove_edge_at_depth_returns_to_the_previous_state() {
+        let emb = OpEmbeddings::new_random(11);
+        let mut gacc = GraphAccumulator::new();
+        gacc.values = distinct_baseline();
+        let baseline = gacc.values;
+        let baseline_edges = gacc.edge_count;
+
+        gacc.add_edge_at_depth(&emb, OpKind::Sub, OpKind::Sqrt, 2);
+        gacc.remove_edge_at_depth(&emb, OpKind::Sub, OpKind::Sqrt, 2);
+
+        // Round-tripping through a large baseline (values up to ~140) loses
+        // a few ULPs to floating-point rounding, so this compares within a
+        // tight epsilon rather than bit-for-bit.
+        for i in 0..GRAPH_ACC_DIM {
+            assert!(
+                (gacc.values[i] - baseline[i]).abs() < 1e-4,
+                "values[{i}] mismatch: got {} want {}",
+                gacc.values[i],
+                baseline[i]
+            );
+        }
+        assert_eq!(gacc.edge_count, baseline_edges);
+    }
+
+    #[test]
+    fn remove_edge_matches_remove_edge_at_depth_one() {
+        let emb = OpEmbeddings::new_random(15);
+        let mut gacc = GraphAccumulator::new();
+        gacc.add_edge(&emb, OpKind::Add, OpKind::Mul);
+        gacc.remove_edge(&emb, OpKind::Add, OpKind::Mul);
+
+        assert_eq!(
+            gacc.values, [0.0f32; GRAPH_ACC_DIM],
+            "add_edge then remove_edge must return to zero"
+        );
+        assert_eq!(gacc.edge_count, 0);
+    }
+
+    // ========================================================================
+    // add_leaf / remove_leaf
+    // ========================================================================
+
+    #[test]
+    fn add_leaf_increments_node_count_by_exactly_one() {
+        let mut gacc = GraphAccumulator::new();
+        gacc.node_count = 5;
+        gacc.add_leaf();
+        assert_eq!(gacc.node_count, 6);
+    }
+
+    #[test]
+    fn remove_leaf_decrements_node_count_by_exactly_one_when_nonzero() {
+        let mut gacc = GraphAccumulator::new();
+        gacc.node_count = 5;
+        gacc.remove_leaf();
+        assert_eq!(gacc.node_count, 4);
+    }
+
+    // ========================================================================
+    // add_op_node_at_depth / add_op_node / remove_op_node_at_depth / remove_op_node
+    // ========================================================================
+
+    #[test]
+    fn add_op_node_at_depth_increments_node_count_once_regardless_of_child_count() {
+        let emb = OpEmbeddings::new_random(9);
+        let mut gacc = GraphAccumulator::new();
+        gacc.node_count = 2;
+        gacc.edge_count = 1;
+
+        gacc.add_op_node_at_depth(
+            &emb,
+            OpKind::Add,
+            &[OpKind::Mul, OpKind::Var, OpKind::Sqrt],
+            4,
+        );
+
+        assert_eq!(
+            gacc.node_count, 3,
+            "node_count increments by exactly one, not once per child"
+        );
+        assert_eq!(
+            gacc.edge_count, 4,
+            "edge_count increments once per child edge"
+        );
+    }
+
+    #[test]
+    fn add_op_node_at_depth_increments_node_count_once_even_with_zero_children() {
+        let emb = OpEmbeddings::new_random(9);
+        let mut gacc = GraphAccumulator::new();
+        gacc.node_count = 2;
+
+        gacc.add_op_node_at_depth(&emb, OpKind::Neg, &[], 0);
+
+        assert_eq!(gacc.node_count, 3);
+        assert_eq!(gacc.edge_count, 0);
+    }
+
+    #[test]
+    fn remove_op_node_at_depth_decrements_node_count_by_exactly_one() {
+        let emb = OpEmbeddings::new_random(9);
+        let mut gacc = GraphAccumulator::new();
+        gacc.node_count = 5;
+        gacc.edge_count = 10;
+
+        gacc.remove_op_node_at_depth(&emb, OpKind::Add, &[OpKind::Mul, OpKind::Var], 2);
+
+        assert_eq!(gacc.node_count, 4);
+        assert_eq!(
+            gacc.edge_count, 8,
+            "edge_count decrements once per child edge"
+        );
+    }
+
+    #[test]
+    fn add_op_node_matches_add_op_node_at_depth_one() {
+        let emb = OpEmbeddings::new_random(9);
+
+        let mut via_wrapper = GraphAccumulator::new();
+        via_wrapper.add_op_node(&emb, OpKind::Add, &[OpKind::Mul, OpKind::Var]);
+
+        let mut via_direct = GraphAccumulator::new();
+        via_direct.add_op_node_at_depth(&emb, OpKind::Add, &[OpKind::Mul, OpKind::Var], 1);
+
+        assert_eq!(via_wrapper.values, via_direct.values);
+        assert_eq!(via_wrapper.edge_count, via_direct.edge_count);
+        assert_eq!(via_wrapper.node_count, via_direct.node_count);
+        assert_ne!(
+            via_wrapper.node_count, 0,
+            "sanity: add_op_node must actually do something"
+        );
+    }
+
+    #[test]
+    fn remove_op_node_matches_remove_op_node_at_depth_one_and_returns_to_zero() {
+        let emb = OpEmbeddings::new_random(9);
+
+        let mut via_wrapper = GraphAccumulator::new();
+        via_wrapper.add_op_node(&emb, OpKind::Add, &[OpKind::Mul, OpKind::Var]);
+        via_wrapper.remove_op_node(&emb, OpKind::Add, &[OpKind::Mul, OpKind::Var]);
+
+        let mut via_direct = GraphAccumulator::new();
+        via_direct.add_op_node_at_depth(&emb, OpKind::Add, &[OpKind::Mul, OpKind::Var], 1);
+        via_direct.remove_op_node_at_depth(&emb, OpKind::Add, &[OpKind::Mul, OpKind::Var], 1);
+
+        assert_eq!(via_wrapper.values, via_direct.values);
+        assert_eq!(via_wrapper.edge_count, via_direct.edge_count);
+        assert_eq!(via_wrapper.node_count, via_direct.node_count);
+
+        // Two edges' worth of add-then-subtract can leave a few ULPs of
+        // floating-point rounding noise, so this compares within a tight
+        // epsilon rather than bit-for-bit.
+        for (i, &v) in via_wrapper.values.iter().enumerate() {
+            assert!(
+                v.abs() < 1e-4,
+                "add_op_node then remove_op_node must return to ~zero: values[{i}] = {v}"
+            );
+        }
+        assert_eq!(via_wrapper.node_count, 0);
+        assert_eq!(via_wrapper.edge_count, 0);
+    }
+
+    // ========================================================================
+    // add_2hop_edge / remove_2hop_edge
+    // ========================================================================
+
+    #[test]
+    fn add_2hop_edge_writes_the_exact_triple_product_into_the_2hop_section() {
+        let emb = OpEmbeddings::new_random(13);
+        let gp = *emb.get(OpKind::Div);
+        let p = shift1(emb.get(OpKind::Neg));
+        let c = shift_by(emb.get(OpKind::Abs), 2);
+
+        let mut expected = [0.0f32; GRAPH_ACC_DIM];
+        for i in 0..K {
+            expected[3 * K + i] = gp[i] * p[i] * c[i];
+        }
+
+        let mut gacc = GraphAccumulator::new();
+        gacc.add_2hop_edge(&emb, OpKind::Div, OpKind::Neg, OpKind::Abs);
+
+        assert_eq!(gacc.values, expected);
+        assert_eq!(
+            gacc.edge_count, 0,
+            "add_2hop_edge must not touch edge_count"
+        );
+        assert_eq!(
+            gacc.node_count, 0,
+            "add_2hop_edge must not touch node_count"
+        );
+    }
+
+    #[test]
+    fn remove_2hop_edge_subtracts_the_exact_triple_product() {
+        let emb = OpEmbeddings::new_random(13);
+        let gp = *emb.get(OpKind::Div);
+        let p = shift1(emb.get(OpKind::Neg));
+        let c = shift_by(emb.get(OpKind::Abs), 2);
+
+        let mut gacc = GraphAccumulator::new();
+        gacc.values = distinct_baseline();
+
+        let mut expected = distinct_baseline();
+        for i in 0..K {
+            expected[3 * K + i] -= gp[i] * p[i] * c[i];
+        }
+
+        gacc.remove_2hop_edge(&emb, OpKind::Div, OpKind::Neg, OpKind::Abs);
+
+        assert_eq!(gacc.values, expected);
+    }
+
+    #[test]
+    fn add_2hop_edge_then_remove_2hop_edge_returns_to_the_previous_state() {
+        let emb = OpEmbeddings::new_random(13);
+        let mut gacc = GraphAccumulator::new();
+        gacc.values = distinct_baseline();
+        let baseline = gacc.values;
+
+        gacc.add_2hop_edge(&emb, OpKind::Div, OpKind::Neg, OpKind::Abs);
+        gacc.remove_2hop_edge(&emb, OpKind::Div, OpKind::Neg, OpKind::Abs);
+
+        for i in 0..GRAPH_ACC_DIM {
+            assert!(
+                (gacc.values[i] - baseline[i]).abs() < 1e-4,
+                "values[{i}] mismatch: got {} want {}",
+                gacc.values[i],
+                baseline[i]
+            );
+        }
+    }
+
+    // ========================================================================
+    // normalize_in_place: 2-hop section
+    // ========================================================================
+
+    #[test]
+    fn normalize_in_place_normalizes_the_2hop_section_when_populated() {
+        let emb = OpEmbeddings::new_random(21);
+        let mut gacc = GraphAccumulator::new();
+        gacc.add_2hop_edge(&emb, OpKind::Add, OpKind::Mul, OpKind::Var);
+        gacc.add_2hop_edge(&emb, OpKind::Sub, OpKind::Div, OpKind::Sqrt);
+
+        let normed = gacc.normalized();
+
+        let sum_sq: f32 = normed.values[3 * K..4 * K].iter().map(|v| v * v).sum();
+        let norm = sqrtf(sum_sq);
+        assert!(
+            (norm - 1.0).abs() < 1e-5,
+            "2-hop section norm should be 1.0, got {norm}"
+        );
+    }
+
+    // Note on the `norm < 1e-12` guard in `l2_normalize_section` (the `<` vs
+    // `<=` mutant at that line): the boundary is only observable when a
+    // section's L2 norm lands on *exactly* 1e-12, which no combination of
+    // `OpEmbeddings::new_random` seeds and edge counts here can be made to
+    // hit deterministically — it is not exercised by any test in this file,
+    // by design rather than oversight.
 }

--- a/pixelflow-search/src/nnue/guide/accumulator.rs
+++ b/pixelflow-search/src/nnue/guide/accumulator.rs
@@ -353,7 +353,7 @@ mod tests {
     // ========================================================================
 
     #[test]
-    fn graph_acc_normalize_unit_norm_per_section() {
+    fn normalized_should_give_each_section_unit_norm() {
         let emb = OpEmbeddings::new_random(42);
         let mut gacc = GraphAccumulator::new();
         // Build a non-trivial accumulator: several edges
@@ -391,7 +391,7 @@ mod tests {
     }
 
     #[test]
-    fn graph_acc_normalize_scalars_preserved() {
+    fn normalized_should_preserve_the_scalar_fields() {
         let emb = OpEmbeddings::new_random(42);
         let mut gacc = GraphAccumulator::new();
         gacc.add_edge(&emb, OpKind::Add, OpKind::Mul);
@@ -420,7 +420,7 @@ mod tests {
     }
 
     #[test]
-    fn graph_acc_normalize_zero_is_safe() {
+    fn normalized_should_leave_an_all_zero_accumulator_untouched() {
         // A fresh (zero) accumulator should normalize without NaN/Inf.
         let gacc = GraphAccumulator::new();
         let normed = gacc.normalized();
@@ -434,7 +434,7 @@ mod tests {
     }
 
     #[test]
-    fn graph_acc_normalize_in_place_matches_normalized() {
+    fn normalize_in_place_should_match_normalized() {
         let emb = OpEmbeddings::new_random(42);
         let mut gacc = GraphAccumulator::new();
         gacc.add_edge(&emb, OpKind::Add, OpKind::Mul);
@@ -456,7 +456,7 @@ mod tests {
     }
 
     #[test]
-    fn graph_acc_normalize_scale_invariance() {
+    fn normalized_should_be_invariant_to_input_scale() {
         // Doubling all edges (adding each edge twice) should yield the same
         // normalized vector, proving scale invariance.
         let emb = OpEmbeddings::new_random(42);
@@ -485,7 +485,7 @@ mod tests {
     }
 
     #[test]
-    fn graph_acc_normalize_idempotent() {
+    fn normalized_should_be_idempotent() {
         // Normalizing twice should produce the same result.
         let emb = OpEmbeddings::new_random(42);
         let mut gacc = GraphAccumulator::new();
@@ -510,7 +510,7 @@ mod tests {
     // ========================================================================
 
     #[test]
-    fn graph_acc_remove_leaf_saturates_at_zero() {
+    fn remove_leaf_should_saturate_at_zero() {
         let mut acc = GraphAccumulator::new();
         acc.remove_leaf();
         assert_eq!(acc.node_count, 0, "node_count must not underflow");
@@ -555,7 +555,7 @@ mod tests {
     // ========================================================================
 
     #[test]
-    fn add_edge_at_depth_writes_the_exact_marginal_and_binding_values() {
+    fn add_edge_at_depth_should_write_the_exact_marginal_and_binding_values() {
         let emb = OpEmbeddings::new_random(7);
         let p = *emb.get(OpKind::Add);
         let c = *emb.get(OpKind::Mul);
@@ -585,7 +585,7 @@ mod tests {
     }
 
     #[test]
-    fn remove_edge_at_depth_subtracts_the_exact_marginal_and_binding_values() {
+    fn remove_edge_at_depth_should_subtract_the_exact_marginal_and_binding_values() {
         let emb = OpEmbeddings::new_random(11);
         let p = *emb.get(OpKind::Sub);
         let c = *emb.get(OpKind::Sqrt);
@@ -613,7 +613,7 @@ mod tests {
     }
 
     #[test]
-    fn add_edge_at_depth_then_remove_edge_at_depth_returns_to_the_previous_state() {
+    fn add_edge_at_depth_then_remove_edge_at_depth_should_return_to_the_previous_state() {
         let emb = OpEmbeddings::new_random(11);
         let mut gacc = GraphAccumulator::new();
         gacc.values = distinct_baseline();
@@ -638,7 +638,7 @@ mod tests {
     }
 
     #[test]
-    fn remove_edge_matches_remove_edge_at_depth_one() {
+    fn remove_edge_should_match_remove_edge_at_depth_one() {
         let emb = OpEmbeddings::new_random(15);
         let mut gacc = GraphAccumulator::new();
         gacc.add_edge(&emb, OpKind::Add, OpKind::Mul);
@@ -656,7 +656,7 @@ mod tests {
     // ========================================================================
 
     #[test]
-    fn add_leaf_increments_node_count_by_exactly_one() {
+    fn add_leaf_should_increment_node_count_by_exactly_one() {
         let mut gacc = GraphAccumulator::new();
         gacc.node_count = 5;
         gacc.add_leaf();
@@ -664,7 +664,7 @@ mod tests {
     }
 
     #[test]
-    fn remove_leaf_decrements_node_count_by_exactly_one_when_nonzero() {
+    fn remove_leaf_should_decrement_node_count_by_exactly_one_when_nonzero() {
         let mut gacc = GraphAccumulator::new();
         gacc.node_count = 5;
         gacc.remove_leaf();
@@ -676,7 +676,7 @@ mod tests {
     // ========================================================================
 
     #[test]
-    fn add_op_node_at_depth_increments_node_count_once_regardless_of_child_count() {
+    fn add_op_node_at_depth_should_increment_node_count_once_regardless_of_child_count() {
         let emb = OpEmbeddings::new_random(9);
         let mut gacc = GraphAccumulator::new();
         gacc.node_count = 2;
@@ -700,7 +700,7 @@ mod tests {
     }
 
     #[test]
-    fn add_op_node_at_depth_increments_node_count_once_even_with_zero_children() {
+    fn add_op_node_at_depth_should_increment_node_count_once_even_with_zero_children() {
         let emb = OpEmbeddings::new_random(9);
         let mut gacc = GraphAccumulator::new();
         gacc.node_count = 2;
@@ -712,7 +712,7 @@ mod tests {
     }
 
     #[test]
-    fn remove_op_node_at_depth_decrements_node_count_by_exactly_one() {
+    fn remove_op_node_at_depth_should_decrement_node_count_by_exactly_one() {
         let emb = OpEmbeddings::new_random(9);
         let mut gacc = GraphAccumulator::new();
         gacc.node_count = 5;
@@ -728,7 +728,7 @@ mod tests {
     }
 
     #[test]
-    fn add_op_node_matches_add_op_node_at_depth_one() {
+    fn add_op_node_should_match_add_op_node_at_depth_one() {
         let emb = OpEmbeddings::new_random(9);
 
         let mut via_wrapper = GraphAccumulator::new();
@@ -747,7 +747,7 @@ mod tests {
     }
 
     #[test]
-    fn remove_op_node_matches_remove_op_node_at_depth_one_and_returns_to_zero() {
+    fn remove_op_node_should_match_remove_op_node_at_depth_one_and_return_to_zero() {
         let emb = OpEmbeddings::new_random(9);
 
         let mut via_wrapper = GraphAccumulator::new();
@@ -780,7 +780,7 @@ mod tests {
     // ========================================================================
 
     #[test]
-    fn add_2hop_edge_writes_the_exact_triple_product_into_the_2hop_section() {
+    fn add_2hop_edge_should_write_the_exact_triple_product_into_the_2hop_section() {
         let emb = OpEmbeddings::new_random(13);
         let gp = *emb.get(OpKind::Div);
         let p = shift1(emb.get(OpKind::Neg));
@@ -806,7 +806,7 @@ mod tests {
     }
 
     #[test]
-    fn remove_2hop_edge_subtracts_the_exact_triple_product() {
+    fn remove_2hop_edge_should_subtract_the_exact_triple_product() {
         let emb = OpEmbeddings::new_random(13);
         let gp = *emb.get(OpKind::Div);
         let p = shift1(emb.get(OpKind::Neg));
@@ -826,7 +826,7 @@ mod tests {
     }
 
     #[test]
-    fn add_2hop_edge_then_remove_2hop_edge_returns_to_the_previous_state() {
+    fn add_2hop_edge_then_remove_2hop_edge_should_return_to_the_previous_state() {
         let emb = OpEmbeddings::new_random(13);
         let mut gacc = GraphAccumulator::new();
         gacc.values = distinct_baseline();
@@ -850,7 +850,7 @@ mod tests {
     // ========================================================================
 
     #[test]
-    fn normalize_in_place_normalizes_the_2hop_section_when_populated() {
+    fn normalize_in_place_should_normalize_the_2hop_section_when_populated() {
         let emb = OpEmbeddings::new_random(21);
         let mut gacc = GraphAccumulator::new();
         gacc.add_2hop_edge(&emb, OpKind::Add, OpKind::Mul, OpKind::Var);
@@ -867,7 +867,7 @@ mod tests {
     }
 
     #[test]
-    fn normalize_in_place_normalizes_a_section_whose_norm_is_exactly_the_guard_threshold() {
+    fn normalize_in_place_should_normalize_a_section_whose_norm_is_exactly_the_guard_threshold() {
         // `l2_normalize_section` skips a section when `norm < 1e-12`, so the
         // threshold itself must still normalize. A single populated lane makes
         // the section norm `sqrtf(x*x)`, which is exactly `x` for this value —
@@ -894,7 +894,7 @@ mod tests {
     }
 
     #[test]
-    fn normalize_in_place_leaves_a_section_whose_norm_is_below_the_guard_threshold_untouched() {
+    fn normalize_in_place_should_leave_a_section_below_the_guard_threshold_untouched() {
         // The other side of the same boundary: strictly below 1e-12 the
         // section is left alone rather than amplified toward 1.0.
         const BELOW_THRESHOLD: f32 = 1e-13;

--- a/pixelflow-search/src/nnue/guide/accumulator.rs
+++ b/pixelflow-search/src/nnue/guide/accumulator.rs
@@ -640,15 +640,37 @@ mod tests {
     #[test]
     fn remove_edge_should_match_remove_edge_at_depth_one() {
         let emb = OpEmbeddings::new_random(15);
-        let mut gacc = GraphAccumulator::new();
-        gacc.add_edge(&emb, OpKind::Add, OpKind::Mul);
-        gacc.remove_edge(&emb, OpKind::Add, OpKind::Mul);
+
+        // Compared against `remove_edge_at_depth(.., 1)` from an equivalent
+        // nonzero state rather than by adding and removing through the
+        // wrappers alone. A round trip through both wrappers cancels whatever
+        // depth they agree on, so it holds even if both drifted to the same
+        // wrong depth — and depth selects the cyclic shift in the binding
+        // section, so a coordinated drift silently changes the encoding the
+        // backward-compatible wrappers exist to preserve.
+        let mut through_wrapper = GraphAccumulator::new();
+        through_wrapper.add_edge_at_depth(&emb, OpKind::Mul, OpKind::Sqrt, 1);
+        through_wrapper.remove_edge(&emb, OpKind::Add, OpKind::Mul);
+
+        let mut at_depth_one = GraphAccumulator::new();
+        at_depth_one.add_edge_at_depth(&emb, OpKind::Mul, OpKind::Sqrt, 1);
+        at_depth_one.remove_edge_at_depth(&emb, OpKind::Add, OpKind::Mul, 1);
 
         assert_eq!(
-            gacc.values, [0.0f32; GRAPH_ACC_DIM],
+            through_wrapper.values, at_depth_one.values,
+            "remove_edge must be remove_edge_at_depth(.., 1)"
+        );
+        assert_eq!(through_wrapper.edge_count, at_depth_one.edge_count);
+
+        // The round trip still has to hold.
+        let mut round_trip = GraphAccumulator::new();
+        round_trip.add_edge(&emb, OpKind::Add, OpKind::Mul);
+        round_trip.remove_edge(&emb, OpKind::Add, OpKind::Mul);
+        assert_eq!(
+            round_trip.values, [0.0f32; GRAPH_ACC_DIM],
             "add_edge then remove_edge must return to zero"
         );
-        assert_eq!(gacc.edge_count, 0);
+        assert_eq!(round_trip.edge_count, 0);
     }
 
     // ========================================================================

--- a/pixelflow-search/src/nnue/guide/mod.rs
+++ b/pixelflow-search/src/nnue/guide/mod.rs
@@ -129,7 +129,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn guide_score_candidates_is_finite_and_ordered() {
+    fn guide_score_candidates_returns_one_finite_score_per_candidate() {
         let backbone = ExprNnue::new_random(1);
         let guide = Guide::new_random(backbone, 2);
 
@@ -152,7 +152,7 @@ mod tests {
     }
 
     #[test]
-    fn guide_score_candidates_empty_is_empty() {
+    fn guide_score_candidates_returns_empty_for_empty_candidates() {
         let backbone = ExprNnue::new_random(1);
         let guide = Guide::new_random(backbone, 2);
         let graph = GraphSummary {

--- a/pixelflow-search/src/nnue/guide/mod.rs
+++ b/pixelflow-search/src/nnue/guide/mod.rs
@@ -210,7 +210,7 @@ mod tests {
     // ========================================================================
 
     #[test]
-    fn guide_score_candidates_returns_one_finite_score_per_candidate() {
+    fn guide_score_candidates_should_return_one_finite_score_per_candidate() {
         let backbone = ExprNnue::new_random(1);
         let guide = Guide::new_random(backbone, 2);
 
@@ -233,7 +233,7 @@ mod tests {
     }
 
     #[test]
-    fn guide_score_candidates_returns_empty_for_empty_candidates() {
+    fn guide_score_candidates_should_return_empty_for_empty_candidates() {
         let backbone = ExprNnue::new_random(1);
         let guide = Guide::new_random(backbone, 2);
         let graph = GraphSummary {

--- a/pixelflow-search/src/nnue/guide/mod.rs
+++ b/pixelflow-search/src/nnue/guide/mod.rs
@@ -155,37 +155,37 @@ mod tests {
     }
 
     #[test]
-    fn shift_by_zero_amount_is_the_identity() {
+    fn shift_by_should_return_the_identity_for_a_zero_amount() {
         let arr = ramp();
         assert_eq!(shift_by(&arr, 0), arr);
     }
 
     #[test]
-    fn shift_by_one_rotates_every_element_left_by_one() {
+    fn shift_by_should_rotate_every_element_left_by_one_for_an_amount_of_one() {
         let arr = ramp();
         assert_eq!(shift_by(&arr, 1), rotate_left(&arr, 1));
     }
 
     #[test]
-    fn shift_by_k_minus_one_rotates_almost_all_the_way_around() {
+    fn shift_by_should_rotate_almost_all_the_way_around_for_k_minus_one() {
         let arr = ramp();
         assert_eq!(shift_by(&arr, K - 1), rotate_left(&arr, K - 1));
     }
 
     #[test]
-    fn shift_by_k_wraps_back_to_the_identity() {
+    fn shift_by_should_wrap_back_to_the_identity_at_k() {
         let arr = ramp();
         assert_eq!(shift_by(&arr, K), arr);
     }
 
     #[test]
-    fn shift_by_k_plus_one_matches_shift_by_one() {
+    fn shift_by_should_match_shift_by_one_at_k_plus_one() {
         let arr = ramp();
         assert_eq!(shift_by(&arr, K + 1), shift_by(&arr, 1));
     }
 
     #[test]
-    fn shift_by_near_usize_max_does_not_overflow_and_matches_its_residue_mod_k() {
+    fn shift_by_should_not_overflow_near_usize_max_and_should_match_its_residue_mod_k() {
         // `amount % K` never overflows, but a `%` -> `+` mutation of the
         // internal `amount = amount % K` line is arithmetically equivalent
         // to the correct code for every amount that doesn't overflow
@@ -199,7 +199,7 @@ mod tests {
     }
 
     #[test]
-    fn shift1_is_shift_by_one() {
+    fn shift1_should_equal_shift_by_one() {
         let arr = ramp();
         assert_eq!(shift1(&arr), shift_by(&arr, 1));
         assert_eq!(shift1(&arr), rotate_left(&arr, 1));

--- a/pixelflow-search/src/nnue/guide/mod.rs
+++ b/pixelflow-search/src/nnue/guide/mod.rs
@@ -128,6 +128,87 @@ impl SaturationGuide for Guide {
 mod tests {
     use super::*;
 
+    // ========================================================================
+    // shift_by / shift1
+    // ========================================================================
+
+    /// A K-element ramp `[0.0, 1.0, ..., K-1 as f32]` — every element
+    /// distinct, so a rotation, a constant fill, or a mis-indexed lookup all
+    /// produce visibly different arrays from the correct answer.
+    fn ramp() -> [f32; K] {
+        let mut a = [0.0f32; K];
+        for (i, v) in a.iter_mut().enumerate() {
+            *v = i as f32;
+        }
+        a
+    }
+
+    /// Left-rotation computed independently of [`shift_by`] (slice-style,
+    /// not the `(i + amount) % K` formula under test), used as the expected
+    /// value in the tests below.
+    fn rotate_left(a: &[f32; K], amount: usize) -> [f32; K] {
+        let amount = amount % K;
+        let mut out = [0.0f32; K];
+        out[..K - amount].copy_from_slice(&a[amount..]);
+        out[K - amount..].copy_from_slice(&a[..amount]);
+        out
+    }
+
+    #[test]
+    fn shift_by_zero_amount_is_the_identity() {
+        let arr = ramp();
+        assert_eq!(shift_by(&arr, 0), arr);
+    }
+
+    #[test]
+    fn shift_by_one_rotates_every_element_left_by_one() {
+        let arr = ramp();
+        assert_eq!(shift_by(&arr, 1), rotate_left(&arr, 1));
+    }
+
+    #[test]
+    fn shift_by_k_minus_one_rotates_almost_all_the_way_around() {
+        let arr = ramp();
+        assert_eq!(shift_by(&arr, K - 1), rotate_left(&arr, K - 1));
+    }
+
+    #[test]
+    fn shift_by_k_wraps_back_to_the_identity() {
+        let arr = ramp();
+        assert_eq!(shift_by(&arr, K), arr);
+    }
+
+    #[test]
+    fn shift_by_k_plus_one_matches_shift_by_one() {
+        let arr = ramp();
+        assert_eq!(shift_by(&arr, K + 1), shift_by(&arr, 1));
+    }
+
+    #[test]
+    fn shift_by_near_usize_max_does_not_overflow_and_matches_its_residue_mod_k() {
+        // `amount % K` never overflows, but a `%` -> `+` mutation of the
+        // internal `amount = amount % K` line is arithmetically equivalent
+        // to the correct code for every amount that doesn't overflow
+        // `amount + K` (both feed into an outer `% K` that discards any
+        // added multiple of K). usize::MAX is chosen specifically to make
+        // that mutated addition overflow (and panic, under this workspace's
+        // debug overflow-checks) where the correct code would not.
+        let arr = ramp();
+        let want = rotate_left(&arr, usize::MAX % K);
+        assert_eq!(shift_by(&arr, usize::MAX), want);
+    }
+
+    #[test]
+    fn shift1_is_shift_by_one() {
+        let arr = ramp();
+        assert_eq!(shift1(&arr), shift_by(&arr, 1));
+        assert_eq!(shift1(&arr), rotate_left(&arr, 1));
+    }
+
+    // ========================================================================
+    // Guide::score_candidates
+    // ========================================================================
+
     #[test]
     fn guide_score_candidates_returns_one_finite_score_per_candidate() {
         let backbone = ExprNnue::new_random(1);

--- a/pixelflow-search/src/nnue/guide/scoring.rs
+++ b/pixelflow-search/src/nnue/guide/scoring.rs
@@ -375,7 +375,7 @@ impl SaturationHead {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::nnue::factored::OpKind;
+    use crate::nnue::factored::{OpEmbeddings, OpKind};
 
     fn test_backbone() -> ExprNnue {
         ExprNnue::new_random(42)
@@ -987,5 +987,179 @@ mod tests {
                 "graph_proj_b[{k}]"
             );
         }
+    }
+
+    // ── Index and orientation pinning ────────────────────────────────────
+    //
+    // The exact-value tests above use uniform fixtures, which pin arithmetic
+    // but not indexing: when every input and weight is the same number,
+    // reading row 0, column 0, or the transpose gives the same answer. Each
+    // test below makes exactly one (index, index) pair live, with no index
+    // equal to zero, so a substituted index reads a zero and collapses the
+    // result.
+
+    #[test]
+    fn compute_graph_embed_should_index_the_projection_by_both_hidden_lane_and_column() {
+        const LANE: usize = 3;
+        const COLUMN: usize = 5;
+
+        let mut head = SaturationHead::new();
+        head.graph_proj_w[LANE][COLUMN] = 3.0;
+        let mut hidden = [0.0f32; HIDDEN_DIM];
+        hidden[LANE] = 2.0;
+
+        let embed = head.compute_graph_embed(&hidden);
+
+        for (k, &v) in embed.iter().enumerate() {
+            let want = if k == COLUMN { 6.0 } else { 0.0 };
+            assert!(
+                (v - want).abs() < 1e-6,
+                "embed[{k}]: got {v}, expected {want}"
+            );
+        }
+    }
+
+    #[test]
+    fn compute_mask_features_should_index_both_mlp_layers_by_lane_and_column() {
+        const IN: usize = 2;
+        const MID: usize = 4;
+        const OUT: usize = 7;
+
+        let mut head = SaturationHead::new();
+        head.mask_mlp_w1[IN][MID] = 3.0;
+        head.mask_mlp_w2[MID][OUT] = 5.0;
+
+        let mut embed = [0.0f32; EMBED_DIM];
+        embed[IN] = 2.0;
+
+        // Layer 1: h[MID] = 2*3 = 6, every other hidden lane 0 (and the ReLU
+        // leaves both alone). Layer 2: out[OUT] = 6*5 = 30.
+        let out = head.compute_mask_features(&embed);
+
+        for (k, &v) in out.iter().enumerate() {
+            let want = if k == OUT { 30.0 } else { 0.0 };
+            assert!(
+                (v - want).abs() < 1e-6,
+                "out[{k}]: got {v}, expected {want}"
+            );
+        }
+    }
+
+    #[test]
+    fn bilinear_score_should_respect_the_interaction_orientation_and_the_bias_lane() {
+        // `transformed[j] += mask_features[i] * interaction[i][j]`, so with a
+        // single off-diagonal entry live the transpose sends the mass to a
+        // different lane than the rule embedding reads.
+        const ROW: usize = 2;
+        const COL: usize = 5;
+
+        let mut head = SaturationHead::new();
+        head.interaction[ROW][COL] = 1.0;
+        head.mask_bias_proj[COL] = 7.0;
+
+        let mut mask_features = [0.0f32; EMBED_DIM];
+        mask_features[ROW] = 1.0;
+        let mut rule_embed = [0.0f32; EMBED_DIM];
+        rule_embed[COL] = 1.0;
+
+        // transformed[COL] = 1, plus the bias lane 7, times rule_embed[COL].
+        // Transposing the interaction puts the 1 on lane ROW instead, which
+        // rule_embed does not read, leaving 7. Reading `mask_bias_proj[0]`
+        // instead of `[k]` drops the 7, leaving 1.
+        let score = head.bilinear_score(&mask_features, &rule_embed);
+        assert!(
+            (score - 8.0).abs() < 1e-6,
+            "score: got {score}, expected 8.0"
+        );
+    }
+
+    #[test]
+    fn forward_graph_should_clamp_a_negative_preactivation_before_the_shared_trunk() {
+        // `apply_trunk` ends in its own ReLU, so an identity trunk cannot
+        // separate the two stages — a negative lane is clamped either way.
+        // A negating trunk can: clamped-then-negated stays 0, while
+        // negated-without-clamping becomes positive and survives the trunk's
+        // own ReLU.
+        let mut backbone = ExprNnue::new();
+        for i in 0..HIDDEN_DIM {
+            backbone.trunk_w[i][i] = -1.0;
+        }
+
+        let mut head = SaturationHead::new();
+        head.graph_b1 = [-1.0; HIDDEN_DIM];
+
+        let hidden = head.forward_graph(&backbone, &GraphAccumulator::new());
+
+        for (j, &h) in hidden.iter().enumerate() {
+            assert!(
+                h.abs() < 1e-6,
+                "hidden[{j}]: got {h}, expected 0.0 — a -1.0 preactivation must be \
+                 clamped by the tower's ReLU before the negating trunk sees it"
+            );
+        }
+    }
+
+    #[test]
+    fn encode_rule_from_arena_should_start_the_projection_from_the_rule_bias() {
+        // Every selector fixture above leaves `rule_proj_b` at zero, and
+        // `randomize` deliberately zeroes it too, so replacing
+        // `let mut out = self.rule_proj_b` with an all-zero array is
+        // invisible everywhere else. Zero the projection weights and give the
+        // bias distinct lanes: the output is then exactly the bias.
+        let backbone = test_backbone();
+        let (arena, lhs, rhs) = sample_rule_arena();
+
+        let mut head = SaturationHead::new();
+        for k in 0..EMBED_DIM {
+            head.rule_proj_b[k] = k as f32 + 1.0;
+        }
+
+        let out = head.encode_rule_from_arena(&backbone, &arena, lhs, rhs);
+
+        for (k, &v) in out.iter().enumerate() {
+            let want = k as f32 + 1.0;
+            assert!(
+                (v - want).abs() < 1e-4,
+                "out[{k}]: got {v}, expected {want}"
+            );
+        }
+    }
+
+    #[test]
+    fn mask_score_all_rules_graph_should_compose_the_graph_tower_projection_and_scorer() {
+        // `Guide::score_candidates` routes through this path, but the only
+        // exact composition test covers the `_with_hidden` variant; the graph
+        // variant was checked for length and finiteness alone. Rewiring it to
+        // `backbone.compute_expr_embed` instead of `self.compute_graph_embed`
+        // would go unnoticed.
+        let backbone = test_backbone();
+        let mut head = SaturationHead::new();
+        head.randomize(7);
+
+        let mut gacc = GraphAccumulator::new();
+        let emb = OpEmbeddings::new_random(3);
+        gacc.add_edge(&emb, OpKind::Add, OpKind::Mul);
+        gacc.add_edge(&emb, OpKind::Sub, OpKind::Div);
+        gacc.node_count = 3;
+        gacc.edge_count = 2;
+
+        let (arena, lhs, rhs) = sample_rule_arena();
+        let rule = head.encode_rule_from_arena(&backbone, &arena, lhs, rhs);
+        let rules = [rule];
+
+        let got = head.mask_score_all_rules_graph(&backbone, &gacc, &rules);
+
+        let hidden = head.forward_graph(&backbone, &gacc);
+        let graph_embed = head.compute_graph_embed(&hidden);
+        let mask_features = head.compute_mask_features(&graph_embed);
+        let want = head.bilinear_score(&mask_features, &rules[0]);
+
+        assert_eq!(got.len(), 1);
+        assert!(
+            (got[0] - want).abs() < 1e-3,
+            "graph scoring must be forward_graph -> compute_graph_embed -> \
+             compute_mask_features -> bilinear_score; got {}, want {want}",
+            got[0]
+        );
     }
 }

--- a/pixelflow-search/src/nnue/guide/scoring.rs
+++ b/pixelflow-search/src/nnue/guide/scoring.rs
@@ -502,7 +502,7 @@ mod tests {
     }
 
     #[test]
-    fn forward_graph_matches_hand_computed_value_when_node_count_is_positive() {
+    fn forward_graph_should_match_a_hand_computed_value_when_node_count_is_positive() {
         let backbone = identity_trunk_backbone();
         let mut head = SaturationHead::new();
         head.graph_b1 = [10.0; HIDDEN_DIM];
@@ -548,17 +548,27 @@ mod tests {
         let backbone = identity_trunk_backbone();
         let mut head = SaturationHead::new();
         head.graph_b1 = [5.0; HIDDEN_DIM];
+        head.graph_w1[0] = [1.0; HIDDEN_DIM];
 
-        // All-zero accumulator: node_count == 0 takes the `else` branch
-        // (scale = 1.0). Under a `>` -> `==`/`>=` mutation the `if` branch is
-        // taken instead, computing `1.0 / sqrtf(0.0) = inf`; since
-        // `gacc.values` are all zero, `0.0 * inf` is NaN, which poisons every
-        // hidden entry and is trivially distinguishable from the expected 5.0.
-        let gacc = GraphAccumulator::new();
+        // One populated lane, so the output depends on the scale's *value* and
+        // not merely on its finiteness: an all-zero accumulator multiplies
+        // every candidate scale by 0.0 and lands on the bias either way, which
+        // would leave 0.0, 1.0 and 2.0 indistinguishable here.
+        let mut gacc = GraphAccumulator::new();
+        gacc.values[0] = 8.0;
+
+        // node_count stays 0, so `node_count > 0` is false and the scale is
+        // 1.0. Every scalar feature is log2(1 + 0) = 0 and contributes nothing.
+        // A `>` -> `>=`/`==` mutation takes the other branch and computes
+        // `1.0 / sqrtf(0.0)` = inf, sending the lane to inf rather than 13.0.
+        let expected = 5.0 + 8.0 * 1.0;
 
         let hidden = head.forward_graph(&backbone, &gacc);
         for (j, &h) in hidden.iter().enumerate() {
-            assert!((h - 5.0).abs() < 1e-6, "hidden[{j}]: got {h}, expected 5.0");
+            assert!(
+                (h - expected).abs() < 1e-6,
+                "hidden[{j}]: got {h}, expected {expected}"
+            );
         }
     }
 
@@ -689,6 +699,25 @@ mod tests {
             head.rule_proj_w[block_start + k][k] = weight;
         }
         head
+    }
+
+    #[test]
+    fn encode_rule_from_arena_places_lhs_embedding_at_the_first_concat_block() {
+        let backbone = test_backbone();
+        let (arena, lhs, rhs) = sample_rule_arena();
+        let z_lhs = embed_of(&backbone, &arena, lhs);
+
+        let head = concat_block_selector(0, 2.0);
+        let out = head.encode_rule_from_arena(&backbone, &arena, lhs, rhs);
+
+        for k in 0..EMBED_DIM {
+            let expected = 2.0 * z_lhs[k];
+            assert!(
+                (out[k] - expected).abs() < 1e-3,
+                "block1[{k}]: got {}, expected {expected}",
+                out[k]
+            );
+        }
     }
 
     #[test]
@@ -855,6 +884,19 @@ mod tests {
                 );
             }
         }
+        // The three arrays `randomize` leaves at a literal 0.0. Asserted rather
+        // than merely noted above: without these, `randomize` could start
+        // writing a nonzero literal into any of them, or consume RNG while
+        // populating them, and every other assertion here would still pass —
+        // the reference stream would simply shift in lockstep.
+        for k in 0..EMBED_DIM {
+            assert!(
+                close(head.mask_mlp_b2[k], 0.0),
+                "mask_mlp_b2[{k}] must stay zero, got {}",
+                head.mask_mlp_b2[k]
+            );
+        }
+
         for i in 0..RULE_CONCAT_DIM {
             for k in 0..EMBED_DIM {
                 assert!(
@@ -863,6 +905,13 @@ mod tests {
                 );
             }
         }
+        for k in 0..EMBED_DIM {
+            assert!(
+                close(head.rule_proj_b[k], 0.0),
+                "rule_proj_b[{k}] must stay zero, got {}",
+                head.rule_proj_b[k]
+            );
+        }
         for i in 0..EMBED_DIM {
             for j in 0..EMBED_DIM {
                 assert!(
@@ -870,6 +919,13 @@ mod tests {
                     "interaction[{i}][{j}]"
                 );
             }
+        }
+        for k in 0..EMBED_DIM {
+            assert!(
+                close(head.mask_bias_proj[k], 0.0),
+                "mask_bias_proj[{k}] must stay zero, got {}",
+                head.mask_bias_proj[k]
+            );
         }
         for row in 0..GRAPH_INPUT_DIM {
             for col in 0..HIDDEN_DIM {

--- a/pixelflow-search/src/nnue/guide/scoring.rs
+++ b/pixelflow-search/src/nnue/guide/scoring.rs
@@ -478,4 +478,423 @@ mod tests {
             assert!(e1[i].is_finite());
         }
     }
+
+    #[test]
+    fn graph_input_dim_is_the_sum_of_graph_acc_dim_and_scalar_feature_count() {
+        // GRAPH_ACC_DIM (128) + SCALAR_FEATURE_COUNT (4) = 132. Written as a
+        // literal (rather than re-deriving via `+`) so a `+` -> `*` mutation
+        // on the const declaration (128 * 4 = 512) is unambiguously wrong.
+        assert_eq!(GRAPH_INPUT_DIM, 132);
+        assert_eq!(GRAPH_ACC_DIM, 128);
+        assert_eq!(SCALAR_FEATURE_COUNT, 4);
+    }
+
+    /// An `ExprNnue` whose shared trunk is the identity (zero bias, identity
+    /// weight matrix). `apply_trunk` then returns its input unchanged for any
+    /// non-negative vector, letting `forward_graph` tests assert an exact
+    /// pre-trunk hidden value without also having to hand-verify the trunk.
+    fn identity_trunk_backbone() -> ExprNnue {
+        let mut backbone = ExprNnue::new();
+        for i in 0..HIDDEN_DIM {
+            backbone.trunk_w[i][i] = 1.0;
+        }
+        backbone
+    }
+
+    #[test]
+    fn forward_graph_matches_hand_computed_value_when_node_count_is_positive() {
+        let backbone = identity_trunk_backbone();
+        let mut head = SaturationHead::new();
+        head.graph_b1 = [10.0; HIDDEN_DIM];
+        for i in 0..GRAPH_ACC_DIM {
+            head.graph_w1[i] = [3.0; HIDDEN_DIM];
+        }
+        head.graph_w1[GRAPH_ACC_DIM] = [100.0; HIDDEN_DIM]; // edge_count row
+        head.graph_w1[GRAPH_ACC_DIM + 1] = [200.0; HIDDEN_DIM]; // node_count row
+        head.graph_w1[GRAPH_ACC_DIM + 2] = [300.0; HIDDEN_DIM]; // node_budget row
+        head.graph_w1[GRAPH_ACC_DIM + 3] = [400.0; HIDDEN_DIM]; // epoch_budget row
+
+        let mut gacc = GraphAccumulator::new();
+        gacc.values = [2.0; GRAPH_ACC_DIM];
+        gacc.node_count = 4; // sqrtf(4) = 2 -> scale = 0.5
+        gacc.edge_count = 2;
+        gacc.node_budget = 5;
+        gacc.epoch_budget = 6;
+
+        let hidden = head.forward_graph(&backbone, &gacc);
+
+        let scale = 1.0 / sqrtf(4.0f32);
+        let main_sum = GRAPH_ACC_DIM as f32 * (2.0 * scale) * 3.0;
+        let ec = log2f(1.0 + 2.0f32);
+        let nc = log2f(1.0 + 4.0f32);
+        let nb = log2f(1.0 + 5.0f32);
+        let eb = log2f(1.0 + 6.0f32);
+        let expected = 10.0 + main_sum + ec * 100.0 + nc * 200.0 + nb * 300.0 + eb * 400.0;
+        assert!(
+            expected > 0.0,
+            "fixture must stay in the ReLU's positive branch"
+        );
+
+        for (j, &h) in hidden.iter().enumerate() {
+            assert!(
+                (h - expected).abs() < 1e-2,
+                "hidden[{j}]: got {h}, expected {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn forward_graph_uses_scale_one_when_node_count_is_zero() {
+        let backbone = identity_trunk_backbone();
+        let mut head = SaturationHead::new();
+        head.graph_b1 = [5.0; HIDDEN_DIM];
+
+        // All-zero accumulator: node_count == 0 takes the `else` branch
+        // (scale = 1.0). Under a `>` -> `==`/`>=` mutation the `if` branch is
+        // taken instead, computing `1.0 / sqrtf(0.0) = inf`; since
+        // `gacc.values` are all zero, `0.0 * inf` is NaN, which poisons every
+        // hidden entry and is trivially distinguishable from the expected 5.0.
+        let gacc = GraphAccumulator::new();
+
+        let hidden = head.forward_graph(&backbone, &gacc);
+        for (j, &h) in hidden.iter().enumerate() {
+            assert!((h - 5.0).abs() < 1e-6, "hidden[{j}]: got {h}, expected 5.0");
+        }
+    }
+
+    #[test]
+    fn compute_graph_embed_matches_hand_computed_value_for_constant_inputs() {
+        let mut head = SaturationHead::new();
+        head.graph_proj_b = [1.0; EMBED_DIM];
+        head.graph_proj_w = [[4.0; EMBED_DIM]; HIDDEN_DIM];
+        let hidden = [2.0f32; HIDDEN_DIM];
+
+        let embed = head.compute_graph_embed(&hidden);
+
+        // expected[k] = b[k] + sum_j hidden[j] * w[j][k] = 1.0 + 64 * (2.0 * 4.0)
+        let expected = 1.0 + HIDDEN_DIM as f32 * (2.0 * 4.0);
+        for (k, &e) in embed.iter().enumerate() {
+            assert!(
+                (e - expected).abs() < 1e-2,
+                "embed[{k}]: got {e}, expected {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn compute_mask_features_matches_hand_computed_value_for_constant_inputs() {
+        let mut head = SaturationHead::new();
+        head.mask_mlp_b1 = [1.0; MLP_HIDDEN];
+        head.mask_mlp_w1 = [[4.0; MLP_HIDDEN]; MASK_INPUT_DIM];
+        head.mask_mlp_b2 = [5.0; EMBED_DIM];
+        head.mask_mlp_w2 = [[3.0; EMBED_DIM]; MLP_HIDDEN];
+        let embed = [2.0f32; EMBED_DIM];
+
+        let out = head.compute_mask_features(&embed);
+
+        // h[j] = 1.0 + 32 * (2.0 * 4.0) = 257.0 (positive, ReLU is a no-op)
+        let hidden_val = 1.0 + MASK_INPUT_DIM as f32 * (2.0 * 4.0);
+        assert!(
+            hidden_val > 0.0,
+            "fixture must stay in the ReLU's positive branch"
+        );
+        // out[k] = 5.0 + 16 * (257.0 * 3.0)
+        let expected = 5.0 + MLP_HIDDEN as f32 * (hidden_val * 3.0);
+        for (k, &o) in out.iter().enumerate() {
+            assert!(
+                (o - expected).abs() < 1e-1,
+                "out[{k}]: got {o}, expected {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn mask_score_all_rules_with_hidden_matches_manual_composition_of_backbone_and_head() {
+        let backbone = test_backbone();
+        let mut head = SaturationHead::new();
+        head.randomize(11);
+
+        let hidden = [0.3f32; HIDDEN_DIM];
+        let rule_embeds = [[0.2f32; EMBED_DIM], [0.7f32; EMBED_DIM]];
+
+        // Reference: replay the same two steps `mask_score_all_rules_with_hidden`
+        // is documented to perform, calling the same (private, same-module)
+        // helpers it calls.
+        let expr_embed = backbone.compute_expr_embed(&hidden);
+        let mask_features = head.compute_mask_features(&expr_embed);
+        let expected: Vec<f32> = rule_embeds
+            .iter()
+            .map(|re| head.bilinear_score(&mask_features, re))
+            .collect();
+
+        let actual = head.mask_score_all_rules_with_hidden(&backbone, &hidden, &rule_embeds);
+
+        assert_eq!(actual.len(), expected.len(), "one score per rule embed");
+        for (a, e) in actual.iter().zip(expected.iter()) {
+            assert!((a - e).abs() < 1e-4, "got {a}, expected {e}");
+        }
+        // Distinct rule embeddings must not collapse to the same score — guards
+        // against a constant-vector replacement of the whole function body.
+        assert!(
+            (actual[0] - actual[1]).abs() > 1e-6,
+            "distinct rule embeds should score differently"
+        );
+    }
+
+    #[test]
+    fn bilinear_score_responds_to_bias_addition_and_rule_embed_scaling() {
+        let mut head = SaturationHead::new();
+        head.interaction = [[1.0; EMBED_DIM]; EMBED_DIM];
+        head.mask_bias_proj = [3.0; EMBED_DIM];
+        let mask_features = [1.0f32; EMBED_DIM];
+        let rule_embed = [2.0f32; EMBED_DIM];
+
+        let score = head.bilinear_score(&mask_features, &rule_embed);
+
+        // transformed[k] = sum_i mask_features[i] * interaction[i][k] = 32.0
+        // score = sum_k (transformed[k] + bias[k]) * rule_embed[k]
+        //       = 32 * ((32.0 + 3.0) * 2.0)
+        let transformed = EMBED_DIM as f32;
+        let expected = EMBED_DIM as f32 * ((transformed + 3.0) * 2.0);
+        assert!(
+            (score - expected).abs() < 1e-2,
+            "got {score}, expected {expected}"
+        );
+    }
+
+    fn sample_rule_arena() -> (ExprArena, ExprId, ExprId) {
+        let mut arena = ExprArena::with_capacity(4);
+        let x = arena.push_var(0);
+        let one = arena.push_const(1.0);
+        let lhs = arena.push_binary(OpKind::Add, x, one);
+        let rhs = arena.push_binary(OpKind::Mul, x, one);
+        (arena, lhs, rhs)
+    }
+
+    fn embed_of(backbone: &ExprNnue, arena: &ExprArena, root: ExprId) -> [f32; EMBED_DIM] {
+        let acc = EdgeAccumulator::from_arena_dag(arena, root, &backbone.embeddings);
+        let hidden = backbone.forward_expr_only(&acc);
+        backbone.compute_expr_embed(&hidden)
+    }
+
+    /// A `SaturationHead` whose `rule_proj_w` is a "selector": projecting
+    /// picks out `concat[block_start + k]` (scaled by `weight`) as output `k`,
+    /// with every other row zeroed. Lets a concat-block test read that block
+    /// straight out of `encode_rule_from_arena`'s output without disturbing
+    /// the other three blocks (a real `RULE_CONCAT_DIM x EMBED_DIM` matrix
+    /// would mix them all together).
+    fn concat_block_selector(block_start: usize, weight: f32) -> SaturationHead {
+        let mut head = SaturationHead::new();
+        for k in 0..EMBED_DIM {
+            head.rule_proj_w[block_start + k][k] = weight;
+        }
+        head
+    }
+
+    #[test]
+    fn encode_rule_from_arena_places_rhs_embedding_at_the_second_concat_block() {
+        let backbone = test_backbone();
+        let (arena, lhs, rhs) = sample_rule_arena();
+        let z_rhs = embed_of(&backbone, &arena, rhs);
+
+        let head = concat_block_selector(EMBED_DIM, 2.0);
+        let out = head.encode_rule_from_arena(&backbone, &arena, lhs, rhs);
+
+        for k in 0..EMBED_DIM {
+            let expected = 2.0 * z_rhs[k];
+            assert!(
+                (out[k] - expected).abs() < 1e-3,
+                "block2[{k}]: got {}, expected {expected}",
+                out[k]
+            );
+        }
+    }
+
+    #[test]
+    fn encode_rule_from_arena_concat_block_three_is_the_elementwise_difference() {
+        let backbone = test_backbone();
+        let (arena, lhs, rhs) = sample_rule_arena();
+        let z_lhs = embed_of(&backbone, &arena, lhs);
+        let z_rhs = embed_of(&backbone, &arena, rhs);
+
+        let head = concat_block_selector(2 * EMBED_DIM, 2.0);
+        let out = head.encode_rule_from_arena(&backbone, &arena, lhs, rhs);
+
+        for k in 0..EMBED_DIM {
+            let expected = 2.0 * (z_lhs[k] - z_rhs[k]);
+            assert!(
+                (out[k] - expected).abs() < 1e-3,
+                "block3[{k}]: got {}, expected {expected}",
+                out[k]
+            );
+        }
+    }
+
+    #[test]
+    fn encode_rule_from_arena_concat_block_four_is_the_elementwise_product() {
+        let backbone = test_backbone();
+        let (arena, lhs, rhs) = sample_rule_arena();
+        let z_lhs = embed_of(&backbone, &arena, lhs);
+        let z_rhs = embed_of(&backbone, &arena, rhs);
+
+        let head = concat_block_selector(3 * EMBED_DIM, 2.0);
+        let out = head.encode_rule_from_arena(&backbone, &arena, lhs, rhs);
+
+        for k in 0..EMBED_DIM {
+            let expected = 2.0 * (z_lhs[k] * z_rhs[k]);
+            assert!(
+                (out[k] - expected).abs() < 1e-3,
+                "block4[{k}]: got {}, expected {expected}",
+                out[k]
+            );
+        }
+    }
+
+    #[test]
+    fn randomize_matches_a_hand_recomputed_he_initialization_reference() {
+        let seed = 99u64;
+        let mut head = SaturationHead::new();
+        head.randomize(seed);
+
+        // Independent reference re-implementation of the same LCG stepping and
+        // He-init formulas, kept out of `SaturationHead::randomize` on
+        // purpose: an operator mutation there (RNG update, a scale formula, or
+        // a `next_f32() * scale` use site) shows up here as a numeric
+        // mismatch instead of hiding behind an `is_finite()`/determinism-only
+        // check.
+        let mut rng_state = seed.wrapping_add(54321);
+        let mut next_f32 = || {
+            rng_state = rng_state.wrapping_mul(6364136223846793005).wrapping_add(1);
+            (rng_state >> 33) as f32 / (1u64 << 31) as f32 * 2.0 - 1.0
+        };
+
+        let scale_mask_input = sqrtf(2.0 / MASK_INPUT_DIM as f32);
+        let scale_hidden = sqrtf(2.0 / MLP_HIDDEN as f32);
+        let scale_concat = sqrtf(2.0 / RULE_CONCAT_DIM as f32);
+        let scale_graph = sqrtf(2.0 / GRAPH_INPUT_DIM as f32);
+        let scale_proj = sqrtf(2.0 / HIDDEN_DIM as f32);
+
+        let mut exp_mask_mlp_w1 = [[0.0f32; MLP_HIDDEN]; MASK_INPUT_DIM];
+        for i in 0..MASK_INPUT_DIM {
+            for j in 0..MLP_HIDDEN {
+                exp_mask_mlp_w1[i][j] = next_f32() * scale_mask_input;
+            }
+        }
+        let mut exp_mask_mlp_b1 = [0.0f32; MLP_HIDDEN];
+        for b in &mut exp_mask_mlp_b1 {
+            *b = next_f32().abs() * 0.1;
+        }
+        let mut exp_mask_mlp_w2 = [[0.0f32; EMBED_DIM]; MLP_HIDDEN];
+        for j in 0..MLP_HIDDEN {
+            for k in 0..EMBED_DIM {
+                exp_mask_mlp_w2[j][k] = next_f32() * scale_hidden;
+            }
+        }
+        // mask_mlp_b2 is set to a literal 0.0 in `randomize` — no RNG consumed.
+
+        let mut exp_rule_proj_w = [[0.0f32; EMBED_DIM]; RULE_CONCAT_DIM];
+        for i in 0..RULE_CONCAT_DIM {
+            for k in 0..EMBED_DIM {
+                exp_rule_proj_w[i][k] = next_f32() * scale_concat;
+            }
+        }
+        // rule_proj_b: literal 0.0, no RNG consumed.
+
+        let mut exp_interaction = [[0.0f32; EMBED_DIM]; EMBED_DIM];
+        for i in 0..EMBED_DIM {
+            for j in 0..EMBED_DIM {
+                exp_interaction[i][j] = if i == j { 1.0 } else { next_f32() * 0.1 };
+            }
+        }
+        // mask_bias_proj: literal 0.0, no RNG consumed.
+
+        let mut exp_graph_w1 = [[0.0f32; HIDDEN_DIM]; GRAPH_INPUT_DIM];
+        for row in 0..GRAPH_INPUT_DIM {
+            for col in 0..HIDDEN_DIM {
+                exp_graph_w1[row][col] = next_f32() * scale_graph;
+            }
+        }
+        let mut exp_graph_b1 = [0.0f32; HIDDEN_DIM];
+        for b in &mut exp_graph_b1 {
+            *b = next_f32().abs() * 0.1;
+        }
+        let mut exp_graph_proj_w = [[0.0f32; EMBED_DIM]; HIDDEN_DIM];
+        for j in 0..HIDDEN_DIM {
+            for k in 0..EMBED_DIM {
+                exp_graph_proj_w[j][k] = next_f32() * scale_proj;
+            }
+        }
+        let mut exp_graph_proj_b = [0.0f32; EMBED_DIM];
+        for b in &mut exp_graph_proj_b {
+            *b = next_f32().abs() * 0.1;
+        }
+
+        let close = |a: f32, b: f32| (a - b).abs() < 1e-6;
+
+        for i in 0..MASK_INPUT_DIM {
+            for j in 0..MLP_HIDDEN {
+                assert!(
+                    close(head.mask_mlp_w1[i][j], exp_mask_mlp_w1[i][j]),
+                    "mask_mlp_w1[{i}][{j}]: got {}, expected {}",
+                    head.mask_mlp_w1[i][j],
+                    exp_mask_mlp_w1[i][j]
+                );
+            }
+        }
+        for j in 0..MLP_HIDDEN {
+            assert!(
+                close(head.mask_mlp_b1[j], exp_mask_mlp_b1[j]),
+                "mask_mlp_b1[{j}]"
+            );
+        }
+        for j in 0..MLP_HIDDEN {
+            for k in 0..EMBED_DIM {
+                assert!(
+                    close(head.mask_mlp_w2[j][k], exp_mask_mlp_w2[j][k]),
+                    "mask_mlp_w2[{j}][{k}]"
+                );
+            }
+        }
+        for i in 0..RULE_CONCAT_DIM {
+            for k in 0..EMBED_DIM {
+                assert!(
+                    close(head.rule_proj_w[i][k], exp_rule_proj_w[i][k]),
+                    "rule_proj_w[{i}][{k}]"
+                );
+            }
+        }
+        for i in 0..EMBED_DIM {
+            for j in 0..EMBED_DIM {
+                assert!(
+                    close(head.interaction[i][j], exp_interaction[i][j]),
+                    "interaction[{i}][{j}]"
+                );
+            }
+        }
+        for row in 0..GRAPH_INPUT_DIM {
+            for col in 0..HIDDEN_DIM {
+                assert!(
+                    close(head.graph_w1[row][col], exp_graph_w1[row][col]),
+                    "graph_w1[{row}][{col}]"
+                );
+            }
+        }
+        for j in 0..HIDDEN_DIM {
+            assert!(close(head.graph_b1[j], exp_graph_b1[j]), "graph_b1[{j}]");
+        }
+        for j in 0..HIDDEN_DIM {
+            for k in 0..EMBED_DIM {
+                assert!(
+                    close(head.graph_proj_w[j][k], exp_graph_proj_w[j][k]),
+                    "graph_proj_w[{j}][{k}]"
+                );
+            }
+        }
+        for k in 0..EMBED_DIM {
+            assert!(
+                close(head.graph_proj_b[k], exp_graph_proj_b[k]),
+                "graph_proj_b[{k}]"
+            );
+        }
+    }
 }

--- a/pixelflow-search/src/nnue/guide/scoring.rs
+++ b/pixelflow-search/src/nnue/guide/scoring.rs
@@ -382,7 +382,7 @@ mod tests {
     }
 
     #[test]
-    fn bilinear_score_matches_manual_computation_for_all_ones_vectors() {
+    fn bilinear_score_should_match_manual_computation_for_all_ones_vectors() {
         let head = SaturationHead::new();
         let mut randomized = head.clone();
         randomized.randomize(42);
@@ -413,7 +413,7 @@ mod tests {
     }
 
     #[test]
-    fn randomize_is_deterministic_and_finite_with_near_identity_diagonal() {
+    fn randomize_should_be_deterministic_and_finite_with_a_near_identity_diagonal() {
         let mut a = SaturationHead::new();
         a.randomize(42);
         let mut b = SaturationHead::new();
@@ -438,7 +438,7 @@ mod tests {
     }
 
     #[test]
-    fn forward_graph_uses_backbone_trunk() {
+    fn forward_graph_should_use_the_backbone_trunk() {
         let backbone = test_backbone();
         let mut head = SaturationHead::new();
         head.randomize(7);
@@ -460,7 +460,7 @@ mod tests {
     }
 
     #[test]
-    fn encode_rule_from_arena_is_deterministic() {
+    fn encode_rule_from_arena_should_be_deterministic() {
         let backbone = test_backbone();
         let mut head = SaturationHead::new();
         head.randomize(3);
@@ -480,7 +480,7 @@ mod tests {
     }
 
     #[test]
-    fn graph_input_dim_is_the_sum_of_graph_acc_dim_and_scalar_feature_count() {
+    fn graph_input_dim_should_equal_graph_acc_dim_plus_the_scalar_feature_count() {
         // GRAPH_ACC_DIM (128) + SCALAR_FEATURE_COUNT (4) = 132. Written as a
         // literal (rather than re-deriving via `+`) so a `+` -> `*` mutation
         // on the const declaration (128 * 4 = 512) is unambiguously wrong.
@@ -544,7 +544,7 @@ mod tests {
     }
 
     #[test]
-    fn forward_graph_uses_scale_one_when_node_count_is_zero() {
+    fn forward_graph_should_use_a_scale_of_one_when_node_count_is_zero() {
         let backbone = identity_trunk_backbone();
         let mut head = SaturationHead::new();
         head.graph_b1 = [5.0; HIDDEN_DIM];
@@ -573,7 +573,7 @@ mod tests {
     }
 
     #[test]
-    fn compute_graph_embed_matches_hand_computed_value_for_constant_inputs() {
+    fn compute_graph_embed_should_match_a_hand_computed_value_for_constant_inputs() {
         let mut head = SaturationHead::new();
         head.graph_proj_b = [1.0; EMBED_DIM];
         head.graph_proj_w = [[4.0; EMBED_DIM]; HIDDEN_DIM];
@@ -592,7 +592,7 @@ mod tests {
     }
 
     #[test]
-    fn compute_mask_features_matches_hand_computed_value_for_constant_inputs() {
+    fn compute_mask_features_should_match_a_hand_computed_value_for_constant_inputs() {
         let mut head = SaturationHead::new();
         head.mask_mlp_b1 = [1.0; MLP_HIDDEN];
         head.mask_mlp_w1 = [[4.0; MLP_HIDDEN]; MASK_INPUT_DIM];
@@ -619,7 +619,7 @@ mod tests {
     }
 
     #[test]
-    fn mask_score_all_rules_with_hidden_matches_manual_composition_of_backbone_and_head() {
+    fn mask_score_all_rules_with_hidden_should_match_a_manual_composition_of_backbone_and_head() {
         let backbone = test_backbone();
         let mut head = SaturationHead::new();
         head.randomize(11);
@@ -652,7 +652,7 @@ mod tests {
     }
 
     #[test]
-    fn bilinear_score_responds_to_bias_addition_and_rule_embed_scaling() {
+    fn bilinear_score_should_respond_to_bias_addition_and_rule_embed_scaling() {
         let mut head = SaturationHead::new();
         head.interaction = [[1.0; EMBED_DIM]; EMBED_DIM];
         head.mask_bias_proj = [3.0; EMBED_DIM];
@@ -702,7 +702,7 @@ mod tests {
     }
 
     #[test]
-    fn encode_rule_from_arena_places_lhs_embedding_at_the_first_concat_block() {
+    fn encode_rule_from_arena_should_place_the_lhs_embedding_at_the_first_concat_block() {
         let backbone = test_backbone();
         let (arena, lhs, rhs) = sample_rule_arena();
         let z_lhs = embed_of(&backbone, &arena, lhs);
@@ -721,7 +721,7 @@ mod tests {
     }
 
     #[test]
-    fn encode_rule_from_arena_places_rhs_embedding_at_the_second_concat_block() {
+    fn encode_rule_from_arena_should_place_the_rhs_embedding_at_the_second_concat_block() {
         let backbone = test_backbone();
         let (arena, lhs, rhs) = sample_rule_arena();
         let z_rhs = embed_of(&backbone, &arena, rhs);
@@ -740,7 +740,7 @@ mod tests {
     }
 
     #[test]
-    fn encode_rule_from_arena_concat_block_three_is_the_elementwise_difference() {
+    fn encode_rule_from_arena_should_place_the_elementwise_difference_at_the_third_concat_block() {
         let backbone = test_backbone();
         let (arena, lhs, rhs) = sample_rule_arena();
         let z_lhs = embed_of(&backbone, &arena, lhs);
@@ -760,7 +760,7 @@ mod tests {
     }
 
     #[test]
-    fn encode_rule_from_arena_concat_block_four_is_the_elementwise_product() {
+    fn encode_rule_from_arena_should_place_the_elementwise_product_at_the_fourth_concat_block() {
         let backbone = test_backbone();
         let (arena, lhs, rhs) = sample_rule_arena();
         let z_lhs = embed_of(&backbone, &arena, lhs);
@@ -780,7 +780,7 @@ mod tests {
     }
 
     #[test]
-    fn randomize_matches_a_hand_recomputed_he_initialization_reference() {
+    fn randomize_should_match_a_hand_recomputed_he_initialization_reference() {
         let seed = 99u64;
         let mut head = SaturationHead::new();
         head.randomize(seed);

--- a/pixelflow-search/src/nnue/guide/scoring.rs
+++ b/pixelflow-search/src/nnue/guide/scoring.rs
@@ -502,6 +502,41 @@ mod tests {
     }
 
     #[test]
+    fn forward_graph_should_index_the_weight_matrix_by_both_lane_and_hidden_column() {
+        // The hand-computed test below fills every accumulator lane and every
+        // weight row uniformly, which pins the arithmetic but not the
+        // indexing: with `values` all 2.0 and every row `[3.0; HIDDEN_DIM]`,
+        // reading `graph_w1[0][j]` or `graph_w1[i][0]` instead of
+        // `graph_w1[i][j]` produces the same answer. This one is sparse
+        // instead, so exactly one (lane, column) pair is live.
+        //
+        // Neither index is zero, so both substitutions read a zero and
+        // collapse the output.
+        const LANE: usize = 7;
+        const COLUMN: usize = 5;
+
+        let backbone = identity_trunk_backbone();
+        let mut head = SaturationHead::new();
+        head.graph_w1[LANE][COLUMN] = 3.0;
+
+        let mut gacc = GraphAccumulator::new();
+        gacc.values[LANE] = 2.0;
+        gacc.node_count = 1; // scale = 1/sqrt(1) = 1
+
+        // Every scalar-feature row is left at zero, so `log2(1 + node_count)`
+        // being nonzero here contributes nothing either way.
+        let hidden = head.forward_graph(&backbone, &gacc);
+
+        for (j, &h) in hidden.iter().enumerate() {
+            let want = if j == COLUMN { 6.0 } else { 0.0 };
+            assert!(
+                (h - want).abs() < 1e-6,
+                "hidden[{j}]: got {h}, expected {want}"
+            );
+        }
+    }
+
+    #[test]
     fn forward_graph_should_match_a_hand_computed_value_when_node_count_is_positive() {
         let backbone = identity_trunk_backbone();
         let mut head = SaturationHead::new();

--- a/pixelflow-search/src/nnue/guide/scoring.rs
+++ b/pixelflow-search/src/nnue/guide/scoring.rs
@@ -382,7 +382,7 @@ mod tests {
     }
 
     #[test]
-    fn bilinear_score_computation() {
+    fn bilinear_score_matches_manual_computation_for_all_ones_vectors() {
         let head = SaturationHead::new();
         let mut randomized = head.clone();
         randomized.randomize(42);
@@ -413,7 +413,7 @@ mod tests {
     }
 
     #[test]
-    fn verify_randomize_is_deterministic_and_finite() {
+    fn randomize_is_deterministic_and_finite_with_near_identity_diagonal() {
         let mut a = SaturationHead::new();
         a.randomize(42);
         let mut b = SaturationHead::new();
@@ -460,7 +460,7 @@ mod tests {
     }
 
     #[test]
-    fn encode_rule_from_arena_deterministic() {
+    fn encode_rule_from_arena_is_deterministic() {
         let backbone = test_backbone();
         let mut head = SaturationHead::new();
         head.randomize(3);

--- a/pixelflow-search/src/nnue/mod.rs
+++ b/pixelflow-search/src/nnue/mod.rs
@@ -1229,7 +1229,7 @@ mod tests {
     }
 
     #[test]
-    fn bwd_generator_applies_rewrites_from_templates() {
+    fn bwd_generator_should_apply_rewrites_from_templates() {
         use crate::egraph::collect_rule_templates;
         let templates = collect_rule_templates();
         let config = BwdGenConfig::default();

--- a/pixelflow-search/src/nnue/mod.rs
+++ b/pixelflow-search/src/nnue/mod.rs
@@ -1229,7 +1229,7 @@ mod tests {
     }
 
     #[test]
-    fn bwd_generator_with_templates() {
+    fn bwd_generator_applies_rewrites_from_templates() {
         use crate::egraph::collect_rule_templates;
         let templates = collect_rule_templates();
         let config = BwdGenConfig::default();


### PR DESCRIPTION
## Summary

Recurring test-quality-control audit (STYLE.md compliance + `cargo mutants`), this round scoped to `pixelflow-search/src/nnue/{mod.rs, factored.rs, guide/*.rs}` — the recently-encapsulated (#1015) saturation-guide module, which hadn't been through an audit pass yet.

- **STYLE.md test names**: renamed test functions across `nnue/{mod,factored,guide/mod,guide/scoring}.rs` so each reads as a complete "it should ..." sentence — dropped the `verify_`/bare-noun-phrase anti-pattern, fixed `guide_score_candidates_is_finite_and_ordered` (a name claiming an ordering property the test never actually asserted), and removed a redundant weaker duplicate of `param_count_exceeds_10k_and_memory_stays_under_200kb`.
- **Mutation testing**: `cargo mutants -p pixelflow-search --file 'pixelflow-search/src/nnue/guide/*.rs' --no-shuffle -- --lib nnue::` found **185/256 mutants surviving** — the module's characterization tests mostly asserted `.is_finite()`/shape properties rather than exact values, so arithmetic-operator mutations (`+`/`-`, `+=`/`-=`, `*`/`÷`) went uncaught. Replaced with exact hand-computed-value assertions throughout `GraphAccumulator` (edge/leaf/op-node add+remove, 2-hop bindings, reset, normalization), `shift_by`/`shift1`, and `SaturationHead` (forward pass, mask features, rule encoding, bilinear scoring, and a golden-model reimplementation of `randomize()`'s RNG + He-init arithmetic).

**Result:** 251/256 caught, 1 left surviving and documented in-line (`l2_normalize_section`'s `norm < 1e-12` vs `<=` boundary — only observable when a section's L2 norm lands on exactly `1e-12`, not practically constructible from `OpEmbeddings::new_random` seeds), 4 unviable (compiler rejects them outright — e.g. mutating a `const` used as an array bound).

No production code changed — this is test-only. The module itself (`nnue::guide`) is documented as intentionally inert scaffolding for a not-yet-started Phase 3 (see module doc + `docs/plans/2026-07-07-guided-saturation-redesign.md`), tested only via its own characterization tests — an accepted, already-documented exception to STYLE.md's "test public API" rule that this PR does not change.

## Verification

- `cargo test -p pixelflow-search --lib` — 155 passed, 0 failed, 1 ignored (pre-existing).
- `cargo clippy -p pixelflow-search --all-targets --all-features -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean (for touched files).
- `cargo build --workspace --lib --bins` — clean.
- `cargo mutants -p pixelflow-search --file 'pixelflow-search/src/nnue/guide/*.rs' --no-shuffle -- --lib nnue::` — 251/256 caught (see above).
- Confirmed `cargo check -p pixelflow-search --no-default-features` fails identically on `main` (pre-existing, unrelated `ExprNnue::from_bytes` gap in `egraph/extraction.rs` — not touched by this PR).

## Test plan

- [x] `cargo test -p pixelflow-search --lib`
- [x] `cargo clippy -p pixelflow-search --all-targets --all-features -- -D warnings`
- [x] `cargo mutants` on the touched files
- [x] `cargo build --workspace`

---
_Generated by [Claude Code](https://claude.ai/code/session_01NMYULHwhXnCe1CG6358cty)_