### PR TITLE
perf(pixelflow-search): make validated extraction cheap again

### DIFF
--- a/docs/results/journal.jsonl
+++ b/docs/results/journal.jsonl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:62fa1d46f5390065e91af330451f151281bc0999de4e26c9513aaa1b462e6820
-size 8665
+oid sha256:7f2f0a536b3ad9bd59464a3fc9152f6476a20d6efde0d8f6bfefb38264a95750
+size 9799

--- a/pixelflow-pipeline/Cargo.toml
+++ b/pixelflow-pipeline/Cargo.toml
@@ -18,6 +18,10 @@ default = ["training"]
 # `[dev-dependencies]` feature does not reach them.
 training = ["pixelflow-search/std", "pixelflow-ir/oracle"]
 profiling = ["pprof"]
+# Pass-through to pixelflow-search's opt-in extraction-loop phase timers
+# (Round 2b extraction-overhead investigation). See
+# `pixelflow-search::egraph::profile` and `profile_extraction`'s bin doc.
+extraction-profile = ["pixelflow-search/extraction-profile"]
 
 [dependencies]
 pixelflow-codegen = { path = "../pixelflow-codegen" }
@@ -92,6 +96,13 @@ bench = false
 [[bin]]
 name = "bench_jit_compile_cost"
 path = "src/bin/bench_jit_compile_cost.rs"
+required-features = ["training"]
+# libtest harness rejects Criterion's bencher flags under `cargo bench --benches`.
+bench = false
+
+[[bin]]
+name = "profile_extraction"
+path = "src/bin/profile_extraction.rs"
 required-features = ["training"]
 # libtest harness rejects Criterion's bencher flags under `cargo bench --benches`.
 bench = false

--- a/pixelflow-pipeline/src/bin/profile_extraction.rs
+++ b/pixelflow-pipeline/src/bin/profile_extraction.rs
@@ -1,0 +1,417 @@
+//! Round 2b extraction-overhead investigation
+//! (docs/plans/2026-08-17-cost-model-domain.md, anti-row A6): determinism
+//! digest + phase-timing attribution over
+//! `IncrementalExtractor::extract_choices_only`.
+//!
+//! Two things, one binary, because both need the same per-kernel setup (load
+//! a DEV corpus expression, build + saturate its e-graph, run NNUE
+//! extraction under the canonical weights):
+//!
+//! 1. **Determinism digest** — the acceptance test the later Fix phase must
+//!    hold to. Runs NNUE extraction over every sampled DEV expression and
+//!    folds every chosen form (the exact `choices_to_arena` output, node for
+//!    node — op kinds, constants, child ids, root id) plus every predicted
+//!    log-cost into one FNV-1a digest. Two runs against the same corpus and
+//!    weights on the same source must print the identical digest; a changed
+//!    digest after a "performance-only" change means extraction chose a
+//!    different form or scored one differently, which is a semantics
+//!    regression under HARD CONSTRAINT (1), not a speed win.
+//!
+//! 2. **Phase attribution** — only meaningful under
+//!    `--features extraction-profile` (this crate passes the flag through to
+//!    `pixelflow-search/extraction-profile`; see
+//!    `pixelflow_search::egraph::profile`). Resets the profiler's
+//!    thread-local buckets before each kernel's extraction call and reads
+//!    them back after, so the aggregated report is mean us/kernel and call
+//!    counts per phase over the whole run — not a cumulative total that
+//!    would hide per-kernel variance.
+//!
+//! Run:
+//! ```bash
+//! # digest only (any build)
+//! cargo run --release -p pixelflow-pipeline --features training \
+//!     --bin profile_extraction -- --max-kernels 280
+//!
+//! # digest + phase attribution
+//! cargo run --release -p pixelflow-pipeline --features training,extraction-profile \
+//!     --bin profile_extraction -- --max-kernels 280
+//! ```
+
+use std::path::PathBuf;
+use std::time::Instant;
+
+use clap::Parser;
+
+use pixelflow_ir::{ExprArena, ExprId, ExprNode};
+use pixelflow_search::egraph::{EGraph, IncrementalExtractor, all_rules, choices_to_arena};
+use pixelflow_search::nnue::ExprNnue;
+
+use pixelflow_pipeline::extraction_head_weights_path;
+use pixelflow_pipeline::training::corpus::read_corpus;
+
+/// E-graph saturation budget — matches `prod_kernel_jit.rs` and
+/// `bench_extraction_3way`'s `SATURATE_LIMIT`. Deliberately the same value:
+/// a digest minted under a different saturation budget is not comparable.
+const SATURATE_LIMIT: usize = 40;
+
+/// Alternatives considered per e-class during NNUE refinement — matches
+/// `bench_extraction_3way`'s `EXTRACT_TOP_K` and `pixelflow-compiler`'s.
+const EXTRACT_TOP_K: usize = 8;
+
+#[derive(Parser)]
+#[command(name = "profile_extraction")]
+#[command(about = "Determinism digest + phase-timing attribution for NNUE extraction (Round 2b)")]
+struct Args {
+    /// Directory holding the tiered corpus written by `gen_bench_corpus`.
+    #[arg(long, default_value = "pixelflow-pipeline/data")]
+    corpus_dir: String,
+
+    /// Maximum DEV-tier expressions to run (0 = the whole tier).
+    #[arg(long, default_value_t = 0)]
+    max_kernels: usize,
+
+    /// NNUE weights to extract with. Defaults to the canonical
+    /// `extraction_head_weights_path()` — pass an explicit throwaway
+    /// checkpoint's path only when the canonical one isn't what you want to
+    /// pin the digest to.
+    #[arg(long)]
+    weights: Option<PathBuf>,
+}
+
+// ---------------------------------------------------------------------------
+// FNV-1a digest over the exact bytes `choices_to_arena` would materialise.
+// ---------------------------------------------------------------------------
+
+/// Deterministic across runs and platforms (no hashmap-seed randomness,
+/// unlike `std::hash::DefaultHasher`) — the entire point of a cross-run
+/// digest is that it does NOT change unless the inputs do.
+struct Fnv1a(u64);
+
+impl Fnv1a {
+    fn new() -> Self {
+        Self(0xcbf29ce484222325)
+    }
+
+    fn write_u8(&mut self, b: u8) {
+        self.0 = (self.0 ^ u64::from(b)).wrapping_mul(0x0000_0100_0000_01b3);
+    }
+
+    fn write_bytes(&mut self, bs: &[u8]) {
+        for &b in bs {
+            self.write_u8(b);
+        }
+    }
+
+    fn write_u32(&mut self, v: u32) {
+        self.write_bytes(&v.to_le_bytes());
+    }
+
+    fn write_f32(&mut self, v: f32) {
+        // Bit pattern, not the float value: two NaN payloads with the same
+        // meaning must still show up as a digest change if the bits differ,
+        // because the JIT compiles the bit pattern, not the mathematical
+        // value.
+        self.write_bytes(&v.to_bits().to_le_bytes());
+    }
+
+    fn finish(&self) -> u64 {
+        self.0
+    }
+}
+
+/// Fold every node of `arena` (in arena order — `choices_to_arena` builds
+/// deterministically, so identical choices always produce byte-identical
+/// arenas in the same order) plus the root id into `h`.
+fn hash_arena(h: &mut Fnv1a, arena: &ExprArena, root: ExprId) {
+    h.write_u32(arena.len() as u32);
+    h.write_u32(root.0);
+    for i in 0..arena.len() {
+        let id = ExprId(i as u32);
+        match arena.node(id) {
+            ExprNode::Var(v) => {
+                h.write_u8(0);
+                h.write_u8(*v);
+            }
+            ExprNode::Const(c) => {
+                h.write_u8(1);
+                h.write_f32(*c);
+            }
+            ExprNode::Param(p) => {
+                h.write_u8(2);
+                h.write_u8(*p);
+            }
+            ExprNode::Buffer(b) => {
+                h.write_u8(3);
+                h.write_u8(0); // padding tag byte, kept stable across variants
+                h.write_bytes(&b.0.to_le_bytes());
+            }
+            ExprNode::Unary(op, a) => {
+                h.write_u8(4);
+                h.write_u8(*op as u8);
+                h.write_u32(a.0);
+            }
+            ExprNode::Binary(op, a, b) => {
+                h.write_u8(5);
+                h.write_u8(*op as u8);
+                h.write_u32(a.0);
+                h.write_u32(b.0);
+            }
+            ExprNode::Ternary(op, a, b, c) => {
+                h.write_u8(6);
+                h.write_u8(*op as u8);
+                h.write_u32(a.0);
+                h.write_u32(b.0);
+                h.write_u32(c.0);
+            }
+            ExprNode::Nary(op, start, len) => {
+                h.write_u8(7);
+                h.write_u8(*op as u8);
+                h.write_u32(u32::from(*len));
+                for child in arena.nary_children_slice(*start, *len) {
+                    h.write_u32(child.0);
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Phase attribution (only does anything under `extraction-profile`)
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "extraction-profile")]
+mod attribution {
+    use pixelflow_search::egraph::profile::{self, Bucket};
+
+    const BUCKETS: [Bucket; 7] = [
+        Bucket::CandidateEnumeration,
+        Bucket::TrySwapBackfill,
+        Bucket::AcyclicityCheck,
+        Bucket::ChosenVariance,
+        Bucket::PinnedChoices,
+        Bucket::AccumulatorRebuild,
+        Bucket::NnueForward,
+    ];
+
+    #[derive(Clone, Copy, Default)]
+    pub struct Totals {
+        nanos: u64,
+        count: u64,
+    }
+
+    pub struct Attribution {
+        per_bucket: [Totals; 7],
+        kernels: u64,
+    }
+
+    impl Attribution {
+        pub fn new() -> Self {
+            Self {
+                per_bucket: [Totals::default(); 7],
+                kernels: 0,
+            }
+        }
+
+        /// Call once per kernel, immediately before the timed extraction
+        /// call.
+        pub fn reset_for_kernel(&self) {
+            profile::reset();
+        }
+
+        /// Call once per kernel, immediately after the timed extraction
+        /// call, before the next kernel's `reset_for_kernel`.
+        pub fn absorb_kernel(&mut self) {
+            self.kernels += 1;
+            for (i, (_bucket, stats)) in profile::snapshot().into_iter().enumerate() {
+                self.per_bucket[i].nanos += stats.nanos;
+                self.per_bucket[i].count += stats.count;
+            }
+        }
+
+        /// `(bucket name, mean us/kernel, mean calls/kernel, total calls)`.
+        pub fn report(&self) -> Vec<(&'static str, f64, f64, u64)> {
+            let n = self.kernels.max(1) as f64;
+            BUCKETS
+                .iter()
+                .zip(self.per_bucket.iter())
+                .map(|(b, t)| {
+                    (
+                        b.name(),
+                        (t.nanos as f64 / 1000.0) / n,
+                        t.count as f64 / n,
+                        t.count,
+                    )
+                })
+                .collect()
+        }
+
+        pub fn kernels(&self) -> u64 {
+            self.kernels
+        }
+    }
+}
+
+#[cfg(not(feature = "extraction-profile"))]
+mod attribution {
+    pub struct Attribution;
+    impl Attribution {
+        pub fn new() -> Self {
+            Self
+        }
+        pub fn reset_for_kernel(&self) {}
+        pub fn absorb_kernel(&mut self) {}
+        pub fn report(&self) -> Vec<(&'static str, f64, f64, u64)> {
+            Vec::new()
+        }
+        pub fn kernels(&self) -> u64 {
+            0
+        }
+    }
+}
+
+fn main() {
+    let args = Args::parse();
+
+    let weights_path = args.weights.unwrap_or_else(extraction_head_weights_path);
+    eprintln!("Loading NNUE weights from {}", weights_path.display());
+    let weights_bytes = std::fs::read(&weights_path).unwrap_or_else(|e| {
+        panic!(
+            "profile_extraction: failed to read weights at {}: {e}. Train a checkpoint first \
+             (bootstrap_extraction_head), even a throwaway one — determinism is what's under \
+             test here, not quality.",
+            weights_path.display()
+        )
+    });
+    let nnue = ExprNnue::from_bytes(&weights_bytes).unwrap_or_else(|e| {
+        panic!(
+            "profile_extraction: ExprNnue::from_bytes rejected {}: {e}",
+            weights_path.display()
+        )
+    });
+    eprintln!("NNUE weights loaded OK ({} bytes).", weights_bytes.len());
+
+    let corpus_path = PathBuf::from(&args.corpus_dir).join("corpus_dev.bin");
+    eprintln!("Loading DEV corpus from {}", corpus_path.display());
+    let mut entries = read_corpus(&corpus_path).unwrap_or_else(|e| {
+        panic!(
+            "profile_extraction: failed to read corpus at {}: {e}. Generate one first: \
+             cargo run --release -p pixelflow-pipeline --features training --bin gen_bench_corpus \
+             -- --target 1500",
+            corpus_path.display()
+        )
+    });
+    if args.max_kernels > 0 && entries.len() > args.max_kernels {
+        entries.truncate(args.max_kernels);
+    }
+    eprintln!("Running {} DEV expressions.", entries.len());
+    if entries.len() < 200 {
+        eprintln!(
+            "WARNING: only {} expressions — the task's acceptance bar for the phase-attribution \
+             report is >= 200 DEV expressions. Regenerate the corpus with a larger --target if \
+             this run is meant to satisfy that bar.",
+            entries.len()
+        );
+    }
+
+    #[cfg(feature = "extraction-profile")]
+    eprintln!("extraction-profile feature: ON — phase attribution will be reported.");
+    #[cfg(not(feature = "extraction-profile"))]
+    eprintln!(
+        "extraction-profile feature: OFF — digest only. Rebuild with \
+         `--features training,extraction-profile` for phase attribution."
+    );
+
+    let mut digest = Fnv1a::new();
+    let mut attribution = attribution::Attribution::new();
+    let mut total_us = 0.0f64;
+    let mut kernels_run = 0u64;
+    let mut num_classes_sum = 0u64;
+    let mut num_classes_max = 0usize;
+    let wall_start = Instant::now();
+
+    for (name, arena, root) in &entries {
+        let mut eg = EGraph::with_rules(all_rules());
+        let root_class = eg.add_arena(arena, *root);
+        eg.saturate_with_limit(SATURATE_LIMIT);
+        let num_classes = eg.num_classes();
+        num_classes_sum += num_classes as u64;
+        num_classes_max = num_classes_max.max(num_classes);
+
+        let extractor = IncrementalExtractor::new(&nnue, EXTRACT_TOP_K);
+
+        attribution.reset_for_kernel();
+        let t0 = Instant::now();
+        let (cost, extraction) = extractor.extract_choices_only(&eg, root_class);
+        let elapsed_us = t0.elapsed().as_secs_f64() * 1e6;
+        attribution.absorb_kernel();
+
+        let (out_arena, out_root) = choices_to_arena(&extraction);
+
+        hash_arena(&mut digest, &out_arena, out_root);
+        digest.write_f32(cost);
+
+        total_us += elapsed_us;
+        kernels_run += 1;
+
+        let _ = name; // kernel name only matters for future per-kernel debugging output
+    }
+
+    let wall_us = wall_start.elapsed().as_secs_f64() * 1e6;
+
+    println!("=== profile_extraction: Round 2b determinism + attribution ===");
+    println!("kernels run:        {kernels_run}");
+    println!("weights:            {}", weights_path.display());
+    println!("corpus:             {}", corpus_path.display());
+    println!("saturate_limit:     {SATURATE_LIMIT}");
+    println!("extract_top_k:      {EXTRACT_TOP_K}");
+    println!(
+        "e-graph size:       mean {:.0} classes/kernel, max {} classes — the O(N) evidence for \
+         the buckets below is this number, not the reachable-subtree size",
+        num_classes_sum as f64 / kernels_run.max(1) as f64,
+        num_classes_max
+    );
+    println!();
+    println!("DETERMINISM DIGEST (FNV-1a over every chosen form + predicted cost):");
+    println!("  digest = {:016x}", digest.finish());
+    println!();
+    println!(
+        "MEAN EXTRACTION WALL TIME: {:.2} us/kernel (sum {:.2} ms over {} kernels; \
+         includes egraph build+saturate is NOT counted — only extract_choices_only)",
+        total_us / kernels_run.max(1) as f64,
+        total_us / 1000.0,
+        kernels_run
+    );
+    println!(
+        "(run wall clock including corpus/egraph setup: {:.2} ms total)",
+        wall_us / 1000.0
+    );
+    println!();
+
+    let report = attribution.report();
+    if report.is_empty() {
+        println!(
+            "No phase attribution — rebuild with --features training,extraction-profile to get \
+             per-bucket timing."
+        );
+    } else {
+        println!(
+            "PHASE ATTRIBUTION over {} kernels (mean us/kernel, mean calls/kernel, total calls):",
+            attribution.kernels()
+        );
+        let mut bucket_us_sum = 0.0f64;
+        for (name, mean_us, mean_calls, total_calls) in &report {
+            println!(
+                "  {name:<24} {mean_us:>10.2} us/kernel   {mean_calls:>8.2} calls/kernel   \
+                 {total_calls:>10} total calls"
+            );
+            bucket_us_sum += mean_us;
+        }
+        let residual = (total_us / kernels_run.max(1) as f64) - bucket_us_sum;
+        println!(
+            "  {:<24} {residual:>10.2} us/kernel   (total {:.2} - sum of buckets above {:.2})",
+            "everything_else",
+            total_us / kernels_run.max(1) as f64,
+            bucket_us_sum
+        );
+    }
+}

--- a/pixelflow-search/Cargo.toml
+++ b/pixelflow-search/Cargo.toml
@@ -26,3 +26,9 @@ pixelflow-ir = { path = "../pixelflow-ir", features = ["oracle"] }
 # `training = ["pixelflow-search/std"]` resolving.
 std = []
 default = ["std"]
+# Round 2b extraction-overhead investigation (docs/plans/2026-08-17-cost-model-domain.md,
+# anti-row A6): thread-local wall-clock buckets in `egraph::profile`, wrapped
+# around specific phases of `IncrementalExtractor::extract_choices_only`.
+# Off by default and not re-exported from `egraph`'s public API list — an
+# opt-in measurement instrument, not a shipped capability.
+extraction-profile = []

--- a/pixelflow-search/src/egraph/extract.rs
+++ b/pixelflow-search/src/egraph/extract.rs
@@ -8,6 +8,7 @@ use super::cost::{CostFunction, CostModel};
 use super::deps::var_variance;
 use super::graph::EGraph;
 use super::node::{EClassId, ENode};
+use super::profile;
 use crate::nnue::{EdgeAccumulator, ExprNnue};
 use alloc::vec::Vec;
 use pixelflow_ir::Variance;
@@ -104,10 +105,15 @@ impl<'g> Extraction<'g> {
         choices[canonical.0 as usize] = Some(node_idx);
         if let Some(ENode::Op { children, .. }) = self.egraph.nodes(canonical).get(node_idx) {
             for &child in children {
-                backfill_well_founded(self.egraph, child, &mut choices);
+                profile::timed(profile::Bucket::TrySwapBackfill, || {
+                    backfill_well_founded(self.egraph, child, &mut choices);
+                });
             }
         }
-        if choices_have_cycle_from(self.egraph, self.root, &choices) {
+        let has_cycle = profile::timed(profile::Bucket::AcyclicityCheck, || {
+            choices_have_cycle_from(self.egraph, self.root, &choices)
+        });
+        if has_cycle {
             return None;
         }
         Some(Self {
@@ -157,7 +163,7 @@ impl<'g> Extraction<'g> {
     /// both of which take this view rather than re-deriving it (one
     /// definition, imported, not restated).
     pub(crate) fn pinned_choices(&self) -> Vec<Option<usize>> {
-        pin_shift_counts(self.egraph, &self.choices)
+        pin_shift_counts(self.egraph, self.root, &self.choices)
     }
 
     /// Unwrap into the raw choice vector.
@@ -326,7 +332,9 @@ impl<'a> IncrementalExtractor<'a> {
             &self.nnue.embeddings,
             true,
         );
-        let mut current_cost = self.nnue.predict_log_cost_with_features(&current_acc);
+        let mut current_cost = profile::timed(profile::Bucket::NnueForward, || {
+            self.nnue.predict_log_cost_with_features(&current_acc)
+        });
 
         // Refinement passes: for each e-class, try ALL alternatives (up to top_k),
         // accept the BEST improvement (not first). Repeat until fixpoint or max passes.
@@ -336,7 +344,9 @@ impl<'a> IncrementalExtractor<'a> {
         // This is O(reachable_classes) per candidate, same as the old tree-based path,
         // but now sharing-aware. True incremental updates can be added later.
         for _pass in 0..MAX_PASSES {
-            let active = self.get_active_classes(&current_extraction);
+            let active = profile::timed(profile::Bucket::CandidateEnumeration, || {
+                self.get_active_classes(&current_extraction)
+            });
             let mut improved = false;
 
             for &class in &active {
@@ -393,7 +403,9 @@ impl<'a> IncrementalExtractor<'a> {
                         &self.nnue.embeddings,
                         true,
                     );
-                    let test_cost = self.nnue.predict_log_cost_with_features(&test_acc);
+                    let test_cost = profile::timed(profile::Bucket::NnueForward, || {
+                        self.nnue.predict_log_cost_with_features(&test_acc)
+                    });
 
                     if test_cost < best_swap_cost {
                         best_swap_cost = test_cost;
@@ -1078,52 +1090,98 @@ pub fn build_extracted_dag_from_choices(
 /// child and it panics. Substituting a `Const` from the same class is sound
 /// by definition: same class means equal value.
 ///
+/// Scoped to classes reachable from `root` via the ORIGINAL (unpinned)
+/// `choices` — the same traversal [`Extraction::chosen_variance`] and
+/// [`choices_to_arena`] perform once pinning has settled. `choices` can
+/// (and, on a graph that has been through several `try_swap`/backfill
+/// passes, routinely does) hold `Some` entries for classes no longer
+/// reachable from `root` under the CURRENT choice function — `try_swap`
+/// only ever adds entries via `backfill_well_founded`, never retracts a
+/// stale one from an earlier candidate. Walking `0..egraph.num_classes()`
+/// unconditionally, as this used to, re-derives and re-pins every one of
+/// those stale entries even though nothing downstream ever reads them
+/// (`choices_to_arena`/`chosen_variance` only ever visit classes reachable
+/// from `root`) — pure wasted work on a saturated e-graph's full class
+/// count, not the reachable subtree's.
+///
+/// Using unpinned `choices` (rather than the pins already decided so far in
+/// this same walk) to decide which children to descend into is deliberately
+/// a superset of the classes [`choices_to_arena`] will actually visit once
+/// pinning is final: pinning a count class to a `Const` can only ever REMOVE
+/// reachability (a `Const` has no children to recurse into), never add it,
+/// so this walk's reachable set is never missing a class the final pinned
+/// tree needs. The decision written into `pinned[ci]` for any one count
+/// class does not depend on visitation order either — it is "keep the
+/// existing choice if already `Const`, else the class's first `Const`
+/// node", the same answer no matter which of possibly several referencing
+/// `Shl`/`Shr` nodes is processed first — so interleaving the decision with
+/// the traversal (instead of a full resolve-then-walk pass) cannot change
+/// the returned vector's values, only which unreachable entries are left
+/// untouched (they pass through from `choices` unread either way).
+///
 /// # Panics
 ///
 /// Panics if a shift-count class holds no `Const` at all. That cannot arise
 /// from a well-formed arena (the count entered as a literal) and would panic
 /// in the emitter regardless — failing here names the real cause.
-fn pin_shift_counts(egraph: &EGraph, choices: &[Option<usize>]) -> alloc::vec::Vec<Option<usize>> {
+fn pin_shift_counts(
+    egraph: &EGraph,
+    root: EClassId,
+    choices: &[Option<usize>],
+) -> alloc::vec::Vec<Option<usize>> {
+    let num_classes = choices.len();
     let mut pinned = choices.to_vec();
-    for idx in 0..egraph.num_classes() {
-        let canonical = egraph.find(EClassId(idx as u32));
-        if canonical.0 as usize != idx {
+    let mut visited: alloc::vec::Vec<bool> = alloc::vec![false; num_classes];
+    let mut stack: Vec<EClassId> = alloc::vec![egraph.find(root)];
+
+    while let Some(class) = stack.pop() {
+        let canonical = egraph.find(class);
+        let idx = canonical.0 as usize;
+        if idx >= num_classes || visited[idx] {
             continue;
         }
-        let Some(node_idx) = pinned.get(idx).and_then(|o| *o) else {
+        visited[idx] = true;
+
+        // Deliberately reads the ORIGINAL (unpinned) choice, not `pinned`,
+        // to decide what this class's traversal children are — see the
+        // "superset" reasoning in the doc comment above.
+        let Some(node_idx) = choices.get(idx).and_then(|o| *o) else {
             continue;
         };
         let Some(ENode::Op { op, children }) = egraph.nodes(canonical).get(node_idx) else {
             continue;
         };
-        if !matches!(
+        if matches!(
             op.kind(),
             pixelflow_ir::OpKind::Shl | pixelflow_ir::OpKind::Shr
-        ) {
-            continue;
-        }
-        let Some(&count) = children.get(1) else {
-            continue;
-        };
-        let count_class = egraph.find(count);
-        let ci = count_class.0 as usize;
-        let count_nodes = egraph.nodes(count_class);
-        if let Some(chosen) = pinned.get(ci).and_then(|o| *o)
-            && matches!(count_nodes.get(chosen), Some(ENode::Const(_)))
+        ) && let Some(&count) = children.get(1)
         {
-            continue;
+            let count_class = egraph.find(count);
+            let ci = count_class.0 as usize;
+            let count_nodes = egraph.nodes(count_class);
+            let already_const = pinned
+                .get(ci)
+                .and_then(|o| *o)
+                .is_some_and(|chosen| matches!(count_nodes.get(chosen), Some(ENode::Const(_))));
+            if !already_const {
+                let const_idx = count_nodes
+                    .iter()
+                    .position(|n| matches!(n, ENode::Const(_)))
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "pin_shift_counts: shift-count e-class {ci} holds no Const; \
+                             the emitter's immediate-only shift lowering cannot be met"
+                        )
+                    });
+                pinned[ci] = Some(const_idx);
+            }
         }
-        let const_idx = count_nodes
-            .iter()
-            .position(|n| matches!(n, ENode::Const(_)))
-            .unwrap_or_else(|| {
-                panic!(
-                    "pin_shift_counts: shift-count e-class {ci} holds no Const; \
-                     the emitter's immediate-only shift lowering cannot be met"
-                )
-            });
-        pinned[ci] = Some(const_idx);
+
+        for &child in children {
+            stack.push(child);
+        }
     }
+
     pinned
 }
 

--- a/pixelflow-search/src/egraph/extract.rs
+++ b/pixelflow-search/src/egraph/extract.rs
@@ -377,15 +377,23 @@ impl<'a> IncrementalExtractor<'a> {
         let choices: Vec<Option<usize>> = alloc::vec![None; num_classes];
         let mut current_extraction = Extraction::from_backfill(egraph, root_class, choices);
 
+        // One accumulator scratch, reused for every accumulator built for
+        // this kernel — the bootstrap build below and all 194-375 (Round 2b
+        // attribution) per-candidate builds in the refinement loop — instead
+        // of each paying its own fresh heap allocation. See
+        // `EdgeAccumulator::from_cost_dag_scratch`'s doc comment.
+        let mut acc_scratch = crate::nnue::factored::AccumulatorScratch::new(num_classes);
+
         // Build initial DAG-aware accumulator. Sharing-aware by construction:
         // shared subexpressions are counted once (computation) plus one
         // var_ref edge (register load) per later reference. Variance is
         // computed from the CHOSEN nodes (P1(c)) — see
         // `Extraction::chosen_variance`.
-        let current_acc = EdgeAccumulator::from_dag_choices_with_variance(
+        let current_acc = EdgeAccumulator::from_dag_choices_with_variance_scratch(
             &current_extraction,
             &self.nnue.embeddings,
             true,
+            &mut acc_scratch,
         );
         let mut current_cost = profile::timed(profile::Bucket::NnueForward, || {
             self.nnue.predict_log_cost_with_features(&current_acc)
@@ -453,10 +461,11 @@ impl<'a> IncrementalExtractor<'a> {
                         continue;
                     };
 
-                    let test_acc = EdgeAccumulator::from_dag_choices_with_variance(
+                    let test_acc = EdgeAccumulator::from_dag_choices_with_variance_scratch(
                         &candidate,
                         &self.nnue.embeddings,
                         true,
+                        &mut acc_scratch,
                     );
                     let test_cost = profile::timed(profile::Bucket::NnueForward, || {
                         self.nnue.predict_log_cost_with_features(&test_acc)

--- a/pixelflow-search/src/egraph/extract.rs
+++ b/pixelflow-search/src/egraph/extract.rs
@@ -99,23 +99,78 @@ impl<'g> Extraction<'g> {
     /// This is the NNUE refinement search's per-candidate constructor —
     /// unlike [`Extraction::from_backfill`], a cycle here is a normal
     /// search outcome (reject this candidate, try another), not a bug.
+    ///
+    /// ## Acyclicity check scope, and the one case it does NOT match
+    /// `choices_have_cycle_from` bit-for-bit
+    ///
+    /// The check is scoped to `canonical`'s own new outgoing edges
+    /// ([`choices_have_cycle_through`]) rather than re-walking the whole
+    /// tree from `root`: this swap changes exactly one vertex's outgoing
+    /// edge — `canonical`'s — plus adds fresh backfilled subtrees hanging
+    /// off `node_idx`'s children, each internally acyclic by construction
+    /// ([`backfill_well_founded`] never revisits a class that already has a
+    /// choice, so a backfilled region can only ever terminate by joining
+    /// the pre-existing tree, not by cutting back into it). PROVIDED
+    /// `canonical` is itself currently reachable from `root`, a graph
+    /// mutated at exactly one vertex's outgoing edge gains a cycle if and
+    /// only if that vertex becomes reachable from itself through the new
+    /// edge, so checking forward reachability from `node_idx`'s children
+    /// back to `canonical` is equivalent to (but bounded by the
+    /// forward-reachable set from the new children, not the whole
+    /// root-reachable tree, unlike) a full re-walk from root.
+    ///
+    /// That proviso can fail: `extract_choices_only`'s refinement loop
+    /// takes its `active` class list once per pass and then mutates
+    /// `current_extraction` as it goes, so a class visited later in the
+    /// same pass can, by the time its own `try_swap` call runs, no longer
+    /// be root-reachable at all — an earlier accepted swap in the same
+    /// pass severed the only path to it. For such a `canonical`, this
+    /// check and a full `choices_have_cycle_from(root)` walk can disagree
+    /// (this one may reject a "cycle" the root walk would call
+    /// unreachable-hence-irrelevant, or the reverse). That disagreement
+    /// never reaches an observable output, though: every consumer that
+    /// scores or materialises a candidate —
+    /// [`crate::nnue::EdgeAccumulator::from_dag_choices_with_variance`]
+    /// (hence the NNUE cost comparison) and [`choices_to_arena`] alike —
+    /// walks forward from `root` only, so a `canonical` unreachable from
+    /// root is invisible to both regardless of what this function decides
+    /// for it; accept or reject, the candidate's score is bit-identical to
+    /// `current_cost` and it never wins the refinement loop's strict `<`
+    /// comparison. Confirmed by this crate's determinism harness
+    /// (`profile_extraction`'s digest) across the 280-expression DEV
+    /// corpus: bit-identical chosen forms and predicted costs before and
+    /// after this function stopped matching `choices_have_cycle_from`
+    /// exactly.
     pub(crate) fn try_swap(&self, class: EClassId, node_idx: usize) -> Option<Self> {
         let canonical = self.egraph.find(class);
         let mut choices = self.choices.clone();
         choices[canonical.0 as usize] = Some(node_idx);
-        if let Some(ENode::Op { children, .. }) = self.egraph.nodes(canonical).get(node_idx) {
-            for &child in children {
-                profile::timed(profile::Bucket::TrySwapBackfill, || {
-                    backfill_well_founded(self.egraph, child, &mut choices);
-                });
+
+        let new_children: &[EClassId] = match self.egraph.nodes(canonical).get(node_idx) {
+            Some(ENode::Op { children, .. }) => children,
+            _ => &[],
+        };
+
+        for &child in new_children {
+            profile::timed(profile::Bucket::TrySwapBackfill, || {
+                backfill_well_founded(self.egraph, child, &mut choices);
+            });
+        }
+
+        // A leaf swap (Var/Const/Buffer, or an Op with no children) adds no
+        // outgoing edge at all, so it cannot possibly close a cycle — only
+        // removes `canonical`'s old edges, which can only ever break a
+        // cycle, never create one. Skip the walk entirely rather than
+        // paying for a reachability check with nothing to find.
+        if !new_children.is_empty() {
+            let has_cycle = profile::timed(profile::Bucket::AcyclicityCheck, || {
+                choices_have_cycle_through(self.egraph, canonical, new_children, &choices)
+            });
+            if has_cycle {
+                return None;
             }
         }
-        let has_cycle = profile::timed(profile::Bucket::AcyclicityCheck, || {
-            choices_have_cycle_from(self.egraph, self.root, &choices)
-        });
-        if has_cycle {
-            return None;
-        }
+
         Some(Self {
             egraph: self.egraph,
             root: self.root,
@@ -643,6 +698,49 @@ fn choices_have_cycle_from(egraph: &EGraph, root: EClassId, choices: &[Option<us
         if let Some(ENode::Op { children, .. }) = egraph.nodes(canonical).get(node_idx) {
             for &child in children.iter().rev() {
                 stack.push((child, false));
+            }
+        }
+    }
+
+    false
+}
+
+/// Check whether `canonical` is forward-reachable from `new_children` by
+/// following `choices`. Used by [`Extraction::try_swap`] as the equivalent,
+/// but far cheaper, replacement for a full [`choices_have_cycle_from`]
+/// re-walk from root — see that method's doc comment for why scoping the
+/// check to the one changed vertex's new edges is sound. Plain reachability
+/// (no gray/black coloring) is enough here, unlike
+/// [`choices_have_cycle_from`]: we are not distinguishing "cycle" from
+/// "revisited via legitimate DAG sharing" for the whole tree, only asking
+/// whether ANY forward path from the new edges leads back to `canonical` —
+/// which is exactly what a cycle through the swapped vertex means.
+///
+/// Bounded by the size of the forward-reachable set from `new_children`,
+/// not `egraph.num_classes()`.
+fn choices_have_cycle_through(
+    egraph: &EGraph,
+    canonical: EClassId,
+    new_children: &[EClassId],
+    choices: &[Option<usize>],
+) -> bool {
+    let num_classes = choices.len();
+    let mut visited: alloc::collections::BTreeSet<u32> = alloc::collections::BTreeSet::new();
+    let mut stack: Vec<EClassId> = new_children.to_vec();
+
+    while let Some(class) = stack.pop() {
+        let c = egraph.find(class);
+        if c == canonical {
+            return true;
+        }
+        let idx = c.0 as usize;
+        if idx >= num_classes || !visited.insert(c.0) {
+            continue;
+        }
+        let node_idx = choices.get(idx).and_then(|o| *o).unwrap_or(0);
+        if let Some(ENode::Op { children, .. }) = egraph.nodes(c).get(node_idx) {
+            for &child in children {
+                stack.push(child);
             }
         }
     }

--- a/pixelflow-search/src/egraph/mod.rs
+++ b/pixelflow-search/src/egraph/mod.rs
@@ -34,6 +34,7 @@ mod graph;
 mod labeler;
 mod node;
 pub mod ops;
+pub mod profile;
 pub mod provenance;
 pub mod rewrite;
 pub mod saturate;

--- a/pixelflow-search/src/egraph/profile.rs
+++ b/pixelflow-search/src/egraph/profile.rs
@@ -1,0 +1,156 @@
+//! Extraction-loop phase profiling — OPT-IN via the `extraction-profile`
+//! Cargo feature, off by default and not part of this crate's public API
+//! contract. It exists to attribute wall time inside
+//! [`super::extract::IncrementalExtractor::extract_choices_only`] to
+//! specific phases (candidate enumeration, `try_swap` backfill, the
+//! acyclicity check, the `chosen_variance` walk, `pinned_choices`, the
+//! `EdgeAccumulator` rebuild, and the NNUE forward pass) for the Round 2b
+//! extraction-overhead investigation
+//! (docs/plans/2026-08-17-cost-model-domain.md, anti-row A6).
+//!
+//! [`Bucket`] itself is always compiled (call sites pass it unconditionally
+//! so instrumentation and non-instrumentation builds share one call shape),
+//! but every stateful piece — the thread-local counters, [`record`],
+//! [`reset`], [`snapshot`] — exists only under the feature. With the feature
+//! off, [`timed`] is `f()` and nothing else: no thread-local, no `Instant`,
+//! no branch.
+
+/// One phase of the extraction refinement loop. See the module doc for what
+/// each variant covers; the exact wrap points live in `extract.rs` (for
+/// `TrySwapBackfill`/`AcyclicityCheck`/`CandidateEnumeration`/`NnueForward`)
+/// and `nnue/factored.rs` (for `ChosenVariance`/`PinnedChoices`/
+/// `AccumulatorRebuild`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[allow(dead_code)] // constructed only under the feature's call sites
+pub enum Bucket {
+    /// Building the per-pass active-class list
+    /// ([`super::extract::IncrementalExtractor::get_active_classes`]) — the
+    /// literal "which e-classes are candidates this pass" walk.
+    CandidateEnumeration,
+    /// `backfill_well_founded` calls made inside
+    /// [`super::extract::Extraction::try_swap`] to complete a swapped
+    /// node's newly-reachable children.
+    TrySwapBackfill,
+    /// `choices_have_cycle_from` call inside
+    /// [`super::extract::Extraction::try_swap`].
+    AcyclicityCheck,
+    /// [`super::extract::Extraction::chosen_variance`].
+    ChosenVariance,
+    /// [`super::extract::Extraction::pinned_choices`] (`pin_shift_counts`).
+    PinnedChoices,
+    /// `EdgeAccumulator::from_cost_dag`'s structural walk, excluding the
+    /// `pinned_choices`/`chosen_variance` sub-calls (each has its own
+    /// bucket).
+    AccumulatorRebuild,
+    /// `ExprNnue::predict_log_cost_with_features`.
+    NnueForward,
+}
+
+const BUCKET_COUNT: usize = 7;
+const ALL_BUCKETS: [Bucket; BUCKET_COUNT] = [
+    Bucket::CandidateEnumeration,
+    Bucket::TrySwapBackfill,
+    Bucket::AcyclicityCheck,
+    Bucket::ChosenVariance,
+    Bucket::PinnedChoices,
+    Bucket::AccumulatorRebuild,
+    Bucket::NnueForward,
+];
+
+impl Bucket {
+    fn idx(self) -> usize {
+        match self {
+            Bucket::CandidateEnumeration => 0,
+            Bucket::TrySwapBackfill => 1,
+            Bucket::AcyclicityCheck => 2,
+            Bucket::ChosenVariance => 3,
+            Bucket::PinnedChoices => 4,
+            Bucket::AccumulatorRebuild => 5,
+            Bucket::NnueForward => 6,
+        }
+    }
+
+    /// Stable snake_case name for reports (JSONL keys, printed tables).
+    pub fn name(self) -> &'static str {
+        match self {
+            Bucket::CandidateEnumeration => "candidate_enumeration",
+            Bucket::TrySwapBackfill => "try_swap_backfill",
+            Bucket::AcyclicityCheck => "acyclicity_check",
+            Bucket::ChosenVariance => "chosen_variance",
+            Bucket::PinnedChoices => "pinned_choices",
+            Bucket::AccumulatorRebuild => "accumulator_rebuild",
+            Bucket::NnueForward => "nnue_forward",
+        }
+    }
+}
+
+#[cfg(feature = "extraction-profile")]
+mod imp {
+    use super::{ALL_BUCKETS, BUCKET_COUNT, Bucket};
+    use std::cell::RefCell;
+    use std::time::{Duration, Instant};
+
+    #[derive(Clone, Copy, Default)]
+    pub struct BucketStats {
+        pub nanos: u64,
+        pub count: u64,
+    }
+
+    std::thread_local! {
+        static COUNTERS: RefCell<[BucketStats; BUCKET_COUNT]> =
+            RefCell::new([BucketStats { nanos: 0, count: 0 }; BUCKET_COUNT]);
+    }
+
+    /// Zero every bucket on the current thread. Call once per measured unit
+    /// (e.g. once per corpus expression) so `snapshot` reports that unit's
+    /// cost, not a running total.
+    pub fn reset() {
+        COUNTERS.with(|c| *c.borrow_mut() = [BucketStats::default(); BUCKET_COUNT]);
+    }
+
+    /// Add one observation to `bucket`.
+    pub fn record(bucket: Bucket, dur: Duration) {
+        COUNTERS.with(|c| {
+            let mut c = c.borrow_mut();
+            let s = &mut c[bucket.idx()];
+            s.nanos += dur.as_nanos() as u64;
+            s.count += 1;
+        });
+    }
+
+    /// `(bucket, stats)` for every bucket, in [`super::ALL_BUCKETS`] order.
+    pub fn snapshot() -> [(Bucket, BucketStats); BUCKET_COUNT] {
+        COUNTERS.with(|c| {
+            let c = *c.borrow();
+            let mut out = [(Bucket::CandidateEnumeration, BucketStats::default()); BUCKET_COUNT];
+            for (i, b) in ALL_BUCKETS.into_iter().enumerate() {
+                out[i] = (b, c[i]);
+            }
+            out
+        })
+    }
+
+    /// Run `f`, attributing its wall time to `bucket`.
+    #[inline]
+    pub fn timed<T>(bucket: Bucket, f: impl FnOnce() -> T) -> T {
+        let start = Instant::now();
+        let out = f();
+        record(bucket, start.elapsed());
+        out
+    }
+}
+
+#[cfg(not(feature = "extraction-profile"))]
+mod imp {
+    use super::Bucket;
+
+    /// Feature off: run `f` with no timing, no thread-local touch.
+    #[inline(always)]
+    pub fn timed<T>(_bucket: Bucket, f: impl FnOnce() -> T) -> T {
+        f()
+    }
+}
+
+pub use imp::timed;
+#[cfg(feature = "extraction-profile")]
+pub use imp::{BucketStats, record, reset, snapshot};

--- a/pixelflow-search/src/nnue/factored.rs
+++ b/pixelflow-search/src/nnue/factored.rs
@@ -987,16 +987,24 @@ impl EdgeAccumulator {
         // `ChoicesCostDag::pinned`'s doc comment for why splitting these
         // across two different choice views is a train/deploy skew, not
         // just a redundant computation.
-        let pinned = extraction.pinned_choices();
-        let variance = with_variance.then(|| extraction.chosen_variance(&pinned));
-        Self::from_cost_dag(
-            &ChoicesCostDag {
-                extraction,
-                pinned,
-                variance,
-            },
-            emb,
-        )
+        let pinned = crate::egraph::profile::timed(crate::egraph::profile::Bucket::PinnedChoices, || {
+            extraction.pinned_choices()
+        });
+        let variance = with_variance.then(|| {
+            crate::egraph::profile::timed(crate::egraph::profile::Bucket::ChosenVariance, || {
+                extraction.chosen_variance(&pinned)
+            })
+        });
+        crate::egraph::profile::timed(crate::egraph::profile::Bucket::AccumulatorRebuild, || {
+            Self::from_cost_dag(
+                &ChoicesCostDag {
+                    extraction,
+                    pinned,
+                    variance,
+                },
+                emb,
+            )
+        })
     }
 
     /// Add N var-reference edges (representing register loads of a shared value).

--- a/pixelflow-search/src/nnue/factored.rs
+++ b/pixelflow-search/src/nnue/factored.rs
@@ -620,6 +620,44 @@ impl Default for EdgeAccumulator {
     }
 }
 
+/// Reusable working buffers for [`EdgeAccumulator::from_cost_dag_scratch`] —
+/// see that method's doc comment. Sized to a `CostDag::id_bound()`; call
+/// [`Self::reset_for`] before each use rather than reconstructing.
+pub(crate) struct AccumulatorScratch {
+    expanded: alloc::vec::Vec<bool>,
+    edge_emitted: alloc::vec::Vec<bool>,
+    stack: alloc::vec::Vec<(u32, u32)>,
+    children: alloc::vec::Vec<u32>,
+}
+
+impl AccumulatorScratch {
+    pub(crate) fn new(bound: usize) -> Self {
+        Self {
+            expanded: alloc::vec![false; bound],
+            edge_emitted: alloc::vec![false; bound],
+            stack: alloc::vec::Vec::new(),
+            children: alloc::vec::Vec::new(),
+        }
+    }
+
+    /// Reset every buffer to its "fresh, empty" state for a walk over a
+    /// `CostDag` with the given `id_bound()`. Resizes `expanded`/
+    /// `edge_emitted` only when `bound` actually changed (it doesn't, across
+    /// candidates for the same e-graph) — otherwise reuses the existing
+    /// allocation and just re-fills it with `false`, which is the same
+    /// content a fresh `vec![false; bound]` would hold.
+    fn reset_for(&mut self, bound: usize) {
+        if self.expanded.len() != bound {
+            self.expanded.resize(bound, false);
+            self.edge_emitted.resize(bound, false);
+        }
+        self.expanded.fill(false);
+        self.edge_emitted.fill(false);
+        self.stack.clear();
+        self.children.clear();
+    }
+}
+
 impl EdgeAccumulator {
     /// Create a zero-initialized dual accumulator.
     #[must_use]
@@ -822,22 +860,45 @@ impl EdgeAccumulator {
     /// variance for some expanded nodes but not all of them (a half-populated
     /// histogram would silently feed the model garbage fractions).
     fn from_cost_dag<D: CostDag>(dag: &D, emb: &OpEmbeddings) -> Self {
+        let mut scratch = AccumulatorScratch::new(dag.id_bound());
+        Self::from_cost_dag_scratch(dag, emb, &mut scratch)
+    }
+
+    /// Same walk as [`Self::from_cost_dag`], but its four working buffers
+    /// (`expanded`, `edge_emitted`, the DFS `stack`, and the per-node
+    /// `children` scratch) live in caller-supplied `scratch` instead of
+    /// being freshly heap-allocated on every call.
+    ///
+    /// [`IncrementalExtractor::extract_choices_only`](crate::egraph::extract::IncrementalExtractor::extract_choices_only)
+    /// evaluates 194-375 candidates per kernel (Round 2b attribution), each
+    /// needing a fresh accumulator — reusing one `AccumulatorScratch`
+    /// across all of them turns that many `malloc`/`free` pairs per buffer
+    /// into one allocation for the whole kernel. Every buffer is fully
+    /// reset (resized if needed, then zero/empty-filled) at the top of
+    /// this call before anything reads it, so reuse changes only where the
+    /// backing memory comes from, never what value the walk below
+    /// observes — behaviorally identical to [`Self::from_cost_dag`].
+    fn from_cost_dag_scratch<D: CostDag>(
+        dag: &D,
+        emb: &OpEmbeddings,
+        scratch: &mut AccumulatorScratch,
+    ) -> Self {
         let mut acc = Self::new();
         let bound = dag.id_bound();
-        let mut expanded = alloc::vec![false; bound];
-        // Tracks which child nodes have already received their computation
-        // edge. The first reference is a computation edge; every later
-        // reference is a register reload (a single var_ref edge).
-        let mut edge_emitted = alloc::vec![false; bound];
+        scratch.reset_for(bound);
+        let AccumulatorScratch {
+            expanded,
+            edge_emitted,
+            stack,
+            children,
+        } = scratch;
         // Variance counters
         let mut n_const: u32 = 0;
         let mut n_frame: u32 = 0;
         let mut n_scanline: u32 = 0;
         let mut n_pixel: u32 = 0;
         let mut variance_classified: u32 = 0;
-        // Stack: (node id, depth). Reused children scratch buffer.
-        let mut stack: Vec<(u32, u32)> = alloc::vec![(dag.root(), 0)];
-        let mut children: Vec<u32> = Vec::new();
+        stack.push((dag.root(), 0));
 
         while let Some((id, depth)) = stack.pop() {
             let idx = id as usize;
@@ -854,7 +915,7 @@ impl EdgeAccumulator {
             expanded[idx] = true;
 
             children.clear();
-            let Some(parent_op) = dag.resolve(id, &mut children) else {
+            let Some(parent_op) = dag.resolve(id, children) else {
                 continue; // No recorded choice — contributes nothing.
             };
             acc.node_count += 1;
@@ -981,6 +1042,25 @@ impl EdgeAccumulator {
         emb: &OpEmbeddings,
         with_variance: bool,
     ) -> Self {
+        let mut scratch = AccumulatorScratch::new(extraction.egraph().num_classes());
+        Self::from_dag_choices_with_variance_scratch(extraction, emb, with_variance, &mut scratch)
+    }
+
+    /// Same as [`Self::from_dag_choices_with_variance`], but the
+    /// `EdgeAccumulator::from_cost_dag` walk's working buffers come from
+    /// caller-supplied `scratch` instead of a fresh allocation — see
+    /// [`Self::from_cost_dag_scratch`]'s doc comment for why that matters
+    /// on `IncrementalExtractor`'s hot path
+    /// ([`crate::egraph::extract::IncrementalExtractor::extract_choices_only`],
+    /// the only caller). `pinned`/`variance` are still freshly computed and
+    /// owned per call — they are `ChoicesCostDag`'s DATA, read throughout
+    /// the walk, not scratch that could be reset mid-walk.
+    pub(crate) fn from_dag_choices_with_variance_scratch(
+        extraction: &crate::egraph::extract::Extraction<'_>,
+        emb: &OpEmbeddings,
+        with_variance: bool,
+        scratch: &mut AccumulatorScratch,
+    ) -> Self {
         // Computed once and shared by `resolve`/`child_kind` (structure) and
         // `chosen_variance` (variance) below, so both walk the identical
         // Shl/Shr-pinned view `choices_to_arena` will materialise — see
@@ -996,13 +1076,14 @@ impl EdgeAccumulator {
             })
         });
         crate::egraph::profile::timed(crate::egraph::profile::Bucket::AccumulatorRebuild, || {
-            Self::from_cost_dag(
+            Self::from_cost_dag_scratch(
                 &ChoicesCostDag {
                     extraction,
                     pinned,
                     variance,
                 },
                 emb,
+                scratch,
             )
         })
     }

--- a/pixelflow-search/src/nnue/factored.rs
+++ b/pixelflow-search/src/nnue/factored.rs
@@ -1067,9 +1067,10 @@ impl EdgeAccumulator {
         // `ChoicesCostDag::pinned`'s doc comment for why splitting these
         // across two different choice views is a train/deploy skew, not
         // just a redundant computation.
-        let pinned = crate::egraph::profile::timed(crate::egraph::profile::Bucket::PinnedChoices, || {
-            extraction.pinned_choices()
-        });
+        let pinned =
+            crate::egraph::profile::timed(crate::egraph::profile::Bucket::PinnedChoices, || {
+                extraction.pinned_choices()
+            });
         let variance = with_variance.then(|| {
             crate::egraph::profile::timed(crate::egraph::profile::Bucket::ChosenVariance, || {
                 extraction.chosen_variance(&pinned)


### PR DESCRIPTION
## Summary

Round 2b extraction-overhead investigation (`docs/plans/2026-08-17-cost-model-domain.md`,
anti-row A6): the NNUE refinement loop inside `IncrementalExtractor::extract_choices_only`
was re-doing whole-e-graph work — full `num_classes` scans, a full-tree acyclicity re-walk,
fresh heap buffers — on every one of the ~194-375 per-kernel candidate evaluations, even
though almost all of that work touched classes the final extraction never reads. Three
targeted fixes bound that work to what's actually reachable, without changing what gets
extracted.

### Per-commit before/after (280-expression DEV corpus, canonical `extraction_head.bin`,
`SATURATE_LIMIT=40`, `EXTRACT_TOP_K=8`; mean us/kernel)

| Commit | Fix | Bucket moved | Before → after | Total after |
|---|---|---|---|---|
| `2197f855` | bound `pin_shift_counts` to the reachable-from-root set instead of `0..num_classes` | `pinned_choices` | 864.53 → 465.07 (‑46%) | 3383.16 (‑11%) |
| `55eb4e16` | scope `try_swap`'s acyclicity check to the swapped edge (`choices_have_cycle_through`) instead of a full-tree re-walk | `acyclicity_check` | 516.07 → 220.79 (‑57%) | 3156.75 (‑17% cumulative) |
| `de4c3963` | reuse `EdgeAccumulator::from_cost_dag`'s four scratch buffers across candidates (`AccumulatorScratch`) instead of allocating fresh every call | `accumulator_rebuild` | 1175.84 → 1142.88 (‑3%) | 3143.92 (‑17% cumulative) |

Each commit's own before/after and reasoning is in its commit message; each is independently
digest-verified.

### Final numbers vs. baseline

- **Baseline** (profile phase, pre-fix): mean extraction **3,798.62 us/kernel** over 280 DEV
  kernels (buckets: `accumulator_rebuild` 1176us / 31.0%, `pinned_choices` 867us / 22.8%,
  `chosen_variance` 611us / 16.0%, `acyclicity` 510us / 13.5%, `everything_else` 264us,
  `try_swap_backfill` 194us, `nnue_forward` 162us, `candidate_enum` 14us).
- **Round-2a end-to-end figure**: 5,210us mean (a different, less-isolated measurement
  context — kept here only as the other reference point named in the close-out brief).
- **This branch, re-measured after rebase onto `main`**: mean extraction **3,199–3,267
  us/kernel** across repeated runs (single-process wall-clock variance; digest-verified
  identical on every run) — a **~15-16% reduction** vs. the 3,798.62 baseline.
- Post-fix bucket shape (last measured run, 280 kernels): `accumulator_rebuild` 1197.13us
  (37.4%, now dominant), `chosen_variance` 580.54us (18.1%, untouched — no safe fix
  available, see below), `pinned_choices` 545.83us (17.1%), `acyclicity_check` 233.09us
  (7.3%), `everything_else` 258.02us (8.1%), `try_swap_backfill` 210.47us (6.6%),
  `nnue_forward` 160.04us (5.0%), `candidate_enumeration` 14.15us (0.4%).

### Determinism guarantee

Every commit is gated on the Round 2b acceptance harness (`profile_extraction`, added in
`2197f855`): an FNV-1a digest folded over every chosen form (`choices_to_arena`'s exact
output — op kinds, constants, child ids, root id) plus every predicted log-cost, across all
280 DEV-corpus expressions. The digest is **`141b0db6eae4d377`** before this branch's changes
and **unchanged** after each of the three fixes individually, after the full branch, and
again after rebasing onto `main` — a changed digest under any of these fixes would mean
extraction chose a different form or scored one differently, which is a semantics
regression, not a speed win. `55eb4e16`'s commit message documents one proven-benign
digest-invariant divergence between the old and new acyclicity check (a stale-reachability
edge case that never reaches an observable output) rather than hiding it.

### A6 (O-delta incrementality) was deliberately not built

`accumulator_rebuild` is now the dominant bucket (37.4%). It is O(reachable_classes) per
candidate because each `try_swap` can change DAG sharing, so the accumulator must be
rebuilt from the walked structure every time; true incremental (O(delta)) updates would cut
this further but are exactly what anti-row A6 in
`docs/plans/2026-08-17-cost-model-domain.md` rules out (~2x win for major added complexity,
not worth it) — this stays out of scope by design, not oversight.

A fourth fix (extending `de4c3963`'s scratch-buffer-reuse pattern to `pin_shift_counts`'s
`pinned`/`visited` vectors and `chosen_variance`'s `variance` vector) was evaluated and not
pursued: `de4c3963`'s own measurement — four similarly-sized buffers reused,
`accumulator_rebuild` only moved ‑3% — shows allocator churn on ~800-element buffers isn't
the dominant cost in this allocator; the DFS/scan work is. The same pattern here is expected
to yield a similarly marginal return, while `pinned_choices`' returned `Vec` must outlive the
call (unlike the purely-local scratch reused in `de4c3963`), adding real borrow-checker
complexity for it. Not clearly a win, so per the close-out brief's "don't chase past ~250us
mean or two more fixes" guidance, this branch stops at the three landed commits.

### Housekeeping

- `86e5691a`: commits a stray uncommitted journal entry (LFS pointer only) left in the
  worktree from regenerating the local `extraction_head.bin` used as this digest baseline's
  weights.
- `67267778`: a `cargo fmt` line-width fix in `de4c3963`'s new code, caught by this close-out
  pass's `cargo fmt --all`.

## Test plan

- [x] `cargo test -p pixelflow-search` (default profile): 128 passed, 0 failed — before and
      after rebase.
- [x] `cargo test --workspace`: all green (17 `test result: ok` blocks, 0 failed).
- [x] `cargo test -p pixelflow-pipeline --features training`: all green (10 `test result: ok`
      blocks, 0 failed).
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean, exit 0.
- [x] `cargo fmt --all`: clean (after the `67267778` fix).
- [x] Determinism digest `141b0db6eae4d377`: unchanged through every fix, the full branch,
      and post-rebase.
- [x] Rebased linearly onto `origin/main` (`5489a72a`); no conflicts.
- Note: a pre-existing, environment-dependent test failure in
  `pixelflow-search::math::algebra::platform_specific_fold_tests::declines_muladd_only_where_the_roundings_differ`
  was found under `cargo test --release` only (not the default profile the task and prior
  commits use). Confirmed reproducible on the pre-branch base commit (`9576ee1f`) under
  `--release` too, so it predates and is unrelated to this branch's changes — not fixed here,
  flagged for a separate investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>