### PR TITLE
test(pixelflow-core): give the pre-existing SSE2 tests descriptive names

### DIFF
--- a/pixelflow-core/tests/x86_backend_tests.rs
+++ b/pixelflow-core/tests/x86_backend_tests.rs
@@ -7,7 +7,7 @@ mod tests {
     use std::prelude::v1::*;
 
     #[test]
-    fn sse2_arithmetic() {
+    fn add_sub_mul_and_div_should_operate_lanewise_on_all_four_lanes() {
         let a = F32x4::splat(2.0);
         let b = F32x4::splat(3.0);
 
@@ -30,7 +30,7 @@ mod tests {
     }
 
     #[test]
-    fn sse2_sequential() {
+    fn sequential_should_produce_four_consecutive_values_from_the_given_start() {
         let seq = F32x4::sequential(10.0);
         let mut out = [0.0; 4];
         seq.store(&mut out);
@@ -38,7 +38,7 @@ mod tests {
     }
 
     #[test]
-    fn sse2_logic() {
+    fn cmp_lt_and_simd_select_should_choose_lanes_by_the_comparison_result() {
         let a = F32x4::splat(1.0);
         let b = F32x4::splat(2.0);
 
@@ -62,7 +62,7 @@ mod tests {
     }
 
     #[test]
-    fn sse2_bitwise() {
+    fn bitand_should_compute_the_lanewise_bitwise_and() {
         let a = F32x4::splat(1.0); // 1.0 is 0x3f800000
         let b = F32x4::splat(2.0); // 2.0 is 0x40000000
         let c = a & b;
@@ -72,7 +72,7 @@ mod tests {
     }
 
     #[test]
-    fn sse2_math() {
+    fn simd_sqrt_simd_abs_and_simd_min_should_compute_correct_lane_results() {
         let a = F32x4::splat(4.0);
         let sqrt = a.simd_sqrt();
         let mut out = [0.0; 4];
@@ -90,7 +90,7 @@ mod tests {
     }
 
     #[test]
-    fn sse2_mask_any_all() {
+    fn any_and_all_should_report_whether_any_or_every_lane_is_true() {
         // Test MaskOps methods directly on masks
         let zero = F32x4::splat(0.0);
         let zero_mask = zero.float_to_mask();
@@ -109,14 +109,14 @@ mod tests {
 
     #[test]
     #[should_panic]
-    fn sse2_store_panic() {
+    fn store_should_panic_when_the_output_slice_is_shorter_than_four_lanes() {
         let a = F32x4::default();
         let mut out = [0.0; 3]; // Too small
         a.store(&mut out);
     }
 
     #[test]
-    fn sse2_reciprocal_math() {
+    fn recip_and_simd_rsqrt_should_approximate_the_reciprocal_and_inverse_sqrt() {
         let a = F32x4::splat(4.0);
         let mut out = [0.0; 4];
 


### PR DESCRIPTION
## Summary

Renames the eight original `sse2_*` tests in `x86_backend_tests.rs` to state the behaviour they assert rather than the area they touch. Bodies unchanged; identifiers only.

| before | after |
|---|---|
| `sse2_arithmetic` | `add_sub_mul_and_div_should_operate_lanewise_on_all_four_lanes` |
| `sse2_sequential` | `sequential_should_produce_four_consecutive_values_from_the_given_start` |
| `sse2_logic` | `cmp_lt_and_simd_select_should_choose_lanes_by_the_comparison_result` |
| `sse2_bitwise` | `bitand_should_compute_the_lanewise_bitwise_and` |
| `sse2_math` | `simd_sqrt_simd_abs_and_simd_min_should_compute_correct_lane_results` |
| `sse2_mask_any_all` | `any_and_all_should_report_whether_any_or_every_lane_is_true` |
| `sse2_store_panic` | `store_should_panic_when_the_output_slice_is_shorter_than_four_lanes` |
| `sse2_reciprocal_math` | `recip_and_simd_rsqrt_should_approximate_the_reciprocal_and_inverse_sqrt` |

## Why this exists as its own PR

This is the only part of **#1025** that isn't already on `main`.

#1025 appeared to add six operations' worth of coverage. It doesn't: it *renamed* these eight pre-existing tests, and a normalised comparison counted the new names as new operations. Its remaining ~30 tests re-cover ground `main` now holds via #1027 and #1024 — including `gather`, `add_masked`, `pack_rgba` and `i32_to_f32`, whose versions on `main` were reworked during review because the originals could not detect the behaviour their names claimed.

So the rename is extracted here and #1025 closed, rather than merging a third near-identical copy of the file.

## Test plan

- [x] `cargo test -p pixelflow-core --test x86_backend_tests` — 43 passed, 0 failed
- [x] `cargo clippy -p pixelflow-core --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_019WC8B9eNCHTyyRMx2yrLnj)_