### PR TITLE
test(pixelflow-graphics): close spatial_bsp.rs STYLE.md violation + mutation gaps

### DIFF
--- a/docs/bugs/2026-08-26-test-quality-audit-followup.md
+++ b/docs/bugs/2026-08-26-test-quality-audit-followup.md
@@ -1,0 +1,154 @@
+# Test quality control follow-up — 2026-08-26
+
+Scope: scheduled continuation of
+`docs/bugs/2026-08-15-test-quality-audit-followup.md`. `main` had not moved
+on any of that pass's "recommended next steps" targets since `ce2df0e8`
+(the intervening `9576ee1f` was an unrelated refactor), so this pass picks
+up backlog item 3: `pixelflow-graphics/src/spatial_bsp.rs`, open since the
+2026-07-20 audit first flagged it and re-confirmed still-open by every
+intervening pass.
+
+## `pixelflow-graphics/src/spatial_bsp.rs` — STYLE.md "test public API" violation
+
+~22 tests reached directly into the private `SpatialBSP::interiors` field
+(`bsp.interiors[0]`, `bsp.interiors.iter()`). `InteriorNode`'s own fields
+(`axis`, `threshold`, `left`, `right`) were already public — only the
+containing field was private, with no accessor.
+
+### Fixed
+
+- Added `SpatialBSP::interiors(&self) -> &[InteriorNode]`, a minimal public
+  accessor returning the interior-node slice (mirrors the existing
+  `interior_count()`/`leaf_count()`). Rewrote every test that read
+  `bsp.interiors[...]`/`.iter()` to go through it instead. No behavioral
+  change; same assertions, same access pattern otherwise.
+- Found and fixed a real bug while doing this mechanical rewrite: one test
+  had `matches!(root.left, NodeRef::Leaf(_));` as a bare statement — the
+  `bool` it produces was discarded instead of asserted, so the check was a
+  silent no-op. Wrapped both occurrences in `assert!()`.
+- Renamed 9 test names that were bare noun phrases (violating STYLE.md's
+  "it should" rule): `single_leaf`, `two_leaves`, `empty_bsp`,
+  `four_leaves_grid`, `many_items_stress_test`, `stack_of_wide_strips`,
+  `node_ref_types_are_distinct`, `binary_tree_property_interior_count`,
+  `binary_tree_exact_interior_count`.
+
+`cargo test -p pixelflow-graphics --lib spatial_bsp::`: 56/56 passed
+(unchanged count at this point — the bug fix above and the accessor
+rewrite didn't add tests, just corrected two of them).
+
+## Mutation testing: the same file, now that it's STYLE-clean
+
+`cargo-mutants` v27.1.0 (freshly installed — not present in this
+environment, consistent with every prior pass).
+
+**First sweep** (`cargo mutants -p pixelflow-graphics --file
+.../spatial_bsp.rs -j 4`): **74 mutants, 15 missed, 55 caught, 4
+unviable.** All 15 were in the split-axis heuristic (`build_tree`) and the
+SIMD blend path (`traverse`). The existing tests checked loose bounds
+("threshold is in `[25, 75]`", "axis is `X`") that happened to hold under
+several different wrong formulas — sufficient to pin *approximate*
+behavior, not exact arithmetic.
+
+### Fixed: 8 new tests, each built to disagree with a specific mutant
+
+- **cx/cy center formula** (`* 0.5` → `/`/`+`, `+` → `*`,
+  `pixelflow-graphics/src/spatial_bsp.rs:149`): two items whose Y
+  center-spread (15) exceeds X (10) only under the correct formula — each
+  mutant inflates the X spread (4× for `/`, 2× for `+`) past 15 and flips
+  the axis to X.
+- **`extent_x > extent_y` → `==`/`>=`** (line 164): two scenarios — one
+  with a strict, non-tied inequality where the bbox-width fallback would
+  independently disagree (catches `==`), one with an exact tie (bounds in
+  eighths, exactly representable in `f32`, for a bit-exact tie rather than
+  a merely-close one) where `>=` fires before the fallback ever runs
+  (catches `>=`).
+- **bbox width/height tie-break** (`-` → `+`/`/`, lines 161–162): tied
+  centers with a bbox min close to zero (exposes the `/` mutant via a
+  blown-up ratio) and, separately, shifted far from zero (exposes the `+`
+  mutant via a blown-up sum) — each flips the width-vs-height comparison
+  outcome that a plain subtraction wouldn't.
+- **median-threshold sort comparator** (`+` → `*`/`-`, `/` → `%`, lines
+  175/185/186): three items whose sum-order and product-order differ,
+  fed to `from_positioned` in *descending* sum-order rather than
+  already-sorted. This mattered more than expected — see methodology note
+  below.
+- **`mid_idx - 1` → `mid_idx / 1`** (line 190): the same three-item
+  fixture; the mutant reads `items[mid_idx]` for both sides of the
+  average instead of `items[mid_idx - 1]` and `items[mid_idx]`, which this
+  asymmetric set turns into a different number (0.5 vs. the correct -5.5).
+- **`!mask.any()` → `mask.any()`** (line 290, `traverse`): SIMD lanes
+  straddling the split threshold via `Field::sequential`, asserting the
+  per-lane color on both sides of the boundary rather than "no panic" —
+  the mutant makes any mixed mask take the right-only early return,
+  silently dropping the left-child result for the lanes that need it.
+
+**Re-run after the first 8 tests: 74 mutants, 5 missed** (down from 15).
+All 5 were sort-comparator mutants that survived despite direct targeting.
+
+### Methodology finding: an already-sorted fixture under-exercises `sort_by`
+
+The sort-comparator mutants target `ca`/`cb` inside the closure passed to
+`items.sort_by`, e.g. `let ca = (a.bounds.0 + a.bounds.2) / 2.0;`. My first
+attempt fed the three items in ascending sum-order — already correctly
+sorted. Rust's small-slice insertion sort then needs zero swaps, and the
+specific sequence of comparator calls it makes never puts the item whose
+`a`-role formula is mutated into a comparison where the corruption changes
+the outcome (an item that's never re-examined after its initial "no swap
+needed" comparison never has its own `a`-role value meaningfully used
+again). Re-running the fixture with items given in **descending** sum-order
+forces every element through a real comparison, and closed 4 of the 5
+remaining gaps — same expected threshold value, since the algorithm sorts
+internally and shouldn't depend on input order (confirmed empirically:
+tests still pass with the same `-5.5`).
+
+**Second re-run: 74 mutants, 1 missed** (`spatial_bsp.rs:185:52`, `/ 2.0`
+→ `* 2.0` inside the Y sort comparator). Diagnosed as a genuine equivalent
+mutant: dividing and multiplying by a positive constant are both monotonic
+scalings, so they can never change a `partial_cmp`-based comparator's
+ordering for any input — no test can distinguish them. Documented with a
+comment at the site (matching the precedent in
+`pixelflow-compiler/src/codegen/util.rs`) rather than chased further.
+
+**Final state: 74 mutants, 73 caught, 1 documented equivalent, 0 real
+gaps.**
+
+## Verified
+
+- `cargo test -p pixelflow-graphics --lib spatial_bsp::`: 64 passed, 0
+  failed.
+- `cargo test -p pixelflow-graphics` (all targets incl. doctests): 160 lib
+  tests + all integration/doctest targets passed, 0 failed.
+- `cargo test --workspace --lib`: passed (exit 0), 0 failed.
+- `cargo clippy -p pixelflow-graphics --lib --tests`: clean.
+- `cargo fmt -p pixelflow-graphics -- --check`: clean.
+- `cargo mutants -p pixelflow-graphics --file
+  pixelflow-graphics/src/spatial_bsp.rs`: 74 mutants, 73 caught, 1
+  documented equivalent, 0 missed.
+
+## Recommended next steps (not done here)
+
+Backlog carried forward from 2026-08-15, minus the item closed above:
+
+1. `pixelflow-search/src/egraph/cost.rs` — still open per the 08-08
+   audit: a partial mutants run found one real gap (`CostModel::zero()`,
+   already fixed) before its own slow `--lib` baseline (~110s) timed out
+   the pass. Still needs either a narrower test filter or a longer time
+   budget.
+2. `pixelflow-codegen/src/emit/*` (~1,400 lines) — flagged since 08-08 as
+   never mutation-tested under its post-crate-split location. Still true.
+3. `actor-scheduler/src/lib.rs`'s `backoff_unit_tests` — re-investigated
+   this pass while scoping work (not independently re-verified with a
+   fresh mutants run, just re-read against the audit trail): both halves
+   of the original 2026-07-20 finding are already resolved — the
+   mutation-weakness half by `9deb9852` ("Add mutation-targeted tests for
+   actor-scheduler", exact-value jitter/timeout assertions), and the
+   private-API-violation half by an explicit, documented 2026-07-24
+   Flexibility-clause judgment call (the precise Ok/Timeout boundary cases
+   require observing an *unstarted* backoff attempt, unreachable through
+   the public surface without racing a real sleep against a timeout).
+   Recommend removing this from the backlog; nothing left to do without
+   re-litigating a decision already made and documented.
+4. `pixelflow-core/src/backend/x86.rs`'s `F32x8`/`F32x16`/`U32x8`/
+   `U32x16`/`Mask8`/`Mask16` (AVX2/AVX-512) impls, and `arm.rs`'s NEON
+   impls — never tested at the unit level at all under a build that
+   actually activates those ISA levels (`xtask isa-matrix`).

--- a/pixelflow-graphics/src/spatial_bsp.rs
+++ b/pixelflow-graphics/src/spatial_bsp.rs
@@ -181,6 +181,11 @@ impl<L> SpatialBSP<L> {
             (Axis::X, threshold)
         } else {
             // Sort by Y center, split at median
+            //
+            // `/ 2.0` here is an equivalent mutant to `* 2.0` under cargo-mutants: both are
+            // positive monotonic scalings, so they never change the comparator's ordering for
+            // any input, only its constant factor. No test can distinguish them — left as `/`
+            // to match the actual center-of-bounds formula.
             items.sort_by(|a, b| {
                 let ca = (a.bounds.1 + a.bounds.3) / 2.0;
                 let cb = (b.bounds.1 + b.bounds.3) / 2.0;

--- a/pixelflow-graphics/src/spatial_bsp.rs
+++ b/pixelflow-graphics/src/spatial_bsp.rs
@@ -2008,19 +2008,22 @@ mod tests {
         // differs from their X product-order. Kills a `+` -> `*` mutant in the
         // sort-by-center-x comparator: sorting by product instead of sum reorders
         // the items, changing which pair straddles the median split and so which
-        // threshold comes out.
+        // threshold comes out. Given in descending sum-order (rather than already
+        // sorted) so the sort actually has to move every element and exercises the
+        // comparator's mutated argument in every slot — an already-sorted input
+        // lets insertion sort skip the comparisons that would expose it.
         let items = vec![
             Positioned {
-                bounds: (-10.0, 0.0, -9.0, 10.0), // center x = -9.5, sum-sorted 1st
-                leaf: SolidColor::new(255, 0, 0, 255),
+                bounds: (8.0, 0.0, 12.0, 10.0), // center x = 10.0, sum-sorted last
+                leaf: SolidColor::new(0, 0, 255, 255),
             },
             Positioned {
-                bounds: (-2.0, 0.0, 3.0, 10.0), // center x = 0.5, sum-sorted 2nd
+                bounds: (-2.0, 0.0, 3.0, 10.0), // center x = 0.5, sum-sorted middle
                 leaf: SolidColor::new(0, 255, 0, 255),
             },
             Positioned {
-                bounds: (8.0, 0.0, 12.0, 10.0), // center x = 10.0, sum-sorted 3rd
-                leaf: SolidColor::new(0, 0, 255, 255),
+                bounds: (-10.0, 0.0, -9.0, 10.0), // center x = -9.5, sum-sorted first
+                leaf: SolidColor::new(255, 0, 0, 255),
             },
         ];
 
@@ -2030,32 +2033,34 @@ mod tests {
         assert_eq!(root.axis, Axis::X, "identical Y bounds force an X split");
         assert_eq!(
             root.threshold, -5.5,
-            "sum order is [item0, item1, item2]; median threshold = \
-             (item0.x_max + item1.x_min) / 2 = (-9 + -2) / 2"
+            "sum order is [(-10,-9), (-2,3), (8,12)]; median threshold = \
+             (-9 + -2) / 2"
         );
     }
 
     #[test]
     fn y_axis_threshold_sorts_by_sum_of_bounds_not_product_or_wrong_neighbor() {
         // Same construction as the X-axis test above, transposed onto Y (identical
-        // X forces a Y split). Kills the analogous `+` -> `*` sort-key mutants for
-        // the Y branch, plus a `mid_idx - 1` -> `mid_idx / 1` mutant in the
-        // threshold formula: that mutant reads `items[mid_idx]` for *both* sides of
-        // the average instead of `items[mid_idx - 1]` and `items[mid_idx]`, which
-        // this asymmetric item set turns into a different number (0.5 instead of
-        // -5.5).
+        // X forces a Y split) and likewise given in descending sum-order so the
+        // sort has to move every element. Kills the analogous `+` -> `*`/`-`
+        // sort-key mutants for the Y branch's `ca`/`cb` (both arguments of the
+        // comparator, not just one), a `/` -> `%` mutant in `cb`, and a
+        // `mid_idx - 1` -> `mid_idx / 1` mutant in the threshold formula: that
+        // mutant reads `items[mid_idx]` for *both* sides of the average instead of
+        // `items[mid_idx - 1]` and `items[mid_idx]`, which this asymmetric item set
+        // turns into a different number (0.5 instead of -5.5).
         let items = vec![
             Positioned {
-                bounds: (0.0, -10.0, 10.0, -9.0), // center y = -9.5, sum-sorted 1st
-                leaf: SolidColor::new(255, 0, 0, 255),
+                bounds: (0.0, 8.0, 10.0, 12.0), // center y = 10.0, sum-sorted last
+                leaf: SolidColor::new(0, 0, 255, 255),
             },
             Positioned {
-                bounds: (0.0, -2.0, 10.0, 3.0), // center y = 0.5, sum-sorted 2nd
+                bounds: (0.0, -2.0, 10.0, 3.0), // center y = 0.5, sum-sorted middle
                 leaf: SolidColor::new(0, 255, 0, 255),
             },
             Positioned {
-                bounds: (0.0, 8.0, 10.0, 12.0), // center y = 10.0, sum-sorted 3rd
-                leaf: SolidColor::new(0, 0, 255, 255),
+                bounds: (0.0, -10.0, 10.0, -9.0), // center y = -9.5, sum-sorted first
+                leaf: SolidColor::new(255, 0, 0, 255),
             },
         ];
 
@@ -2065,8 +2070,8 @@ mod tests {
         assert_eq!(root.axis, Axis::Y, "identical X bounds force a Y split");
         assert_eq!(
             root.threshold, -5.5,
-            "sum order is [item0, item1, item2]; median threshold = \
-             (item0.y_max + item1.y_min) / 2 = (-9 + -2) / 2"
+            "sum order is [(-10,-9), (-2,3), (8,12)]; median threshold = \
+             (-9 + -2) / 2"
         );
     }
 

--- a/pixelflow-graphics/src/spatial_bsp.rs
+++ b/pixelflow-graphics/src/spatial_bsp.rs
@@ -1861,4 +1861,268 @@ mod tests {
             "Item 2 should be visible on left side"
         );
     }
+
+    // ========================================================================
+    // Split Heuristic Arithmetic Tests (cargo-mutants gaps, 2026-08-26 audit)
+    // ========================================================================
+
+    #[test]
+    fn split_axis_prefers_center_spread_when_it_exceeds_bbox_extent() {
+        // Two items whose center-to-center spread is larger on Y (15) than on X
+        // (10), computed via item *centers* rather than raw bounding-box extent.
+        // Kills three surviving mutants in the cx/cy formula (`* 0.5` -> `/ 0.5`,
+        // `* 0.5` -> `+ 0.5`, and `bounds.0 + bounds.2` -> `bounds.0 * bounds.2`):
+        // each inflates the X center-spread well past 15, wrongly flipping the
+        // split axis to X.
+        let items = vec![
+            Positioned {
+                bounds: (-5.0, -7.5, 5.0, 7.5), // center (0, 0)
+                leaf: SolidColor::new(255, 0, 0, 255),
+            },
+            Positioned {
+                bounds: (5.0, 7.5, 15.0, 22.5), // center (10, 15)
+                leaf: SolidColor::new(0, 0, 255, 255),
+            },
+        ];
+
+        let bsp = SpatialBSP::from_positioned(items);
+        assert_eq!(
+            bsp.interiors()[0].axis,
+            Axis::Y,
+            "Y center-spread (15) exceeds X center-spread (10), so split must be on Y"
+        );
+    }
+
+    #[test]
+    fn split_prefers_strictly_larger_center_spread_over_bbox_fallback() {
+        // X center-spread (~20) is strictly greater than Y center-spread (10), so
+        // the split must be on X via the first `extent_x > extent_y` branch — even
+        // though the items are so thin in X and so tall in Y that the *bounding-box*
+        // fallback (width vs height) would independently prefer Y. Kills a `>` ->
+        // `==` mutant on that branch: under the mutant, 20 == 10 is false, so the
+        // code falls through the `else if` (also false) into the bbox fallback and
+        // wrongly picks Y.
+        let items = vec![
+            Positioned {
+                bounds: (0.0, 0.0, 0.001, 500.0), // center (~0.0005, 250)
+                leaf: SolidColor::new(255, 0, 0, 255),
+            },
+            Positioned {
+                bounds: (20.0, 10.0, 20.001, 510.0), // center (~20.0005, 260)
+                leaf: SolidColor::new(0, 0, 255, 255),
+            },
+        ];
+
+        let bsp = SpatialBSP::from_positioned(items);
+        assert_eq!(
+            bsp.interiors()[0].axis,
+            Axis::X,
+            "X center-spread (~20) strictly exceeds Y center-spread (10)"
+        );
+    }
+
+    #[test]
+    fn split_axis_tie_break_uses_bbox_width_against_a_small_min_x() {
+        // Item centers coincide exactly on both axes (extent_x == extent_y == 0),
+        // so the split falls through to the bbox width-vs-height tie-break. Bounds
+        // are eighths (exactly representable in f32) so the two items' centers are
+        // bit-for-bit equal rather than merely close. Real width (10.0, from
+        // max_x - min_x = 10.125 - 0.125) is less than height (50), so the split
+        // must be on Y. Kills two surviving mutants:
+        //  - `max_x - min_x` -> `max_x / min_x`: with min_x this close to zero, the
+        //    ratio (81.0) blows past height and wrongly flips the axis to X.
+        //  - `extent_x > extent_y` -> `extent_x >= extent_y`: with the tie at
+        //    exactly 0, `>=` fires immediately and picks X before the bbox
+        //    fallback ever runs.
+        let items = vec![
+            Positioned {
+                bounds: (0.125, 40.0, 10.125, 60.0), // center (5.125, 50)
+                leaf: SolidColor::new(255, 0, 0, 255),
+            },
+            Positioned {
+                bounds: (3.125, 25.0, 7.125, 75.0), // center (5.125, 50) — tied
+                leaf: SolidColor::new(0, 0, 255, 255),
+            },
+        ];
+
+        let bsp = SpatialBSP::from_positioned(items);
+        assert_eq!(
+            bsp.interiors()[0].axis,
+            Axis::Y,
+            "tied centers fall back to bbox width (10.0) vs height (50), favoring Y"
+        );
+    }
+
+    #[test]
+    fn split_axis_tie_break_width_subtracts_not_adds_the_bbox_bounds() {
+        // Same tie-break setup as above, but with the x-range shifted far from zero
+        // (1000..1010) so a `max_x - min_x` -> `max_x + min_x` mutant produces a
+        // huge sum (2010) instead of the true width (10), wrongly flipping the
+        // axis to X.
+        let items = vec![
+            Positioned {
+                bounds: (1000.0, 40.0, 1010.0, 60.0), // center (1005, 50)
+                leaf: SolidColor::new(255, 0, 0, 255),
+            },
+            Positioned {
+                bounds: (1002.0, 25.0, 1008.0, 75.0), // center (1005, 50) — tied
+                leaf: SolidColor::new(0, 0, 255, 255),
+            },
+        ];
+
+        let bsp = SpatialBSP::from_positioned(items);
+        assert_eq!(
+            bsp.interiors()[0].axis,
+            Axis::Y,
+            "tied centers fall back to bbox width (10) vs height (50), favoring Y"
+        );
+    }
+
+    #[test]
+    fn split_axis_tie_break_height_subtracts_not_adds_the_bbox_bounds() {
+        // Mirrors the width test above but for height: y-range shifted to
+        // 1000..1005 so a `max_y - min_y` -> `max_y + min_y` mutant produces 2005
+        // instead of the true height (5), wrongly flipping the axis from X to Y.
+        let items = vec![
+            Positioned {
+                bounds: (0.0, 1000.0, 50.0, 1005.0), // center (25, 1002.5)
+                leaf: SolidColor::new(255, 0, 0, 255),
+            },
+            Positioned {
+                bounds: (10.0, 1001.0, 40.0, 1004.0), // center (25, 1002.5) — tied
+                leaf: SolidColor::new(0, 0, 255, 255),
+            },
+        ];
+
+        let bsp = SpatialBSP::from_positioned(items);
+        assert_eq!(
+            bsp.interiors()[0].axis,
+            Axis::X,
+            "tied centers fall back to bbox width (50) vs height (5), favoring X"
+        );
+    }
+
+    #[test]
+    fn x_axis_threshold_sorts_by_sum_of_bounds_not_product() {
+        // Three items with identical Y (forcing an X split) whose X sum-order
+        // differs from their X product-order. Kills a `+` -> `*` mutant in the
+        // sort-by-center-x comparator: sorting by product instead of sum reorders
+        // the items, changing which pair straddles the median split and so which
+        // threshold comes out.
+        let items = vec![
+            Positioned {
+                bounds: (-10.0, 0.0, -9.0, 10.0), // center x = -9.5, sum-sorted 1st
+                leaf: SolidColor::new(255, 0, 0, 255),
+            },
+            Positioned {
+                bounds: (-2.0, 0.0, 3.0, 10.0), // center x = 0.5, sum-sorted 2nd
+                leaf: SolidColor::new(0, 255, 0, 255),
+            },
+            Positioned {
+                bounds: (8.0, 0.0, 12.0, 10.0), // center x = 10.0, sum-sorted 3rd
+                leaf: SolidColor::new(0, 0, 255, 255),
+            },
+        ];
+
+        let bsp = SpatialBSP::from_positioned(items);
+        let root = &bsp.interiors()[bsp.interior_count() - 1];
+
+        assert_eq!(root.axis, Axis::X, "identical Y bounds force an X split");
+        assert_eq!(
+            root.threshold, -5.5,
+            "sum order is [item0, item1, item2]; median threshold = \
+             (item0.x_max + item1.x_min) / 2 = (-9 + -2) / 2"
+        );
+    }
+
+    #[test]
+    fn y_axis_threshold_sorts_by_sum_of_bounds_not_product_or_wrong_neighbor() {
+        // Same construction as the X-axis test above, transposed onto Y (identical
+        // X forces a Y split). Kills the analogous `+` -> `*` sort-key mutants for
+        // the Y branch, plus a `mid_idx - 1` -> `mid_idx / 1` mutant in the
+        // threshold formula: that mutant reads `items[mid_idx]` for *both* sides of
+        // the average instead of `items[mid_idx - 1]` and `items[mid_idx]`, which
+        // this asymmetric item set turns into a different number (0.5 instead of
+        // -5.5).
+        let items = vec![
+            Positioned {
+                bounds: (0.0, -10.0, 10.0, -9.0), // center y = -9.5, sum-sorted 1st
+                leaf: SolidColor::new(255, 0, 0, 255),
+            },
+            Positioned {
+                bounds: (0.0, -2.0, 10.0, 3.0), // center y = 0.5, sum-sorted 2nd
+                leaf: SolidColor::new(0, 255, 0, 255),
+            },
+            Positioned {
+                bounds: (0.0, 8.0, 10.0, 12.0), // center y = 10.0, sum-sorted 3rd
+                leaf: SolidColor::new(0, 0, 255, 255),
+            },
+        ];
+
+        let bsp = SpatialBSP::from_positioned(items);
+        let root = &bsp.interiors()[bsp.interior_count() - 1];
+
+        assert_eq!(root.axis, Axis::Y, "identical X bounds force a Y split");
+        assert_eq!(
+            root.threshold, -5.5,
+            "sum order is [item0, item1, item2]; median threshold = \
+             (item0.y_max + item1.y_min) / 2 = (-9 + -2) / 2"
+        );
+    }
+
+    // ========================================================================
+    // SIMD Lane Blending Tests
+    // ========================================================================
+
+    #[test]
+    fn eval_blends_correctly_when_simd_lanes_straddle_the_threshold() {
+        use pixelflow_core::{materialize_discrete, PARALLELISM};
+
+        // Kills a `delete !` mutant on `!mask.any()` in `traverse`: once the
+        // `mask.all()` early-out is ruled out, a *mixed* mask (some lanes left of
+        // the threshold, some right) must fall through to the `Select` blend.
+        // Deleting the `!` makes any mixed mask take the right-only early return,
+        // silently dropping the left-child values for the lanes that need them.
+        let items = vec![
+            Positioned {
+                bounds: (0.0, 0.0, 50.0, 100.0),
+                leaf: SolidColor::new(255, 0, 0, 255),
+            },
+            Positioned {
+                bounds: (50.0, 0.0, 100.0, 100.0),
+                leaf: SolidColor::new(0, 0, 255, 255),
+            },
+        ];
+        let bsp = SpatialBSP::from_positioned(items);
+        let threshold = bsp.interiors()[0].threshold;
+
+        // Start one unit below the threshold so consecutive SIMD lanes straddle it:
+        // lane 0 is left of the split, the last lane is at/right of it.
+        let mut pixels = [0u32; PARALLELISM];
+        materialize_discrete(&bsp, threshold - 1.0, 50.0, &mut pixels);
+
+        let expected_red = {
+            let red = SolidColor::new(255, 0, 0, 255);
+            let mut buf = [0u32; PARALLELISM];
+            materialize_discrete(&red, 0.0, 0.0, &mut buf);
+            buf[0]
+        };
+        let expected_blue = {
+            let blue = SolidColor::new(0, 0, 255, 255);
+            let mut buf = [0u32; PARALLELISM];
+            materialize_discrete(&blue, 0.0, 0.0, &mut buf);
+            buf[0]
+        };
+
+        assert_eq!(
+            pixels[0], expected_red,
+            "lane at threshold - 1 is left of the split and must stay red"
+        );
+        assert_eq!(
+            pixels[PARALLELISM - 1],
+            expected_blue,
+            "the last lane is at/right of the split and must be blue, even though \
+             lane 0 in the same SIMD group is red"
+        );
+    }
 }

--- a/pixelflow-graphics/src/spatial_bsp.rs
+++ b/pixelflow-graphics/src/spatial_bsp.rs
@@ -223,6 +223,15 @@ impl<L> SpatialBSP<L> {
     pub fn leaf_count(&self) -> usize {
         self.leaves.len()
     }
+
+    /// Interior nodes in construction order — routing data only (axis, threshold, children).
+    ///
+    /// The root is always the last element (index `interior_count() - 1`). Exposed for
+    /// structural assertions in tests; `eval()` is the primary way to consume a tree.
+    #[must_use]
+    pub fn interiors(&self) -> &[InteriorNode] {
+        &self.interiors
+    }
 }
 
 // ============================================================================
@@ -349,7 +358,7 @@ mod tests {
     }
 
     #[test]
-    fn single_leaf() {
+    fn eval_does_not_panic_for_a_single_leaf_bsp() {
         let bsp = SpatialBSP::single(SolidColor::new(255, 0, 0, 255));
 
         assert_eq!(
@@ -369,7 +378,7 @@ mod tests {
     }
 
     #[test]
-    fn two_leaves() {
+    fn two_items_produce_one_interior_and_two_leaves() {
         let items = vec![
             Positioned {
                 bounds: (0.0, 0.0, 50.0, 100.0),
@@ -388,7 +397,7 @@ mod tests {
     }
 
     #[test]
-    fn empty_bsp() {
+    fn empty_positioned_list_produces_zero_interiors_and_leaves() {
         let bsp: SpatialBSP<SolidColor> = SpatialBSP::from_positioned(vec![]);
 
         assert_eq!(bsp.interior_count(), 0, "Empty BSP has no interior nodes");
@@ -400,7 +409,7 @@ mod tests {
     }
 
     #[test]
-    fn four_leaves_grid() {
+    fn four_non_overlapping_items_produce_three_interior_nodes() {
         // 2x2 grid
         let items = vec![
             Positioned {
@@ -500,7 +509,7 @@ mod tests {
         // Verify the split axis and threshold are correct
         // Left item spans [0, 25], right item spans [75, 100]
         // Threshold should be in the gap (25, 75), ideally around 50
-        let root = &bsp.interiors[0];
+        let root = &bsp.interiors()[0];
         assert_eq!(
             root.axis,
             Axis::X,
@@ -528,7 +537,7 @@ mod tests {
         ];
 
         let bsp = SpatialBSP::from_positioned(items);
-        let root = &bsp.interiors[0];
+        let root = &bsp.interiors()[0];
 
         assert_eq!(root.axis, Axis::Y, "Should split on Y for tall items");
     }
@@ -548,7 +557,7 @@ mod tests {
         ];
 
         let bsp = SpatialBSP::from_positioned(items);
-        let root = &bsp.interiors[0];
+        let root = &bsp.interiors()[0];
 
         assert_eq!(root.axis, Axis::X, "Should split on X for wide items");
     }
@@ -661,7 +670,7 @@ mod tests {
 
         // Verify threshold is in the gap between items
         // Left item spans [-100, -50], right item spans [-50, 0]
-        let root = &bsp.interiors[0];
+        let root = &bsp.interiors()[0];
         assert!(
             root.threshold >= -100.0 && root.threshold <= 0.0,
             "Threshold must separate the items: {} should be in [-100, 0]",
@@ -685,7 +694,7 @@ mod tests {
         let bsp = SpatialBSP::from_positioned(items);
 
         assert_eq!(bsp.leaf_count(), 2);
-        assert!(bsp.interiors[0].threshold > 1e6);
+        assert!(bsp.interiors()[0].threshold > 1e6);
     }
 
     #[test]
@@ -714,7 +723,7 @@ mod tests {
     // ========================================================================
 
     #[test]
-    fn binary_tree_property_interior_count() {
+    fn binary_tree_has_n_minus_one_interiors_for_n_leaves_across_a_range() {
         // For n leaves, binary tree has n-1 interior nodes
         for n in 2..=16 {
             let items: Vec<_> = (0..n)
@@ -760,7 +769,7 @@ mod tests {
     }
 
     #[test]
-    fn many_items_stress_test() {
+    fn one_thousand_items_produce_correct_leaf_and_interior_counts() {
         // Create 1000 non-overlapping items
         let items: Vec<_> = (0..1000)
             .map(|i| {
@@ -914,7 +923,7 @@ mod tests {
     // ========================================================================
 
     #[test]
-    fn node_ref_types_are_distinct() {
+    fn both_children_are_leaves_when_two_items_are_split_once() {
         let items = vec![
             Positioned {
                 bounds: (0.0, 0.0, 50.0, 100.0),
@@ -932,11 +941,19 @@ mod tests {
         assert_eq!(bsp.interior_count(), 1);
         assert_eq!(bsp.leaf_count(), 2);
 
-        let root = &bsp.interiors[0];
+        let root = &bsp.interiors()[0];
 
         // Both children should be leaves (not interiors)
-        matches!(root.left, NodeRef::Leaf(_));
-        matches!(root.right, NodeRef::Leaf(_));
+        assert!(
+            matches!(root.left, NodeRef::Leaf(_)),
+            "left child should be a leaf, got {:?}",
+            root.left
+        );
+        assert!(
+            matches!(root.right, NodeRef::Leaf(_)),
+            "right child should be a leaf, got {:?}",
+            root.right
+        );
     }
 
     #[test]
@@ -967,7 +984,7 @@ mod tests {
         assert_eq!(bsp.leaf_count(), 4);
 
         // Root should be last interior
-        let root = &bsp.interiors[2];
+        let root = &bsp.interiors()[2];
 
         // At least one child should be an interior node
         let has_interior_child =
@@ -1074,7 +1091,7 @@ mod tests {
         ];
 
         let bsp = SpatialBSP::from_positioned(items);
-        let root = &bsp.interiors[0];
+        let root = &bsp.interiors()[0];
 
         // Based on line 148: width >= height, so square splits on X
         assert_eq!(root.axis, Axis::X);
@@ -1094,7 +1111,7 @@ mod tests {
         ];
 
         let bsp = SpatialBSP::from_positioned(items);
-        assert_eq!(bsp.interiors[0].axis, Axis::X);
+        assert_eq!(bsp.interiors()[0].axis, Axis::X);
     }
 
     #[test]
@@ -1111,7 +1128,7 @@ mod tests {
         ];
 
         let bsp = SpatialBSP::from_positioned(items);
-        assert_eq!(bsp.interiors[0].axis, Axis::Y);
+        assert_eq!(bsp.interiors()[0].axis, Axis::Y);
     }
 
     // ========================================================================
@@ -1133,7 +1150,7 @@ mod tests {
         ];
 
         let bsp = SpatialBSP::from_positioned(items);
-        let root = &bsp.interiors[0];
+        let root = &bsp.interiors()[0];
 
         // Threshold should be between 40.0 and 60.0 (in the gap)
         assert!(
@@ -1158,7 +1175,7 @@ mod tests {
         ];
 
         let bsp = SpatialBSP::from_positioned(items);
-        let root = &bsp.interiors[0];
+        let root = &bsp.interiors()[0];
 
         // Threshold should be at or very close to 50.0
         assert!(
@@ -1184,7 +1201,7 @@ mod tests {
 
         let bsp = SpatialBSP::from_positioned(items);
         assert_eq!(bsp.leaf_count(), 2);
-        assert!(bsp.interiors[0].threshold.is_finite());
+        assert!(bsp.interiors()[0].threshold.is_finite());
     }
 
     // ========================================================================
@@ -1206,7 +1223,7 @@ mod tests {
         ];
 
         let bsp = SpatialBSP::from_positioned(items);
-        let threshold = bsp.interiors[0].threshold;
+        let threshold = bsp.interiors()[0].threshold;
 
         // Sample exactly at threshold (should go right, >= threshold)
         let result = bsp.eval_raw(
@@ -1234,7 +1251,7 @@ mod tests {
         ];
 
         let bsp = SpatialBSP::from_positioned(items);
-        let threshold = bsp.interiors[0].threshold;
+        let threshold = bsp.interiors()[0].threshold;
 
         // Sample just below threshold
         let result = bsp.eval_raw(
@@ -1261,7 +1278,7 @@ mod tests {
         ];
 
         let bsp = SpatialBSP::from_positioned(items);
-        let threshold = bsp.interiors[0].threshold;
+        let threshold = bsp.interiors()[0].threshold;
 
         // Sample just above threshold
         let result = bsp.eval_raw(
@@ -1484,7 +1501,7 @@ mod tests {
         let num_leaves = bsp.leaf_count();
 
         // Every interior node must point to valid indices
-        for interior in bsp.interiors.iter() {
+        for interior in bsp.interiors().iter() {
             match interior.left {
                 NodeRef::Interior(i) => {
                     assert!(
@@ -1552,7 +1569,7 @@ mod tests {
                     reachable.insert(i);
                 }
                 NodeRef::Interior(i) => {
-                    let interior = &bsp.interiors[i as usize];
+                    let interior = &bsp.interiors()[i as usize];
                     collect_leaves(bsp, interior.left, reachable);
                     collect_leaves(bsp, interior.right, reachable);
                 }
@@ -1606,7 +1623,7 @@ mod tests {
         // Verify each interior node's threshold correctly partitions
         fn verify_partition<L>(bsp: &SpatialBSP<L>, node: NodeRef, centers: &[f32], depth: usize) {
             if let NodeRef::Interior(i) = node {
-                let interior = &bsp.interiors[i as usize];
+                let interior = &bsp.interiors()[i as usize];
                 let threshold = interior.threshold;
                 let axis = interior.axis;
 
@@ -1627,7 +1644,7 @@ mod tests {
                             }
                         }
                         NodeRef::Interior(i) => {
-                            let interior = &bsp.interiors[i as usize];
+                            let interior = &bsp.interiors()[i as usize];
                             collect_centers(bsp, interior.left, centers, output);
                             collect_centers(bsp, interior.right, centers, output);
                         }
@@ -1687,7 +1704,7 @@ mod tests {
         let bsp = SpatialBSP::from_positioned(items);
 
         // Interior nodes shouldn't point to themselves or have identical children
-        for (idx, interior) in bsp.interiors.iter().enumerate() {
+        for (idx, interior) in bsp.interiors().iter().enumerate() {
             // Left and right must be different
             let left_is_self = matches!(interior.left, NodeRef::Interior(i) if i as usize == idx);
             let right_is_self = matches!(interior.right, NodeRef::Interior(i) if i as usize == idx);
@@ -1721,7 +1738,7 @@ mod tests {
     }
 
     #[test]
-    fn binary_tree_exact_interior_count() {
+    fn binary_tree_interior_count_is_never_more_or_fewer_than_n_minus_one() {
         // For n leaves, must have EXACTLY n-1 interiors (not >=, not <=, exactly)
         for n in 2..=20 {
             let items: Vec<_> = (0..n)
@@ -1762,7 +1779,7 @@ mod tests {
 
         let bsp = SpatialBSP::from_positioned(items);
 
-        for (idx, interior) in bsp.interiors.iter().enumerate() {
+        for (idx, interior) in bsp.interiors().iter().enumerate() {
             assert!(
                 interior.threshold.is_finite(),
                 "Interior {} has non-finite threshold: {}",
@@ -1797,7 +1814,7 @@ mod tests {
     }
 
     #[test]
-    fn stack_of_wide_strips() {
+    fn eval_picks_correct_item_in_a_vertical_stack() {
         use pixelflow_core::{materialize_discrete, PARALLELISM};
 
         // Create 2 wide, short items, stacked vertically.


### PR DESCRIPTION
## Summary

Scheduled test-quality-control pass, continuing
`docs/bugs/2026-08-15-test-quality-audit-followup.md`'s backlog item 3:
`pixelflow-graphics/src/spatial_bsp.rs`, open since the 2026-07-20 audit
first flagged it and re-confirmed still-open by every intervening pass.
Full write-up: `docs/bugs/2026-08-26-test-quality-audit-followup.md`.

- **STYLE.md "test public API" violation**: ~22 tests reached directly
  into the private `SpatialBSP::interiors` field. Added a minimal public
  `SpatialBSP::interiors()` accessor (mirrors the existing
  `interior_count()`/`leaf_count()`) and rewrote every test to go through
  it instead. No behavioral change.
- **Real bug found along the way**: one test had
  `matches!(root.left, NodeRef::Leaf(_));` as a bare statement — the
  `bool` was discarded instead of asserted, so the check was a silent
  no-op. Fixed with `assert!()`.
- **Descriptive names**: renamed 9 test names that were bare noun phrases
  (`single_leaf`, `two_leaves`, `empty_bsp`, etc.) to full "it should"
  sentences per STYLE.md.
- **Mutation testing**: `cargo mutants` found 15 real gaps in the
  split-axis heuristic and SIMD blend path once the file was STYLE-clean
  (existing tests checked loose bounds that held under several wrong
  formulas). Added 8 new tests, each built with hand-picked inputs to
  disagree with a specific mutant, closing 15 → 5 → 1 → 0 real gaps (the
  last was a genuine equivalent mutant, documented in a comment rather
  than chased).
- Re-evaluated backlog item 4 (`actor-scheduler`'s `backoff_unit_tests`)
  while scoping this pass: both halves of that finding are already
  resolved by prior commits/decisions; recommend dropping it from the
  backlog (see doc for detail).

## Test plan

- [x] `cargo test -p pixelflow-graphics --lib spatial_bsp::` — 64/64 passed
- [x] `cargo test -p pixelflow-graphics` (all targets incl. doctests) — passed
- [x] `cargo test --workspace --lib` — passed
- [x] `cargo clippy -p pixelflow-graphics --lib --tests` — clean
- [x] `cargo fmt -p pixelflow-graphics -- --check` — clean
- [x] `cargo mutants -p pixelflow-graphics --file pixelflow-graphics/src/spatial_bsp.rs` — 74 mutants, 73 caught, 1 documented equivalent, 0 missed

https://claude.ai/code/session_013ytq4y3VxsDRBudRfuBsp3


---
_Generated by [Claude Code](https://claude.ai/code/session_013ytq4y3VxsDRBudRfuBsp3)_