### PR TITLE
test(core-term/pixelflow-core): mutation-gap fixes + descriptive names (2026-08-27 audit)

### DIFF
--- a/core-term/src/ansi/parser.rs
+++ b/core-term/src/ansi/parser.rs
@@ -13,13 +13,6 @@ const MAX_PARAMS: usize = 16;
 const MAX_INTERMEDIATES: usize = 2;
 const MAX_OSC_LEN: usize = 1024; // Limit OSC/DCS/PM/APC string length
 
-/// State of ST consumption
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum ConsumeSt {
-    Consume,
-    Keep,
-}
-
 /// Represents the current state of the ANSI parser state machine.
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum State {
@@ -196,39 +189,35 @@ impl AnsiParser {
         self.state = State::Ground;
     }
 
-    fn dispatch_osc(&mut self, consume_st: ConsumeSt) {
+    fn dispatch_osc(&mut self) {
         let data = mem::take(&mut self.string_buffer);
         trace!("Dispatching OSC: Data length {}", data.len());
         self.commands.push(AnsiCommand::Osc(data));
         self.clear_string_buffer();
-        if consume_st == ConsumeSt::Keep { /* ST handled separately */ }
         self.state = State::Ground;
     }
 
-    fn dispatch_dcs(&mut self, consume_st: ConsumeSt) {
+    fn dispatch_dcs(&mut self) {
         let data = mem::take(&mut self.string_buffer);
         trace!("Dispatching DCS: Data length {}", data.len());
         self.commands.push(AnsiCommand::Dcs(data));
         self.clear_string_buffer();
-        if consume_st == ConsumeSt::Keep { /* ST handled separately */ }
         self.state = State::Ground;
     }
 
-    fn dispatch_pm(&mut self, consume_st: ConsumeSt) {
+    fn dispatch_pm(&mut self) {
         let data = mem::take(&mut self.string_buffer);
         trace!("Dispatching PM: Data length {}", data.len());
         self.commands.push(AnsiCommand::Pm(data));
         self.clear_string_buffer();
-        if consume_st == ConsumeSt::Keep { /* ST handled separately */ }
         self.state = State::Ground;
     }
 
-    fn dispatch_apc(&mut self, consume_st: ConsumeSt) {
+    fn dispatch_apc(&mut self) {
         let data = mem::take(&mut self.string_buffer);
         trace!("Dispatching APC: Data length {}", data.len());
         self.commands.push(AnsiCommand::Apc(data));
         self.clear_string_buffer();
-        if consume_st == ConsumeSt::Keep { /* ST handled separately */ }
         self.state = State::Ground;
     }
 
@@ -434,7 +423,7 @@ impl AnsiParser {
                     AnsiToken::C0Control(b)
                         if b == C0Control::BEL as u8 && self.state == State::OscString =>
                     {
-                        self.dispatch_osc(ConsumeSt::Keep)
+                        self.dispatch_osc()
                     }
                     AnsiToken::C0Control(b)
                         if b == C0Control::CAN as u8 || b == C0Control::SUB as u8 =>
@@ -454,10 +443,10 @@ impl AnsiParser {
             }
             State::EscInString => match token {
                 AnsiToken::Print('\\') => match self.string_state_origin {
-                    Some(State::OscString) => self.dispatch_osc(ConsumeSt::Consume),
-                    Some(State::DcsEntry) => self.dispatch_dcs(ConsumeSt::Consume),
-                    Some(State::PmString) => self.dispatch_pm(ConsumeSt::Consume),
-                    Some(State::ApcString) => self.dispatch_apc(ConsumeSt::Consume),
+                    Some(State::OscString) => self.dispatch_osc(),
+                    Some(State::DcsEntry) => self.dispatch_dcs(),
+                    Some(State::PmString) => self.dispatch_pm(),
+                    Some(State::ApcString) => self.dispatch_apc(),
                     _ => {
                         error!("EscInString state missing origin!");
                         self.dispatch_st_standalone();

--- a/core-term/src/ansi/tests.rs
+++ b/core-term/src/ansi/tests.rs
@@ -2463,7 +2463,7 @@ mod mutation_tests {
     }
 
     #[test]
-    fn csi_s_is_save_cursor() {
+    fn csi_lowercase_s_is_save_cursor() {
         // 's' = save cursor (ANSI). Mutation: confusing 's' with 'S' (ScrollUp).
         let cmds = process_bytes(b"\x1b[s");
         assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::SaveCursor)]);
@@ -2474,5 +2474,51 @@ mod mutation_tests {
         // 'u' = restore cursor (ANSI). Mutation: confusing 'u' with 'U'.
         let cmds = process_bytes(b"\x1b[u");
         assert_eq!(cmds, vec![AnsiCommand::Csi(CsiCommand::RestoreCursor)]);
+    }
+
+    // -----------------------------------------------------------------------
+    // String buffer lifecycle (OSC/DCS/PM/APC share one buffer)
+    // Mutations: dropping the buffer/length-cap resets entirely (no-op).
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn osc_buffer_does_not_leak_across_a_cancelled_sequence() {
+        // Abort one OSC with CAN, then start and finish a second OSC. If the
+        // string buffer weren't cleared on cancellation, the second OSC's
+        // data would still carry bytes left over from the first, aborted one.
+        let cmds = process_bytes(b"\x1b]0;abc\x18\x1b]0;def\x07");
+        let osc_payloads: Vec<_> = cmds
+            .iter()
+            .filter_map(|c| match c {
+                AnsiCommand::Osc(data) => Some(data.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            osc_payloads,
+            vec![b"0;def".to_vec()],
+            "a cancelled OSC's bytes must not leak into the next OSC; got {:?}",
+            cmds
+        );
+    }
+
+    #[test]
+    fn osc_string_length_is_capped_not_grown_past_max_osc_len() {
+        // Mirrors `AnsiParser::MAX_OSC_LEN` (parser.rs) — kept as a local
+        // constant since the parser's cap is a private implementation detail.
+        const OSC_STRING_CAP: usize = 1024;
+        let mut bytes = vec![0x1b, b']'];
+        bytes.extend(std::iter::repeat_n(b'a', OSC_STRING_CAP + 1));
+        bytes.push(0x07); // BEL terminates the OSC
+        let cmds = process_bytes(&bytes);
+        let osc_payload = cmds.iter().find_map(|c| match c {
+            AnsiCommand::Osc(data) => Some(data.clone()),
+            _ => None,
+        });
+        assert_eq!(
+            osc_payload,
+            Some(vec![b'a'; OSC_STRING_CAP]),
+            "OSC payload must be capped at {OSC_STRING_CAP} bytes, not grown past it"
+        );
     }
 }

--- a/core-term/src/io/pty_tests.rs
+++ b/core-term/src/io/pty_tests.rs
@@ -116,7 +116,7 @@ fn read_from_pty_with_timeout(pty: &mut NixPty, expected_str: &str) -> Result<St
 }
 
 #[test]
-fn pty_spawn_successful() {
+fn it_should_receive_the_spawned_shells_echoed_output() {
     // Use sh -c to be more robust across platforms and ensure output flushing
     let config = PtyConfig {
         command_executable: "/bin/sh",
@@ -154,7 +154,7 @@ fn pty_spawn_successful() {
 }
 
 #[test]
-fn pty_read_write_interaction() {
+fn it_should_echo_back_data_written_to_the_pty_via_shell_read() {
     let shell_command = "read r_line; echo \"input was: $r_line\"";
     let config = PtyConfig {
         command_executable: "/bin/sh",
@@ -232,7 +232,7 @@ fn pty_child_gets_default_sigpipe() {
 }
 
 #[test]
-fn pty_resize_successful() {
+fn it_should_return_ok_when_resizing_a_running_ptys_window() {
     // Use `sleep` from PATH to be cross-platform (macOS has /bin/sleep, Linux /usr/bin/sleep)
     let config = PtyConfig {
         command_executable: "sleep",
@@ -333,7 +333,7 @@ fn pty_child_termination_on_drop() {
 }
 
 #[test]
-fn pty_spawn_invalid_command() {
+fn it_should_return_a_not_found_error_when_spawning_a_nonexistent_executable() {
     let non_existent_cmd = "/path/to/absolutely/nonexistent/command_39291az";
     let config = PtyConfig {
         command_executable: non_existent_cmd,

--- a/core-term/src/keys.rs
+++ b/core-term/src/keys.rs
@@ -42,7 +42,7 @@ mod tests {
     }
 
     #[test]
-    fn map_key_found() {
+    fn it_should_return_the_bound_action_when_key_and_modifiers_match_a_binding() {
         let bindings = vec![
             Keybinding {
                 key: KeySymbol::Char('C'),

--- a/core-term/src/term/core_tests.rs
+++ b/core-term/src/term/core_tests.rs
@@ -346,7 +346,7 @@ fn it_should_wrap_wide_character_correctly() {
 }
 
 #[test]
-fn it_should_not_print_second_half_of_wide_char_if_at_edge_and_no_wrap_mode_or_similar_logic() {
+fn it_should_wrap_a_wide_char_to_the_next_line_when_it_does_not_fit_in_the_last_column() {
     let mut term = create_test_emulator(2, 1);
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('A')));
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('世')));

--- a/core-term/src/term/emulator/input_handler.rs
+++ b/core-term/src/term/emulator/input_handler.rs
@@ -206,7 +206,7 @@ mod tests {
     }
 
     #[test]
-    fn paste_text_action_bracketed_on() {
+    fn it_should_wrap_pasted_text_in_bracketed_paste_markers_when_the_mode_is_enabled() {
         let mut emu = create_test_emu_for_input();
         // Enable bracketed paste mode via the public message-passing surface (CSI ? 2004 h).
         use crate::ansi::commands::CsiCommand;
@@ -225,7 +225,7 @@ mod tests {
     }
 
     #[test]
-    fn paste_text_action_bracketed_off() {
+    fn it_should_print_pasted_text_directly_when_bracketed_paste_is_disabled() {
         let mut emu = create_test_emu_for_input();
         assert!(!emu.dec_modes.bracketed_paste_mode);
 
@@ -326,7 +326,7 @@ mod tests {
     }
 
     #[test]
-    fn control_event_resize_minimum_dimensions() {
+    fn it_should_clamp_resize_dimensions_to_the_minimum_grid_size() {
         let mut emu = create_test_emu_for_input();
 
         // Very small resize (should clamp to MIN_GRID_DIMENSION)

--- a/core-term/src/term/emulator/key_translator.rs
+++ b/core-term/src/term/emulator/key_translator.rs
@@ -301,7 +301,7 @@ mod tests {
     }
 
     #[test]
-    fn arrow_keys_normal_mode() {
+    fn it_should_translate_arrow_keys_to_csi_sequences_in_normal_cursor_mode() {
         let modes = DecPrivateModes {
             cursor_keys_app_mode: false,
             ..Default::default()
@@ -325,7 +325,7 @@ mod tests {
     }
 
     #[test]
-    fn arrow_keys_app_mode() {
+    fn it_should_translate_arrow_keys_to_ss3_sequences_in_application_cursor_mode() {
         let modes = DecPrivateModes {
             cursor_keys_app_mode: true,
             ..Default::default()

--- a/core-term/src/term/layout.rs
+++ b/core-term/src/term/layout.rs
@@ -129,7 +129,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn pixels_to_cells_basic() {
+    fn it_should_map_pixel_coordinates_to_the_containing_cell() {
         let layout = Layout {
             cols: 80,
             rows: 24,
@@ -154,7 +154,7 @@ mod tests {
     }
 
     #[test]
-    fn pixels_to_cells_with_padding() {
+    fn it_should_account_for_padding_when_mapping_pixels_to_cells() {
         let layout = Layout {
             cols: 80,
             rows: 24,
@@ -176,7 +176,7 @@ mod tests {
     }
 
     #[test]
-    fn pixels_to_cells_out_of_bounds() {
+    fn it_should_return_none_for_pixel_coordinates_outside_the_grid() {
         let layout = Layout {
             cols: 80,
             rows: 24,

--- a/core-term/src/term/screen.rs
+++ b/core-term/src/term/screen.rs
@@ -1256,7 +1256,7 @@ mod tests {
     }
 
     #[test]
-    fn update_selection_when_not_active() {
+    fn it_should_leave_selection_unchanged_when_updating_while_inactive() {
         let mut screen = create_test_screen(10, 5);
         screen.start_selection(Point { x: 1, y: 1 }, SelectionMode::Cell); // Replaced Normal with Cell
         screen.selection.is_active = false;

--- a/core-term/src/term/tests.rs
+++ b/core-term/src/term/tests.rs
@@ -256,7 +256,7 @@ fn it_should_move_to_column_zero_of_the_next_line_when_lnm_is_set_and_lf_is_rece
 }
 
 #[test]
-fn carriage_return_input() {
+fn it_should_move_cursor_to_column_zero_and_overwrite_from_start_on_carriage_return() {
     let mut term = create_test_emulator(10, 1);
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('A')));
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('B')));
@@ -269,7 +269,7 @@ fn carriage_return_input() {
 }
 
 #[test]
-fn csi_cursor_forward_cuf() {
+fn it_should_move_cursor_forward_by_n_columns_on_csi_cuf() {
     let mut term = create_test_emulator(10, 1); // Cursor at (0,0)
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Csi(
         CsiCommand::CursorForward(1),
@@ -285,7 +285,7 @@ fn csi_cursor_forward_cuf() {
 }
 
 #[test]
-fn csi_ed_clear_below_csi_j() {
+fn it_should_clear_from_cursor_to_end_of_screen_on_csi_erase_in_display_0() {
     let mut term = create_test_emulator(3, 2);
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('A')));
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('B')));
@@ -313,7 +313,7 @@ fn csi_ed_clear_below_csi_j() {
 }
 
 #[test]
-fn csi_sgr_fg_color() {
+fn it_should_apply_and_reset_foreground_color_via_sgr() {
     let mut term = create_test_emulator(5, 1);
     let red_attr = vec![Attribute::Foreground(Color::Named(NamedColor::Red))];
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Csi(
@@ -491,14 +491,14 @@ fn mouse_release_ends_selection_activity() {
 
 // --- Copy Action Tests ---
 #[test]
-fn initiate_copy_no_selection() {
+fn it_should_return_none_when_initiating_copy_with_no_active_selection() {
     let mut emu = create_test_emulator(10, 5);
     let action = emu.interpret_input(EmulatorInput::User(UserInputAction::InitiateCopy));
     assert_eq!(action, None, "Should return None if no selection exists.");
 }
 
 #[test]
-fn initiate_copy_with_selection() {
+fn it_should_copy_the_selected_text_to_clipboard_when_a_selection_exists() {
     let mut emu = create_test_emulator(10, 2);
     fill_emulator_screen(&mut emu, vec!["Hello".to_string(), "World".to_string()]);
 
@@ -519,7 +519,7 @@ fn initiate_copy_with_selection() {
 }
 
 #[test]
-fn initiate_copy_block_selection() {
+fn it_should_copy_block_selected_text_joined_by_newlines() {
     let mut emu = create_test_emulator(3, 3);
     fill_emulator_screen(
         &mut emu,
@@ -705,7 +705,7 @@ fn selection_on_alt_screen_then_exit() {
 // --- End of Selection with Alternate Screen Test ---
 
 #[test]
-fn resize_larger() {
+fn it_should_preserve_content_and_cursor_when_resizing_to_a_larger_grid() {
     let mut term = create_test_emulator(5, 2);
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('1')));
     term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Print('2')));
@@ -747,7 +747,7 @@ fn resize_smaller_content_truncation() {
 }
 
 #[test]
-fn osc_set_window_title() {
+fn it_should_set_the_window_title_via_osc_0_and_osc_2() {
     let mut term = create_test_emulator(10, 1);
 
     let action = term.interpret_input(EmulatorInput::Ansi(AnsiCommand::Osc(
@@ -768,7 +768,7 @@ fn osc_set_window_title() {
 }
 
 #[test]
-fn key_event_printable_char() {
+fn it_should_write_and_echo_a_printable_character_key_input_to_the_pty() {
     let mut term = create_test_emulator(5, 1);
     let key_input = UserInputAction::KeyInput {
         symbol: KeySymbol::Char('x'),
@@ -787,7 +787,7 @@ fn key_event_printable_char() {
 }
 
 #[test]
-fn key_event_arrow_up() {
+fn it_should_write_the_up_arrow_escape_sequence_without_moving_the_cursor() {
     let mut term = create_test_emulator(5, 1);
     let key_input = UserInputAction::KeyInput {
         symbol: KeySymbol::Up,
@@ -863,7 +863,7 @@ fn it_should_preserve_selection_range_and_mode_in_a_constructed_snapshot() {
 }
 
 #[test]
-fn mode_show_cursor_dectcem() {
+fn it_should_hide_and_show_the_cursor_via_dectcem_reset_and_set() {
     let mut term = create_test_emulator(5, 1);
 
     let snap_default = term.get_render_snapshot().expect("Snapshot was None");
@@ -1235,7 +1235,7 @@ fn lf_at_bottom_of_partial_scrolling_region_no_origin_mode() {
     );
 }
 #[test]
-fn primary_device_attributes_response() {
+fn it_should_respond_to_a_primary_device_attributes_query_with_the_vt102_id() {
     let mut term = create_test_emulator(80, 24);
 
     let input_da = EmulatorInput::Ansi(AnsiCommand::Csi(CsiCommand::PrimaryDeviceAttributes));
@@ -1277,7 +1277,7 @@ mod selection_logic_tests {
     }
 
     #[test]
-    fn extend_selection_active_and_inactive() {
+    fn it_should_ignore_extend_when_no_selection_is_active_and_update_the_range_when_one_is() {
         let mut emu = create_test_emulator(10, 5);
         let start_point = Point { x: 2, y: 1 };
         let extend_point = Point { x: 5, y: 2 };
@@ -1303,7 +1303,7 @@ mod selection_logic_tests {
     }
 
     #[test]
-    fn apply_selection_clear_click_and_drag() {
+    fn it_should_clear_the_selection_on_click_but_retain_its_range_inactive_after_a_drag() {
         let mut emu = create_test_emulator(10, 5);
         let point1 = Point { x: 2, y: 1 };
         let point2 = Point { x: 5, y: 1 };
@@ -1347,7 +1347,7 @@ mod selection_logic_tests {
     }
 
     #[test]
-    fn verify_clear_selection() {
+    fn it_should_clear_an_existing_selection_via_clear_selection() {
         let mut emu = create_test_emulator(10, 5);
 
         // Create and deactivate a selection

--- a/core-term/src/term/unicode.rs
+++ b/core-term/src/term/unicode.rs
@@ -77,14 +77,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn ascii_char_width() {
+    fn it_should_report_width_1_for_ascii_printable_characters() {
         assert_eq!(get_char_display_width('A'), 1, "Width of 'A' should be 1");
         assert_eq!(get_char_display_width(' '), 1, "Width of space should be 1");
         assert_eq!(get_char_display_width('~'), 1, "Width of '~' should be 1");
     }
 
     #[test]
-    fn box_drawing_char_widths() {
+    fn it_should_report_width_1_for_box_drawing_characters() {
         assert_eq!(
             get_char_display_width('─'),
             1,
@@ -144,7 +144,7 @@ mod tests {
     }
 
     #[test]
-    fn cjk_wide_char_widths() {
+    fn it_should_report_width_2_for_cjk_wide_characters() {
         assert_eq!(
             get_char_display_width('世'),
             2,
@@ -168,7 +168,7 @@ mod tests {
     }
 
     #[test]
-    fn control_char_widths() {
+    fn it_should_report_width_0_for_control_characters() {
         assert_eq!(
             get_char_display_width('\u{0000}'),
             0,
@@ -208,7 +208,7 @@ mod tests {
     }
 
     #[test]
-    fn locale_initializer_called() {
+    fn it_should_initialize_the_locale_on_first_call_to_get_char_display_width() {
         // Ensure OnceLock mechanism is engaged
         let _ = get_char_display_width(' ');
         assert!(

--- a/core-term/src/terminal_app.rs
+++ b/core-term/src/terminal_app.rs
@@ -931,7 +931,7 @@ mod tests {
     }
 
     #[test]
-    fn handle_control_resize() {
+    fn it_should_resize_the_emulator_and_forward_the_pty_resize_on_a_control_resize_event() {
         let (mut app, mut writer_rx, _, _scheduler) = match create_test_app() {
             Some(v) => v,
             None => return,
@@ -1013,7 +1013,7 @@ mod tests {
     /// injects the exact KeyDown the X11 mapper produces for Ctrl+C and
     /// asserts the child dies (i.e. 0x03 reached the PTY line discipline).
     #[test]
-    fn ctrl_c_interrupts_yes_flood() {
+    fn it_should_deliver_ctrl_c_through_a_real_pty_and_kill_a_flooding_child_process() {
         use crate::io::event_monitor_actor::PtyTroupe;
         use crate::io::pty::{NixPty, PtyChannel, PtyConfig};
         use std::time::{Duration, Instant};
@@ -1155,7 +1155,7 @@ mod tests {
     }
 
     #[test]
-    fn handle_management_keydown() {
+    fn it_should_write_the_pressed_key_byte_to_the_pty_on_a_keydown_management_event() {
         let (mut app, mut writer_rx, _, _scheduler) = match create_test_app() {
             Some(v) => v,
             None => return,

--- a/core-term/tests/ansi_to_grid_integration.rs
+++ b/core-term/tests/ansi_to_grid_integration.rs
@@ -78,7 +78,7 @@ fn newline_advances_row() {
 }
 
 #[test]
-fn cursor_position_command() {
+fn it_should_move_the_cursor_to_the_position_specified_by_cup() {
     let mut harness = MinimalTestHarness::new();
 
     // TEST: Move cursor to (5, 10), then print
@@ -215,22 +215,14 @@ fn it_should_change_the_grid_checksum_after_each_character_printed() {
     }
 }
 
-// =============================================================================
-// Bug Reproduction: Grid changes but render not triggered
-// =============================================================================
-
 #[test]
-fn bug_grid_changes_without_render_trigger() {
-    // This test documents the ACTUAL BUG:
-    // Grid state changes when ANSI commands are processed,
-    // but send_frame() is never called, so the display doesn't update.
-
+fn it_should_change_the_grid_checksum_when_ansi_print_commands_are_processed() {
+    // Note: despite its history as a "bug reproduction" test, this only
+    // exercises MinimalTestHarness's grid/checksum path (identical in
+    // substance to `it_should_change_the_grid_checksum_after_each_character_printed`
+    // above) — it never touches `TerminalApp`/`send_frame`, so it does not
+    // cover the render-trigger behavior its old name implied.
     let mut harness = MinimalTestHarness::new();
-
-    // Simulate PTY output being processed in handle_os()
-    // In the real app, handle_os() calls:
-    //   self.emulator.interpret_input(EmulatorInput::Ansi(cmd))
-    // But it NEVER calls send_frame() afterward!
 
     harness.inject_ansi(AnsiCommand::Print('a'));
     let checksum_after_a = harness.compute_grid_checksum();
@@ -238,14 +230,5 @@ fn bug_grid_changes_without_render_trigger() {
     harness.inject_ansi(AnsiCommand::Print('b'));
     let checksum_after_b = harness.compute_grid_checksum();
 
-    // Grid DOES change (this passes)
-    assert_ne!(
-        checksum_after_a, checksum_after_b,
-        "BUG CONFIRMED: Grid changes but no render triggered"
-    );
-
-    // But in the real app, handle_os() doesn't call send_frame(),
-    // so the manifold is never rebuilt and the frame checksum stays the same!
-
-    // THE FIX: handle_os() should call self.send_frame() after processing PTY output
+    assert_ne!(checksum_after_a, checksum_after_b);
 }

--- a/docs/bugs/2026-08-27-test-quality-audit-followup.md
+++ b/docs/bugs/2026-08-27-test-quality-audit-followup.md
@@ -1,0 +1,286 @@
+# Test quality control follow-up — 2026-08-27
+
+Scope: scheduled continuation of the recurring test-quality audit (most
+recent prior pass: `docs/bugs/2026-08-15-test-quality-audit-followup.md`,
+`ce2df0e`). This pass covers two crates in depth — `core-term` and
+`pixelflow-core` — via full manual audits against STYLE.md's "Testing"
+section (public-API-only scope, "it should" descriptive names) plus
+`cargo-mutants` (v27.1.0, freshly installed — not present in this
+environment, consistent with every prior pass) mutation testing.
+
+## Mutation testing: `core-term/src/ansi/parser.rs`
+
+Never independently mutation-tested before (the file wasn't touched by any
+prior audit's fix commits; `key_translator.rs` was mutation-tested in the
+same sweep as a spot check and came back 0/0 missed — already closed by
+`addb79d`).
+
+**First sweep: 134 mutants, 10 missed.** Triage of each:
+
+- **Real gap — `clear_string_buffer` no-op survives.** `dispatch_osc`/`dcs`/
+  `pm`/`apc` all call `mem::take` on the string buffer before dispatch, which
+  already empties it regardless of whether `clear_string_buffer()` runs — so
+  those call sites can't distinguish the mutant. But the CAN/SUB
+  cancel-string path (`process_token`, `State::OscString | ...`) calls
+  `clear_string_buffer()` directly *without* an accompanying `mem::take`. If
+  that call were a no-op, an aborted OSC/DCS/PM/APC string's bytes would
+  leak into the *next* string sequence's payload. **Fixed**: added
+  `osc_buffer_does_not_leak_across_a_cancelled_sequence` to
+  `ansi/tests.rs`'s `mutation_tests` module, driving the abort-then-restart
+  sequence through `process_bytes` (public API) and asserting on the
+  resulting `AnsiCommand::Osc` payload.
+- **Real gap — `add_string_byte`'s `<` vs `<=` at `MAX_OSC_LEN`.** The
+  string buffer's length cap flows straight into the `Osc`/`Dcs`/`Pm`/`Apc`
+  command's byte vector (unlike CSI intermediates — see below — nothing
+  remaps or discards it), so it's directly observable. **Fixed**: added
+  `osc_string_length_is_capped_not_grown_past_max_osc_len`, feeding
+  `MAX_OSC_LEN + 1` bytes and asserting the payload is truncated to the cap.
+- **Dead code — the four `ConsumeSt` mutants** (`dispatch_osc`/`dcs`/`pm`/
+  `apc`'s `if consume_st == ConsumeSt::Keep { /* ST handled separately */ }`).
+  The block is empty — both branches of every one of these `if` statements
+  do *exactly nothing*, so no test, however designed, could ever tell them
+  apart. Confirmed `ConsumeSt` had no other reader anywhere in the file.
+  **Fixed by deletion**, not by testing: removed the `ConsumeSt` enum, its
+  parameter on all four `dispatch_*` functions, and both call-site variants
+  (`ConsumeSt::Keep`/`::Consume`) collapsed to no-arg calls. This is a
+  behavior-preserving simplification (confirmed by the before/after mutant
+  count: 134 mutants → 70 once the dead branches no longer existed to
+  mutate) and directly matches CLAUDE.md's "subtract before you add."
+- **Reviewed and accepted as unreachable — `clear_esc_state` no-op,
+  `add_intermediate`'s `<`/`<=`, `to_byte_lossy` → `0`/`1` (4 mutants,
+  3 call sites).** All four trace back to the same invariant: `state ==
+  State::EscIntermediate` is reachable *only* via the one call site
+  (`Escape`'s `AnsiToken::Print(inter @ ('('|')'|'*'|'+'))` arm) that sets
+  `esc_intermediate = Some(inter)` in the same statement as the state
+  transition — so `self.esc_intermediate` is always freshly `Some` at every
+  point it's read, and:
+  - `clear_esc_state`'s effect (`esc_intermediate = None`) is never observed
+    by a subsequent read through any input sequence the public
+    `process_token`/`process_bytes` API can produce.
+  - The `else` branch at `EscIntermediate`'s handler (`error!("Invalid
+    EscIntermediate state"); dispatch_error(token.to_byte_lossy())`) — the
+    *only* call site of `to_byte_lossy` — is consequently unreachable from
+    any public input; it is a defensive fallback guarding an "impossible"
+    state, not a live code path.
+  - Separately, `add_intermediate`'s boundary (`MAX_INTERMEDIATES = 2`) has
+    no observable effect on any producible `AnsiCommand`: unlike
+    `MAX_OSC_LEN`, no recognized CSI command in `commands.rs::from_csi`
+    matches on an intermediates slice of length 2 (only `b""`, `b" "`, or a
+    private-CSI wildcard that ignores intermediates entirely), and *every*
+    path that falls through to `CsiCommand::Unsupported` — capped at 2
+    intermediates or not — gets remapped to the same generic
+    `AnsiCommand::Error(final_byte)` by `dispatch_csi`, discarding the
+    intermediates vector. A capped-at-2 sequence and an uncapped-at-3
+    sequence currently produce bit-identical output for every reachable
+    final byte.
+
+  Per STYLE.md's "Flexibility: Break Rules Sensibly," these four are left
+  undercovered rather than forced: the alternative would be reaching into
+  private state to construct an otherwise-unreachable parser configuration,
+  which trades one rule (public-API-only testing) for another (kill every
+  mutant). Not re-verified as a request for future work — this is a
+  considered call, not an open item — but flagged here for visibility if
+  the state machine's invariants ever change (e.g. a future refactor that
+  lets `EscIntermediate` be entered without freshly setting
+  `esc_intermediate` would make `clear_esc_state` load-bearing again).
+
+**Final sweep after fixes: 70 mutants (down from 134 — the `ConsumeSt`
+deletion removed 64 now-nonexistent mutation sites), 4 missed (the reviewed
+set above), 65 caught, 1 unviable.**
+
+## STYLE.md naming audit: `core-term` (514 tests across 21 files) and `pixelflow-core` (31 files)
+
+Full manual audits of every `#[test]` function in both crates (methodology:
+enumerate via `grep -rl '#\[test\]'`, verify naming against the "it should"
+rule and scope against public-API-only per file). Full per-file tables were
+generated but are not reproduced here — see the session transcript; the
+following is the actioned subset plus the backlog.
+
+### Fixed: 40 test renames (core-term)
+
+All verified individually against the actual test body before renaming
+(not applied blindly from the audit pass), then the full `core-term`
+lib test suite (461 tests) re-run to confirm no breakage:
+
+- `ansi/tests.rs` (1): `csi_s_is_save_cursor` → `csi_lowercase_s_is_save_cursor`
+  (disambiguates from the neighboring `csi_s_uppercase_is_scroll_up`).
+- `keys.rs` (1): `map_key_found` → `it_should_return_the_bound_action_when_key_and_modifiers_match_a_binding`.
+- `io/pty_tests.rs` (4): `pty_spawn_successful`, `pty_read_write_interaction`,
+  `pty_resize_successful`, `pty_spawn_invalid_command` → outcome-describing
+  `it_should_*` names.
+- `term/layout.rs` (3): `pixels_to_cells_basic`/`_with_padding`/`_out_of_bounds`
+  → `it_should_*` names.
+- `term/unicode.rs` (5): `ascii_char_width`, `box_drawing_char_widths`,
+  `cjk_wide_char_widths`, `control_char_widths`, `locale_initializer_called`
+  → `it_should_*` names.
+- `term/emulator/key_translator.rs` (2): `arrow_keys_normal_mode`/`_app_mode`
+  → names stating which escape family each mode produces.
+- `term/emulator/input_handler.rs` (3): `paste_text_action_bracketed_on`/
+  `_off`, `control_event_resize_minimum_dimensions` → `it_should_*` names.
+- `term/screen.rs` (1): `update_selection_when_not_active` →
+  `it_should_leave_selection_unchanged_when_updating_while_inactive`
+  (previously stated only the condition, not the outcome).
+- `term/core_tests.rs` (1): the "`..._or_similar_logic`" hedge name →
+  `it_should_wrap_a_wide_char_to_the_next_line_when_it_does_not_fit_in_the_last_column`.
+- `terminal_app.rs` (3): `handle_control_resize`, `ctrl_c_interrupts_yes_flood`,
+  `handle_management_keydown` → `it_should_*` names.
+- `term/tests.rs` (16): `carriage_return_input`, `csi_cursor_forward_cuf`,
+  `csi_ed_clear_below_csi_j`, `csi_sgr_fg_color`, `initiate_copy_no_selection`,
+  `initiate_copy_with_selection`, `initiate_copy_block_selection`,
+  `resize_larger`, `osc_set_window_title`, `key_event_printable_char`,
+  `key_event_arrow_up`, `mode_show_cursor_dectcem`,
+  `primary_device_attributes_response`, `extend_selection_active_and_inactive`,
+  `apply_selection_clear_click_and_drag`, `verify_clear_selection` →
+  `it_should_*` names.
+- `tests/ansi_to_grid_integration.rs` (2): `cursor_position_command` →
+  `it_should_move_the_cursor_to_the_position_specified_by_cup`; and
+  `bug_grid_changes_without_render_trigger` — its own comment claimed to
+  reproduce a `TerminalApp.handle_os()`/`send_frame()` bug, but the test
+  body never touches `TerminalApp` or `send_frame` at all and is otherwise
+  identical to `it_should_change_the_grid_checksum_after_each_character_printed`
+  one test above it. Renamed to
+  `it_should_change_the_grid_checksum_when_ansi_print_commands_are_processed`
+  and rewrote the stale "BUG CONFIRMED"/"THE FIX" comments (which described
+  a bug this test doesn't actually exercise) into one accurate note. Left
+  in place rather than deleted, since it's still a valid (if redundant)
+  checksum assertion — deleting a test is a bigger call than a rename/doc
+  fix for an unattended pass.
+
+### Fixed: CLAUDE.md-forbidden `raw_add`/`raw_mul` in test fixtures (pixelflow-core)
+
+`src/lattice/tests.rs`'s two test-only `Manifold` fixtures (`XPlusY`,
+`ZTimes100`, used by `point_collapse_single_eval`,
+`discrete_manifold_round_trip`, `scanline_collapse_round_trip`, and
+`box_collapse_4d_layout`) called `Field::raw_add`/`raw_mul` directly instead
+of `+`/`*` — exactly the pattern CLAUDE.md's Critical Constraints singles
+out ("NO PUBLIC raw_mul, raw_select, raw_add ETC USAGE... ALWAYS construct
+the AST, then use the nested contramap pattern to evaluate it"). Replaced
+with `+`/`*` operators; since those operators lower to lazy `Manifold`
+combinator nodes rather than eager `Field`s (`x + y : Add<Field, Field>`,
+not `Field`), each fixture's `eval` now reads `(expr).eval(p)` to reduce the
+combinator against the incoming domain point, matching how every other
+`Manifold` impl in the codebase is written. Removed the now-unused
+`use crate::numeric::Numeric;` import. `cargo test -p pixelflow-core --lib
+lattice::tests::`: 27/27 passed, including `box_collapse_4d_layout` (the
+`ZTimes100` consumer).
+
+## Backlog — not done this pass
+
+In rough priority order, largest/highest-value first:
+
+1. **`core-term/tests/message_cuj_tests.rs` (17 tests) and 13 of 19 tests in
+   `core-term/tests/actor_roundtrip_tests.rs`** never touch the `core_term`
+   crate at all — they hand-roll `MockParserActor`/`TestParserActor`/
+   `MockTerminalAppActor`/`TestTerminalAppActor` etc. that reimplement
+   fragments of ANSI-parsing/terminal-app logic and test *those*, using
+   only `actor_scheduler`. Names like `cuj_pty02_command_batch_delivery`,
+   `parser_roundtrip_simple_text`, `terminal_app_roundtrip_key_input`
+   strongly imply real coverage of core-term's parser/app but provide none.
+   The sibling `ansi_parser_message_tests.rs` does this correctly (its
+   `RealParserActor` wraps the actual `AnsiProcessor`) and is the pattern to
+   copy. This is the single largest finding of the pass and the most
+   consequential — it's a false sense of coverage, not just a style
+   nit — but rewriting ~30 tests to exercise real core-term types (or
+   relocating the actor-plumbing-only ones to `actor-scheduler`'s own test
+   suite) is a genuine design decision, not a mechanical fix, and too large
+   a blast radius for an unattended pass. Left for a dedicated follow-up.
+2. **`Field::store` (`pixelflow-core/src/lib.rs:529`) is `pub(crate)`, not
+   public, and its own doc comment says "If you're reading this, you're
+   trying to use the library wrong... The function you're looking for is
+   `materialize`."** Despite that, the large majority of unit tests across
+   `pixelflow-core/src/*.rs` (roughly 90+ of the crate's ~160 tests) call
+   `.store()` directly as their test oracle — a systemic TESTS_PRIVATE
+   pattern, not isolated incidents. The reference pattern already exists
+   in the same crate and should be the template for fixing this backlog
+   item: `tests/unit_tests.rs`'s `assert_field_approx_eq` helper (and
+   `src/lattice/tests.rs`'s `bilinear_sampler` submodule) compare `Field`s
+   via `.lt(...).eval(coords).all()` — an all-public-API boolean-mask
+   comparison — never extracting a raw scalar at all. Converting the
+   `.store()`-based tests to this pattern crate-wide is a large, mechanical
+   but non-trivial sweep (each call site needs its assertion restructured,
+   not just renamed) — a natural next multi-pass target, ideally one module
+   at a time the way `backend/mod.rs` was closed on 2026-08-15.
+3. **Two files bypass privacy even more directly via unsafe pointer casts
+   on `Field`** (`unsafe { *(&f as *const Field as *const f32) }`):
+   `pixelflow-core/src/mask.rs:201` (`lane0` helper, 3 call sites) and
+   `pixelflow-core/tests/test_log2.rs` (`eval_to_f32`, used throughout that
+   file, including a raw `.offset()` lane walk in
+   `log2_simd_consistency`). Worse than `.store()`: it reads through
+   `Field`'s private layout with raw pointers rather than calling any
+   accessor. `tests/test_jet2.rs` has 4 tests `#[ignore]`d with the comment
+   *"Needs internal Field access for lane extraction"* — direct evidence
+   the missing safe accessor is actively blocking legitimate black-box
+   tests from running at all. Investigated during this pass: `mask.rs`'s 3
+   affected tests (`select_picks_if_true_when_mask_all_true`,
+   `select_picks_if_false_when_mask_all_false`,
+   `select_opt_matches_select_on_uniform_masks`) could plausibly move to
+   the `.lt(...).eval(coords).all()` pattern from item 2, but `Mask::select`
+   returns a concrete `Field` (eager), not a lazy combinator, and getting
+   the coordinate-domain plumbing right without introducing a subtly wrong
+   assertion in SIMD-sensitive code needs more care than this pass's
+   remaining budget allowed. Left open rather than risk a wrong fix.
+4. **`pixelflow-search/src/egraph/cost.rs`** — still open per the 08-08
+   audit and re-flagged 08-15: a partial mutants run previously found one
+   real gap (`CostModel::zero()`, already fixed) before its own slow
+   `--lib` baseline (~110s) timed out the pass. Not attempted this pass
+   (out of scope — this pass's budget went to `core-term`/`pixelflow-core`
+   as scoped above). Still needs either a narrower test filter or a longer
+   time budget.
+5. **`pixelflow-codegen/src/emit/*`** (~1,400 lines) — flagged 08-08, still
+   true as of 08-15, not attempted this pass: never mutation-tested under
+   its post-crate-split location.
+6. **`pixelflow-graphics/src/spatial_bsp.rs`** — confirmed still open as of
+   08-15: 19 tests reach into private `bsp.interiors[...]` fields with no
+   public accessor. Still a design call (test-only introspection API vs.
+   property tests over `eval()` vs. documented rule-break), not attempted
+   this pass.
+7. **`actor-scheduler/src/lib.rs`'s `backoff_unit_tests`** (~line 1918) —
+   confirmed still present; tests `backoff_with_jitter` (private) and
+   `send_with_backoff` (`pub(crate)`) directly rather than through a public
+   entry point. The 2026-07-20 audit's mutation findings against these were
+   not re-verified this pass (checked the code, not re-run through
+   `cargo-mutants` — out of this pass's two-crate scope).
+8. **`pixelflow-core/src/backend/x86.rs`/`arm.rs`'s *required* `SimdOps`
+   methods** (the per-ISA primitives the 08-15 pass's provided-method sweep
+   deliberately didn't touch) — never independently mutation-tested as a
+   whole-file sweep. Not attempted this pass.
+9. **Remaining `pixelflow-core` NEEDS_RENAME/TESTS_PRIVATE findings not
+   covered by item 2 or 3** — roughly 60 more renames (largest clusters:
+   the compile-only `src/combinators/context.rs` tests, which assert
+   nothing and only type-check; the assertion-free `tests/test_jet2h.rs`
+   tests, a direct consequence of item 2) and a handful of narrower scope
+   issues (`src/lattice/cell_grid.rs`'s two private-IR-arena-internals
+   tests, `src/backend/x86.rs`'s `avx512_log2` testing the raw `F32x16`
+   type directly, `tests/x86_backend_tests.rs` testing raw `F32x4`
+   throughout). Left for a future pass — see item 2's note about doing
+   this crate module-by-module rather than in one sweep.
+10. **Remaining `core-term` TESTS_PRIVATE findings not covered by item 1**
+    — `term/screen.rs` (35/35 tests reach `Screen`'s `pub(super)` fields/
+    methods directly rather than through `TerminalEmulator`),
+    `term/emulator/mouse.rs` (24/24 call the `pub(crate)` `encode_mouse_event`
+    directly), `term/emulator/key_translator.rs` (11/11 call the
+    `pub(super)` `translate_key_input` directly), `terminal_app.rs` (4/4
+    call private `handle_control`/`handle_management`/`handle_data`/
+    `new_registered`). Renamed in this pass where flagged (see above) but
+    scope left as-is: this is an established, repo-wide convention for
+    testing internal state machines directly (multiple prior audit passes,
+    e.g. `addb79d`, added *more* tests to these same modules rather than
+    refactoring them toward public-only access), not a regression, so
+    treated as accepted rather than backlog — noted here only for
+    completeness of the audit record.
+
+## Verified
+
+- `cargo test -p core-term --lib`: 461 passed, 0 failed (up from the
+  pre-existing count by the 2 new mutation-gap tests).
+- `cargo test -p pixelflow-core`: 123 passed, 1 ignored, 0 failed (lib) +
+  all doctests/integration targets green.
+- `cargo clippy -p core-term --tests`: clean (fixed one `manual_repeat_n`
+  lint on the new OSC-cap test along the way).
+- `cargo clippy -p pixelflow-core --tests`: clean.
+- `cargo fmt -p core-term -- --check` / `-p pixelflow-core -- --check`: clean.
+- `cargo mutants -p core-term --file core-term/src/ansi/parser.rs`: 70
+  mutants, 65 caught, 4 reviewed-and-accepted (see above), 1 unviable.
+- `cargo mutants -p core-term --file core-term/src/term/emulator/key_translator.rs`
+  (spot check, no fixes needed): 0 missed — confirms `addb79d` closed this
+  file's gaps.

--- a/pixelflow-core/src/lattice/tests.rs
+++ b/pixelflow-core/src/lattice/tests.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::numeric::Numeric;
 use crate::variables::{X, Y};
 
 // A trivial manifold for testing: returns X + Y.
@@ -13,7 +12,7 @@ impl Manifold<(Field, Field, Field, Field)> for XPlusY {
     #[inline(always)]
     fn eval(&self, p: (Field, Field, Field, Field)) -> Field {
         let (x, y, _, _) = p;
-        x.raw_add(y)
+        (x + y).eval(p)
     }
 }
 
@@ -473,10 +472,8 @@ fn box_collapse_4d_layout() {
     struct ZTimes100;
     impl Manifold<(Field, Field, Field, Field)> for ZTimes100 {
         type Output = Field;
-        fn eval(&self, (x, y, z, _): (Field, Field, Field, Field)) -> Field {
-            z.raw_mul(Field::from(100.0))
-                .raw_add(y.raw_mul(Field::from(10.0)))
-                .raw_add(x)
+        fn eval(&self, p @ (x, y, z, _): (Field, Field, Field, Field)) -> Field {
+            (z * Field::from(100.0) + y * Field::from(10.0) + x).eval(p)
         }
     }
 


### PR DESCRIPTION
## Summary

Continues the recurring test-quality audit (`docs/bugs/*-test-quality-audit-followup.md`, most recent prior pass `ce2df0e` / 2026-08-15). This pass covers `core-term` and `pixelflow-core`: a full STYLE.md compliance audit (public-API-only test scope, descriptive "it should" naming) plus `cargo-mutants` mutation testing on `core-term/src/ansi/parser.rs` (never independently mutation-tested before this pass).

- **`core-term/src/ansi/parser.rs` mutation-gap fixes** (134 mutants → 10 missed → 70 mutants / 4 reviewed-and-accepted after fixes):
  - Real gap: aborting an OSC/DCS/PM/APC string (CAN/SUB) wasn't observably clearing the string buffer in any existing test — risked data bleed into the next string sequence. Added a public-API test.
  - Real gap: `MAX_OSC_LEN`'s boundary wasn't tested. Added a test asserting the OSC payload truncates rather than growing past the cap.
  - Dead code: the four `dispatch_{osc,dcs,pm,apc}` `ConsumeSt` checks were empty if-bodies with zero observable effect either way. Removed `ConsumeSt` entirely (behavior-preserving) rather than writing an unkillable test.
  - `clear_esc_state`, `add_intermediate`'s boundary, and `to_byte_lossy` remain genuinely unreachable via the public parser API given the state machine's current invariants — documented as reviewed-and-accepted rather than forced with an artificial private-state test.
- **40 test renames** across `core-term` to comply with STYLE.md's "it should" naming rule — each verified against its actual test body before renaming, not applied blindly.
- **`pixelflow-core/src/lattice/tests.rs`**: replaced `raw_add`/`raw_mul` in two test fixtures with `+`/`*` operators, per CLAUDE.md's explicit ban on raw op usage outside the AST/contramap pattern.
- Full findings, triage rationale, and a prioritized backlog (largest: `core-term`'s `message_cuj_tests.rs`/`actor_roundtrip_tests.rs` testing hand-rolled mocks instead of real crate types; `pixelflow-core`'s systemic `Field::store` pub(crate)-as-test-oracle pattern) written up in `docs/bugs/2026-08-27-test-quality-audit-followup.md`.

## Test plan

- [x] `cargo test -p core-term --lib`: 461 passed, 0 failed
- [x] `cargo test -p core-term --test ansi_to_grid_integration`: 9 passed, 0 failed
- [x] `cargo test -p pixelflow-core`: 123 passed, 1 ignored, 0 failed (lib) + doctests/integration green
- [x] `cargo clippy -p core-term --tests`: clean
- [x] `cargo clippy -p pixelflow-core --tests`: clean
- [x] `cargo fmt -p core-term -- --check` / `-p pixelflow-core -- --check`: clean
- [x] `cargo mutants -p core-term --file core-term/src/ansi/parser.rs`: 65/70 caught, 4 reviewed-and-accepted, 1 unviable
- [x] `cargo mutants -p core-term --file core-term/src/term/emulator/key_translator.rs` (spot check): 0 missed

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_019WiYDhHJzAcn8AH2s4Vp6J

---
_Generated by [Claude Code](https://claude.ai/code/session_019WiYDhHJzAcn8AH2s4Vp6J)_