### PR TITLE
test: salvage the real work from #1022, #1030 and #1031; delete the no-op ConsumeSt

### DIFF
--- a/core-term/src/ansi/parser.rs
+++ b/core-term/src/ansi/parser.rs
@@ -13,13 +13,6 @@ const MAX_PARAMS: usize = 16;
 const MAX_INTERMEDIATES: usize = 2;
 const MAX_OSC_LEN: usize = 1024; // Limit OSC/DCS/PM/APC string length
 
-/// State of ST consumption
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum ConsumeSt {
-    Consume,
-    Keep,
-}
-
 /// Represents the current state of the ANSI parser state machine.
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum State {
@@ -196,39 +189,35 @@ impl AnsiParser {
         self.state = State::Ground;
     }
 
-    fn dispatch_osc(&mut self, consume_st: ConsumeSt) {
+    fn dispatch_osc(&mut self) {
         let data = mem::take(&mut self.string_buffer);
         trace!("Dispatching OSC: Data length {}", data.len());
         self.commands.push(AnsiCommand::Osc(data));
         self.clear_string_buffer();
-        if consume_st == ConsumeSt::Keep { /* ST handled separately */ }
         self.state = State::Ground;
     }
 
-    fn dispatch_dcs(&mut self, consume_st: ConsumeSt) {
+    fn dispatch_dcs(&mut self) {
         let data = mem::take(&mut self.string_buffer);
         trace!("Dispatching DCS: Data length {}", data.len());
         self.commands.push(AnsiCommand::Dcs(data));
         self.clear_string_buffer();
-        if consume_st == ConsumeSt::Keep { /* ST handled separately */ }
         self.state = State::Ground;
     }
 
-    fn dispatch_pm(&mut self, consume_st: ConsumeSt) {
+    fn dispatch_pm(&mut self) {
         let data = mem::take(&mut self.string_buffer);
         trace!("Dispatching PM: Data length {}", data.len());
         self.commands.push(AnsiCommand::Pm(data));
         self.clear_string_buffer();
-        if consume_st == ConsumeSt::Keep { /* ST handled separately */ }
         self.state = State::Ground;
     }
 
-    fn dispatch_apc(&mut self, consume_st: ConsumeSt) {
+    fn dispatch_apc(&mut self) {
         let data = mem::take(&mut self.string_buffer);
         trace!("Dispatching APC: Data length {}", data.len());
         self.commands.push(AnsiCommand::Apc(data));
         self.clear_string_buffer();
-        if consume_st == ConsumeSt::Keep { /* ST handled separately */ }
         self.state = State::Ground;
     }
 
@@ -434,7 +423,7 @@ impl AnsiParser {
                     AnsiToken::C0Control(b)
                         if b == C0Control::BEL as u8 && self.state == State::OscString =>
                     {
-                        self.dispatch_osc(ConsumeSt::Keep)
+                        self.dispatch_osc()
                     }
                     AnsiToken::C0Control(b)
                         if b == C0Control::CAN as u8 || b == C0Control::SUB as u8 =>
@@ -454,10 +443,10 @@ impl AnsiParser {
             }
             State::EscInString => match token {
                 AnsiToken::Print('\\') => match self.string_state_origin {
-                    Some(State::OscString) => self.dispatch_osc(ConsumeSt::Consume),
-                    Some(State::DcsEntry) => self.dispatch_dcs(ConsumeSt::Consume),
-                    Some(State::PmString) => self.dispatch_pm(ConsumeSt::Consume),
-                    Some(State::ApcString) => self.dispatch_apc(ConsumeSt::Consume),
+                    Some(State::OscString) => self.dispatch_osc(),
+                    Some(State::DcsEntry) => self.dispatch_dcs(),
+                    Some(State::PmString) => self.dispatch_pm(),
+                    Some(State::ApcString) => self.dispatch_apc(),
                     _ => {
                         error!("EscInString state missing origin!");
                         self.dispatch_st_standalone();

--- a/core-term/src/ansi/tests.rs
+++ b/core-term/src/ansi/tests.rs
@@ -2266,6 +2266,40 @@ mod mutation_tests {
         );
     }
 
+    #[test]
+    fn osc_string_longer_than_the_length_limit_is_truncated_not_dropped() {
+        // Mirrors MAX_OSC_LEN in ansi/parser.rs. A hostile or buggy peer can send an
+        // unbounded OSC payload, so the parser caps it — but the command must still
+        // arrive, truncated, rather than being discarded or growing without bound.
+        const MAX_OSC_LEN: usize = 1024;
+
+        let mut input = b"\x1b]0;".to_vec();
+        input.extend_from_slice(&vec![b'x'; MAX_OSC_LEN * 2]);
+        input.push(0x07); // BEL terminates the string
+
+        let cmds = process_bytes(&input);
+        let Some(AnsiCommand::Osc(data)) = cmds.first() else {
+            panic!("an over-long OSC must still yield an Osc command; got {cmds:?}");
+        };
+        assert_eq!(
+            data.len(),
+            MAX_OSC_LEN,
+            "OSC payload must be capped at MAX_OSC_LEN (ansi/parser.rs)"
+        );
+    }
+
+    #[test]
+    fn osc_cancelled_by_can_does_not_leak_its_bytes_into_the_next_osc() {
+        // Cancelling must clear the string buffer, not merely return to ground:
+        // a retained buffer would prefix the *next* OSC's payload.
+        let cmds = process_bytes(b"\x1b]0;oldjunk\x18\x1b]1;newdata\x07");
+        assert_eq!(
+            cmds,
+            vec![AnsiCommand::Osc(b"1;newdata".to_vec())],
+            "the cancelled sequence's bytes must not appear in the next OSC's payload"
+        );
+    }
+
     // -----------------------------------------------------------------------
     // CSI param overflow: u16 saturation at MAX
     // Mutation: removing checked_mul/checked_add would panic or wrap on overflow

--- a/core-term/src/term/layout.rs
+++ b/core-term/src/term/layout.rs
@@ -176,6 +176,34 @@ mod tests {
     }
 
     #[test]
+    fn pixels_to_cells_misses_when_only_one_axis_is_inside_the_padding() {
+        let layout = Layout {
+            cols: 80,
+            rows: 24,
+            cell_width_px: 10,
+            cell_height_px: 20,
+            padding_x: 5,
+            padding_y: 10,
+        };
+
+        // Both coordinates inside the padding is the easy case; each axis must also
+        // reject on its own, or dropping either bounds check still passes.
+        assert_eq!(
+            layout.pixels_to_cells(4, 10),
+            None,
+            "x inside padding, y past it"
+        );
+        assert_eq!(
+            layout.pixels_to_cells(5, 9),
+            None,
+            "y inside padding, x past it"
+        );
+
+        // The corner where both axes have just cleared their padding is a hit.
+        assert_eq!(layout.pixels_to_cells(5, 10), Some((0, 0)));
+    }
+
+    #[test]
     fn pixels_to_cells_out_of_bounds() {
         let layout = Layout {
             cols: 80,

--- a/core-term/tests/ansi_to_grid_integration.rs
+++ b/core-term/tests/ansi_to_grid_integration.rs
@@ -78,7 +78,7 @@ fn newline_advances_row() {
 }
 
 #[test]
-fn cursor_position_command() {
+fn it_should_move_the_cursor_to_the_position_specified_by_cup() {
     let mut harness = MinimalTestHarness::new();
 
     // TEST: Move cursor to (5, 10), then print
@@ -215,22 +215,14 @@ fn it_should_change_the_grid_checksum_after_each_character_printed() {
     }
 }
 
-// =============================================================================
-// Bug Reproduction: Grid changes but render not triggered
-// =============================================================================
-
 #[test]
-fn bug_grid_changes_without_render_trigger() {
-    // This test documents the ACTUAL BUG:
-    // Grid state changes when ANSI commands are processed,
-    // but send_frame() is never called, so the display doesn't update.
-
+fn it_should_change_the_grid_checksum_when_ansi_print_commands_are_processed() {
+    // Note: despite its history as a "bug reproduction" test, this only
+    // exercises MinimalTestHarness's grid/checksum path (identical in
+    // substance to `it_should_change_the_grid_checksum_after_each_character_printed`
+    // above) — it never touches `TerminalApp`/`send_frame`, so it does not
+    // cover the render-trigger behavior its old name implied.
     let mut harness = MinimalTestHarness::new();
-
-    // Simulate PTY output being processed in handle_os()
-    // In the real app, handle_os() calls:
-    //   self.emulator.interpret_input(EmulatorInput::Ansi(cmd))
-    // But it NEVER calls send_frame() afterward!
 
     harness.inject_ansi(AnsiCommand::Print('a'));
     let checksum_after_a = harness.compute_grid_checksum();
@@ -238,14 +230,5 @@ fn bug_grid_changes_without_render_trigger() {
     harness.inject_ansi(AnsiCommand::Print('b'));
     let checksum_after_b = harness.compute_grid_checksum();
 
-    // Grid DOES change (this passes)
-    assert_ne!(
-        checksum_after_a, checksum_after_b,
-        "BUG CONFIRMED: Grid changes but no render triggered"
-    );
-
-    // But in the real app, handle_os() doesn't call send_frame(),
-    // so the manifold is never rebuilt and the frame checksum stays the same!
-
-    // THE FIX: handle_os() should call self.send_frame() after processing PTY output
+    assert_ne!(checksum_after_a, checksum_after_b);
 }

--- a/docs/bugs/2026-08-26-test-quality-audit-followup.md
+++ b/docs/bugs/2026-08-26-test-quality-audit-followup.md
@@ -1,0 +1,160 @@
+# Test quality control follow-up — 2026-08-26
+
+Scope: scheduled continuation of
+`docs/bugs/2026-08-15-test-quality-audit-followup.md`. `main` had not moved
+on any of that pass's "recommended next steps" targets since `ce2df0e8`
+(the intervening `9576ee1f` was an unrelated refactor), so this pass picks
+up backlog item 3: `pixelflow-graphics/src/spatial_bsp.rs`, open since the
+2026-07-20 audit first flagged it and re-confirmed still-open by every
+intervening pass.
+
+## `pixelflow-graphics/src/spatial_bsp.rs`
+
+~22 tests read the private `SpatialBSP::interiors` field directly
+(`bsp.interiors[0]`, `bsp.interiors.iter()`). `InteriorNode`'s own fields
+(`axis`, `threshold`, `left`, `right`) were already public — only the
+containing field was private, with no accessor.
+
+### Fixed
+
+- This audit originally read that as a STYLE.md "test public API" violation
+  and added `SpatialBSP::interiors(&self) -> &[InteriorNode]` to fix it.
+  That accessor was **not** merged, and the direct field reads stand. Its
+  own doc comment gave the game away — "Exposed for structural assertions
+  in tests" is a public API widened for test access, which CLAUDE.md forbids
+  without explicit permission, and STYLE.md's preference for public-API
+  tests does not outrank it. No accessor was needed in any case: `mod tests`
+  is a child of the module declaring the field, so it can read
+  `self.interiors` directly. The public surface is unchanged.
+- Found and fixed a real bug while doing this rewrite: one test
+  had `matches!(root.left, NodeRef::Leaf(_));` as a bare statement — the
+  `bool` it produces was discarded instead of asserted, so the check was a
+  silent no-op. Wrapped both occurrences in `assert!()`.
+- Renamed 9 test names that were bare noun phrases (violating STYLE.md's
+  "it should" rule): `single_leaf`, `two_leaves`, `empty_bsp`,
+  `four_leaves_grid`, `many_items_stress_test`, `stack_of_wide_strips`,
+  `node_ref_types_are_distinct`, `binary_tree_property_interior_count`,
+  `binary_tree_exact_interior_count`. These renames were also dropped on
+  merge: #1027 had already renamed the same tests on `main`, and this branch
+  predated it, so keeping them would have reverted the newer names.
+
+`cargo test -p pixelflow-graphics --lib spatial_bsp::`: 56/56 passed at the
+time of this audit; 64/64 as merged, the difference being the mutation-gap
+tests below landing on top of #1027's.
+
+## Mutation testing: the same file, now that it's STYLE-clean
+
+`cargo-mutants` v27.1.0 (freshly installed — not present in this
+environment, consistent with every prior pass).
+
+**First sweep** (`cargo mutants -p pixelflow-graphics --file
+.../spatial_bsp.rs -j 4`): **74 mutants, 15 missed, 55 caught, 4
+unviable.** All 15 were in the split-axis heuristic (`build_tree`) and the
+SIMD blend path (`traverse`). The existing tests checked loose bounds
+("threshold is in `[25, 75]`", "axis is `X`") that happened to hold under
+several different wrong formulas — sufficient to pin *approximate*
+behavior, not exact arithmetic.
+
+### Fixed: 8 new tests, each built to disagree with a specific mutant
+
+- **cx/cy center formula** (`* 0.5` → `/`/`+`, `+` → `*`,
+  `pixelflow-graphics/src/spatial_bsp.rs:149`): two items whose Y
+  center-spread (15) exceeds X (10) only under the correct formula — each
+  mutant inflates the X spread (4× for `/`, 2× for `+`) past 15 and flips
+  the axis to X.
+- **`extent_x > extent_y` → `==`/`>=`** (line 164): two scenarios — one
+  with a strict, non-tied inequality where the bbox-width fallback would
+  independently disagree (catches `==`), one with an exact tie (bounds in
+  eighths, exactly representable in `f32`, for a bit-exact tie rather than
+  a merely-close one) where `>=` fires before the fallback ever runs
+  (catches `>=`).
+- **bbox width/height tie-break** (`-` → `+`/`/`, lines 161–162): tied
+  centers with a bbox min close to zero (exposes the `/` mutant via a
+  blown-up ratio) and, separately, shifted far from zero (exposes the `+`
+  mutant via a blown-up sum) — each flips the width-vs-height comparison
+  outcome that a plain subtraction wouldn't.
+- **median-threshold sort comparator** (`+` → `*`/`-`, `/` → `%`, lines
+  175/185/186): three items whose sum-order and product-order differ,
+  fed to `from_positioned` in *descending* sum-order rather than
+  already-sorted. This mattered more than expected — see methodology note
+  below.
+- **`mid_idx - 1` → `mid_idx / 1`** (line 190): the same three-item
+  fixture; the mutant reads `items[mid_idx]` for both sides of the
+  average instead of `items[mid_idx - 1]` and `items[mid_idx]`, which this
+  asymmetric set turns into a different number (0.5 vs. the correct -5.5).
+- **`!mask.any()` → `mask.any()`** (line 290, `traverse`): SIMD lanes
+  straddling the split threshold via `Field::sequential`, asserting the
+  per-lane color on both sides of the boundary rather than "no panic" —
+  the mutant makes any mixed mask take the right-only early return,
+  silently dropping the left-child result for the lanes that need it.
+
+**Re-run after the first 8 tests: 74 mutants, 5 missed** (down from 15).
+All 5 were sort-comparator mutants that survived despite direct targeting.
+
+### Methodology finding: an already-sorted fixture under-exercises `sort_by`
+
+The sort-comparator mutants target `ca`/`cb` inside the closure passed to
+`items.sort_by`, e.g. `let ca = (a.bounds.0 + a.bounds.2) / 2.0;`. My first
+attempt fed the three items in ascending sum-order — already correctly
+sorted. Rust's small-slice insertion sort then needs zero swaps, and the
+specific sequence of comparator calls it makes never puts the item whose
+`a`-role formula is mutated into a comparison where the corruption changes
+the outcome (an item that's never re-examined after its initial "no swap
+needed" comparison never has its own `a`-role value meaningfully used
+again). Re-running the fixture with items given in **descending** sum-order
+forces every element through a real comparison, and closed 4 of the 5
+remaining gaps — same expected threshold value, since the algorithm sorts
+internally and shouldn't depend on input order (confirmed empirically:
+tests still pass with the same `-5.5`).
+
+**Second re-run: 74 mutants, 1 missed** (`spatial_bsp.rs:185:52`, `/ 2.0`
+→ `* 2.0` inside the Y sort comparator). Diagnosed as a genuine equivalent
+mutant: dividing and multiplying by a positive constant are both monotonic
+scalings, so they can never change a `partial_cmp`-based comparator's
+ordering for any input — no test can distinguish them. Documented with a
+comment at the site (matching the precedent in
+`pixelflow-compiler/src/codegen/util.rs`) rather than chased further.
+
+**Final state: 74 mutants, 73 caught, 1 documented equivalent, 0 real
+gaps.**
+
+## Verified
+
+- `cargo test -p pixelflow-graphics --lib spatial_bsp::`: 64 passed, 0
+  failed.
+- `cargo test -p pixelflow-graphics` (all targets incl. doctests): 160 lib
+  tests + all integration/doctest targets passed, 0 failed.
+- `cargo test --workspace --lib`: passed (exit 0), 0 failed.
+- `cargo clippy -p pixelflow-graphics --lib --tests`: clean.
+- `cargo fmt -p pixelflow-graphics -- --check`: clean.
+- `cargo mutants -p pixelflow-graphics --file
+  pixelflow-graphics/src/spatial_bsp.rs`: 74 mutants, 73 caught, 1
+  documented equivalent, 0 missed.
+
+## Recommended next steps (not done here)
+
+Backlog carried forward from 2026-08-15, minus the item closed above:
+
+1. `pixelflow-search/src/egraph/cost.rs` — still open per the 08-08
+   audit: a partial mutants run found one real gap (`CostModel::zero()`,
+   already fixed) before its own slow `--lib` baseline (~110s) timed out
+   the pass. Still needs either a narrower test filter or a longer time
+   budget.
+2. `pixelflow-codegen/src/emit/*` (~1,400 lines) — flagged since 08-08 as
+   never mutation-tested under its post-crate-split location. Still true.
+3. `actor-scheduler/src/lib.rs`'s `backoff_unit_tests` — re-investigated
+   this pass while scoping work (not independently re-verified with a
+   fresh mutants run, just re-read against the audit trail): both halves
+   of the original 2026-07-20 finding are already resolved — the
+   mutation-weakness half by `9deb9852` ("Add mutation-targeted tests for
+   actor-scheduler", exact-value jitter/timeout assertions), and the
+   private-API-violation half by an explicit, documented 2026-07-24
+   Flexibility-clause judgment call (the precise Ok/Timeout boundary cases
+   require observing an *unstarted* backoff attempt, unreachable through
+   the public surface without racing a real sleep against a timeout).
+   Recommend removing this from the backlog; nothing left to do without
+   re-litigating a decision already made and documented.
+4. `pixelflow-core/src/backend/x86.rs`'s `F32x8`/`F32x16`/`U32x8`/
+   `U32x16`/`Mask8`/`Mask16` (AVX2/AVX-512) impls, and `arm.rs`'s NEON
+   impls — never tested at the unit level at all under a build that
+   actually activates those ISA levels (`xtask isa-matrix`).

--- a/pixelflow-core/src/lattice/tests.rs
+++ b/pixelflow-core/src/lattice/tests.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::numeric::Numeric;
 use crate::variables::{X, Y};
 
 // A trivial manifold for testing: returns X + Y.
@@ -13,7 +12,7 @@ impl Manifold<(Field, Field, Field, Field)> for XPlusY {
     #[inline(always)]
     fn eval(&self, p: (Field, Field, Field, Field)) -> Field {
         let (x, y, _, _) = p;
-        x.raw_add(y)
+        (x + y).eval(p)
     }
 }
 
@@ -473,10 +472,8 @@ fn box_collapse_4d_layout() {
     struct ZTimes100;
     impl Manifold<(Field, Field, Field, Field)> for ZTimes100 {
         type Output = Field;
-        fn eval(&self, (x, y, z, _): (Field, Field, Field, Field)) -> Field {
-            z.raw_mul(Field::from(100.0))
-                .raw_add(y.raw_mul(Field::from(10.0)))
-                .raw_add(x)
+        fn eval(&self, p @ (x, y, z, _): (Field, Field, Field, Field)) -> Field {
+            (z * Field::from(100.0) + y * Field::from(10.0) + x).eval(p)
         }
     }
 

--- a/pixelflow-graphics/src/spatial_bsp.rs
+++ b/pixelflow-graphics/src/spatial_bsp.rs
@@ -181,6 +181,11 @@ impl<L> SpatialBSP<L> {
             (Axis::X, threshold)
         } else {
             // Sort by Y center, split at median
+            //
+            // `/ 2.0` here is an equivalent mutant to `* 2.0` under cargo-mutants: both are
+            // positive monotonic scalings, so they never change the comparator's ordering for
+            // any input, only its constant factor. No test can distinguish them — left as `/`
+            // to match the actual center-of-bounds formula.
             items.sort_by(|a, b| {
                 let ca = (a.bounds.1 + a.bounds.3) / 2.0;
                 let cb = (b.bounds.1 + b.bounds.3) / 2.0;
@@ -914,7 +919,7 @@ mod tests {
     // ========================================================================
 
     #[test]
-    fn node_ref_types_are_distinct() {
+    fn both_children_are_leaves_when_two_items_are_split_once() {
         let items = vec![
             Positioned {
                 bounds: (0.0, 0.0, 50.0, 100.0),
@@ -935,8 +940,16 @@ mod tests {
         let root = &bsp.interiors[0];
 
         // Both children should be leaves (not interiors)
-        matches!(root.left, NodeRef::Leaf(_));
-        matches!(root.right, NodeRef::Leaf(_));
+        assert!(
+            matches!(root.left, NodeRef::Leaf(_)),
+            "left child should be a leaf, got {:?}",
+            root.left
+        );
+        assert!(
+            matches!(root.right, NodeRef::Leaf(_)),
+            "right child should be a leaf, got {:?}",
+            root.right
+        );
     }
 
     #[test]
@@ -1845,6 +1858,275 @@ mod tests {
         assert_eq!(
             pixels[0], expected_blue,
             "Item 2 should be visible on left side"
+        );
+    }
+
+    // ========================================================================
+    // Split Heuristic Arithmetic Tests (cargo-mutants gaps, 2026-08-26 audit)
+    // ========================================================================
+
+    #[test]
+    fn split_axis_prefers_center_spread_when_it_exceeds_bbox_extent() {
+        // Two items whose center-to-center spread is larger on Y (15) than on X
+        // (10), computed via item *centers* rather than raw bounding-box extent.
+        // Kills three surviving mutants in the cx/cy formula (`* 0.5` -> `/ 0.5`,
+        // `* 0.5` -> `+ 0.5`, and `bounds.0 + bounds.2` -> `bounds.0 * bounds.2`):
+        // each inflates the X center-spread well past 15, wrongly flipping the
+        // split axis to X.
+        let items = vec![
+            Positioned {
+                bounds: (-5.0, -7.5, 5.0, 7.5), // center (0, 0)
+                leaf: SolidColor::new(255, 0, 0, 255),
+            },
+            Positioned {
+                bounds: (5.0, 7.5, 15.0, 22.5), // center (10, 15)
+                leaf: SolidColor::new(0, 0, 255, 255),
+            },
+        ];
+
+        let bsp = SpatialBSP::from_positioned(items);
+        assert_eq!(
+            bsp.interiors[0].axis,
+            Axis::Y,
+            "Y center-spread (15) exceeds X center-spread (10), so split must be on Y"
+        );
+    }
+
+    #[test]
+    fn split_prefers_strictly_larger_center_spread_over_bbox_fallback() {
+        // X center-spread (~20) is strictly greater than Y center-spread (10), so
+        // the split must be on X via the first `extent_x > extent_y` branch — even
+        // though the items are so thin in X and so tall in Y that the *bounding-box*
+        // fallback (width vs height) would independently prefer Y. Kills a `>` ->
+        // `==` mutant on that branch: under the mutant, 20 == 10 is false, so the
+        // code falls through the `else if` (also false) into the bbox fallback and
+        // wrongly picks Y.
+        let items = vec![
+            Positioned {
+                bounds: (0.0, 0.0, 0.001, 500.0), // center (~0.0005, 250)
+                leaf: SolidColor::new(255, 0, 0, 255),
+            },
+            Positioned {
+                bounds: (20.0, 10.0, 20.001, 510.0), // center (~20.0005, 260)
+                leaf: SolidColor::new(0, 0, 255, 255),
+            },
+        ];
+
+        let bsp = SpatialBSP::from_positioned(items);
+        assert_eq!(
+            bsp.interiors[0].axis,
+            Axis::X,
+            "X center-spread (~20) strictly exceeds Y center-spread (10)"
+        );
+    }
+
+    #[test]
+    fn split_axis_tie_break_uses_bbox_width_against_a_small_min_x() {
+        // Item centers coincide exactly on both axes (extent_x == extent_y == 0),
+        // so the split falls through to the bbox width-vs-height tie-break. Bounds
+        // are eighths (exactly representable in f32) so the two items' centers are
+        // bit-for-bit equal rather than merely close. Real width (10.0, from
+        // max_x - min_x = 10.125 - 0.125) is less than height (50), so the split
+        // must be on Y. Kills two surviving mutants:
+        //  - `max_x - min_x` -> `max_x / min_x`: with min_x this close to zero, the
+        //    ratio (81.0) blows past height and wrongly flips the axis to X.
+        //  - `extent_x > extent_y` -> `extent_x >= extent_y`: with the tie at
+        //    exactly 0, `>=` fires immediately and picks X before the bbox
+        //    fallback ever runs.
+        let items = vec![
+            Positioned {
+                bounds: (0.125, 40.0, 10.125, 60.0), // center (5.125, 50)
+                leaf: SolidColor::new(255, 0, 0, 255),
+            },
+            Positioned {
+                bounds: (3.125, 25.0, 7.125, 75.0), // center (5.125, 50) — tied
+                leaf: SolidColor::new(0, 0, 255, 255),
+            },
+        ];
+
+        let bsp = SpatialBSP::from_positioned(items);
+        assert_eq!(
+            bsp.interiors[0].axis,
+            Axis::Y,
+            "tied centers fall back to bbox width (10.0) vs height (50), favoring Y"
+        );
+    }
+
+    #[test]
+    fn split_axis_tie_break_width_subtracts_not_adds_the_bbox_bounds() {
+        // Same tie-break setup as above, but with the x-range shifted far from zero
+        // (1000..1010) so a `max_x - min_x` -> `max_x + min_x` mutant produces a
+        // huge sum (2010) instead of the true width (10), wrongly flipping the
+        // axis to X.
+        let items = vec![
+            Positioned {
+                bounds: (1000.0, 40.0, 1010.0, 60.0), // center (1005, 50)
+                leaf: SolidColor::new(255, 0, 0, 255),
+            },
+            Positioned {
+                bounds: (1002.0, 25.0, 1008.0, 75.0), // center (1005, 50) — tied
+                leaf: SolidColor::new(0, 0, 255, 255),
+            },
+        ];
+
+        let bsp = SpatialBSP::from_positioned(items);
+        assert_eq!(
+            bsp.interiors[0].axis,
+            Axis::Y,
+            "tied centers fall back to bbox width (10) vs height (50), favoring Y"
+        );
+    }
+
+    #[test]
+    fn split_axis_tie_break_height_subtracts_not_adds_the_bbox_bounds() {
+        // Mirrors the width test above but for height: y-range shifted to
+        // 1000..1005 so a `max_y - min_y` -> `max_y + min_y` mutant produces 2005
+        // instead of the true height (5), wrongly flipping the axis from X to Y.
+        let items = vec![
+            Positioned {
+                bounds: (0.0, 1000.0, 50.0, 1005.0), // center (25, 1002.5)
+                leaf: SolidColor::new(255, 0, 0, 255),
+            },
+            Positioned {
+                bounds: (10.0, 1001.0, 40.0, 1004.0), // center (25, 1002.5) — tied
+                leaf: SolidColor::new(0, 0, 255, 255),
+            },
+        ];
+
+        let bsp = SpatialBSP::from_positioned(items);
+        assert_eq!(
+            bsp.interiors[0].axis,
+            Axis::X,
+            "tied centers fall back to bbox width (50) vs height (5), favoring X"
+        );
+    }
+
+    #[test]
+    fn x_axis_threshold_sorts_by_sum_of_bounds_not_product() {
+        // Three items with identical Y (forcing an X split) whose X sum-order
+        // differs from their X product-order. Kills a `+` -> `*` mutant in the
+        // sort-by-center-x comparator: sorting by product instead of sum reorders
+        // the items, changing which pair straddles the median split and so which
+        // threshold comes out. Given in descending sum-order (rather than already
+        // sorted) so the sort actually has to move every element and exercises the
+        // comparator's mutated argument in every slot — an already-sorted input
+        // lets insertion sort skip the comparisons that would expose it.
+        let items = vec![
+            Positioned {
+                bounds: (8.0, 0.0, 12.0, 10.0), // center x = 10.0, sum-sorted last
+                leaf: SolidColor::new(0, 0, 255, 255),
+            },
+            Positioned {
+                bounds: (-2.0, 0.0, 3.0, 10.0), // center x = 0.5, sum-sorted middle
+                leaf: SolidColor::new(0, 255, 0, 255),
+            },
+            Positioned {
+                bounds: (-10.0, 0.0, -9.0, 10.0), // center x = -9.5, sum-sorted first
+                leaf: SolidColor::new(255, 0, 0, 255),
+            },
+        ];
+
+        let bsp = SpatialBSP::from_positioned(items);
+        let root = &bsp.interiors[bsp.interior_count() - 1];
+
+        assert_eq!(root.axis, Axis::X, "identical Y bounds force an X split");
+        assert_eq!(
+            root.threshold, -5.5,
+            "sum order is [(-10,-9), (-2,3), (8,12)]; median threshold = \
+             (-9 + -2) / 2"
+        );
+    }
+
+    #[test]
+    fn y_axis_threshold_sorts_by_sum_of_bounds_not_product_or_wrong_neighbor() {
+        // Same construction as the X-axis test above, transposed onto Y (identical
+        // X forces a Y split) and likewise given in descending sum-order so the
+        // sort has to move every element. Kills the analogous `+` -> `*`/`-`
+        // sort-key mutants for the Y branch's `ca`/`cb` (both arguments of the
+        // comparator, not just one), a `/` -> `%` mutant in `cb`, and a
+        // `mid_idx - 1` -> `mid_idx / 1` mutant in the threshold formula: that
+        // mutant reads `items[mid_idx]` for *both* sides of the average instead of
+        // `items[mid_idx - 1]` and `items[mid_idx]`, which this asymmetric item set
+        // turns into a different number (0.5 instead of -5.5).
+        let items = vec![
+            Positioned {
+                bounds: (0.0, 8.0, 10.0, 12.0), // center y = 10.0, sum-sorted last
+                leaf: SolidColor::new(0, 0, 255, 255),
+            },
+            Positioned {
+                bounds: (0.0, -2.0, 10.0, 3.0), // center y = 0.5, sum-sorted middle
+                leaf: SolidColor::new(0, 255, 0, 255),
+            },
+            Positioned {
+                bounds: (0.0, -10.0, 10.0, -9.0), // center y = -9.5, sum-sorted first
+                leaf: SolidColor::new(255, 0, 0, 255),
+            },
+        ];
+
+        let bsp = SpatialBSP::from_positioned(items);
+        let root = &bsp.interiors[bsp.interior_count() - 1];
+
+        assert_eq!(root.axis, Axis::Y, "identical X bounds force a Y split");
+        assert_eq!(
+            root.threshold, -5.5,
+            "sum order is [(-10,-9), (-2,3), (8,12)]; median threshold = \
+             (-9 + -2) / 2"
+        );
+    }
+
+    // ========================================================================
+    // SIMD Lane Blending Tests
+    // ========================================================================
+
+    #[test]
+    fn eval_blends_correctly_when_simd_lanes_straddle_the_threshold() {
+        use pixelflow_core::{materialize_discrete, PARALLELISM};
+
+        // Kills a `delete !` mutant on `!mask.any()` in `traverse`: once the
+        // `mask.all()` early-out is ruled out, a *mixed* mask (some lanes left of
+        // the threshold, some right) must fall through to the `Select` blend.
+        // Deleting the `!` makes any mixed mask take the right-only early return,
+        // silently dropping the left-child values for the lanes that need them.
+        let items = vec![
+            Positioned {
+                bounds: (0.0, 0.0, 50.0, 100.0),
+                leaf: SolidColor::new(255, 0, 0, 255),
+            },
+            Positioned {
+                bounds: (50.0, 0.0, 100.0, 100.0),
+                leaf: SolidColor::new(0, 0, 255, 255),
+            },
+        ];
+        let bsp = SpatialBSP::from_positioned(items);
+        let threshold = bsp.interiors[0].threshold;
+
+        // Start one unit below the threshold so consecutive SIMD lanes straddle it:
+        // lane 0 is left of the split, the last lane is at/right of it.
+        let mut pixels = [0u32; PARALLELISM];
+        materialize_discrete(&bsp, threshold - 1.0, 50.0, &mut pixels);
+
+        let expected_red = {
+            let red = SolidColor::new(255, 0, 0, 255);
+            let mut buf = [0u32; PARALLELISM];
+            materialize_discrete(&red, 0.0, 0.0, &mut buf);
+            buf[0]
+        };
+        let expected_blue = {
+            let blue = SolidColor::new(0, 0, 255, 255);
+            let mut buf = [0u32; PARALLELISM];
+            materialize_discrete(&blue, 0.0, 0.0, &mut buf);
+            buf[0]
+        };
+
+        assert_eq!(
+            pixels[0], expected_red,
+            "lane at threshold - 1 is left of the split and must stay red"
+        );
+        assert_eq!(
+            pixels[PARALLELISM - 1],
+            expected_blue,
+            "the last lane is at/right of the split and must be blue, even though \
+             lane 0 in the same SIMD group is red"
         );
     }
 }


### PR DESCRIPTION
Three open audit PRs — #1022, #1030, #1031 — each contained work worth keeping but could not be merged as written. All three branched before the PRs that have since landed (#996, #1027), so a plain merge would have **deleted tests that are currently on `main`**. This extracts what is genuinely new in each, rebuilt against current `main`.

## Why not just merge them

A body-level comparison (comparing normalised test bodies, not names, so renames don't count as coverage) against current `main`:

| PR | Lines changed | New test bodies | Would have deleted |
|---|---|---|---|
| #1022 | 286 across 14 files | **3** | 68 tests in `screen.rs`, 12 in `term/tests.rs` (#996's) |
| #1031 | 392 across 15 files | **2** (the same two as #1022) | the same 80 |
| #1030 | 478 across 2 files | **29** | 21 tests in `spatial_bsp.rs` (#1027's) |

This is the same measurement error that #1025 was closed for: renaming a test is not new coverage.

## What landed

**`core-term/src/ansi/tests.rs`** — two new tests, from #1022/#1031:

- `osc_string_longer_than_the_length_limit_is_truncated_not_dropped`. `main` had no coverage of `MAX_OSC_LEN` at all. Verified load-bearing: replacing the cap guard with `if true` fails it.
- `osc_cancelled_by_can_does_not_leak_its_bytes_into_the_next_osc`. Kept for the contract it states at the public API, but recorded honestly in its commit message: **it kills no single mutant.** The buffer is cleared both when CAN cancels and again in `enter_string_state`, so each site masks the other and the test only fails when both clears are removed. Its value is guarding a future refactor that consolidates the two, not closing a present gap.

**`core-term/src/term/layout.rs`** — `pixels_to_cells_misses_when_only_one_axis_is_inside_the_padding`. The existing `pixels_to_cells_with_padding` only probes points inside the padding on *both* axes, so dropping either half of the bounds check survives it. Verified load-bearing: removing the `y_px` clause fails the new test while the old one still passes.

**`core-term/src/ansi/parser.rs`** — delete `ConsumeSt`. Its only consumer in all four string dispatchers was `if consume_st == ConsumeSt::Keep { /* ST handled separately */ }` — an empty body, so the parameter had no behavioral effect. It encoded an intended BEL-vs-`ESC \` distinction that was never implemented; both paths are already correct without it, since BEL leaves no ST to consume and the `\` is consumed by its own match arm. If that distinction is ever needed it should be implemented, not stubbed.

**`pixelflow-core/src/lattice/tests.rs`** — replace `raw_add`/`raw_mul` in two test manifolds with the construct-AST-then-`eval` pattern `CLAUDE.md` prescribes.

**`core-term/tests/ansi_to_grid_integration.rs`** — rename `bug_grid_changes_without_render_trigger` and drop its trailing advice. The comment told a future reader that `handle_os()` should call `send_frame()` after processing PTY output. That is wrong against the current design: PTY data arrives through `handle_data`, which intentionally does not send a frame, leaving VSync's `RequestFrame` to pick the state up so a busy PTY cannot flood the renderer. The test never touched that path in any case — it only exercises the harness checksum, duplicating the test above it.

**`pixelflow-graphics/src/spatial_bsp.rs`** — #1030's 29 new tests (split-axis selection, threshold placement at and around the boundary, structural invariants over the interior array, bbox-fallback tie-breaks), **without** the `pub fn interiors(&self) -> &[InteriorNode]` it added. That accessor's own doc comment read "Exposed for structural assertions in tests" — a public API widened purely for test access, which `CLAUDE.md` forbids without explicit permission. It is also unnecessary: `mod tests` is a child of the module declaring the private `interiors` field, so it reads `self.interiors` directly. The same accessor was stripped from #1027 before merging. **The public surface is unchanged from `main`.**

Also kept from #1030: the fix for a test that wrote `matches!(root.left, NodeRef::Leaf(_));` as a bare statement, discarding the `bool` instead of asserting it — a silent no-op check. A sweep confirms no other occurrence of that pattern in the workspace.

The audit doc that came with #1030 has been corrected where it described the accessor and the renames that were not taken, so it no longer contradicts the tree.

## Test plan

- [x] `cargo test -p core-term` — 542 lib + 55 integration, 0 failed
- [x] `cargo test -p pixelflow-core --lib` — 123 passed, 0 failed
- [x] `cargo test -p pixelflow-graphics` — 160 lib (64 in `spatial_bsp`), 0 failed
- [x] `cargo clippy -p core-term -p pixelflow-core -p pixelflow-graphics --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — clean
- [x] Both new mutation-relevant tests verified load-bearing by actually applying the mutant and observing the failure; the third recorded as not load-bearing rather than claimed as coverage
- [ ] `cargo xtask isa-matrix --clippy` across all four levels — running at time of writing; this PR is a draft until it reports

Once this merges, #1022, #1030 and #1031 should be closed as salvaged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019WC8B9eNCHTyyRMx2yrLnj

---
_Generated by [Claude Code](https://claude.ai/code/session_019WC8B9eNCHTyyRMx2yrLnj)_